### PR TITLE
add remote browser support (Browser Use cloud) + multi-daemon + rename to bu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env — auto-loaded. Only needed for remote browsers.
+BROWSER_USE_API_KEY=bu_your_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 *.log
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Protocol: one JSON line per direction. Request: `{method, params, session_id}` (
 
 Daemon attaches to the first real page at startup, buffers events in `deque(maxlen=500)`.
 
-`HARNESLESS_NAME` (default `default`) suffixes socket/pid/log — multiple daemons coexist, no supervisor. `HARNESLESS_CDP_WS` overrides the local DevToolsActivePort lookup (remote via `start_remote_daemon()`). `HARNESLESS_REMOTE_BROWSER_ID` + `BROWSER_USE_API_KEY` → daemon stops the cloud browser on shutdown.
+`BU_NAME` (default `default`) suffixes socket/pid/log — multiple daemons coexist, no supervisor. `BU_CDP_WS` overrides the local DevToolsActivePort lookup (remote via `start_remote_daemon()`). `BU_BROWSER_ID` + `BROWSER_USE_API_KEY` → daemon stops the cloud browser on shutdown.
 
 ## Design decisions worth preserving
 
@@ -30,7 +30,7 @@ Daemon attaches to the first real page at startup, buffers events in `deque(maxl
 
 - Helpers ≤ 15 lines. No classes. No deps beyond stdlib + cdp-use + websockets.
 - Don't add meta verbs lightly; if it can be a helper calling `cdp()`, it's a helper.
-- Never add: CLI argparse, tests, logging framework, config files, session manager, retries, daemon supervisor. Multiple daemons are fine (one per `HARNESLESS_NAME`) — just don't build a thing that manages them.
+- Never add: CLI argparse, tests, logging framework, config files, session manager, retries, daemon supervisor. Multiple daemons are fine (one per `BU_NAME`) — just don't build a thing that manages them.
 - Taste test: could the LLM rewrite this from scratch after reading it once?
 
 ## Known gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
 # AGENTS.md
 
-For agents **modifying** harnesless. For using it, see SKILL.md.
+For agents **modifying** bu. For using it, see SKILL.md.
 
 ## Philosophy
 
-Both agent-browser (60+ verbs) and browser-use (~20 verbs) are walled gardens. Harnesless inverts this: few helpers, LLM edits them at runtime. Every design decision flows from that.
+Both agent-browser (60+ verbs) and browser-use (~20 verbs) are walled gardens. bu inverts this: few helpers, LLM edits them at runtime. Every design decision flows from that.
 
 ## Architecture
 
 ```
-Chrome / Browser Use cloud ── CDP WS ─▶ daemon.py ── /tmp/harnesless-<NAME>.sock ─▶ run.py
+Chrome / Browser Use cloud ── CDP WS ─▶ daemon.py ── /tmp/bu-<NAME>.sock ─▶ run.py
 ```
 
 Protocol: one JSON line per direction. Request: `{method, params, session_id}` (CDP passthrough) or `{meta: ...}`. Response: `{result}` / `{error}` / `{events}` / `{session_id}`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,14 @@ Both agent-browser (60+ verbs) and browser-use (~20 verbs) are walled gardens. H
 ## Architecture
 
 ```
-Chrome (127.0.0.1:9222) ── CDP WS ─▶ daemon.py ── /tmp/harnesless.sock ─▶ run.py (one per tool call)
-                                     (long-running)                        (from helpers import *; exec(stdin))
+Chrome / Browser Use cloud ── CDP WS ─▶ daemon.py ── /tmp/harnesless-<NAME>.sock ─▶ run.py
 ```
 
 Protocol: one JSON line per direction. Request: `{method, params, session_id}` (CDP passthrough) or `{meta: ...}`. Response: `{result}` / `{error}` / `{events}` / `{session_id}`.
 
-Daemon attaches to the first real page target at startup, buffers events in `deque(maxlen=500)`.
+Daemon attaches to the first real page at startup, buffers events in `deque(maxlen=500)`.
+
+`HARNESLESS_NAME` (default `default`) suffixes socket/pid/log — multiple daemons coexist, no supervisor. `HARNESLESS_CDP_WS` overrides the local DevToolsActivePort lookup (remote via `start_remote_daemon()`). `HARNESLESS_REMOTE_BROWSER_ID` + `BROWSER_USE_API_KEY` → daemon stops the cloud browser on shutdown.
 
 ## Design decisions worth preserving
 
@@ -29,7 +30,7 @@ Daemon attaches to the first real page target at startup, buffers events in `deq
 
 - Helpers ≤ 15 lines. No classes. No deps beyond stdlib + cdp-use + websockets.
 - Don't add meta verbs lightly; if it can be a helper calling `cdp()`, it's a helper.
-- Never add: CLI argparse, tests, logging framework, config files, session manager, retries, multi-daemon.
+- Never add: CLI argparse, tests, logging framework, config files, session manager, retries, daemon supervisor. Multiple daemons are fine (one per `HARNESLESS_NAME`) — just don't build a thing that manages them.
 - Taste test: could the LLM rewrite this from scratch after reading it once?
 
 ## Known gotchas
@@ -40,6 +41,9 @@ Daemon attaches to the first real page target at startup, buffers events in `deq
 - `send_raw` has no timeout — stuck call hangs forever. Add a wrapper if it bites.
 - Daemon's default session goes stale if user closes the attached tab manually. `ensure_real_tab()` re-attaches.
 - Two tuples named `INTERNAL` (daemon.py, helpers.py) — cross-process, can't share module. Keep in sync.
+- Browser Use API is **camelCase** on the wire (`cdpUrl`, `proxyCountryCode`). The SDKs rename — we don't.
+- Remote `cdpUrl` is HTTPS, not ws. `cdp_ws_from_url()` hits `/json/version` → `webSocketDebuggerUrl`.
+- Stop a cloud browser with `PATCH /browsers/{id}` `{"action":"stop"}`. `POST /sessions/{id}/stop` is for agent sessions.
 
 ## Session lessons
 
@@ -47,3 +51,4 @@ Daemon attaches to the first real page target at startup, buffers events in `deq
 - **`http_get` + `ThreadPoolExecutor` beats the browser for static scrapes.** 249 Netflix pages in 2.8s parallel.
 - **`wait(5)` after goto is fragile.** `wait_for_load()` polls `document.readyState`.
 - **Auth-gated sites (Upwork, X) redirect to login.** Not our problem; bail and ask the user.
+- **Screenshots render at ~half viewport width in the transcript.** Don't eyeball click coords off the image — use `js("el.getBoundingClientRect()")` for the real pixel location.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# harnesless
+# bu
 
 LLM-first browser control via CDP. No CLI, no wrappers, just Python and CDP.
 
@@ -35,11 +35,11 @@ Read `SKILL.md` for the full LLM workflow. Read `AGENTS.md` if you're an agent w
 
 ## Files
 
-- `daemon.py` — holds the WebSocket, listens on `/tmp/harnesless.sock`
+- `daemon.py` — holds the WebSocket, listens on `/tmp/bu-<name>.sock`
 - `helpers.py` — ~250 lines of transparent helpers
 - `run.py` — 3 lines: `from helpers import *; exec(stdin)`
-- `SKILL.md` — how an agent *uses* harnesless to drive a browser
-- `AGENTS.md` — how an agent *modifies* harnesless (code structure, extension points)
+- `SKILL.md` — how an agent *uses* bu to drive a browser
+- `AGENTS.md` — how an agent *modifies* bu (code structure, extension points)
 
 ## Stop
 
@@ -47,5 +47,5 @@ Read `SKILL.md` for the full LLM workflow. Read `AGENTS.md` if you're an agent w
 uv run python -c "from helpers import kill_daemon; kill_daemon()"        # default daemon
 uv run python -c "from helpers import kill_daemon; kill_daemon('work')"  # named daemon (also stops remote browser)
 # or
-pkill -f harnesless/daemon.py
+pkill -f bu/daemon.py
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ print(page_info())
 PY
 ```
 
-Parallel agents / remote browsers: `HARNESLESS_NAME=<n> uv run run.py`. See `SKILL.md`.
+Parallel agents / remote browsers: `BU_NAME=<n> uv run run.py`. See `SKILL.md`.
 
 Read `SKILL.md` for the full LLM workflow. Read `AGENTS.md` if you're an agent working ON this codebase (extending helpers, debugging the daemon). Read `helpers.py` for every function — they're all ~5 lines each and you can edit any of them.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ LLM-first browser control via CDP. No CLI, no wrappers, just Python and CDP.
 
 2. Enable Chrome remote debugging: open `chrome://inspect/#remote-debugging`, check the box. Chrome now listens at `127.0.0.1:9222`.
 
-3. Start the daemon:
+3. (Optional) For remote browsers: `cp .env.example .env` and fill in `BROWSER_USE_API_KEY`.
+
+4. Start the daemon:
    ```
    uv run daemon.py &
    ```
@@ -27,6 +29,8 @@ print(page_info())
 PY
 ```
 
+Parallel agents / remote browsers: `HARNESLESS_NAME=<n> uv run run.py`. See `SKILL.md`.
+
 Read `SKILL.md` for the full LLM workflow. Read `AGENTS.md` if you're an agent working ON this codebase (extending helpers, debugging the daemon). Read `helpers.py` for every function — they're all ~5 lines each and you can edit any of them.
 
 ## Files
@@ -40,7 +44,8 @@ Read `SKILL.md` for the full LLM workflow. Read `AGENTS.md` if you're an agent w
 ## Stop
 
 ```
-uv run -c "from helpers import shutdown; shutdown()"
+uv run python -c "from helpers import kill_daemon; kill_daemon()"        # default daemon
+uv run python -c "from helpers import kill_daemon; kill_daemon('work')"  # named daemon (also stops remote browser)
 # or
 pkill -f harnesless/daemon.py
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,19 +1,19 @@
 ---
-name: harnesless
+name: bu
 description: Direct browser control via CDP. Use when the user wants to automate, scrape, test, or interact with web pages. Connects to the user's already-running Chrome.
 allowed-tools: Bash, Read, Edit, Write
 ---
 
-# Harnesless
+# bu
 
-Project: `/Users/greg/Documents/browser-use/hackathons/harnesless/`
+Project: `/Users/greg/Documents/browser-use/hackathons/bu/`
 
 **Read `helpers.py` first.** ~260 lines, one tool call. The code is the doc.
 
 ## Tool call shape
 
 ```bash
-cd /Users/greg/Documents/browser-use/hackathons/harnesless && uv run run.py <<'PY'
+cd /Users/greg/Documents/browser-use/hackathons/bu && uv run run.py <<'PY'
 # any python. helpers pre-imported. daemon auto-starts.
 PY
 ```
@@ -28,7 +28,7 @@ PY
 
 ## Parallel / remote
 
-`BU_NAME` picks the daemon (default `default`). Each name = independent socket `/tmp/harnesless-<NAME>.sock`, independent daemon. Remote:
+`BU_NAME` picks the daemon (default `default`). Each name = independent socket `/tmp/bu-<NAME>.sock`, independent daemon. Remote:
 
 ```bash
 uv run python -c "from helpers import start_remote_daemon; print(start_remote_daemon('work'))"

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,11 +28,11 @@ PY
 
 ## Parallel / remote
 
-`HARNESLESS_NAME` picks the daemon (default `default`). Each name = independent socket `/tmp/harnesless-<NAME>.sock`, independent daemon. Remote:
+`BU_NAME` picks the daemon (default `default`). Each name = independent socket `/tmp/harnesless-<NAME>.sock`, independent daemon. Remote:
 
 ```bash
 uv run python -c "from helpers import start_remote_daemon; print(start_remote_daemon('work'))"
-HARNESLESS_NAME=work uv run run.py <<'PY' ... PY
+BU_NAME=work uv run run.py <<'PY' ... PY
 uv run python -c "from helpers import kill_daemon; kill_daemon('work')"  # stops cloud browser too
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Edit, Write
 
 Project: `/Users/greg/Documents/browser-use/hackathons/harnesless/`
 
-**Read `helpers.py` first.** ~150 lines, one tool call. The code is the doc.
+**Read `helpers.py` first.** ~260 lines, one tool call. The code is the doc.
 
 ## Tool call shape
 
@@ -20,19 +20,23 @@ PY
 
 `run.py` calls `ensure_daemon()` before `exec` — you never start/stop manually unless you want to.
 
-## Setup (once per machine)
+## Setup
 
-`uv sync`. User enables `chrome://inspect/#remote-debugging` in their Chrome.
+`uv sync`. Enable `chrome://inspect/#remote-debugging`. Remote browsers: `cp .env.example .env` + fill `BROWSER_USE_API_KEY`.
 
-**First daemon start of a session may hang** on the CDP WebSocket handshake — Chrome shows a native "Allow debugging connections" dialog the user has to click. Be patient (give ~15s), then retry. Don't surface an error on the first timeout.
+**First local daemon start may hang** on Chrome's "Allow debugging" dialog. Give ~15s, then retry.
 
-## Daemon management
+## Parallel / remote
 
-- Socket at `/tmp/harnesless.sock` IS the lock.
-- `ensure_daemon()` — idempotent, starts if not alive.
-- `kill_daemon()` — graceful shutdown + pkill fallback.
-- Starting the daemon twice is safe: the second one exits on seeing the socket.
-- Logs: `/tmp/harnesless.log`.
+`HARNESLESS_NAME` picks the daemon (default `default`). Each name = independent socket `/tmp/harnesless-<NAME>.sock`, independent daemon. Remote:
+
+```bash
+uv run python -c "from helpers import start_remote_daemon; print(start_remote_daemon('work'))"
+HARNESLESS_NAME=work uv run run.py <<'PY' ... PY
+uv run python -c "from helpers import kill_daemon; kill_daemon('work')"  # stops cloud browser too
+```
+
+Leaving a remote daemon running bills until the session timeout.
 
 ## Post-task ritual (self-improving harness)
 

--- a/daemon.py
+++ b/daemon.py
@@ -1,18 +1,25 @@
-"""Long-running CDP WebSocket holder + Unix socket relay.
-
-Chrome 144+: reads ws URL from <profile>/DevToolsActivePort (written when user
-enables chrome://inspect/#remote-debugging). Avoids the per-connect "Allow?"
-dialog that the classic /json/version endpoint would trigger.
-"""
-import asyncio, json, os, socket, sys
+"""CDP WS holder + Unix socket relay. One daemon per HARNESLESS_NAME."""
+import asyncio, json, os, socket, sys, urllib.request
 from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
 
-SOCK = "/tmp/harnesless.sock"
-LOG = "/tmp/harnesless.log"
-PID = "/tmp/harnesless.pid"
+
+def _load_env():
+    p = Path(__file__).parent / ".env"
+    if not p.exists(): return
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line: continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+_load_env()
+
+NAME = os.environ.get("HARNESLESS_NAME", "default")
+SOCK = f"/tmp/harnesless-{NAME}.sock"
+LOG = f"/tmp/harnesless-{NAME}.log"
+PID = f"/tmp/harnesless-{NAME}.pid"
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -20,6 +27,9 @@ PROFILES = [
     Path.home() / "AppData/Local/Google/Chrome/User Data",
 ]
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
+BU_API = "https://api.browser-use.com/api/v3"
+REMOTE_ID = os.environ.get("HARNESLESS_REMOTE_BROWSER_ID")
+API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
 def log(msg):
@@ -27,13 +37,30 @@ def log(msg):
 
 
 def get_ws_url():
+    if url := os.environ.get("HARNESLESS_CDP_WS"):
+        return url
     for base in PROFILES:
         try:
             port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
         except (FileNotFoundError, NotADirectoryError):
             continue
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
-    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging")
+    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set HARNESLESS_CDP_WS for a remote browser")
+
+
+def stop_remote():
+    if not REMOTE_ID or not API_KEY: return
+    try:
+        req = urllib.request.Request(
+            f"{BU_API}/browsers/{REMOTE_ID}",
+            data=json.dumps({"action": "stop"}).encode(),
+            method="PATCH",
+            headers={"X-Browser-Use-API-Key": API_KEY, "Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=15).read()
+        log(f"stopped remote browser {REMOTE_ID}")
+    except Exception as e:
+        log(f"stop_remote failed ({REMOTE_ID}): {e}")
 
 
 def is_real_page(t):
@@ -45,6 +72,7 @@ class Daemon:
         self.cdp = None
         self.session = None
         self.events = deque(maxlen=BUF)
+        self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
@@ -65,6 +93,7 @@ class Daemon:
         return pages[0]
 
     async def start(self):
+        self.stop = asyncio.Event()
         url = get_ws_url()
         log(f"connecting to {url}")
         self.cdp = CDPClient(url)
@@ -92,7 +121,7 @@ class Daemon:
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
         if meta == "set_session": self.session = req.get("session_id"); return {"session_id": self.session}
-        if meta == "shutdown":    return {"ok": True, "_shutdown": True}
+        if meta == "shutdown":    self.stop.set(); return {"ok": True}
 
         method = req["method"]
         params = req.get("params") or {}
@@ -121,8 +150,6 @@ async def serve(d):
             resp = await d.handle(json.loads(line))
             writer.write((json.dumps(resp, default=str) + "\n").encode())
             await writer.drain()
-            if resp.get("_shutdown"):
-                asyncio.get_event_loop().stop()
         except Exception as e:
             log(f"conn: {e}")
             try:
@@ -135,9 +162,9 @@ async def serve(d):
 
     server = await asyncio.start_unix_server(handler, path=SOCK)
     os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK}")
+    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
     async with server:
-        await server.serve_forever()
+        await d.stop.wait()
 
 
 async def main():
@@ -168,5 +195,6 @@ if __name__ == "__main__":
         log(f"fatal: {e}")
         sys.exit(1)
     finally:
+        stop_remote()
         try: os.unlink(PID)
         except FileNotFoundError: pass

--- a/daemon.py
+++ b/daemon.py
@@ -1,4 +1,4 @@
-"""CDP WS holder + Unix socket relay. One daemon per HARNESLESS_NAME."""
+"""CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
 import asyncio, json, os, socket, sys, urllib.request
 from collections import deque
 from pathlib import Path
@@ -16,7 +16,7 @@ def _load_env():
         os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
 _load_env()
 
-NAME = os.environ.get("HARNESLESS_NAME", "default")
+NAME = os.environ.get("BU_NAME", "default")
 SOCK = f"/tmp/harnesless-{NAME}.sock"
 LOG = f"/tmp/harnesless-{NAME}.log"
 PID = f"/tmp/harnesless-{NAME}.pid"
@@ -28,7 +28,7 @@ PROFILES = [
 ]
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"
-REMOTE_ID = os.environ.get("HARNESLESS_REMOTE_BROWSER_ID")
+REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
@@ -37,7 +37,7 @@ def log(msg):
 
 
 def get_ws_url():
-    if url := os.environ.get("HARNESLESS_CDP_WS"):
+    if url := os.environ.get("BU_CDP_WS"):
         return url
     for base in PROFILES:
         try:
@@ -45,7 +45,7 @@ def get_ws_url():
         except (FileNotFoundError, NotADirectoryError):
             continue
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
-    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set HARNESLESS_CDP_WS for a remote browser")
+    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 
 def stop_remote():

--- a/daemon.py
+++ b/daemon.py
@@ -17,9 +17,9 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/harnesless-{NAME}.sock"
-LOG = f"/tmp/harnesless-{NAME}.log"
-PID = f"/tmp/harnesless-{NAME}.pid"
+SOCK = f"/tmp/bu-{NAME}.sock"
+LOG = f"/tmp/bu-{NAME}.log"
+PID = f"/tmp/bu-{NAME}.pid"
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",

--- a/helpers.py
+++ b/helpers.py
@@ -13,7 +13,7 @@ def _load_env():
         os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
 _load_env()
 
-NAME = os.environ.get("HARNESLESS_NAME", "default")
+NAME = os.environ.get("BU_NAME", "default")
 SOCK = f"/tmp/harnesless-{NAME}.sock"
 PID = f"/tmp/harnesless-{NAME}.pid"
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
@@ -46,7 +46,7 @@ def set_session(s):  return _send({"meta": "set_session", "session_id": s})
 def shutdown():      return _send({"meta": "shutdown"})
 
 
-# --- daemon lifecycle (socket IS the lock; one per HARNESLESS_NAME) ---
+# --- daemon lifecycle (socket IS the lock; one per BU_NAME) ---
 def _paths(name): n = name or NAME; return f"/tmp/harnesless-{n}.sock", f"/tmp/harnesless-{n}.pid"
 
 def daemon_alive(name=None):
@@ -60,7 +60,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     """Idempotent. `env` is merged into the child process env."""
     if daemon_alive(name): return
     import subprocess
-    e = {**os.environ, **({"HARNESLESS_NAME": name} if name else {}), **(env or {})}
+    e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
     subprocess.Popen(["uv", "run", "daemon.py"], cwd=os.path.dirname(os.path.abspath(__file__)),
                      env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
     deadline = time.time() + wait
@@ -113,8 +113,8 @@ def cdp_ws_from_url(cdp_url):
 def start_remote_daemon(name="remote", **create_kwargs):
     if daemon_alive(name): raise RuntimeError(f"daemon {name!r} already alive — kill_daemon({name!r}) first")
     b = browser_use_create(**create_kwargs)
-    ensure_daemon(name=name, env={"HARNESLESS_CDP_WS": cdp_ws_from_url(b["cdpUrl"]),
-                                  "HARNESLESS_REMOTE_BROWSER_ID": b["id"]})
+    ensure_daemon(name=name, env={"BU_CDP_WS": cdp_ws_from_url(b["cdpUrl"]),
+                                  "BU_BROWSER_ID": b["id"]})
     return b
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -14,8 +14,8 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/harnesless-{NAME}.sock"
-PID = f"/tmp/harnesless-{NAME}.pid"
+SOCK = f"/tmp/bu-{NAME}.sock"
+PID = f"/tmp/bu-{NAME}.pid"
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"
 
@@ -47,7 +47,7 @@ def shutdown():      return _send({"meta": "shutdown"})
 
 
 # --- daemon lifecycle (socket IS the lock; one per BU_NAME) ---
-def _paths(name): n = name or NAME; return f"/tmp/harnesless-{n}.sock", f"/tmp/harnesless-{n}.pid"
+def _paths(name): n = name or NAME; return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
 
 def daemon_alive(name=None):
     try:
@@ -67,7 +67,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     while time.time() < deadline:
         if daemon_alive(name): return
         time.sleep(0.2)
-    raise RuntimeError(f"daemon {name or NAME} didn't come up — check /tmp/harnesless-{name or NAME}.log")
+    raise RuntimeError(f"daemon {name or NAME} didn't come up — check /tmp/bu-{name or NAME}.log")
 
 def kill_daemon(name=None):
     """Graceful shutdown, wait up to 15s for finally-block cleanup (remote stop), then SIGTERM."""

--- a/helpers.py
+++ b/helpers.py
@@ -1,9 +1,23 @@
 """Browser control via CDP. Read, edit, extend — this file is yours."""
-import base64, json, socket, time
+import base64, json, os, socket, time, urllib.request
+from pathlib import Path
 
-SOCK = "/tmp/harnesless.sock"
-PID = "/tmp/harnesless.pid"
+
+def _load_env():
+    p = Path(__file__).parent / ".env"
+    if not p.exists(): return
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line: continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+_load_env()
+
+NAME = os.environ.get("HARNESLESS_NAME", "default")
+SOCK = f"/tmp/harnesless-{NAME}.sock"
+PID = f"/tmp/harnesless-{NAME}.pid"
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
+BU_API = "https://api.browser-use.com/api/v3"
 
 
 def _send(req):
@@ -32,39 +46,76 @@ def set_session(s):  return _send({"meta": "set_session", "session_id": s})
 def shutdown():      return _send({"meta": "shutdown"})
 
 
-# --- daemon lifecycle (socket IS the lock) ---
-def daemon_alive():
+# --- daemon lifecycle (socket IS the lock; one per HARNESLESS_NAME) ---
+def _paths(name): n = name or NAME; return f"/tmp/harnesless-{n}.sock", f"/tmp/harnesless-{n}.pid"
+
+def daemon_alive(name=None):
     try:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
+        s.connect(_paths(name)[0]); s.close(); return True
     except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
         return False
 
-def ensure_daemon(wait=60.0):
-    """Start daemon if not running. Idempotent — safe to call always."""
-    if daemon_alive(): return
-    import os, subprocess
-    here = os.path.dirname(os.path.abspath(__file__))
-    subprocess.Popen(["uv", "run", "daemon.py"], cwd=here,
-                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+def ensure_daemon(wait=60.0, name=None, env=None):
+    """Idempotent. `env` is merged into the child process env."""
+    if daemon_alive(name): return
+    import subprocess
+    e = {**os.environ, **({"HARNESLESS_NAME": name} if name else {}), **(env or {})}
+    subprocess.Popen(["uv", "run", "daemon.py"], cwd=os.path.dirname(os.path.abspath(__file__)),
+                     env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
     deadline = time.time() + wait
     while time.time() < deadline:
-        if daemon_alive(): return
+        if daemon_alive(name): return
         time.sleep(0.2)
-    raise RuntimeError("daemon didn't come up — check /tmp/harnesless.log")
+    raise RuntimeError(f"daemon {name or NAME} didn't come up — check /tmp/harnesless-{name or NAME}.log")
 
-def kill_daemon():
-    """Graceful shutdown, then SIGTERM via PID file, then clear socket."""
-    import os, signal
-    try: shutdown()
-    except Exception: pass
+def kill_daemon(name=None):
+    """Graceful shutdown, wait up to 15s for finally-block cleanup (remote stop), then SIGTERM."""
+    import signal
+    sock, pid_path = _paths(name)
     try:
-        os.kill(int(open(PID).read()), signal.SIGTERM)
-    except (FileNotFoundError, ProcessLookupError, ValueError):
-        pass
-    for f in (SOCK, PID):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(5)
+        s.connect(sock); s.sendall(b'{"meta":"shutdown"}\n'); s.recv(1024); s.close()
+    except Exception: pass
+    try: pid = int(open(pid_path).read())
+    except (FileNotFoundError, ValueError): pid = None
+    if pid:
+        for _ in range(75):
+            try: os.kill(pid, 0); time.sleep(0.2)
+            except ProcessLookupError: break
+        else:
+            try: os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError: pass
+    for f in (sock, pid_path):
         try: os.unlink(f)
         except FileNotFoundError: pass
+
+
+# --- Browser Use cloud (remote browsers) ---
+# https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session
+def _bu(path, method, body=None):
+    k = os.environ.get("BROWSER_USE_API_KEY")
+    if not k: raise RuntimeError("BROWSER_USE_API_KEY missing — see .env.example")
+    req = urllib.request.Request(f"{BU_API}{path}", method=method,
+        data=(json.dumps(body).encode() if body is not None else None),
+        headers={"X-Browser-Use-API-Key": k, "Content-Type": "application/json"})
+    return json.loads(urllib.request.urlopen(req, timeout=60).read() or b"{}")
+
+def browser_use_create(**params):
+    return _bu("/browsers", "POST", params)
+
+def browser_use_stop(browser_id):
+    return _bu(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
+
+def cdp_ws_from_url(cdp_url):
+    return json.loads(urllib.request.urlopen(f"{cdp_url}/json/version", timeout=15).read())["webSocketDebuggerUrl"]
+
+def start_remote_daemon(name="remote", **create_kwargs):
+    if daemon_alive(name): raise RuntimeError(f"daemon {name!r} already alive — kill_daemon({name!r}) first")
+    b = browser_use_create(**create_kwargs)
+    ensure_daemon(name=name, env={"HARNESLESS_CDP_WS": cdp_ws_from_url(b["cdpUrl"]),
+                                  "HARNESLESS_REMOTE_BROWSER_ID": b["id"]})
+    return b
 
 
 # --- navigation / page ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "harnesless"
+name = "bu"
 version = "0.1.0"
 description = "LLM-first browser control via CDP"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bu"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cdp-use" },
+    { name = "websockets" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cdp-use", specifier = ">=1.4.5" },
+    { name = "websockets", specifier = ">=16.0" },
+]
+
+[[package]]
 name = "cdp-use"
 version = "1.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -45,21 +60,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "harnesless"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "cdp-use" },
-    { name = "websockets" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "cdp-use", specifier = ">=1.4.5" },
-    { name = "websockets", specifier = ">=16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `start_remote_daemon(name, **params)` creates a Browser Use cloud browser and launches a daemon attached to it; `kill_daemon(name)` stops both. Local Chrome path unchanged.
- `BU_NAME` env var suffixes socket/pid/log — multiple daemons run side-by-side, no supervisor. Parallel agents are just separate `BU_NAME=<n> uv run run.py` invocations.
- Project renamed from harnesless to bu (package name, slash command, file paths). Env vars use `BU_*` prefix.

## Test plan
- [x] Remote lifecycle end-to-end: create → scrape HN → kill_daemon → API confirms `status: stopped`.
- [x] Recording URL captured from the PATCH stop response (verified with `ftyp isom` bytes).
- [x] `kill_daemon` waits up to 15s for graceful exit before SIGTERM so the finally-block remote-stop isn't cut off.
- [x] `start_remote_daemon` fails fast if a daemon with the given name is already alive (prevents orphaned cloud browsers).
- [x] 245-country Netflix scrape via subagent — validates the remote path end-to-end under real load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds remote browser support via Browser Use cloud and multi-daemon management, and renames the project to `bu`. Enables parallel agents and remote sessions with graceful start/stop.

- **New Features**
  - Remote browsers: `start_remote_daemon(name, **params)` creates a Browser Use cloud browser and attaches a daemon; `kill_daemon(name)` stops both.
  - Multi-daemon: `BU_NAME` selects independent `/tmp/bu-<name>.{sock,pid,log}`; `ensure_daemon(name=...)` and `kill_daemon(name=...)` added; `BU_CDP_WS` override for remote CDP; `.env` auto-loaded and remote browser is stopped on daemon exit.

- **Migration**
  - Renamed from `harnesless` to `bu` (package, docs, socket paths).
  - Env vars now `BU_*`: `BU_NAME`, `BU_CDP_WS`, `BU_BROWSER_ID`; add `.env` with `BROWSER_USE_API_KEY` for cloud usage.
  - Docs updated; `.gitignore` now ignores `.env`.

<sup>Written for commit 26ef91aec620d7fa6cc61a2c22e7d85bb8d9c7ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

