### PR TITLE
[codex] Scaffold interaction skill notes

### DIFF
--- a/interaction-skills/cross-origin-iframes.md
+++ b/interaction-skills/cross-origin-iframes.md
@@ -1,0 +1,3 @@
+# Cross-Origin Iframes
+
+Cross-origin iframes are the case where CDP target handling matters most, because DOM access from the top page is blocked and the iframe may appear as its own target. This note should focus on `iframe_target(...)`, target attachment, and when compositor-level coordinate clicks are still the lower-friction option.

--- a/interaction-skills/cross-origin-iframes.md
+++ b/interaction-skills/cross-origin-iframes.md
@@ -1,3 +1,3 @@
 # Cross-Origin Iframes
 
-Cross-origin iframes are the case where CDP target handling matters most, because DOM access from the top page is blocked and the iframe may appear as its own target. This note should focus on `iframe_target(...)`, target attachment, and when compositor-level coordinate clicks are still the lower-friction option.
+Focus on `iframe_target(...)`, target attachment, and when compositor-level coordinate clicks are lower-friction than cross-target DOM work.

--- a/interaction-skills/downloads.md
+++ b/interaction-skills/downloads.md
@@ -1,3 +1,3 @@
 # Downloads
 
-Document how to detect that a download actually started, because many sites only show a transient toast, spinner, or browser-level indicator. Also separate browser-triggered downloads from direct `http_get(...)` fetches, since static assets often do not need the browser at all.
+Separate browser-triggered downloads from direct `http_get(...)` fetches, and document the minimal signals that prove a download actually started.

--- a/interaction-skills/downloads.md
+++ b/interaction-skills/downloads.md
@@ -1,0 +1,3 @@
+# Downloads
+
+Document how to detect that a download actually started, because many sites only show a transient toast, spinner, or browser-level indicator. Also separate browser-triggered downloads from direct `http_get(...)` fetches, since static assets often do not need the browser at all.

--- a/interaction-skills/dropdowns.md
+++ b/interaction-skills/dropdowns.md
@@ -1,3 +1,3 @@
 # Dropdowns
 
-Treat dropdowns as several different classes: native `<select>`, custom menu overlays, searchable comboboxes, and virtualized scroll lists. Re-measure coordinates after opening them, because the clickable options often do not exist or do not have final geometry until the menu is visible.
+Split dropdowns into native selects, custom overlays, searchable comboboxes, and virtualized menus, and always re-measure after opening because option geometry often appears late.

--- a/interaction-skills/dropdowns.md
+++ b/interaction-skills/dropdowns.md
@@ -1,0 +1,3 @@
+# Dropdowns
+
+Treat dropdowns as several different classes: native `<select>`, custom menu overlays, searchable comboboxes, and virtualized scroll lists. Re-measure coordinates after opening them, because the clickable options often do not exist or do not have final geometry until the menu is visible.

--- a/interaction-skills/iframes.md
+++ b/interaction-skills/iframes.md
@@ -1,0 +1,3 @@
+# Iframes
+
+Same-origin iframes usually need DOM traversal through `contentDocument` or `contentWindow`, while page-level coordinate clicks still land at the compositor layer. Keep the coordinate-system warning front and center: iframe element rects are local to the frame and must be offset into page coordinates before clicking.

--- a/interaction-skills/iframes.md
+++ b/interaction-skills/iframes.md
@@ -1,3 +1,3 @@
 # Iframes
 
-Same-origin iframes usually need DOM traversal through `contentDocument` or `contentWindow`, while page-level coordinate clicks still land at the compositor layer. Keep the coordinate-system warning front and center: iframe element rects are local to the frame and must be offset into page coordinates before clicking.
+Cover same-origin iframe traversal through `contentDocument` / `contentWindow`, and keep the frame-local versus page-coordinate warning explicit for clicks.

--- a/interaction-skills/network-requests.md
+++ b/interaction-skills/network-requests.md
@@ -1,0 +1,3 @@
+# Network Requests
+
+Document how to watch or infer network activity when page state is ambiguous, especially for submit flows, downloads, and SPA actions that succeed without obvious DOM changes.

--- a/interaction-skills/print-as-pdf.md
+++ b/interaction-skills/print-as-pdf.md
@@ -1,0 +1,3 @@
+# Print As PDF
+
+Cover both direct PDF generation via CDP and sites that only expose a visible "Print" button which must be clicked before handling the browser print flow.

--- a/interaction-skills/printing.md
+++ b/interaction-skills/printing.md
@@ -1,3 +1,0 @@
-# Printing
-
-Cover both direct PDF generation via CDP and sites that only expose a visible "Print" or "Save as PDF" button in the page UI. The key distinction is whether you want the page content as data or you need to drive the browser's print flow and its follow-up dialog.

--- a/interaction-skills/printing.md
+++ b/interaction-skills/printing.md
@@ -1,0 +1,3 @@
+# Printing
+
+Cover both direct PDF generation via CDP and sites that only expose a visible "Print" or "Save as PDF" button in the page UI. The key distinction is whether you want the page content as data or you need to drive the browser's print flow and its follow-up dialog.

--- a/interaction-skills/scrolling.md
+++ b/interaction-skills/scrolling.md
@@ -1,3 +1,3 @@
 # Scrolling
 
-Scrolling needs separate recipes for page scroll, nested scroll containers, virtualized lists, and dropdown menus with their own internal scroll regions. The main rule is to identify which element is actually consuming wheel events before you scroll, especially on pages with several independent containers visible at once.
+Separate page scroll, nested containers, virtualized lists, and dropdown menus, and identify which element is actually consuming wheel events before scrolling.

--- a/interaction-skills/scrolling.md
+++ b/interaction-skills/scrolling.md
@@ -1,0 +1,3 @@
+# Scrolling
+
+Scrolling needs separate recipes for page scroll, nested scroll containers, virtualized lists, and dropdown menus with their own internal scroll regions. The main rule is to identify which element is actually consuming wheel events before you scroll, especially on pages with several independent containers visible at once.

--- a/interaction-skills/shadow-dom.md
+++ b/interaction-skills/shadow-dom.md
@@ -1,0 +1,3 @@
+# Shadow DOM
+
+Normal `document.querySelector(...)` stops at shadow boundaries, so this note should focus on walking `shadowRoot` recursively instead of assuming one global selector works. Also call out when coordinate clicking is simpler than DOM traversal, especially for deeply nested component libraries.

--- a/interaction-skills/shadow-dom.md
+++ b/interaction-skills/shadow-dom.md
@@ -1,3 +1,3 @@
 # Shadow DOM
 
-Normal `document.querySelector(...)` stops at shadow boundaries, so this note should focus on walking `shadowRoot` recursively instead of assuming one global selector works. Also call out when coordinate clicking is simpler than DOM traversal, especially for deeply nested component libraries.
+Focus on recursive `shadowRoot` traversal, and note when coordinate clicking is simpler than piercing deeply nested component trees.

--- a/interaction-skills/uploads.md
+++ b/interaction-skills/uploads.md
@@ -1,3 +1,3 @@
 # Uploads
 
-Use `upload_file(...)` for real file inputs first, and only fall back to coordinate clicks when the site hides the input behind custom UI. Include both local upload flow and remote-browser flow here, because remote sessions need explicit file availability and cannot assume access to the operator's local disk.
+Prefer `upload_file(...)` for real file inputs, and note separately how remote browsers need files made available inside the remote session rather than on the operator's disk.

--- a/interaction-skills/uploads.md
+++ b/interaction-skills/uploads.md
@@ -1,0 +1,3 @@
+# Uploads
+
+Use `upload_file(...)` for real file inputs first, and only fall back to coordinate clicks when the site hides the input behind custom UI. Include both local upload flow and remote-browser flow here, because remote sessions need explicit file availability and cannot assume access to the operator's local disk.

--- a/interaction-skills/uploads.md
+++ b/interaction-skills/uploads.md
@@ -1,3 +1,1 @@
 # Uploads
-
-Prefer `upload_file(...)` for real file inputs, and note separately how remote browsers need files made available inside the remote session rather than on the operator's disk.


### PR DESCRIPTION
## Summary
- add minimal scaffold notes for uploads, downloads, printing, dropdowns, shadow DOM, iframes, cross-origin iframes, and scrolling
- keep each new interaction note intentionally short so the detailed recipes can be filled in later

## Why
These interaction categories came up repeatedly during live harness use and were worth carving out into dedicated files before filling in the full guidance.

## Validation
- docs-only change
- no automated tests run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded eight interaction skill notes—downloads, print-as-PDF, dropdowns, scrolling, shadow DOM, iframes, cross‑origin iframes, and network requests—and added a stub header for uploads. Notes include brief guidance and recipe placeholders, focusing on network activity monitoring, iframe targeting and page vs element coordinates, shadow DOM traversal, scroll target identification, and reliable download detection.

<sup>Written for commit ebb08d2d2d71301b8669c7478564cd9a5f3fc609. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

