### PR TITLE
[codex] Add misc interaction skill stubs

### DIFF
--- a/interaction-skills/cookies.md
+++ b/interaction-skills/cookies.md
@@ -1,0 +1,3 @@
+# Cookies
+
+Document how to get cookies, save cookies, and set cookies without confusing browser state with page state.

--- a/interaction-skills/drag-and-drop.md
+++ b/interaction-skills/drag-and-drop.md
@@ -1,0 +1,3 @@
+# Drag And Drop
+
+Focus on when drag-and-drop can be driven with low-level input events versus when the site really expects a file upload or DOM-specific drag sequence.

--- a/interaction-skills/screenshots.md
+++ b/interaction-skills/screenshots.md
@@ -1,0 +1,3 @@
+# Screenshots
+
+Separate full-page screenshots from targeted section screenshots, and note when screenshots are only for discovery versus verification.

--- a/interaction-skills/viewport.md
+++ b/interaction-skills/viewport.md
@@ -1,0 +1,3 @@
+# Viewport
+
+Cover how viewport size changes affect layout, coordinate clicks, and any workflow that depends on stable geometry.


### PR DESCRIPTION
## Summary
- add concise interaction-skill stubs for cookies, viewport, screenshots, and drag-and-drop
- keep each file intentionally minimal so the detailed guidance can be filled in later

## Why
These are common cross-site interaction categories and were missing from the scaffolded interaction-skills set.

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add minimal interaction-skill stubs for cookies, viewport, screenshots, and drag-and-drop. These docs fill gaps in the scaffold and set up space for detailed guidance on common cross-site interactions.

<sup>Written for commit 9325a8e14ff0bf2a2955e1c9712df6dc3abcfa3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

