### PR TITLE
[codex] Rewrite README for human setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,22 @@ Paste this into Claude Code or Codex:
 Set up https://github.com/browser-use/harnessless for me.
 
 1. Clone the repo and read `SKILL.md` before doing anything else.
-2. Install the repo.
+2. Move into the repo folder and run `uv sync`.
 3. Enable Chrome remote debugging if needed.
    On macOS, open Chrome directly to `chrome://inspect/#remote-debugging`.
 4. Tell me to tick the remote-debugging checkbox and click the Chrome "Allow" button if it appears.
 5. Connect to my real browser and verify the harness works.
 6. Open https://github.com/browser-use/harnessless in the browser.
-7. Then ask me: "Should I star this repository to demonstrate a task?"
+7. If I am already signed in to GitHub, star the repository to verify the harness works.
+8. If I am not signed in, ask me what task I want to run instead.
 ```
 
-## Example task
+## Example tasks
 
 ```text
 Use this browser harness to open my real Chrome and submit the form on example.com.
+Use this browser harness to export the current page as a PDF.
+Use this browser harness to upload a file on the current site.
 ```
 
 ## Get inspiration

--- a/README.md
+++ b/README.md
@@ -1,50 +1,33 @@
 # bu
 
-LLM-first browser control via CDP. No CLI, no wrappers, just Python and CDP.
+The simplest, most powerful browser agent harness: connect to a real browser, keep setup tiny, and let the agent do the rest.
 
 ## Setup
 
-1. Install deps (uses `uv`):
-   ```
-   uv sync
-   ```
+Humans should not learn a CLI here; the normal setup is to paste one prompt into Claude Code or Codex and let the agent install and use the repo.
 
-2. Enable Chrome remote debugging: open `chrome://inspect/#remote-debugging`, check the box. Chrome now listens at `127.0.0.1:9222`.
+Example prompt:
 
-3. (Optional) For remote browsers: `cp .env.example .env` and fill in `BROWSER_USE_API_KEY`.
-
-4. Start the daemon:
-   ```
-   uv run daemon.py &
-   ```
-
-## Usage
-
-```
-uv run run.py <<'PY'
-goto("https://example.com")
-wait(1)
-screenshot("/tmp/shot.png")
-print(page_info())
-PY
+```text
+Clone https://github.com/browser-use/harnessless, install it, enable Chrome remote debugging if needed, and use this browser harness to do the task in my real browser.
 ```
 
-Parallel agents / remote browsers: `BU_NAME=<n> uv run run.py`. See `SKILL.md`.
+If you are installing it manually, the only real setup is:
 
-Read `SKILL.md` for both usage and maintenance guidance. Read `helpers.py` for every function — they're all ~5 lines each and you can edit any of them.
-
-## Files
-
-- `daemon.py` — holds the WebSocket, listens on `/tmp/bu-<name>.sock`
-- `helpers.py` — ~250 lines of transparent helpers
-- `run.py` — 3 lines: `from helpers import *; exec(stdin)`
-- `SKILL.md` — usage guidance, design constraints, and extension gotchas
-
-## Stop
-
+```bash
+uv sync
 ```
-uv run python -c "from helpers import kill_daemon; kill_daemon()"        # default daemon
-uv run python -c "from helpers import kill_daemon; kill_daemon('work')"  # named daemon (also stops remote browser)
-# or
-pkill -f bu/daemon.py
+
+Then enable Chrome remote debugging at `chrome://inspect/#remote-debugging`.
+
+## Example task
+
+```text
+Use this browser harness to open my real Chrome and submit the form on example.com.
 ```
+
+## How It Works
+
+`run.py` executes plain Python with `helpers.py` preloaded, and `daemon.py` keeps the CDP websocket and socket bridge alive.
+
+Everything else lives in `SKILL.md`, `interaction-skills/`, and `domain-skills/`.

--- a/README.md
+++ b/README.md
@@ -4,30 +4,99 @@ The simplest, most powerful browser agent harness: connect to a real browser, ke
 
 ## Setup
 
-Humans should not learn a CLI here; the normal setup is to paste one prompt into Claude Code or Codex and let the agent install and use the repo.
+Humans should not learn a CLI here. The normal setup is to paste the **setup prompt** into Claude Code (or any coding agent) and let it install the repo, wire up Chrome, and propose the first task.
 
-Example prompt:
+### Setup prompt
 
 ```text
-Clone https://github.com/browser-use/harnessless, install it, enable Chrome remote debugging if needed, and use this browser harness to do the task in my real browser.
+Set up the `bu` browser harness for me.
+
+1. Clone https://github.com/browser-use/harnessless, `cd harnessless`, run `uv sync`.
+2. Read `SKILL.md` end-to-end before anything else — it documents the full
+   workflow, tool shapes, gotchas, and every helper you'll use.
+3. On macOS, open Chrome to the remote-debugging page directly:
+     open -a "Google Chrome" "chrome://inspect/#remote-debugging"
+   (Linux/Windows: tell me that URL and have me open it.)
+   Tell me to tick the "Discover network targets" / remote-debugging checkbox
+   and accept Chrome's "Allow debugging" dialog. Wait until I confirm.
+4. Verify the connection with a single call:
+     uv run run.py <<<'print(page_info())'
+   (The daemon auto-starts on first call.)
+5. Navigate my real browser to https://github.com/browser-use/harnessless.
+6. Propose your first task: **"Star the browser-use/harnessless repo on GitHub."**
+   Run it after I confirm.
 ```
 
-If you are installing it manually, the only real setup is:
+### Manual install
 
 ```bash
+git clone https://github.com/browser-use/harnessless && cd harnessless
 uv sync
+# enable Chrome remote debugging at chrome://inspect/#remote-debugging
 ```
 
-Then enable Chrome remote debugging at `chrome://inspect/#remote-debugging`.
-
-## Example task
+## Example tasks
 
 ```text
-Use this browser harness to open my real Chrome and submit the form on example.com.
+Star the browser-use/harnessless repo on GitHub.
+Scrape every job posting on the current LinkedIn search page.
+Log into my Salesforce sandbox and export the Accounts list as CSV.
+Post a thread on X summarising the last 5 GitHub issues I opened.
 ```
 
-## How It Works
+The agent reads `SKILL.md`, writes plain Python against `helpers.py`, and if
+something isn't covered it drops to raw CDP or edits a helper in place.
 
-`run.py` executes plain Python with `helpers.py` preloaded, and `daemon.py` keeps the CDP websocket and socket bridge alive.
+## Features
 
-Everything else lives in `SKILL.md`, `interaction-skills/`, and `domain-skills/`.
+- **Anything a browser can do.** Helpers are thin; under them is raw CDP
+  (`cdp("Domain.method", **params)`), so there's no "API surface" to hit the
+  wall of. The agent can also edit `helpers.py` mid-task to add what it needs —
+  the harness gets sharper every session.
+- **Tiny, readable.** `daemon.py` 200 lines, `helpers.py` 266 lines, `run.py` 4
+  lines, `SKILL.md` 107 lines. ~580 total. One pass and you've read everything.
+- **Remote browsers via Browser Use cloud.** Set `BROWSER_USE_API_KEY` in
+  `.env`, call `start_remote_daemon("work")`, and you get an isolated cloud
+  Chrome with a live-view URL. Great for parallel sub-agents — each sub-agent
+  gets its own cloud browser, its own CDP session, and its own live URL:
+
+  ```python
+  # spin up N isolated cloud browsers for N sub-agents
+  for name in ("scraper-1", "scraper-2", "scraper-3"):
+      print(start_remote_daemon(name)["liveUrl"])
+  # then each sub-agent runs: BU_NAME=scraper-1 uv run run.py <<<'...'
+  ```
+- **Passes through iframes / shadow DOM / cross-origin.** `click(x, y)` goes via
+  the compositor, so Azure blades, Salesforce consoles, and Stripe checkouts
+  work without selector gymnastics.
+- **Bulk HTTP fallback.** For static pages, skip the browser entirely with
+  `http_get()` + `ThreadPoolExecutor` — hundreds of pages in seconds.
+
+## How it works
+
+- `daemon.py` (200 lines) — holds the CDP WebSocket, relays over a Unix socket
+  at `/tmp/bu-<name>.sock`. One daemon per `BU_NAME`.
+- `helpers.py` (266 lines) — ~25 small functions (`goto`, `click`, `js`,
+  `cdp`, `screenshot`, `upload_file`, …), each about 5 lines. Edit any of them.
+- `run.py` (4 lines) — imports helpers, ensures the daemon, execs stdin as Python.
+- `SKILL.md` (107 lines) — how an agent *uses* the harness.
+- `AGENTS.md` — how an agent *modifies* the harness.
+
+No CLI, no DSL, no wrapper API. Just Python + CDP.
+
+## Parallel / remote
+
+`BU_NAME` picks the daemon (default `default`). Each name = independent socket,
+independent daemon, independent browser (local or cloud).
+
+```bash
+BU_NAME=work uv run run.py <<< 'goto("https://example.com"); print(page_info())'
+uv run python -c "from helpers import kill_daemon; kill_daemon('work')"
+```
+
+## Stop
+
+```bash
+uv run python -c "from helpers import kill_daemon; kill_daemon()"        # default
+uv run python -c "from helpers import kill_daemon; kill_daemon('work')"  # named (also stops remote browser)
+```

--- a/README.md
+++ b/README.md
@@ -1,102 +1,35 @@
 # bu
 
-The simplest, most powerful browser agent harness: connect to a real browser, keep setup tiny, and let the agent do the rest.
+The simplest, thinnest, and most powerful browser agent harness.
 
 ## Setup
 
-Humans should not learn a CLI here. The normal setup is to paste the **setup prompt** into Claude Code (or any coding agent) and let it install the repo, wire up Chrome, and propose the first task.
-
-### Setup prompt
+Paste this into Claude Code or Codex:
 
 ```text
-Set up the `bu` browser harness for me.
-
-1. Clone https://github.com/browser-use/harnessless, `cd harnessless`, run `uv sync`.
-2. Read `SKILL.md` end-to-end before anything else — it documents the full
-   workflow, tool shapes, gotchas, and every helper you'll use.
-3. On macOS, open Chrome to the remote-debugging page directly:
-     open -a "Google Chrome" "chrome://inspect/#remote-debugging"
-   (Linux/Windows: tell me that URL and have me open it.)
-   Tell me to tick the "Discover network targets" / remote-debugging checkbox
-   and accept Chrome's "Allow debugging" dialog. Wait until I confirm.
-4. Verify the connection with a single call:
-     uv run run.py <<<'print(page_info())'
-   (The daemon auto-starts on first call.)
-5. Navigate my real browser to https://github.com/browser-use/harnessless.
-6. Propose your first task: **"Star the browser-use/harnessless repo on GitHub."**
-   Run it after I confirm.
+Clone https://github.com/browser-use/harnessless, set it up for me, enable Chrome remote debugging if needed, read SKILL.md, and use this harness in my real browser for the task I give you next.
 ```
 
-### Manual install
-
-```bash
-git clone https://github.com/browser-use/harnessless && cd harnessless
-uv sync
-# enable Chrome remote debugging at chrome://inspect/#remote-debugging
-```
-
-## Example tasks
+## Example task
 
 ```text
-Star the browser-use/harnessless repo on GitHub.
-Scrape every job posting on the current LinkedIn search page.
-Log into my Salesforce sandbox and export the Accounts list as CSV.
-Post a thread on X summarising the last 5 GitHub issues I opened.
+Use this browser harness to open my real Chrome and submit the form on example.com.
 ```
 
-The agent reads `SKILL.md`, writes plain Python against `helpers.py`, and if
-something isn't covered it drops to raw CDP or edits a helper in place.
+## Get inspiration
 
-## Features
+See [domain-skills/](domain-skills/) for examples on other websites.
 
-- **Anything a browser can do.** Helpers are thin; under them is raw CDP
-  (`cdp("Domain.method", **params)`), so there's no "API surface" to hit the
-  wall of. The agent can also edit `helpers.py` mid-task to add what it needs —
-  the harness gets sharper every session.
-- **Tiny, readable.** `daemon.py` 200 lines, `helpers.py` 266 lines, `run.py` 4
-  lines, `SKILL.md` 107 lines. ~580 total. One pass and you've read everything.
-- **Remote browsers via Browser Use cloud.** Set `BROWSER_USE_API_KEY` in
-  `.env`, call `start_remote_daemon("work")`, and you get an isolated cloud
-  Chrome with a live-view URL. Great for parallel sub-agents — each sub-agent
-  gets its own cloud browser, its own CDP session, and its own live URL:
+## How It Works
 
-  ```python
-  # spin up N isolated cloud browsers for N sub-agents
-  for name in ("scraper-1", "scraper-2", "scraper-3"):
-      print(start_remote_daemon(name)["liveUrl"])
-  # then each sub-agent runs: BU_NAME=scraper-1 uv run run.py <<<'...'
-  ```
-- **Passes through iframes / shadow DOM / cross-origin.** `click(x, y)` goes via
-  the compositor, so Azure blades, Salesforce consoles, and Stripe checkouts
-  work without selector gymnastics.
-- **Bulk HTTP fallback.** For static pages, skip the browser entirely with
-  `http_get()` + `ThreadPoolExecutor` — hundreds of pages in seconds.
+- `SKILL.md` explains how the harness should be used.
+- `run.py` executes plain Python with helpers preloaded.
+- `helpers.py` holds the primitives the agent actually calls.
+- `daemon.py` keeps the CDP websocket and socket bridge alive.
 
-## How it works
+## Optional: Remote browsers
 
-- `daemon.py` (200 lines) — holds the CDP WebSocket, relays over a Unix socket
-  at `/tmp/bu-<name>.sock`. One daemon per `BU_NAME`.
-- `helpers.py` (266 lines) — ~25 small functions (`goto`, `click`, `js`,
-  `cdp`, `screenshot`, `upload_file`, …), each about 5 lines. Edit any of them.
-- `run.py` (4 lines) — imports helpers, ensures the daemon, execs stdin as Python.
-- `SKILL.md` (107 lines) — how an agent *uses* the harness.
-- `AGENTS.md` — how an agent *modifies* the harness.
+Useful for sub-agents or deployment.
 
-No CLI, no DSL, no wrapper API. Just Python + CDP.
-
-## Parallel / remote
-
-`BU_NAME` picks the daemon (default `default`). Each name = independent socket,
-independent daemon, independent browser (local or cloud).
-
-```bash
-BU_NAME=work uv run run.py <<< 'goto("https://example.com"); print(page_info())'
-uv run python -c "from helpers import kill_daemon; kill_daemon('work')"
-```
-
-## Stop
-
-```bash
-uv run python -c "from helpers import kill_daemon; kill_daemon()"        # default
-uv run python -c "from helpers import kill_daemon; kill_daemon('work')"  # named (also stops remote browser)
-```
+- Get a Browser Use API key: [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key)
+- If the agent needs signup or setup context, point it at [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt)

--- a/README.md
+++ b/README.md
@@ -20,12 +20,10 @@ Set up https://github.com/browser-use/harnessless for me.
 8. If I am not signed in, ask me what task I want to run instead.
 ```
 
-## Example tasks
+## Example task
 
 ```text
-Use this browser harness to open my real Chrome and submit the form on example.com.
-Use this browser harness to export the current page as a PDF.
-Use this browser harness to upload a file on the current site.
+Star this repository.
 ```
 
 ## Get inspiration

--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 The simplest, thinnest, and most powerful browser agent harness.
 
-## Setup
+## Setup prompt
 
 Paste this into Claude Code or Codex:
 
 ```text
-Clone https://github.com/browser-use/harnessless, set it up for me, enable Chrome remote debugging if needed, read SKILL.md, and use this harness in my real browser for the task I give you next.
+Set up https://github.com/browser-use/harnessless for me.
+
+1. Clone the repo and read `SKILL.md` before doing anything else.
+2. Install the repo.
+3. Enable Chrome remote debugging if needed.
+   On macOS, open Chrome directly to `chrome://inspect/#remote-debugging`.
+4. Tell me to tick the remote-debugging checkbox and click the Chrome "Allow" button if it appears.
+5. Connect to my real browser and verify the harness works.
+6. Open https://github.com/browser-use/harnessless in the browser.
+7. Then ask me: "Should I star this repository to demonstrate a task?"
 ```
 
 ## Example task
@@ -32,4 +41,4 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 Useful for sub-agents or deployment.
 
 - Get a Browser Use API key: [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key)
-- If the agent needs signup or setup context, point it at [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt)
+- The agent can also sign up by itself by fetching [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt), which contains the setup flow and challenge context for getting a Browser Use API key.


### PR DESCRIPTION
## Summary
- rewrite the README to be human-first and prompt-first
- focus setup on pasting one prompt into Claude Code or Codex
- move detailed operational and structural guidance out of the README and leave that to `SKILL.md`

## Why
The previous README mixed manual usage details with agent-facing guidance. This version treats the human as someone who mainly needs to install the repo, enable Chrome remote debugging, and hand the actual task to an agent.

## Validation
- docs-only change
- no automated tests run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the README around a single, prompt-first setup the coding agent runs end-to-end: clone the repo, read `SKILL.md` first, run `uv sync`, enable Chrome remote debugging (on macOS open `chrome://inspect/#remote-debugging`, tick the box, click “Allow”), verify the connection, open the repo, then star it if signed in or ask for another task. Reduces examples to one task, keeps a “Get inspiration” link to `domain-skills/`, retains a compact “How it works” map, and an optional Remote browsers note with Browser Use API guidance plus an agent self‑signup tip via `llms.txt`.

<sup>Written for commit dc027a518081823df45d767fed050e94e7340d45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

