### PR TITLE
[codex] Clarify README title and how-it-works section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bu
+# Browser Harness
 
 The simplest, thinnest, and most powerful browser agent harness.
 
@@ -32,10 +32,10 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 
 ## How It Works
 
-- `SKILL.md` explains how the harness should be used.
-- `run.py` executes plain Python with helpers preloaded.
-- `helpers.py` holds the primitives the agent actually calls.
-- `daemon.py` keeps the CDP websocket and socket bridge alive.
+- `SKILL.md` is about 100 lines and explains how the harness should be used.
+- `run.py` is about 4 lines and just executes plain Python with helpers preloaded.
+- `helpers.py` is about 260 lines and holds the primitives the agent calls and constantly modifies to sharpen its own harness for the task.
+- `daemon.py` is about 200 lines and keeps the CDP websocket and socket bridge alive.
 
 ## Optional: Remote browsers
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 
 ## How It Works
 
-- `SKILL.md` is ~100 lines and explains how the harness should be used.
-- `run.py` is ~4 lines and just executes plain Python with helpers preloaded.
-- `helpers.py` is ~260 lines and holds the primitives the agent calls and constantly modifies to sharpen its own harness for the task.
-- `daemon.py` is ~200 lines and keeps the CDP websocket and socket bridge alive.
+- `SKILL.md` (~100 lines) explains how the harness should be used.
+- `run.py` (~4 lines) executes plain Python with helpers preloaded.
+- `helpers.py` (~260 lines) holds the primitives the agent calls and constantly modifies to sharpen its own harness.
+- `daemon.py` (~200 lines) keeps the CDP websocket and socket bridge alive.
 
 ## Optional: Remote browsers
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 
 ## How It Works
 
-- `SKILL.md` is about 100 lines and explains how the harness should be used.
-- `run.py` is about 4 lines and just executes plain Python with helpers preloaded.
-- `helpers.py` is about 260 lines and holds the primitives the agent calls and constantly modifies to sharpen its own harness for the task.
-- `daemon.py` is about 200 lines and keeps the CDP websocket and socket bridge alive.
+- `SKILL.md` is ~100 lines and explains how the harness should be used.
+- `run.py` is ~4 lines and just executes plain Python with helpers preloaded.
+- `helpers.py` is ~260 lines and holds the primitives the agent calls and constantly modifies to sharpen its own harness for the task.
+- `daemon.py` is ~200 lines and keeps the CDP websocket and socket bridge alive.
 
 ## Optional: Remote browsers
 


### PR DESCRIPTION
## Summary
- rename the README title to `Browser Harness`
- make the `How It Works` section emphasize how small the core files are
- clarify that `helpers.py` is the file the agent edits to sharpen the harness for a task

## Why
The README should communicate how simple the repo is at a glance, and the current `How It Works` bullets understate that the harness is intentionally tiny and editable.

## Validation
- docs-only change
- no automated tests run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the README title to “Browser Harness” and tighten the “How It Works” bullets with approximate line counts for core files (`SKILL.md` ~100, `run.py` ~4, `helpers.py` ~260, `daemon.py` ~200), plus a clearer note that `helpers.py` is the agent-edited primitive layer for sharpening the harness. Docs-only; no code or behavior changes.

<sup>Written for commit b189d0dcf3c2e7ea8488b044c3c314872c176ff8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

