### PR TITLE
[codex] Add global bu launcher and shared skill guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -6,12 +6,32 @@ allowed-tools: Bash, Read, Edit, Write
 
 # bu
 
+Available interaction skills:
+- `cookies.md`
+- `cross-origin-iframes.md`
+- `dialogs.md`
+- `downloads.md`
+- `drag-and-drop.md`
+- `dropdowns.md`
+- `iframes.md`
+- `network-requests.md`
+- `print-as-pdf.md`
+- `screenshots.md`
+- `scrolling.md`
+- `shadow-dom.md`
+- `tabs.md`
+- `uploads.md`
+- `viewport.md`
+
+Available domain skills:
+- `tiktok/upload.md`
+
 **Read `helpers.py` first.** The code is the doc.
 
 ## Tool call shape
 
 ```bash
-cd /path/to/harnessless && uv run run.py <<'PY'
+bu <<'PY'
 # any python. helpers pre-imported. daemon auto-starts.
 PY
 ```
@@ -19,6 +39,18 @@ PY
 `run.py` calls `ensure_daemon()` before `exec` — you never start/stop manually unless you want to.
 
 ## Setup
+
+### Best everyday setup
+
+Clone the repo once, then install it as an editable tool so `bu` works from any directory:
+
+```bash
+git clone https://github.com/browser-use/harnessless
+cd harnessless
+uv tool install -e .
+```
+
+That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `bu` run uses the new code immediately.
 
 ### Simplest local setup
 
@@ -30,7 +62,7 @@ PY
 5. Verify with:
 
 ```bash
-uv run run.py <<'PY'
+bu <<'PY'
 ensure_real_tab()
 print(page_info())
 PY
@@ -53,12 +85,25 @@ Create `.env` from `.env.example` and set `BROWSER_USE_API_KEY`, then:
 
 ```bash
 uv run python -c "from helpers import start_remote_daemon; print(start_remote_daemon('work'))"
-BU_NAME=work uv run run.py <<'PY'
+BU_NAME=work bu <<'PY'
 print(page_info())
 PY
 ```
 
 Leaving a remote daemon running bills until the session timeout.
+
+Parallel agents should use distinct `BU_NAME`s and can share the same `helpers.py`; shared improvements are expected, and changes should stay general enough that other agents benefit rather than break.
+
+## Search first
+
+After cloning the repo, search `interaction-skills/` for reusable UI mechanics and `domain-skills/` for site-specific workflows before inventing a new approach.
+
+Useful commands:
+
+```bash
+rg --files interaction-skills domain-skills
+rg -n "dropdown|iframe|upload|tiktok" interaction-skills domain-skills
+```
 
 ## Post-task ritual (self-improving harness)
 
@@ -68,6 +113,8 @@ After every browser task, extract ONE generalizable friction point from the inte
 - a correction to a wrong recipe here.
 
 Commit with the task. The skill gets sharper every use. Skip only if nothing was surprising.
+
+If you solve a specific website and learn a lot, create a PR to this repo with reusable learnings in `domain-skills/` or `interaction-skills/` — no secrets, no user data, no overfit recipes, just how the site works, what to wait for, and what patterns matter.
 
 ## What actually works
 
@@ -129,4 +176,4 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 ## Interaction notes
 
 - `interaction-skills/` holds reusable UI mechanics such as dialogs, tabs, dropdowns, iframes, and uploads.
-- `domain-skills/` holds site-specific workflows.
+- `domain-skills/` holds site-specific workflows and should be updated when you discover reusable patterns for a website.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "bu"
 version = "0.1.0"
@@ -7,3 +11,9 @@ dependencies = [
     "cdp-use>=1.4.5",
     "websockets>=16.0",
 ]
+
+[project.scripts]
+bu = "run:main"
+
+[tool.setuptools]
+py-modules = ["run", "helpers", "daemon"]

--- a/run.py
+++ b/run.py
@@ -1,4 +1,11 @@
 import sys
 from helpers import *
-ensure_daemon()
-exec(sys.stdin.read())
+
+
+def main():
+    ensure_daemon()
+    exec(sys.stdin.read())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a real `bu` console entrypoint via `pyproject.toml` and a tiny `run.py` main function
- update `SKILL.md` to recommend editable installation so the harness works from any directory
- document shared-helper mutation, skill searching, and upstreaming reusable website learnings back to this repo

## Why
The harness should be callable from anywhere without forcing agents to prefix every command with `cd /path/to/harnessless && ...`, while still preserving the core feature that agents can edit `helpers.py` and immediately benefit from those changes. The skill also needed to point agents at the interaction/domain skill folders explicitly and make the expectation to upstream reusable learnings concrete.

## Validation
- `uv sync` builds and installs the local `bu` package correctly after adding minimal packaging metadata
- `uv run bu` now resolves to this repo's launcher instead of the unrelated external `browser-use` CLI
- launcher startup reached daemon startup; the remaining runtime failure in this environment was expected because Chrome was not running (`Connect call failed ('127.0.0.1', 53159)`)
- docs and packaging change only


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global `bu` CLI so agents can run the harness from any directory, and refresh the docs to promote editable installs and shared skill guidance. Replaces `uv run run.py` with `bu` and clarifies how to reuse and upstream skills.

- **New Features**
  - Added `bu` console script in `pyproject.toml` (entrypoint `run:main`); `run.py` now ensures the daemon and executes stdin.
  - Docs: recommend editable install (`uv tool install -e .`), list available interaction/domain skills, add search tips, note `BU_NAME` for parallel agents, and call for upstreaming reusable site learnings.

- **Migration**
  - Install once: git clone, then `uv tool install -e .`.
  - Replace `uv run run.py <<'PY'` with `bu <<'PY'`.

<sup>Written for commit c626ecf3ef36bfa7c318db12caef4579581e745a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

