### PR TITLE
[codex] Defer README setup details to SKILL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,9 @@ Paste this into Claude Code or Codex:
 ```text
 Set up https://github.com/browser-use/harnessless for me.
 
-1. Clone the repo and read `SKILL.md` before doing anything else.
-2. Move into the repo folder and run `uv sync`.
-3. Enable Chrome remote debugging if needed.
-   On macOS, open Chrome directly to `chrome://inspect/#remote-debugging`.
-4. Tell me to tick the remote-debugging checkbox and click the Chrome "Allow" button if it appears.
-5. Connect to my real browser and verify the harness works.
-6. Open https://github.com/browser-use/harnessless in the browser.
-7. If I am already signed in to GitHub, star the repository to verify the harness works.
-8. If I am not signed in, ask me what task I want to run instead.
+Read `SKILL.md` and follow its instructions to install and connect this repo to my real browser.
+
+After it is installed, if I am already logged in to GitHub, star this repository as a small verification task.
 ```
 
 ## Example task
@@ -28,16 +22,16 @@ Set up https://github.com/browser-use/harnessless for me.
 Star this repository.
 ```
 
-## Get inspiration
-
-See [domain-skills/](domain-skills/) for examples on other websites.
-
 ## How It Works
 
 - `SKILL.md` (~100 lines) explains how the harness should be used.
 - `run.py` (~4 lines) executes plain Python with helpers preloaded.
 - `helpers.py` (~260 lines) holds the primitives the agent calls and constantly modifies to sharpen its own harness.
 - `daemon.py` (~200 lines) keeps the CDP websocket and socket bridge alive.
+
+## Get inspiration
+
+See [domain-skills/](domain-skills/) for examples on other websites.
 
 ## Optional: Remote browsers
 


### PR DESCRIPTION
## Summary
- simplify the README setup prompt so it points agents at `SKILL.md` for installation and connection details
- keep the verification example in the README as "Star this repository" when already logged in
- move `Get inspiration` below `How It Works`

## Why
The README was duplicating setup instructions that already belong in `SKILL.md`. This keeps the README thinner and pushes the operational detail into the skill file where agents actually need it.

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the README by deferring setup and connection steps to SKILL.md. Keeps the “star this repository” verification when already logged in and moves “Get inspiration” below “How It Works” for a clearer flow.

<sup>Written for commit f3e4386b7530bb3ea93436b5d3db895f51437e3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

