### PR TITLE
[codex] Add spacing between README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ Read `SKILL.md` and follow its instructions to install and connect this repo to 
 After it is installed, if I am already logged in to GitHub, star this repository as a small verification task.
 ```
 
+
 ## Example task
 
 ```text
 Star this repository.
 ```
+
 
 ## How It Works
 
@@ -29,9 +31,11 @@ Star this repository.
 - `helpers.py` (~260 lines) holds the primitives the agent calls and constantly modifies to sharpen its own harness.
 - `daemon.py` (~200 lines) keeps the CDP websocket and socket bridge alive.
 
+
 ## Get inspiration
 
 See [domain-skills/](domain-skills/) for examples on other websites.
+
 
 ## Optional: Remote browsers
 


### PR DESCRIPTION
## Summary
- add a little more vertical spacing between README sections
- keep the content unchanged

## Why
This makes the README source file read a bit more cleanly, even though GitHub's rendered Markdown won't change much.

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add extra vertical spacing between README sections to make the source easier to read. No content or GitHub-rendered output changes.

<sup>Written for commit 844406c4828c40df34ca83f3f15ef118f6c6fef3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

