### PR TITLE
[codex] Tighten README setup prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Set up https://github.com/browser-use/harnessless for me.
 Read `SKILL.md` and follow its instructions to install and connect this repo to my real browser.
 
 After it is installed, if I am already logged in to GitHub, star this repository as a small verification task.
+
+If I am not logged in, just go to browser-use.com.
 ```
 
 
@@ -23,6 +25,8 @@ After it is installed, if I am already logged in to GitHub, star this repository
 Star this repository.
 ```
 
+See [domain-skills/](domain-skills/) for examples on other websites.
+
 
 ## How It Works
 
@@ -30,11 +34,6 @@ Star this repository.
 - `run.py` (~4 lines) executes plain Python with helpers preloaded.
 - `helpers.py` (~260 lines) holds the primitives the agent calls and constantly modifies to sharpen its own harness.
 - `daemon.py` (~200 lines) keeps the CDP websocket and socket bridge alive.
-
-
-## Get inspiration
-
-See [domain-skills/](domain-skills/) for examples on other websites.
 
 
 ## Optional: Remote browsers


### PR DESCRIPTION
## Summary
- add the browser-use fallback to the setup prompt
- move the domain-skills note directly below the example task
- remove the separate Get inspiration section

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified README setup: add a fallback to visit browser-use.com if not logged into GitHub, move the domain-skills link under the example task, and remove the redundant “Get inspiration” section.

<sup>Written for commit 06cf5cccc32ab4a012e54565f546f18db1a5a3a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

