### PR TITLE
Split install and runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Paste this into Claude Code or Codex:
 ```text
 Set up https://github.com/browser-use/harnessless for me.
 
-Read `SKILL.md` and follow its instructions to install and connect this repo to my real browser.
+Read `install.md` first to install and connect this repo to my real browser. Then read `SKILL.md` for normal usage. Always read `helpers.py` because that is where the functions are. When you open a setup or verification tab, activate it so I can see the active browser tab.
 
 After it is installed, if I am already logged in to GitHub, star this repository as a small verification task.
 
@@ -30,7 +30,8 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 
 ## How It Works
 
-- `SKILL.md` (~100 lines) explains how the harness should be used.
+- `install.md` explains first-time install and browser bootstrap.
+- `SKILL.md` explains day-to-day browser harness usage.
 - `run.py` (~4 lines) executes plain Python with helpers preloaded.
 - `helpers.py` (~260 lines) holds the primitives the agent calls and constantly modifies to sharpen its own harness.
 - `daemon.py` (~200 lines) keeps the CDP websocket and socket bridge alive.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: browser-harness
 description: Direct browser control via CDP. Use when the user wants to automate, scrape, test, or interact with web pages. Connects to the user's already-running Chrome.
-allowed-tools: Bash, Read, Edit, Write
 ---
 
 # browser-harness

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Bash, Read, Edit, Write
 
 # browser-harness
 
+For first-time install or reconnect/bootstrap, read `install.md` first. For normal use, stay in this file. **Read `helpers.py` first.** The code is the doc.
+
 Available interaction skills:
 - `cookies.md`
 - `cross-origin-iframes.md`
@@ -26,8 +28,6 @@ Available interaction skills:
 Available domain skills:
 - `tiktok/upload.md`
 
-**Read `helpers.py` first.** The code is the doc.
-
 ## Tool call shape
 
 ```bash
@@ -37,85 +37,6 @@ PY
 ```
 
 `run.py` calls `ensure_daemon()` before `exec` — you never start/stop manually unless you want to.
-
-## Setup
-
-### Best everyday setup
-
-Clone the repo once, then install it as an editable tool so `bh` works from any directory:
-
-```bash
-git clone https://github.com/browser-use/harnessless
-cd harnessless
-uv tool install -e .
-command -v bh
-```
-
-That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `bh` run uses the new code immediately. `browser-harness` is the readable alias for the same command.
-
-Default to this global setup. Use the local-only flow below only for quick testing inside the repo.
-
-### Make it global for the current agent
-
-After the repo is installed, register this repo's `SKILL.md` with the agent you are using:
-
-- **Codex**: add this file as a global skill at `$CODEX_HOME/skills/browser-harness/SKILL.md` (often `~/.codex/skills/browser-harness/SKILL.md`). A symlink to this repo's `SKILL.md` is fine.
-- **Claude Code**: add an import to `~/.claude/CLAUDE.md` that points at this repo's `SKILL.md`, for example `@~/src/harnessless/SKILL.md`.
-
-That makes new Codex or Claude Code sessions in other folders load the browser harness instructions automatically.
-
-To confirm the memory/instructions are loaded:
-
-- **Codex**: start a new session and check that `browser-harness` appears in the available skills.
-- **Claude Code**: run `/memory` and confirm that `~/.claude/CLAUDE.md` and its import are listed.
-
-### Simplest local setup
-
-1. Run `uv sync`.
-2. First try the harness directly. If this works, skip setup entirely:
-
-```bash
-uv run bh <<'PY'
-ensure_real_tab()
-print(page_info())
-PY
-```
-
-3. If that fails and Chrome is already running, open `chrome://inspect/#remote-debugging` in the existing Chrome profile instead of launching a fresh Chrome process.
-   On macOS:
-
-```bash
-osascript -e 'tell application "Google Chrome" to activate' \
-          -e 'tell application "Google Chrome" to open location "chrome://inspect/#remote-debugging"'
-```
-
-   On Linux: use the already-running Chrome window and open that URL manually.
-4. If Chrome is not running, start Chrome first and let the user choose their normal profile if Chrome opens the profile picker. Only after that, open `chrome://inspect/#remote-debugging`.
-   On macOS: `open -a "Google Chrome"`
-5. Tell the user to tick the remote-debugging checkbox. If Chrome shows `Allow`, tell the user to click it once.
-6. Do not ask the user to say "continue". Poll every few seconds and retry the same connect attempt once the permission flow finishes.
-7. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation.
-8. Verify with:
-
-```bash
-uv run bh <<'PY'
-ensure_real_tab()
-if not current_tab()["url"] or current_tab()["url"].startswith(INTERNAL):
-    new_tab("about:blank")
-print(page_info())
-PY
-```
-
-If that fails with a stale websocket or stale socket, restart the daemon once and retry:
-
-Run this from the repo root:
-
-```bash
-uv run python - <<'PY'
-from helpers import kill_daemon
-kill_daemon()
-PY
-```
 
 ### Remote browsers
 

--- a/helpers.py
+++ b/helpers.py
@@ -188,6 +188,7 @@ def current_tab():
     return {"targetId": t.get("targetId"), "url": t.get("url", ""), "title": t.get("title", "")}
 
 def switch_tab(target_id):
+    cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     set_session(sid)
     return sid

--- a/install.md
+++ b/install.md
@@ -1,7 +1,6 @@
 ---
 name: browser-harness-install
 description: Install and bootstrap browser-harness into the current agent, then connect it to the user's real Chrome with minimal prompting.
-allowed-tools: Bash, Read, Edit, Write
 ---
 
 # browser-harness install
@@ -10,9 +9,7 @@ Use this file only for first-time install, reconnect, or cold-start browser boot
 
 ## Install prompt contract
 
-When the user asks to set up this repo, read this file first, then `SKILL.md`.
-
-When you open a setup or verification tab, bring it to the foreground so the user can actually see the active browser tab.
+When you open a setup or verification tab, activate it so the user can actually see the active browser tab.
 
 ## Best everyday setup
 
@@ -57,10 +54,11 @@ osascript -e 'tell application "Google Chrome" to activate' \
 ```
 
    On Linux: use the already-running Chrome window and open that URL manually.
+   If the attach looks blocked or Chrome is not accepting DevTools yet, tell the user: "I opened Chrome's remote-debugging page. Please click `Allow` in Chrome if it appears." Then keep polling instead of waiting for the user to type a follow-up.
 4. If Chrome is not running, start Chrome first and let the user choose their normal profile if Chrome opens the profile picker. Only after that, open `chrome://inspect/#remote-debugging`.
    On macOS: `open -a "Google Chrome"`
 5. Tell the user to tick the remote-debugging checkbox. If Chrome shows `Allow`, tell the user to click it once.
-6. Do not ask the user to say "continue". Poll every few seconds and retry the same connect attempt once the permission flow finishes.
+6. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the Chrome profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. Once it is completed, continue checking and retrying for at least 30 seconds.
 7. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation.
 8. Verify with:
 
@@ -68,7 +66,7 @@ osascript -e 'tell application "Google Chrome" to activate' \
 uv run bh <<'PY'
 ensure_real_tab()
 if not current_tab()["url"] or current_tab()["url"].startswith(INTERNAL):
-    new_tab("about:blank")
+    new_tab("https://github.com/browser-use/browser-harness")
 print(page_info())
 PY
 ```
@@ -82,9 +80,12 @@ kill_daemon()
 PY
 ```
 
+9. After install and browser bootstrap succeed, use the repository page as a small interaction check. If the user is logged in to GitHub, try to star `https://github.com/browser-use/browser-harness` to verify the interaction works. Then ask the user what you should do next.
+
 ## Cold-start reminders
 
 - Try attaching before asking the user to change anything.
 - The first connect may block on Chrome's `Allow` dialog.
+- If attach is blocked on macOS, open `chrome://inspect/#remote-debugging` in the current Chrome profile and explicitly tell the user to click `Allow` if Chrome shows it.
 - Chrome may open the profile picker before any real tab exists.
 - On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.

--- a/install.md
+++ b/install.md
@@ -1,0 +1,90 @@
+---
+name: browser-harness-install
+description: Install and bootstrap browser-harness into the current agent, then connect it to the user's real Chrome with minimal prompting.
+allowed-tools: Bash, Read, Edit, Write
+---
+
+# browser-harness install
+
+Use this file only for first-time install, reconnect, or cold-start browser bootstrap. For day-to-day browser work, read `SKILL.md`. Always read `helpers.py` after cloning; that is where the functions and expected patterns live.
+
+## Install prompt contract
+
+When the user asks to set up this repo, read this file first, then `SKILL.md`.
+
+When you open a setup or verification tab, bring it to the foreground so the user can actually see the active browser tab.
+
+## Best everyday setup
+
+Clone the repo once, then install it as an editable tool so `bh` works from any directory:
+
+```bash
+git clone https://github.com/browser-use/harnessless
+cd harnessless
+uv tool install -e .
+command -v bh
+```
+
+That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `bh` run uses the new code immediately. `browser-harness` is the readable alias for the same command.
+
+## Make it global for the current agent
+
+After the repo is installed, register this repo's `SKILL.md` with the agent you are using:
+
+- **Codex**: add this file as a global skill at `$CODEX_HOME/skills/browser-harness/SKILL.md` (often `~/.codex/skills/browser-harness/SKILL.md`). A symlink to this repo's `SKILL.md` is fine.
+- **Claude Code**: add an import to `~/.claude/CLAUDE.md` that points at this repo's `SKILL.md`, for example `@~/src/harnessless/SKILL.md`.
+
+That makes new Codex or Claude Code sessions in other folders load the runtime browser harness instructions automatically.
+
+## Browser bootstrap
+
+1. Run `uv sync`.
+2. First try the harness directly. If this works, skip manual browser setup:
+
+```bash
+uv run bh <<'PY'
+ensure_real_tab()
+print(page_info())
+PY
+```
+
+3. If that fails and Chrome is already running, open `chrome://inspect/#remote-debugging` in the existing Chrome profile instead of launching a fresh Chrome process.
+   On macOS:
+
+```bash
+osascript -e 'tell application "Google Chrome" to activate' \
+          -e 'tell application "Google Chrome" to open location "chrome://inspect/#remote-debugging"'
+```
+
+   On Linux: use the already-running Chrome window and open that URL manually.
+4. If Chrome is not running, start Chrome first and let the user choose their normal profile if Chrome opens the profile picker. Only after that, open `chrome://inspect/#remote-debugging`.
+   On macOS: `open -a "Google Chrome"`
+5. Tell the user to tick the remote-debugging checkbox. If Chrome shows `Allow`, tell the user to click it once.
+6. Do not ask the user to say "continue". Poll every few seconds and retry the same connect attempt once the permission flow finishes.
+7. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation.
+8. Verify with:
+
+```bash
+uv run bh <<'PY'
+ensure_real_tab()
+if not current_tab()["url"] or current_tab()["url"].startswith(INTERNAL):
+    new_tab("about:blank")
+print(page_info())
+PY
+```
+
+If that fails with a stale websocket or stale socket, restart the daemon once and retry:
+
+```bash
+uv run python - <<'PY'
+from helpers import kill_daemon
+kill_daemon()
+PY
+```
+
+## Cold-start reminders
+
+- Try attaching before asking the user to change anything.
+- The first connect may block on Chrome's `Allow` dialog.
+- Chrome may open the profile picker before any real tab exists.
+- On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.


### PR DESCRIPTION
## Summary
- split first-time install and browser bootstrap instructions into a new `install.md`
- trim `SKILL.md` down to runtime usage guidance and point bootstrap work at `install.md`
- update the README setup prompt so agents read `install.md` first, then `SKILL.md`, and always read `helpers.py`
- bring opened tabs to the foreground by activating the target before attaching in `switch_tab()`

## Why
The previous `SKILL.md` was carrying install, reconnect, and day-to-day usage guidance at the same time. Splitting bootstrap from runtime usage keeps routine context smaller and makes the setup prompt more explicit. The tab activation change also makes setup and verification steps visible to the user in the real browser.

## Validation
- `python3 -m py_compile helpers.py run.py daemon.py`
- attempted live browser smoke test, but Chrome was not accepting DevTools at the time of the check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split first-time install/bootstrap into `install.md` and keep `SKILL.md` focused on runtime. Refined bootstrap prompts and made opened tabs visible by activating targets before attaching.

- **Refactors**
  - Moved install/reconnect/bootstrap steps to `install.md`; `SKILL.md` now covers runtime and links to `install.md` and `helpers.py`.
  - Tightened install prompts: activate setup/verification tabs, try attaching before asking the user, poll while the user clicks Chrome’s Allow, prefer AppleScript `open location` on macOS, and verify by opening the repo URL (optionally star it).
  - Updated `README.md` to read `install.md` first and highlight the setup/verification tabs.

- **Bug Fixes**
  - `switch_tab()` now calls `Target.activateTarget` before `attachToTarget`, so opened tabs are visible during setup and navigation.

<sup>Written for commit c82345e1abd9a170339425b355cb55ab2cb9effc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

