### PR TITLE
[codex] Clarify Chrome remote debugging bootstrap

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -118,8 +118,9 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 
 - **Chrome 144+ `chrome://inspect/#remote-debugging` does NOT serve `/json/version`.** Read `DevToolsActivePort` instead.
 - **Try attaching before asking for setup.** If `uv run bh` already works, skip the remote-debugging instructions entirely.
-- **The first connect may block on Chrome's Allow dialog.** If setup hangs, ask the user to click Allow, then retry once.
-- **Chrome may open the profile picker before any real tab exists.** Pick the user's normal profile first; remote debugging can be enabled while the browser is still not in a usable signed-in context.
+- **The first connect may block on Chrome's Allow dialog.** If setup hangs, explicitly tell the user to click `Allow` in Chrome if it appears, then keep polling for up to 30 seconds instead of treating follow-on errors as a new failure.
+- **`DevToolsActivePort` can exist before the port is actually listening.** Treat connection refused as "still enabling" and keep polling for up to 30 seconds.
+- **Chrome may open the profile picker before any real tab exists.** If Chrome opens both a profile picker and the remote-debugging page, tell the user to choose their normal profile first, then tick the checkbox and click `Allow` if shown.
 - **On macOS, if Chrome is already running, prefer AppleScript `open location` over `open -a ... URL`.** It reuses the current profile and avoids creating an extra startup path through the profile picker.
 - **Omnibox popups are fake `page` targets.** Filter `chrome://omnibox-popup...` and other internals when you need a real tab.
 - **CDP target order != Chrome's visible tab-strip order.** Use UI automation when the user means "the first/second tab I can see"; `Target.activateTarget` only shows a known target.

--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, urllib.request
+import asyncio, json, os, socket, sys, time, urllib.request
 from collections import deque
 from pathlib import Path
 
@@ -44,16 +44,21 @@ def get_ws_url():
             port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
         except (FileNotFoundError, NotADirectoryError):
             continue
-        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        probe.settimeout(1)
-        try:
-            probe.connect(("127.0.0.1", int(port.strip())))
-        except OSError:
-            raise RuntimeError(
-                f"Chrome is not accepting DevTools on 127.0.0.1:{port.strip()} — open Chrome and chrome://inspect/#remote-debugging, then retry"
-            )
-        finally:
-            probe.close()
+        deadline = time.time() + 30
+        while True:
+            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            probe.settimeout(1)
+            try:
+                probe.connect(("127.0.0.1", int(port.strip())))
+                break
+            except OSError:
+                if time.time() >= deadline:
+                    raise RuntimeError(
+                        f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
+                    )
+                time.sleep(1)
+            finally:
+                probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 

--- a/install.md
+++ b/install.md
@@ -31,11 +31,18 @@ After the repo is installed, register this repo's `SKILL.md` with the agent you 
 - **Codex**: add this file as a global skill at `$CODEX_HOME/skills/browser-harness/SKILL.md` (often `~/.codex/skills/browser-harness/SKILL.md`). A symlink to this repo's `SKILL.md` is fine.
 - **Claude Code**: add an import to `~/.claude/CLAUDE.md` that points at this repo's `SKILL.md`, for example `@~/src/browser-harness/SKILL.md`.
 
+Codex command:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness" && ln -sf "$PWD/SKILL.md" "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness/SKILL.md"
+```
+
 That makes new Codex or Claude Code sessions in other folders load the runtime browser harness instructions automatically.
 
 ## Browser bootstrap
 
 1. Run `uv sync`.
+   If `bh` is still missing after that, run `command -v bh >/dev/null || uv tool install -e .`.
 2. First try the harness directly. If this works, skip manual browser setup:
 
 ```bash
@@ -54,12 +61,12 @@ osascript -e 'tell application "Google Chrome" to activate' \
 ```
 
    On Linux: use the already-running Chrome window and open that URL manually.
-   If the attach looks blocked or Chrome is not accepting DevTools yet, tell the user: "I opened Chrome's remote-debugging page. Please click `Allow` in Chrome if it appears." Then keep polling instead of waiting for the user to type a follow-up.
+   If the attach looks blocked or Chrome's remote-debugging page is open but DevTools is not live yet, tell the user: "Chrome is waiting on you. In the Chrome windows I opened, choose your normal profile first if Chrome is showing the profile picker, then tick the remote-debugging checkbox and click `Allow` if Chrome shows it." Then keep polling instead of waiting for the user to type a follow-up.
 4. If Chrome is not running, start Chrome first and let the user choose their normal profile if Chrome opens the profile picker. Only after that, open `chrome://inspect/#remote-debugging`.
    On macOS: `open -a "Google Chrome"`
-5. Tell the user to tick the remote-debugging checkbox. If Chrome shows `Allow`, tell the user to click it once.
-6. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the Chrome profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. Once it is completed, continue checking and retrying for at least 30 seconds.
-7. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation.
+5. Be explicit with the user about the two possible Chrome actions: choose their normal profile if the profile picker is open, and in the remote-debugging tab tick the checkbox and click `Allow` once if Chrome shows it.
+6. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the Chrome profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. After asking, keep retrying for at least 30 seconds even if you see connection-refused, stale websocket, or other weird transient attach errors.
+7. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation. As soon as attach succeeds, continue immediately with the verification task without asking again.
 8. Verify with:
 
 ```bash
@@ -85,7 +92,8 @@ PY
 ## Cold-start reminders
 
 - Try attaching before asking the user to change anything.
-- The first connect may block on Chrome's `Allow` dialog.
+- The first connect may block on Chrome's `Allow` dialog, and Chrome may also stop first on the profile picker.
+- `DevToolsActivePort` can exist before the port is actually listening. Treat connection refused as "still enabling" and keep polling briefly.
 - If attach is blocked on macOS, open `chrome://inspect/#remote-debugging` in the current Chrome profile and explicitly tell the user to click `Allow` if Chrome shows it.
 - Chrome may open the profile picker before any real tab exists.
 - On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.


### PR DESCRIPTION
## What changed
- clarified the install flow for the expected Chrome cold-start case where both the profile picker and remote-debugging permission flow can appear
- made the setup instructions explicitly tell the user to choose their normal profile, tick the remote-debugging checkbox, and click `Allow` if Chrome shows it
- updated the daemon's local DevTools discovery to keep polling for up to 30 seconds when `DevToolsActivePort` exists before the port is actually accepting connections
- tightened the final daemon error so it points at the real manual action instead of looking like an unknown failure

## Why
The first attach can look noisy even when the setup flow is working as intended. In practice, Chrome may open a profile picker and a separate remote-debugging permission tab, and `DevToolsActivePort` can appear before the socket is live. The previous guidance made that state look like confusion rather than the expected next step.

## Impact
- agents should guide the user more explicitly through first-time Chrome setup
- the harness should tolerate transient connection-refused errors during the 30-second enablement window
- once the user completes the Chrome actions, the flow should continue directly into verification instead of treating follow-on errors as a new failure

## Validation
- `python3 -m py_compile daemon.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Chrome remote‑debugging bootstrap and makes the harness resilient to Chrome’s cold‑start by polling up to 30s until DevTools is actually listening. First attach should now proceed without false failures even when the profile picker and the permission tab appear.

- **Bug Fixes**
  - `daemon.py`: After finding `DevToolsActivePort`, probe the port for up to 30s and treat connection‑refused as “still enabling”; improved error to point users to pick their normal profile, tick the checkbox, and click Allow.
  - Docs (`install.md`, `SKILL.md`): Clear steps for cold‑start—choose normal profile first, tick remote‑debugging, click `Allow`, and keep polling; added `uv tool install -e .` fallback and a one‑liner to symlink the Codex skill.

<sup>Written for commit 1e22a0526dec1e275daff8c2cc7d04502e19325b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

