### PR TITLE
[codex] Clean up install bootstrap flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.log
 .env
 uv.lock
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 - `install.md` explains first-time install and browser bootstrap.
 - `SKILL.md` explains day-to-day browser harness usage.
 - `run.py` (~4 lines) executes plain Python with helpers preloaded.
-- `helpers.py` (~260 lines) holds the primitives the agent calls and constantly modifies to sharpen its own harness.
+- `helpers.py` holds the browser primitives the agent calls and sharpens over time.
+- `admin.py` holds daemon bootstrap and optional remote-browser admin helpers.
 - `daemon.py` (~200 lines) keeps the CDP websocket and socket bridge alive.
 
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,7 @@ PY
 ```
 
 `run.py` calls `ensure_daemon()` before `exec` — you never start/stop manually unless you want to.
+
 ### Remote browsers
 
 Remote is optional. Use it for parallel agents, sub-agents, or deployment.
@@ -46,7 +47,7 @@ Run this from the repo root:
 
 ```bash
 uv run python - <<'PY'
-from helpers import start_remote_daemon
+from admin import start_remote_daemon
 print(start_remote_daemon("work"))
 PY
 BU_NAME=work uv run bh <<'PY'
@@ -98,7 +99,7 @@ If you solve a specific website and learn a lot, create a PR to this repo with r
 - **Connect to the user's running Chrome.** Don't launch your own browser.
 - **`cdp-use` is only for `CDPClient.send_raw`.** Prefer raw CDP strings over typed wrappers.
 - **`run.py` stays tiny.** No argparse, subcommands, or extra control layer.
-- **Helpers stay short.** No classes, no extra deps beyond stdlib + `cdp-use` + `websockets`.
+- **Helpers stay short.** Browser primitives in `helpers.py`; daemon/bootstrap and remote session admin live in `admin.py`.
 - **Don't add a manager layer.** No retries framework, session manager, daemon supervisor, config system, or logging framework.
 
 ## Architecture
@@ -125,8 +126,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 - **Omnibox popups are fake `page` targets.** Filter `chrome://omnibox-popup...` and other internals when you need a real tab.
 - **CDP target order != Chrome's visible tab-strip order.** Use UI automation when the user means "the first/second tab I can see"; `Target.activateTarget` only shows a known target.
 - **Default daemon sessions can go stale.** `ensure_real_tab()` re-attaches to a real page.
-- **`no close frame received or sent` usually means a stale daemon / websocket.** Kill the daemon once and retry before assuming setup is wrong.
-- **Keep the two `INTERNAL` tuples in sync.** `daemon.py` and `helpers.py` each define one.
+- **`no close frame received or sent` usually means a stale daemon / websocket.** Restart the daemon once via `admin.restart_daemon()` before assuming setup is wrong.
 - **Browser Use API is camelCase on the wire.** `cdpUrl`, `proxyCountryCode`, etc.
 - **Remote `cdpUrl` is HTTPS, not ws.** Resolve the websocket URL via `/json/version`.
 - **Stop cloud browsers with `PATCH /browsers/{id}` + `{\"action\":\"stop\"}`.**
@@ -134,8 +134,8 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
   `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set.call(el,v); el.dispatchEvent(new Event('input',{bubbles:true}))`.
 - **Radio/checkbox via React**: prefer `el.click()` over `el.checked=true` — React listens to the click event to drive state.
 - **UI-library buttons (MUI Select, dropdown overlays)**: JS `.click()` on `[role=button]` often does NOT fire the library's handler. Screenshot → `click(x,y)` via CDP instead.
-- **Keyboard listeners checking `e.key==='Enter'` on `keypress`**: CDP's `char` event doesn't always fire DOM `keypress` for special keys. Use `dispatch_key(selector, 'Enter')`.
-- **`alert()`/`confirm()` block the page thread.** Call `capture_dialogs()` BEFORE the action, read via `dialogs()` after.
+- **Keyboard listeners checking `e.key==='Enter'` on `keypress`**: prefer `press_key('Enter')`. If a site only reacts to a synthetic DOM `KeyboardEvent`, inject the narrow workaround inline with `js(...)` for that site instead of adding another global helper.
+- **`alert()`/`confirm()` block the page thread.** Prefer `Page.handleJavaScriptDialog` plus `drain_events()`; see `interaction-skills/dialogs.md`.
 - **Same-origin nested iframes** don't show up as CDP targets — walk `document.querySelector('iframe').contentDocument` (or `contentWindow`) recursively. Cross-origin iframes DO appear as targets; use `iframe_target("...")`.
 - **Shadow DOM**: `document.querySelector` doesn't pierce shadow roots. Walk via `element.shadowRoot.querySelectorAll` (and recurse).
 - **Submitting forms**: the "Submit" button isn't always the first `button[type=submit]` — on React Native Web etc. contact-method buttons share that type. Prefer the button whose text matches `/submit/i`, fall back to `form.requestSubmit()`.

--- a/admin.py
+++ b/admin.py
@@ -1,0 +1,128 @@
+import json
+import os
+import socket
+import time
+import urllib.request
+from pathlib import Path
+
+from common import load_env
+
+load_env()
+
+NAME = os.environ.get("BU_NAME", "default")
+BU_API = "https://api.browser-use.com/api/v3"
+
+
+def _paths(name):
+    n = name or NAME
+    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
+
+
+def _log_tail(name):
+    p = f"/tmp/bu-{name or NAME}.log"
+    try:
+        return Path(p).read_text().strip().splitlines()[-1]
+    except (FileNotFoundError, IndexError):
+        return None
+
+
+def daemon_alive(name=None):
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(1)
+        s.connect(_paths(name)[0])
+        s.close()
+        return True
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        return False
+
+
+def ensure_daemon(wait=60.0, name=None, env=None):
+    """Idempotent. `env` is merged into the child process env."""
+    if daemon_alive(name):
+        return
+    import subprocess
+
+    e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
+    p = subprocess.Popen(
+        ["uv", "run", "daemon.py"],
+        cwd=os.path.dirname(os.path.abspath(__file__)),
+        env=e,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    deadline = time.time() + wait
+    while time.time() < deadline:
+        if daemon_alive(name):
+            return
+        if p.poll() is not None:
+            break
+        time.sleep(0.2)
+    msg = _log_tail(name)
+    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+
+
+def restart_daemon(name=None):
+    """Best-effort daemon restart for setup/debug flows."""
+    import signal
+
+    sock, pid_path = _paths(name)
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(5)
+        s.connect(sock)
+        s.sendall(b'{"meta":"shutdown"}\n')
+        s.recv(1024)
+        s.close()
+    except Exception:
+        pass
+    try:
+        pid = int(open(pid_path).read())
+    except (FileNotFoundError, ValueError):
+        pid = None
+    if pid:
+        for _ in range(75):
+            try:
+                os.kill(pid, 0)
+                time.sleep(0.2)
+            except ProcessLookupError:
+                break
+        else:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+    for f in (sock, pid_path):
+        try:
+            os.unlink(f)
+        except FileNotFoundError:
+            pass
+
+
+def _browser_use(path, method, body=None):
+    key = os.environ.get("BROWSER_USE_API_KEY")
+    if not key:
+        raise RuntimeError("BROWSER_USE_API_KEY missing -- see .env.example")
+    req = urllib.request.Request(
+        f"{BU_API}{path}",
+        method=method,
+        data=(json.dumps(body).encode() if body is not None else None),
+        headers={"X-Browser-Use-API-Key": key, "Content-Type": "application/json"},
+    )
+    return json.loads(urllib.request.urlopen(req, timeout=60).read() or b"{}")
+
+
+def _cdp_ws_from_url(cdp_url):
+    return json.loads(urllib.request.urlopen(f"{cdp_url}/json/version", timeout=15).read())["webSocketDebuggerUrl"]
+
+
+def start_remote_daemon(name="remote", **create_kwargs):
+    if daemon_alive(name):
+        raise RuntimeError(f"daemon {name!r} already alive -- restart_daemon({name!r}) first")
+    browser = _browser_use("/browsers", "POST", create_kwargs)
+    ensure_daemon(
+        name=name,
+        env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
+    )
+    return browser

--- a/common.py
+++ b/common.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+
+INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
+
+
+def load_env():
+    p = Path(__file__).parent / ".env"
+    if not p.exists():
+        return
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))

--- a/daemon.py
+++ b/daemon.py
@@ -4,17 +4,9 @@ from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
+from common import INTERNAL, load_env
 
-
-def _load_env():
-    p = Path(__file__).parent / ".env"
-    if not p.exists(): return
-    for line in p.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line: continue
-        k, v = line.split("=", 1)
-        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
-_load_env()
+load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 SOCK = f"/tmp/bu-{NAME}.sock"
@@ -26,7 +18,6 @@ PROFILES = [
     Path.home() / ".config/google-chrome",
     Path.home() / "AppData/Local/Google/Chrome/User Data",
 ]
-INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 API_KEY = os.environ.get("BROWSER_USE_API_KEY")
@@ -112,16 +103,17 @@ class Daemon:
         url = get_ws_url()
         log(f"connecting to {url}")
         self.cdp = CDPClient(url)
-        # Chrome shows a native "Allow debugging" dialog on first connect — user may take a while to click.
+        # Chrome shows a native "Allow debugging" dialog on first connect -- user may take a while to click.
         for attempt in range(12):
             try:
-                await self.cdp.start(); break
+                await self.cdp.start()
+                break
             except Exception as e:
-                log(f"ws handshake attempt {attempt+1} failed: {e} — retrying")
+                log(f"ws handshake attempt {attempt+1} failed: {e} -- retrying")
                 self.cdp = CDPClient(url)
                 await asyncio.sleep(5)
         else:
-            raise RuntimeError("CDP WS handshake never succeeded — did you accept Chrome's Allow dialog?")
+            raise RuntimeError("CDP WS handshake never succeeded -- did you accept Chrome's Allow dialog?")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):

--- a/helpers.py
+++ b/helpers.py
@@ -1,23 +1,12 @@
-"""Browser control via CDP. Read, edit, extend — this file is yours."""
+"""Browser control via CDP. Read, edit, extend -- this file is yours."""
 import base64, json, os, socket, time, urllib.request
-from pathlib import Path
 
+from common import INTERNAL, load_env
 
-def _load_env():
-    p = Path(__file__).parent / ".env"
-    if not p.exists(): return
-    for line in p.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line: continue
-        k, v = line.split("=", 1)
-        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
-_load_env()
+load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 SOCK = f"/tmp/bu-{NAME}.sock"
-PID = f"/tmp/bu-{NAME}.pid"
-INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
-BU_API = "https://api.browser-use.com/api/v3"
 
 
 def _send(req):
@@ -41,87 +30,6 @@ def cdp(method, session_id=None, **params):
 
 
 def drain_events():  return _send({"meta": "drain_events"})["events"]
-def get_session():   return _send({"meta": "session"})["session_id"]
-def set_session(s):  return _send({"meta": "set_session", "session_id": s})
-def shutdown():      return _send({"meta": "shutdown"})
-
-
-# --- daemon lifecycle (socket IS the lock; one per BU_NAME) ---
-def _paths(name): n = name or NAME; return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
-def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
-    try: return Path(p).read_text().strip().splitlines()[-1]
-    except (FileNotFoundError, IndexError): return None
-
-def daemon_alive(name=None):
-    try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(_paths(name)[0]); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
-        return False
-
-def ensure_daemon(wait=60.0, name=None, env=None):
-    """Idempotent. `env` is merged into the child process env."""
-    if daemon_alive(name): return
-    import subprocess
-    e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
-    p = subprocess.Popen(["uv", "run", "daemon.py"], cwd=os.path.dirname(os.path.abspath(__file__)),
-                         env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
-    deadline = time.time() + wait
-    while time.time() < deadline:
-        if daemon_alive(name): return
-        if p.poll() is not None: break
-        time.sleep(0.2)
-    msg = _log_tail(name)
-    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up — check /tmp/bu-{name or NAME}.log")
-
-def kill_daemon(name=None):
-    """Graceful shutdown, wait up to 15s for finally-block cleanup (remote stop), then SIGTERM."""
-    import signal
-    sock, pid_path = _paths(name)
-    try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(5)
-        s.connect(sock); s.sendall(b'{"meta":"shutdown"}\n'); s.recv(1024); s.close()
-    except Exception: pass
-    try: pid = int(open(pid_path).read())
-    except (FileNotFoundError, ValueError): pid = None
-    if pid:
-        for _ in range(75):
-            try: os.kill(pid, 0); time.sleep(0.2)
-            except ProcessLookupError: break
-        else:
-            try: os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError: pass
-    for f in (sock, pid_path):
-        try: os.unlink(f)
-        except FileNotFoundError: pass
-
-
-# --- Browser Use cloud (remote browsers) ---
-# https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session
-def _bu(path, method, body=None):
-    k = os.environ.get("BROWSER_USE_API_KEY")
-    if not k: raise RuntimeError("BROWSER_USE_API_KEY missing — see .env.example")
-    req = urllib.request.Request(f"{BU_API}{path}", method=method,
-        data=(json.dumps(body).encode() if body is not None else None),
-        headers={"X-Browser-Use-API-Key": k, "Content-Type": "application/json"})
-    return json.loads(urllib.request.urlopen(req, timeout=60).read() or b"{}")
-
-def browser_use_create(**params):
-    return _bu("/browsers", "POST", params)
-
-def browser_use_stop(browser_id):
-    return _bu(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
-
-def cdp_ws_from_url(cdp_url):
-    return json.loads(urllib.request.urlopen(f"{cdp_url}/json/version", timeout=15).read())["webSocketDebuggerUrl"]
-
-def start_remote_daemon(name="remote", **create_kwargs):
-    if daemon_alive(name): raise RuntimeError(f"daemon {name!r} already alive — kill_daemon({name!r}) first")
-    b = browser_use_create(**create_kwargs)
-    ensure_daemon(name=name, env={"BU_CDP_WS": cdp_ws_from_url(b["cdpUrl"]),
-                                  "BU_BROWSER_ID": b["id"]})
-    return b
 
 
 # --- navigation / page ---
@@ -190,7 +98,7 @@ def current_tab():
 def switch_tab(target_id):
     cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
-    set_session(sid)
+    _send({"meta": "set_session", "session_id": sid})
     return sid
 
 def new_tab(url="about:blank"):
@@ -238,29 +146,12 @@ def js(expression, target_id=None):
     r = cdp("Runtime.evaluate", session_id=sid, expression=expression, returnByValue=True, awaitPromise=True)
     return r.get("result", {}).get("value")
 
-_KC = {"Enter":13,"Tab":9,"Escape":27,"Backspace":8," ":32,"ArrowLeft":37,"ArrowUp":38,"ArrowRight":39,"ArrowDown":40}
-def dispatch_key(selector, key="Enter", event="keypress"):
-    """Dispatch a DOM KeyboardEvent on the matched element. Use when CDP's press_key doesn't trigger DOM listeners — e.g. `keypress` for Enter on <input type=search> (CDP's `char` event quirk for special keys)."""
-    kc = _KC.get(key, ord(key) if len(key) == 1 else 0)
-    js(f"(()=>{{const e=document.querySelector({json.dumps(selector)});if(e){{e.focus();e.dispatchEvent(new KeyboardEvent({json.dumps(event)},{{key:{json.dumps(key)},code:{json.dumps(key)},keyCode:{kc},which:{kc},bubbles:true}}));}}}})()")
-
-
 def upload_file(selector, path):
     """Set files on a file input via CDP DOM.setFileInputFiles. `path` is an absolute filepath (use tempfile.mkstemp if needed)."""
     doc = cdp("DOM.getDocument", depth=-1)
     nid = cdp("DOM.querySelector", nodeId=doc["root"]["nodeId"], selector=selector)["nodeId"]
     if not nid: raise RuntimeError(f"no element for {selector}")
     cdp("DOM.setFileInputFiles", files=[path] if isinstance(path, str) else list(path), nodeId=nid)
-
-
-def capture_dialogs():
-    """Stub window.alert/confirm/prompt so messages stash in window.__dialogs__. Call BEFORE the action that triggers the dialog; read with dialogs()."""
-    js("window.__dialogs__=[];window.alert=m=>window.__dialogs__.push(String(m));window.confirm=m=>{window.__dialogs__.push(String(m));return true;};window.prompt=(m,d)=>{window.__dialogs__.push(String(m));return d||'';}")
-
-def dialogs():
-    """Return list of captured dialog messages since last capture_dialogs()."""
-    return json.loads(js("JSON.stringify(window.__dialogs__||[])") or "[]")
-
 
 def http_get(url, headers=None, timeout=20.0):
     """Pure HTTP — no browser. Use for static pages / APIs. Wrap in ThreadPoolExecutor for bulk."""

--- a/install.md
+++ b/install.md
@@ -72,8 +72,8 @@ osascript -e 'tell application "Google Chrome" to activate' \
 ```bash
 uv run bh <<'PY'
 ensure_real_tab()
-if not current_tab()["url"] or current_tab()["url"].startswith(INTERNAL):
-    new_tab("https://github.com/browser-use/browser-harness")
+goto("https://github.com/browser-use/browser-harness")
+wait_for_load()
 print(page_info())
 PY
 ```
@@ -82,8 +82,8 @@ If that fails with a stale websocket or stale socket, restart the daemon once an
 
 ```bash
 uv run python - <<'PY'
-from admin import restart_daemon
-restart_daemon()
+from helpers import kill_daemon
+kill_daemon()
 PY
 ```
 

--- a/install.md
+++ b/install.md
@@ -82,8 +82,8 @@ If that fails with a stale websocket or stale socket, restart the daemon once an
 
 ```bash
 uv run python - <<'PY'
-from helpers import kill_daemon
-kill_daemon()
+from admin import restart_daemon
+restart_daemon()
 PY
 ```
 

--- a/interaction-skills/dialogs.md
+++ b/interaction-skills/dialogs.md
@@ -26,13 +26,18 @@ Undetectable by antibot — no JS injected into the page.
 Prevents dialogs from ever appearing. Good when you expect multiple `alert()`/`confirm()` calls in sequence.
 
 ```python
-capture_dialogs()       # replaces window.alert/confirm/prompt with stubs
+js("""
+window.__dialogs__=[];
+window.alert=m=>window.__dialogs__.push(String(m));
+window.confirm=m=>{window.__dialogs__.push(String(m));return true;};
+window.prompt=(m,d)=>{window.__dialogs__.push(String(m));return d||'';};
+""")
 # ... do actions that trigger dialogs ...
-msgs = dialogs()        # read captured messages
+msgs = js("window.__dialogs__||[]")
 ```
 
 Tradeoffs:
-- Stubs are lost on page navigation — must re-call `capture_dialogs()`
+- Stubs are lost on page navigation -- must re-run the snippet
 - `confirm()` always returns `true` (auto-approves)
 - Detectable by antibot (`window.alert.toString()` reveals non-native code)
 - Does NOT handle `beforeunload`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,4 @@ bh = "run:main"
 browser-harness = "run:main"
 
 [tool.setuptools]
-py-modules = ["run", "helpers", "daemon"]
+py-modules = ["run", "helpers", "daemon", "admin", "common"]

--- a/run.py
+++ b/run.py
@@ -1,4 +1,6 @@
 import sys
+
+from admin import ensure_daemon
 from helpers import *
 
 


### PR DESCRIPTION
Superseded by a clean PR branch based directly on current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split daemon/bootstrap and remote-browser admin into `admin.py` and slimmed `helpers.py` to just browser primitives for a simpler install and startup. Added `common.py` for env loading, updated docs, and clarified dialog/keyboard guidance.

- **Refactors**
  - Added `admin.py` with `ensure_daemon`, `restart_daemon`, and `start_remote_daemon` (Browser Use v3).
  - Added `common.py` with `load_env` and shared `INTERNAL`; used by `daemon.py` and `helpers.py`.
  - Trimmed `helpers.py`: removed daemon lifecycle, remote cloud calls, `dispatch_key`, and dialog stubs.
  - Updated `daemon.py` to use `common`; improved handshake logs; small cleanup.
  - `run.py` now imports `ensure_daemon` from `admin.py`.
  - Docs refreshed (`README.md`, `SKILL.md`, `install.md`, `interaction-skills/dialogs.md`); `pyproject.toml` and `.gitignore` updated.

- **Migration**
  - Update imports: `from admin import ensure_daemon, start_remote_daemon, restart_daemon`.
  - Replace `kill_daemon(...)` with `restart_daemon(...)`.
  - Replace `dispatch_key(...)` with `press_key(...)` or a small site-specific JS workaround.
  - Replace `capture_dialogs()`/`dialogs()` with `Page.handleJavaScriptDialog` + `drain_events()` or the snippet shown in `interaction-skills/dialogs.md`.

<sup>Written for commit 377b5499f882dc56505741bc84da4afc2f4023b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

