### PR TITLE
[codex] Clean up install bootstrap flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.log
 .env
 uv.lock
+*.egg-info/

--- a/install.md
+++ b/install.md
@@ -72,8 +72,8 @@ osascript -e 'tell application "Google Chrome" to activate' \
 ```bash
 uv run bh <<'PY'
 ensure_real_tab()
-if not current_tab()["url"] or current_tab()["url"].startswith(INTERNAL):
-    new_tab("https://github.com/browser-use/browser-harness")
+goto("https://github.com/browser-use/browser-harness")
+wait_for_load()
 print(page_info())
 PY
 ```


### PR DESCRIPTION
## Summary
- ignore generated `*.egg-info` directories
- reuse the current attached tab for the GitHub verification step instead of opening a new tab

## Validation
- docs/config-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the install bootstrap by navigating the current attached tab to the GitHub repo and waiting for load, instead of opening a new tab. Also adds `*.egg-info/` to `.gitignore` to avoid tracking generated metadata.

<sup>Written for commit 68f1499e6d0e2fdf279fd2dccf718ceed723f726. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

