### PR TITLE
[codex] Document daemon reuse during setup

### DIFF
--- a/install.md
+++ b/install.md
@@ -52,6 +52,8 @@ print(page_info())
 PY
 ```
 
+   Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session.
+
 3. If that fails and Chrome is already running, open `chrome://inspect/#remote-debugging` in the existing Chrome profile instead of launching a fresh Chrome process.
    On macOS:
 


### PR DESCRIPTION
## Summary
- tell the setup flow to reuse a healthy daemon instead of killing it by default
- warn against killing a daemon another agent may still be using
- point parallel agents toward distinct `BU_NAME`s

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update install docs to prefer reusing a healthy daemon during setup. Add a warning against killing an active daemon and recommend distinct `BU_NAME`s for parallel agents to avoid session conflicts.

<sup>Written for commit eca3467f65eb532f201c46cba5b748afd4e84f65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

