### PR TITLE
[codex] Trim README setup copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 
 The simplest, thinnest, and most powerful harness to control your real browser with your agent.
 
-This repo makes you never use your browser again.
-
 ## Setup prompt
-
-Paste this into Claude Code or Codex:
 
 ```text
 Set up https://github.com/browser-use/browser-harness for me.


### PR DESCRIPTION
## Summary
- remove the extra tagline sentence under the title
- remove the "Paste this into Claude Code or Codex" line above the setup prompt

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim README setup copy to reduce clutter: removed the extra tagline under the title and the “Paste this into Claude Code or Codex” line above the setup prompt.
The setup prompt remains unchanged.

<sup>Written for commit 794d3f6a11add3f7e04cad0f6858f3aec47811e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

