### PR TITLE
[codex] Refine README structure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Set up https://github.com/browser-use/browser-harness for me.
 Read `install.md` first to install and connect this repo to my real browser. Then read `SKILL.md` for normal usage. Always read `helpers.py` because that is where the functions are. When you open a setup or verification tab, activate it so I can see the active browser tab. After it is installed, if I am already logged in to GitHub, star this repository as a small verification task; if I am not logged in, just go to browser-use.com.
 ```
 
-The agent should open [chrome://inspect/#remote-debugging](chrome://inspect/#remote-debugging). When this page appears tick the checkbox so the agent can connect to the real browser.
+When this page appears tick the checkbox so the agent can connect to the real browser.
 
-<img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" />
+<img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />
 
 
 ## Example task
@@ -26,14 +26,14 @@ Star this repository.
 See [domain-skills/](domain-skills/) for examples on other websites.
 
 
-## How It Works
+## Code Structure
 
 - `install.md` explains first-time install and browser bootstrap.
 - `SKILL.md` explains day-to-day browser harness usage.
-- `run.py` (~4 lines) executes plain Python with helpers preloaded.
-- `helpers.py` holds the browser primitives the agent calls and sharpens over time.
-- `admin.py` holds daemon bootstrap and optional remote-browser admin helpers.
-- `daemon.py` (~200 lines) keeps the CDP websocket and socket bridge alive.
+- `run.py` (~13 lines) executes plain Python with helpers preloaded.
+- `helpers.py` (~192 lines) holds the starting tool calls to interact with the browser and can be modified by the agent.
+- `admin.py` (~139 lines) holds daemon bootstrap and optional remote-browser helpers.
+- `daemon.py` (~220 lines) keeps the CDP websocket and socket bridge alive.
 
 
 ## Optional: Remote browsers


### PR DESCRIPTION
## Summary
- rename the README section to `Code Structure`
- update the `helpers.py` and `admin.py` descriptions and restore approximate line counts
- add rounded corners to the remote debugging image

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the README to clarify the code structure and remote debugging setup. Renamed "How It Works" to "Code Structure", updated `run.py`, `helpers.py`, `admin.py`, and `daemon.py` descriptions and approximate line counts, clarified the checkbox step on the remote debugging page, and added rounded corners to the setup image.

<sup>Written for commit f96c1b09bca41d64ddba656bc435fedf844786bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

