### PR TITLE
Top-load browser harness usage guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,29 @@ description: Direct browser control via CDP. Use when the user wants to automate
 
 # browser-harness
 
-For first-time install or reconnect/bootstrap, read `install.md` first. For normal use, stay in this file. **Read `helpers.py` first.** The code is the doc.
+Okay to use this by default to interact with the browser.
+
+## Fast start
+
+Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `install.md` first. For normal use, stay in this file.
+
+```bash
+uv run bh <<'PY'
+ensure_real_tab()
+print(page_info())
+PY
+```
+
+```bash
+uv run bh <<'PY'
+ensure_real_tab()
+goto("https://example.com")
+wait_for_load()
+print(page_info())
+PY
+```
+
+The code is the doc.
 
 Available interaction skills:
 - `cookies.md`

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ description: Direct browser control via CDP. Use when the user wants to automate
 
 # browser-harness
 
-Okay to use this by default to interact with the browser.
+Easiest and most powerful way to interact with the browser.
 
 ## Fast start
 
@@ -13,15 +13,7 @@ Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `in
 
 ```bash
 uv run bh <<'PY'
-ensure_real_tab()
-print(page_info())
-PY
-```
-
-```bash
-uv run bh <<'PY'
-ensure_real_tab()
-goto("https://example.com")
+goto("https://browser-use.com")
 wait_for_load()
 print(page_info())
 PY

--- a/run.py
+++ b/run.py
@@ -3,8 +3,24 @@ import sys
 from admin import ensure_daemon
 from helpers import *
 
+HELP = """Browser Harness
+
+Read SKILL.md for the default workflow and examples.
+
+Typical usage:
+  uv run bh <<'PY'
+  ensure_real_tab()
+  print(page_info())
+  PY
+
+Helpers are pre-imported. The daemon auto-starts and connects to the running browser.
+"""
+
 
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] in {"-h", "--help"}:
+        print(HELP)
+        return
     if sys.stdin.isatty():
         sys.exit("bh reads Python from stdin. Use:\n  bh <<'PY'\n  print(page_info())\n  PY")
     ensure_daemon()


### PR DESCRIPTION
## Summary
- add default-use guidance and fast-start examples to `SKILL.md`
- make `bh --help` point readers to `SKILL.md` and show the core usage pattern

## Testing
- `uv run bh --help`
- verified the updated `SKILL.md` header content locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fast-start example and clearer default-use guidance to `SKILL.md`, and updates `bh --help` with typical usage and a pointer to `SKILL.md`. This makes `browser-harness` the recommended, easier way to control the browser.

- **New Features**
  - `SKILL.md`: New “Fast start” here-doc (`uv run bh`) using `goto("https://browser-use.com")`, `wait_for_load()`, `page_info()`; top-loads “Easiest and most powerful...” message; points to `helpers.py` and `install.md`; ends with “The code is the doc.”
  - `run.py`: Adds `-h/--help` with a quick-start snippet (`ensure_real_tab()`, `page_info()`); notes helpers are pre-imported; the daemon auto-starts and connects to the running browser; directs users to `SKILL.md`.

<sup>Written for commit 869e7ba2b02a378ad927e887e902a98d37b815f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

