### PR TITLE
Print usage hint when bh is run on a TTY

### DIFF
--- a/run.py
+++ b/run.py
@@ -5,6 +5,8 @@ from helpers import *
 
 
 def main():
+    if sys.stdin.isatty():
+        sys.exit("bh reads Python from stdin. Use:\n  bh <<'PY'\n  print(page_info())\n  PY")
     ensure_daemon()
     exec(sys.stdin.read())
 


### PR DESCRIPTION
## Summary
- Bare `bh` blocks forever on `sys.stdin.read()` — no prompt, no output, just a hang.
- Detect TTY stdin and exit with a one-line usage hint instead.
- No argparse, no extra control layer — keeps the "run.py stays tiny" constraint.

## Test plan
- [x] `bh` on a TTY prints the hint and exits non-zero
- [x] `bh <<'PY' ... PY` still works
- [x] `echo '...' | bh` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect TTY stdin and print a usage hint instead of hanging when running bh with no input. Heredoc and piped input still work; on a TTY it exits non-zero.

<sup>Written for commit 29fa06576c974057256e17bb8c7c0d6cb8ec57ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

