### PR TITLE
[codex] Rename CLI to browser-harness run

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -30,7 +30,7 @@ Available domain skills:
 ## Tool call shape
 
 ```bash
-browser-harness run <<'PY'
+browser-harness <<'PY'
 # any python. helpers pre-imported. daemon auto-starts.
 PY
 ```
@@ -46,8 +46,11 @@ If `BROWSER_USE_API_KEY` is already present in `.env` or the environment, start 
 Run this from the repo root:
 
 ```bash
-browser-harness start-remote-daemon work
-BU_NAME=work uv run browser-harness run <<'PY'
+uv run python - <<'PY'
+from admin import start_remote_daemon
+print(start_remote_daemon("work"))
+PY
+BU_NAME=work uv run browser-harness <<'PY'
 print(page_info())
 PY
 ```
@@ -115,7 +118,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 ## Gotchas (field-tested)
 
 - **Chrome 144+ `chrome://inspect/#remote-debugging` does NOT serve `/json/version`.** Read `DevToolsActivePort` instead.
-- **Try attaching before asking for setup.** If `uv run browser-harness run` already works, skip the remote-debugging instructions entirely.
+- **Try attaching before asking for setup.** If `uv run browser-harness` already works, skip the remote-debugging instructions entirely.
 - **The first connect may block on Chrome's Allow dialog.** If setup hangs, explicitly tell the user to click `Allow` in Chrome if it appears, then keep polling for up to 30 seconds instead of treating follow-on errors as a new failure.
 - **`DevToolsActivePort` can exist before the port is actually listening.** Treat connection refused as "still enabling" and keep polling for up to 30 seconds.
 - **Chrome may open the profile picker before any real tab exists.** If Chrome opens both a profile picker and the remote-debugging page, tell the user to choose their normal profile first, then tick the checkbox and click `Allow` if shown.
@@ -123,7 +126,12 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 - **Omnibox popups are fake `page` targets.** Filter `chrome://omnibox-popup...` and other internals when you need a real tab.
 - **CDP target order != Chrome's visible tab-strip order.** Use UI automation when the user means "the first/second tab I can see"; `Target.activateTarget` only shows a known target.
 - **Default daemon sessions can go stale.** `ensure_real_tab()` re-attaches to a real page.
-- **`no close frame received or sent` usually means a stale daemon / websocket.** Restart the daemon once via `browser-harness restart-daemon` before assuming setup is wrong.
+- **`no close frame received or sent` usually means a stale daemon / websocket.** Restart the daemon once with:
+  `uv run python - <<'PY'`
+  `from admin import restart_daemon`
+  `restart_daemon()`
+  `PY`
+  before assuming setup is wrong.
 - **Browser Use API is camelCase on the wire.** `cdpUrl`, `proxyCountryCode`, etc.
 - **Remote `cdpUrl` is HTTPS, not ws.** Resolve the websocket URL via `/json/version`.
 - **Stop cloud browsers with `PATCH /browsers/{id}` + `{\"action\":\"stop\"}`.**

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,7 +30,7 @@ Available domain skills:
 ## Tool call shape
 
 ```bash
-bh <<'PY'
+browser-harness run <<'PY'
 # any python. helpers pre-imported. daemon auto-starts.
 PY
 ```
@@ -46,11 +46,8 @@ If `BROWSER_USE_API_KEY` is already present in `.env` or the environment, start 
 Run this from the repo root:
 
 ```bash
-uv run python - <<'PY'
-from admin import start_remote_daemon
-print(start_remote_daemon("work"))
-PY
-BU_NAME=work uv run bh <<'PY'
+browser-harness start-remote-daemon work
+BU_NAME=work uv run browser-harness run <<'PY'
 print(page_info())
 PY
 ```
@@ -118,7 +115,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 ## Gotchas (field-tested)
 
 - **Chrome 144+ `chrome://inspect/#remote-debugging` does NOT serve `/json/version`.** Read `DevToolsActivePort` instead.
-- **Try attaching before asking for setup.** If `uv run bh` already works, skip the remote-debugging instructions entirely.
+- **Try attaching before asking for setup.** If `uv run browser-harness run` already works, skip the remote-debugging instructions entirely.
 - **The first connect may block on Chrome's Allow dialog.** If setup hangs, explicitly tell the user to click `Allow` in Chrome if it appears, then keep polling for up to 30 seconds instead of treating follow-on errors as a new failure.
 - **`DevToolsActivePort` can exist before the port is actually listening.** Treat connection refused as "still enabling" and keep polling for up to 30 seconds.
 - **Chrome may open the profile picker before any real tab exists.** If Chrome opens both a profile picker and the remote-debugging page, tell the user to choose their normal profile first, then tick the checkbox and click `Allow` if shown.
@@ -126,7 +123,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 - **Omnibox popups are fake `page` targets.** Filter `chrome://omnibox-popup...` and other internals when you need a real tab.
 - **CDP target order != Chrome's visible tab-strip order.** Use UI automation when the user means "the first/second tab I can see"; `Target.activateTarget` only shows a known target.
 - **Default daemon sessions can go stale.** `ensure_real_tab()` re-attaches to a real page.
-- **`no close frame received or sent` usually means a stale daemon / websocket.** Restart the daemon once via `admin.restart_daemon()` before assuming setup is wrong.
+- **`no close frame received or sent` usually means a stale daemon / websocket.** Restart the daemon once via `browser-harness restart-daemon` before assuming setup is wrong.
 - **Browser Use API is camelCase on the wire.** `cdpUrl`, `proxyCountryCode`, etc.
 - **Remote `cdpUrl` is HTTPS, not ws.** Resolve the websocket URL via `/json/version`.
 - **Stop cloud browsers with `PATCH /browsers/{id}` + `{\"action\":\"stop\"}`.**

--- a/admin.py
+++ b/admin.py
@@ -1,7 +1,6 @@
 import json
 import os
 import socket
-import sys
 import time
 import urllib.request
 from pathlib import Path
@@ -138,23 +137,3 @@ def start_remote_daemon(name="remote", **create_kwargs):
         env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
     )
     return browser
-
-
-def main():
-    cmd = sys.argv[1:] or ["run"]
-    if cmd[0] == "run":
-        import run
-
-        run.main()
-        return
-    if cmd[0] == "restart-daemon":
-        restart_daemon(cmd[1] if len(cmd) > 1 else None)
-        return
-    if cmd[0] == "start-remote-daemon":
-        name = cmd[1] if len(cmd) > 1 else "remote"
-        print(json.dumps(start_remote_daemon(name), indent=2))
-        return
-    raise SystemExit(
-        "Usage: browser-harness run | browser-harness restart-daemon [name] | "
-        "browser-harness start-remote-daemon [name]"
-    )

--- a/admin.py
+++ b/admin.py
@@ -1,6 +1,7 @@
 import json
 import os
 import socket
+import sys
 import time
 import urllib.request
 from pathlib import Path
@@ -137,3 +138,23 @@ def start_remote_daemon(name="remote", **create_kwargs):
         env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
     )
     return browser
+
+
+def main():
+    cmd = sys.argv[1:] or ["run"]
+    if cmd[0] == "run":
+        import run
+
+        run.main()
+        return
+    if cmd[0] == "restart-daemon":
+        restart_daemon(cmd[1] if len(cmd) > 1 else None)
+        return
+    if cmd[0] == "start-remote-daemon":
+        name = cmd[1] if len(cmd) > 1 else "remote"
+        print(json.dumps(start_remote_daemon(name), indent=2))
+        return
+    raise SystemExit(
+        "Usage: browser-harness run | browser-harness restart-daemon [name] | "
+        "browser-harness start-remote-daemon [name]"
+    )

--- a/install.md
+++ b/install.md
@@ -22,7 +22,7 @@ uv tool install -e .
 command -v browser-harness
 ```
 
-That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `browser-harness run` uses the new code immediately. Prefer a stable path like `~/Developer/browser-harness`, not `/tmp`.
+That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `browser-harness` uses the new code immediately. Prefer a stable path like `~/Developer/browser-harness`, not `/tmp`.
 
 ## Make it global for the current agent
 
@@ -46,7 +46,7 @@ That makes new Codex or Claude Code sessions in other folders load the runtime b
 2. First try the harness directly. If this works, skip manual browser setup:
 
 ```bash
-uv run browser-harness run <<'PY'
+uv run browser-harness <<'PY'
 ensure_real_tab()
 print(page_info())
 PY
@@ -72,7 +72,7 @@ osascript -e 'tell application "Google Chrome" to activate' \
 8. Verify with:
 
 ```bash
-uv run browser-harness run <<'PY'
+uv run browser-harness <<'PY'
 ensure_real_tab()
 goto("https://github.com/browser-use/browser-harness")
 wait_for_load()
@@ -83,7 +83,10 @@ PY
 If that fails with a stale websocket or stale socket, restart the daemon once and retry:
 
 ```bash
-browser-harness restart-daemon
+uv run python - <<'PY'
+from admin import restart_daemon
+restart_daemon()
+PY
 ```
 
 9. After install and browser bootstrap succeed, use the repository page as a small interaction check. If the user is logged in to GitHub, try to star `https://github.com/browser-use/browser-harness` to verify the interaction works. Then ask the user what you should do next.
@@ -93,7 +96,7 @@ browser-harness restart-daemon
 - Try attaching before asking the user to change anything.
 - The first connect may block on Chrome's `Allow` dialog, and Chrome may also stop first on the profile picker.
 - `DevToolsActivePort` can exist before the port is actually listening. Treat connection refused as "still enabling" and keep polling briefly.
-- If the port is listening but `/json/version` returns `404`, treat that as expected on newer Chrome builds and retry `browser-harness run`.
+- If the port is listening but `/json/version` returns `404`, treat that as expected on newer Chrome builds and retry `browser-harness`.
 - If attach is blocked on macOS, open `chrome://inspect/#remote-debugging` in the current Chrome profile and explicitly tell the user to click `Allow` if Chrome shows it.
 - Chrome may open the profile picker before any real tab exists.
 - On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.

--- a/install.md
+++ b/install.md
@@ -13,16 +13,16 @@ When you open a setup or verification tab, activate it so the user can actually 
 
 ## Best everyday setup
 
-Clone the repo once into a durable location, then install it as an editable tool so `bh` works from any directory:
+Clone the repo once into a durable location, then install it as an editable tool so `browser-harness` works from any directory:
 
 ```bash
 git clone https://github.com/browser-use/browser-harness
 cd browser-harness
 uv tool install -e .
-command -v bh
+command -v browser-harness
 ```
 
-That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `bh` run uses the new code immediately. `browser-harness` is the readable alias for the same command. Prefer a stable path like `~/Developer/browser-harness`, not `/tmp`.
+That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `browser-harness run` uses the new code immediately. Prefer a stable path like `~/Developer/browser-harness`, not `/tmp`.
 
 ## Make it global for the current agent
 
@@ -42,11 +42,11 @@ That makes new Codex or Claude Code sessions in other folders load the runtime b
 ## Browser bootstrap
 
 1. Run `uv sync`.
-   If `bh` is still missing after that, run `command -v bh >/dev/null || uv tool install -e .`.
+   If `browser-harness` is still missing after that, run `command -v browser-harness >/dev/null || uv tool install -e .`.
 2. First try the harness directly. If this works, skip manual browser setup:
 
 ```bash
-uv run bh <<'PY'
+uv run browser-harness run <<'PY'
 ensure_real_tab()
 print(page_info())
 PY
@@ -72,7 +72,7 @@ osascript -e 'tell application "Google Chrome" to activate' \
 8. Verify with:
 
 ```bash
-uv run bh <<'PY'
+uv run browser-harness run <<'PY'
 ensure_real_tab()
 goto("https://github.com/browser-use/browser-harness")
 wait_for_load()
@@ -83,10 +83,7 @@ PY
 If that fails with a stale websocket or stale socket, restart the daemon once and retry:
 
 ```bash
-uv run python - <<'PY'
-from admin import restart_daemon
-restart_daemon()
-PY
+browser-harness restart-daemon
 ```
 
 9. After install and browser bootstrap succeed, use the repository page as a small interaction check. If the user is logged in to GitHub, try to star `https://github.com/browser-use/browser-harness` to verify the interaction works. Then ask the user what you should do next.
@@ -96,7 +93,7 @@ PY
 - Try attaching before asking the user to change anything.
 - The first connect may block on Chrome's `Allow` dialog, and Chrome may also stop first on the profile picker.
 - `DevToolsActivePort` can exist before the port is actually listening. Treat connection refused as "still enabling" and keep polling briefly.
-- If the port is listening but `/json/version` returns `404`, treat that as expected on newer Chrome builds and retry `bh`.
+- If the port is listening but `/json/version` returns `404`, treat that as expected on newer Chrome builds and retry `browser-harness run`.
 - If attach is blocked on macOS, open `chrome://inspect/#remote-debugging` in the current Chrome profile and explicitly tell the user to click `Allow` if Chrome shows it.
 - Chrome may open the profile picker before any real tab exists.
 - On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [project.scripts]
-browser-harness = "admin:main"
+browser-harness = "run:main"
 
 [tool.setuptools]
 py-modules = ["run", "helpers", "daemon", "admin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ dependencies = [
 ]
 
 [project.scripts]
-bh = "run:main"
-browser-harness = "run:main"
+browser-harness = "admin:main"
 
 [tool.setuptools]
 py-modules = ["run", "helpers", "daemon", "admin"]

--- a/run.py
+++ b/run.py
@@ -7,8 +7,8 @@ from helpers import *
 def main():
     if sys.stdin.isatty():
         sys.exit(
-            "browser-harness run reads Python from stdin. Use:\n"
-            "  browser-harness run <<'PY'\n"
+            "browser-harness reads Python from stdin. Use:\n"
+            "  browser-harness <<'PY'\n"
             "  print(page_info())\n"
             "  PY"
         )

--- a/run.py
+++ b/run.py
@@ -6,7 +6,12 @@ from helpers import *
 
 def main():
     if sys.stdin.isatty():
-        sys.exit("bh reads Python from stdin. Use:\n  bh <<'PY'\n  print(page_info())\n  PY")
+        sys.exit(
+            "browser-harness run reads Python from stdin. Use:\n"
+            "  browser-harness run <<'PY'\n"
+            "  print(page_info())\n"
+            "  PY"
+        )
     ensure_daemon()
     exec(sys.stdin.read())
 


### PR DESCRIPTION
## Summary
- remove the `bh` alias and make `browser-harness` the only CLI entrypoint
- route subcommands through `browser-harness run`, `browser-harness restart-daemon`, and `browser-harness start-remote-daemon`
- update install and skill docs to use the explicit command name everywhere

## Validation
- `uv sync`
- `uv tool install -e . --force`
- `browser-harness restart-daemon`
- `browser-harness run <<'PY' ... PY`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the CLI by making `browser-harness` the only command that reads Python from stdin. Removed the `bh` alias and all subcommands; the console script now points to `run:main`, and docs/help were updated.

- **Migration**
  - Reinstall: `uv sync && uv tool install -e . --force`.
  - Update usage: replace `bh` with `browser-harness` (no `run` subcommand).
  - For daemon actions, use Python helpers: `admin.restart_daemon()` and `admin.start_remote_daemon("name")` (e.g., via `uv run python - <<'PY' ... PY`).

<sup>Written for commit 626f82e08ecca1661c6d21eecc9a0603bba0f557. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

