### PR TITLE
[codex] Remove default ensure_real_tab from docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -101,8 +101,8 @@ If you solve a specific website and learn a lot, create a PR to this repo with r
 - **Clicking**: `screenshot()` → look → `click(x, y)`. Passes through iframes/shadow/cross-origin at the compositor level.
 - **Bulk HTTP**: `http_get(url)` + `ThreadPoolExecutor`. No browser for static pages (249 Netflix pages in 2.8s).
 - **After goto**: `wait_for_load()`.
-- **Wrong/stale tab**: `ensure_real_tab()`. Daemon also auto-recovers from stale sessions on next call.
-- **Verification**: `ensure_real_tab(); print(page_info())` is the simplest "is this alive?" check.
+- **Wrong/stale tab**: `ensure_real_tab()`. Use it when the current tab is stale or internal; the daemon also auto-recovers from stale sessions on the next call.
+- **Verification**: `print(page_info())` is the simplest "is this alive?" check.
 - **Iframe sites** (Azure blades, Salesforce): `click(x, y)` passes through; for DOM use `js(expr, target_id=iframe_target("sandbox"))`. Iframe rects are iframe-local — add the host iframe's offset for page coords.
 - **Auth wall**: redirected to login → stop and ask the user. Don't type credentials from screenshots.
 - **Raw CDP** for anything helpers don't cover: `cdp("Domain.method", **params)`.

--- a/install.md
+++ b/install.md
@@ -47,7 +47,6 @@ That makes new Codex or Claude Code sessions in other folders load the runtime b
 
 ```bash
 uv run browser-harness <<'PY'
-ensure_real_tab()
 print(page_info())
 PY
 ```
@@ -73,7 +72,6 @@ osascript -e 'tell application "Google Chrome" to activate' \
 
 ```bash
 uv run browser-harness <<'PY'
-ensure_real_tab()
 goto("https://github.com/browser-use/browser-harness")
 wait_for_load()
 print(page_info())


### PR DESCRIPTION
## Summary
- stop showing `ensure_real_tab()` as the default first step in install/bootstrap snippets
- describe it as a recovery tool for stale or internal tabs instead
- simplify the default verification check to `print(page_info())`

## Validation
- docs-only change
- no automated tests run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `ensure_real_tab()` from install/bootstrap snippets and position it as a recovery step for stale or internal tabs. Simplify the default verification to `print(page_info())` to keep the quick-start flow clean.

<sup>Written for commit 672a641393941a3978745ed10a2101cdd0d1adb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

