### PR TITLE
Emphasize screenshots for verification and exploration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -97,12 +97,13 @@ If you solve a specific website and learn a lot, create a PR to this repo with r
 
 ## What actually works
 
-- **Clicking**: `screenshot()` → look → `click(x, y)`. Passes through iframes/shadow/cross-origin at the compositor level.
+- **Screenshots first**: use `screenshot()` to understand the current page quickly, find visible targets, and decide whether you need a click, a selector, or more navigation.
+- **Clicking**: `screenshot()` → look → `click(x, y)` → `screenshot()` again to verify the result. Coordinate clicks pass through iframes/shadow/cross-origin at the compositor level.
 - **Bulk HTTP**: `http_get(url)` + `ThreadPoolExecutor`. No browser for static pages (249 Netflix pages in 2.8s).
 - **After goto**: `wait_for_load()`.
 - **Wrong/stale tab**: `ensure_real_tab()`. Use it when the current tab is stale or internal; the daemon also auto-recovers from stale sessions on the next call.
-- **Verification**: `print(page_info())` is the simplest "is this alive?" check.
-- **DOM reads**: use `js(...)` for inspection and extraction when coordinates are the wrong tool.
+- **Verification**: `print(page_info())` is the simplest "is this alive?" check, but screenshots are the default way to verify whether a visible action actually worked.
+- **DOM reads**: use `js(...)` for inspection and extraction when the screenshot shows that coordinates are the wrong tool.
 - **Iframe sites** (Azure blades, Salesforce): `click(x, y)` passes through; only drop to iframe DOM work when coordinate clicks are the wrong tool.
 - **Auth wall**: redirected to login → stop and ask the user. Don't type credentials from screenshots.
 - **Raw CDP** for anything helpers don't cover: `cdp("Domain.method", **params)`.
@@ -149,6 +150,8 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 - **Browser Use API is camelCase on the wire.** `cdpUrl`, `proxyCountryCode`, etc.
 - **Remote `cdpUrl` is HTTPS, not ws.** Resolve the websocket URL via `/json/version`.
 - **Stop cloud browsers with `PATCH /browsers/{id}` + `{\"action\":\"stop\"}`.**
+- **After every meaningful action, re-screenshot before assuming it worked.** Use the image to verify changed state, open menus, navigation, visible errors, and whether the page is in the state you expected.
+- **Use screenshots to drive exploration.** They are often the fastest way to find the next click target, notice hidden blockers, and decide if a selector is even worth writing.
 - **Prefer compositor-level actions over framework hacks.** Try screenshots, coordinate clicks, and raw key input before adding DOM-specific workarounds.
 - **If you need framework-specific DOM tricks, check `interaction-skills/` first.** That is where dropdown, dialog, iframe, shadow DOM, and form-specific guidance belongs.
 


### PR DESCRIPTION
## Summary
- make screenshots the default exploration tool in the main skill
- tell agents to re-screenshot after meaningful actions to verify visible state changes
- clarify that screenshots often beat selectors for fast orientation

## Testing
- not run (docs-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates SKILL.md to make screenshots the default for exploration and verifying visible changes. Adds a “Screenshots first” tip, updates the click flow to re-screenshot for verification, ties DOM reads to what the image shows, and adds tips to re-screenshot after meaningful actions and use screenshots to drive exploration.

<sup>Written for commit 2e17c3e07e8b03833574cc987963843cd162b013. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

