### PR TITLE
[codex] Document domain-skill PR ritual

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -93,17 +93,7 @@ After every browser task, extract ONE generalizable friction point from the inte
 
 Commit with the task. The skill gets sharper every use. Skip only if nothing was surprising.
 
-If you spend a couple of corrective steps on one site figuring out a page-specific rule that the agent should know next time, treat that as a reusable domain learning, not just a one-off fix.
-
-When that happens:
-- create or update a domain skill under `domain-skills/<domain>/`
-- create the `<domain>/` directory if it does not exist yet
-- save the learning as a Markdown file with a descriptive name
-- write only reusable mechanics: how the site behaves, what to wait for, what selectors or interaction patterns worked, and what traps matter
-- strip all personal information, secrets, account-specific values, and user-specific content because `domain-skills/` is shared across users
-- open a PR to this public repo contributing the new or updated domain skill
-
-Use `interaction-skills/` instead only when the learning is genuinely cross-site and not specific to one domain.
+If you spend a couple of corrective steps learning a site-specific rule the agent should know next time, add or update a sanitized Markdown skill under `domain-skills/<domain>/` (create the directory if needed) and open a PR to this public repo.
 
 ## What actually works
 
@@ -166,4 +156,3 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 
 - `interaction-skills/` holds reusable UI mechanics such as dialogs, tabs, dropdowns, iframes, and uploads.
 - `domain-skills/` holds site-specific workflows and should be updated when you discover reusable patterns for a website.
-- If the agent had to struggle for a few steps on a page to learn a durable site-specific fact, capture it in `domain-skills/` before ending the task and send it back as a PR.

--- a/SKILL.md
+++ b/SKILL.md
@@ -93,7 +93,7 @@ After every browser task, extract ONE generalizable friction point from the inte
 
 Commit with the task. The skill gets sharper every use. Skip only if nothing was surprising.
 
-If you spend a couple of corrective steps learning a site-specific rule the agent should know next time, add or update a sanitized Markdown skill under `domain-skills/<domain>/` (create the directory if needed) and open a PR to this public repo.
+If you spend a couple of corrective steps learning things you would want to know on the next similar task for the same domain, add or update a Markdown skill under `domain-skills/<domain>/` (create the directory if needed) with all reusable learnings that would speed up the next run, such as where to wait for network requests, which interaction patterns worked, and what traps matter. `domain-skills/` is shared across users, so include only sanitized, reusable guidance and never include sensitive data, secrets, or user-specific details. Then open a PR to this public repo.
 
 ## What actually works
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -93,7 +93,17 @@ After every browser task, extract ONE generalizable friction point from the inte
 
 Commit with the task. The skill gets sharper every use. Skip only if nothing was surprising.
 
-If you solve a specific website and learn a lot, create a PR to this repo with reusable learnings in `domain-skills/` or `interaction-skills/` — no secrets, no user data, no overfit recipes, just how the site works, what to wait for, and what patterns matter.
+If you spend a couple of corrective steps on one site figuring out a page-specific rule that the agent should know next time, treat that as a reusable domain learning, not just a one-off fix.
+
+When that happens:
+- create or update a domain skill under `domain-skills/<domain>/`
+- create the `<domain>/` directory if it does not exist yet
+- save the learning as a Markdown file with a descriptive name
+- write only reusable mechanics: how the site behaves, what to wait for, what selectors or interaction patterns worked, and what traps matter
+- strip all personal information, secrets, account-specific values, and user-specific content because `domain-skills/` is shared across users
+- open a PR to this public repo contributing the new or updated domain skill
+
+Use `interaction-skills/` instead only when the learning is genuinely cross-site and not specific to one domain.
 
 ## What actually works
 
@@ -156,3 +166,4 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 
 - `interaction-skills/` holds reusable UI mechanics such as dialogs, tabs, dropdowns, iframes, and uploads.
 - `domain-skills/` holds site-specific workflows and should be updated when you discover reusable patterns for a website.
+- If the agent had to struggle for a few steps on a page to learn a durable site-specific fact, capture it in `domain-skills/` before ending the task and send it back as a PR.


### PR DESCRIPTION
## What changed
- tightened `SKILL.md` so repeated page-specific struggle is treated as a reusable domain learning
- added an explicit workflow to create or update `domain-skills/<domain>/`, create the domain directory when missing, sanitize content, and contribute it back via PR
- clarified that `interaction-skills/` should only be used instead when the learning is truly cross-site

## Why
The existing guidance encouraged contributing reusable learnings, but it did not clearly tell the agent when to do that or what the expected sequence should be after it learns something durable on a domain.

## Impact
Agents using this skill now have a stronger default behavior for capturing site-specific knowledge without leaking user-specific or sensitive data.

## Validation
- reviewed the `SKILL.md` diff for clarity and consistency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies when to promote site-specific learnings into `domain-skills/<domain>/` and how to submit them via PR.
After a few corrective steps, write a sanitized Markdown skill (create the folder if missing) that captures reusable guidance (e.g., network waits, effective interaction patterns, common traps); `domain-skills/` is shared across users, so never include secrets or user-specific data.

<sup>Written for commit 3fde6af2e1f89a6cb39a4f2934243e6b834914d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

