### PR TITLE
Add thetechgeeks domain-skill for Ubiquiti AU pricing

### DIFF
--- a/domain-skills/thetechgeeks/pricing.md
+++ b/domain-skills/thetechgeeks/pricing.md
@@ -1,0 +1,52 @@
+# The Tech Geeks AU — Ubiquiti pricing
+
+`https://thetechgeeks.com` — Shopify Online Store 2.0, AU Ubiquiti reseller. Prices GST-inclusive ("All Prices Include Australian GST At 10%" in footer).
+
+## Do this first
+
+**Hit the `.js` endpoint, not the DOM.** Shopify exposes canonical product JSON — no scraping, no screenshots.
+
+```python
+import json
+d = json.loads(http_get(f"https://thetechgeeks.com/products/{handle}.js"))
+# {'title', 'price' (AUD cents — divide by 100), 'available', 'variants', 'compare_at_price', ...}
+```
+
+Use this for title / SKU / price. One `http_get` replaces `goto + wait_for_load + screenshot + regex`.
+
+## Do NOT trust `.js.available` for stock
+
+Tech Geeks marks many in-stock products `available: false` (backorder / order-from-supplier). Verified counterexample: UDM-Pro-Max `available: true`, U6-LR `available: false` but Add-to-cart live. To know real stock, cross-check the DOM:
+
+- `document.querySelector('.price--sold-out')` present → truly sold out
+- Body text contains "Sold out" (case-insensitive) near the product title → sold out
+- `document.querySelector('product-form__submit[disabled]')` → sold out
+
+Only if `.js.available = false` AND one of the above fires is the product actually unbuyable.
+
+## Sold-out pages have junk prices
+
+Confirmed: UACC-Rack-12U-Wall listed **$3,080 AUD** (real AU street ~$420–$630). The sold-out listing carries stale / data-entry prices that nobody cleans up.
+
+**Sanity gate before reporting any Tech Geeks price:**
+
+1. If `.js.available = false`, treat the price as unverified.
+2. If the price deviates >2× from another AU vendor or the `store.ui.com` MSRP for the same SKU, assume Tech Geeks is wrong — not the other source.
+3. Only in-stock prices should land in a final table.
+
+## Finding the right product URL
+
+Slugs are long marketing titles, not SKUs. Don't guess. Two reliable shortcuts:
+
+- `https://thetechgeeks.com/search?q=<SKU>` → scrape first `a[href*="/products/"]` link
+- Google `site:thetechgeeks.com <SKU>` when the internal search misses
+
+## Known gaps in their Ubiquiti catalogue (as of 2026-04)
+
+- **USP-PDU-Pro** — not stocked (no AU-plug Ubiquiti SKU exists anywhere in AU; region-wide gap, not a Tech Geeks issue)
+- **U-Cable-C6-CMP** (plenum Cat6) — only **U-Cable-C6-CMR** (riser) is carried
+- `available: false` is common even on items they'll still order in
+
+## Don't use a browser for this
+
+Product pages are static HTML + one JSON endpoint. `http_get` over `asyncio`/`ThreadPoolExecutor` fetches all SKUs in <5s. CDP is wasted here unless you need to click through a cart / checkout flow.


### PR DESCRIPTION
## Summary

Adds `domain-skills/thetechgeeks/pricing.md` — a concise guide for pulling Ubiquiti pricing from thetechgeeks.com (AU reseller) without the failure modes I hit on the first attempt.

## What went wrong that prompted this

A pricing run on 9 UniFi SKUs reported $3,080 AUD for the UACC-Rack-12U-Wall. Verifier confirmed the page really does say $3,080 — but the product is sold out and the real AU street price is ~$420–$630 (MSRP ~USD $399). The agent scraped `document.body.innerText`, regex'd the first `$X.XX AUD`, never took a screenshot, never looked for a "Sold out" badge, and never cross-checked against `store.ui.com` MSRP even though that data was already on hand from an earlier WebSearch.

## What the skill file teaches future-you

- Tech Geeks is Shopify → hit `/products/<handle>.js` for canonical title / price (in AUD cents) / SKU / variants. One `http_get` replaces a full CDP round-trip.
- `.js.available` is NOT a reliable stock signal on this site — many in-stock items return `available: false` (backorder). Cross-check the DOM (`.price--sold-out`, body text, disabled submit).
- Sold-out pages carry junk prices. Sanity gate: if price is >2× another AU vendor or store.ui.com MSRP for the same SKU, Tech Geeks is wrong.
- Slugs are marketing titles, not SKUs — use `/search?q=<SKU>` or `site:thetechgeeks.com <SKU>`, don't guess URLs.
- Known AU catalogue gaps: USP-PDU-Pro (no AU-plug SKU exists), U-Cable-C6-CMP (only CMR stocked).
- Pages are static — `http_get` + async beats CDP for bulk price reads.

## Test plan

- [ ] Re-run the same 9-SKU Ubiquiti pricing task with this skill loaded and confirm the rack either lands in "unavailable" or triggers a second-source check before being reported.
- [ ] Spot-check `/products/<handle>.js` for 2–3 more Ubiquiti SKUs to confirm the price encoding (cents / 100) holds across the catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `domain-skills/thetechgeeks/pricing.md` to pull Ubiquiti AU pricing from thetechgeeks.com via Shopify product JSON. Prevents bad quotes by ignoring sold‑out junk prices and verifying stock before reporting.

- **New Features**
  - Use `https://thetechgeeks.com/products/<handle>.js` for canonical title/SKU/price (AUD cents); avoid DOM/CDP.
  - Treat `.js.available` as unreliable; confirm sold-out via `.price--sold-out`, disabled submit, or “Sold out” text before marking unavailable.
  - Add a sanity gate: if price is >2× another AU vendor or `store.ui.com` MSRP, treat the Tech Geeks price as wrong; only include in-stock prices.
  - Find product URLs via `/search?q=<SKU>` or `site:thetechgeeks.com <SKU>`; pages are static—prefer `http_get` + async.
  - Notes: known gaps include `USP-PDU-Pro` (no AU plug) and `U-Cable-C6-CMP` (only `U-Cable-C6-CMR` stocked).

<sup>Written for commit fc4c42caf89e4f833e4db6d285c67be669cd9033. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

