### PR TITLE
[codex] Add domain skill name helper

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -47,7 +47,10 @@ def drain_events():  return _send({"meta": "drain_events"})["events"]
 
 
 # --- navigation / page ---
-def goto(url):  return cdp("Page.navigate", url=url)
+def goto(url):
+    r = cdp("Page.navigate", url=url)
+    d = (Path(__file__).parent / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0])
+    return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]} if d.is_dir() else r
 
 def page_info():
     """{url, title, w, h, sx, sy, pw, ph} — viewport + scroll + page size."""
@@ -55,40 +58,6 @@ def page_info():
             expression="JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})",
             returnByValue=True)
     return json.loads(r["result"]["value"])
-
-
-def _domain_skill_candidates(hostname):
-    host = (hostname or "").lower().strip(".")
-    if not host:
-        return []
-    parts = [p for p in host.split(".") if p and p != "www"]
-    if not parts:
-        return []
-    seen, out = set(), []
-    for i in range(len(parts) - 1):
-        candidate = ".".join(parts[i:])
-        if candidate not in seen:
-            seen.add(candidate)
-            out.append(candidate)
-    leaf = parts[0]
-    if leaf not in seen:
-        out.append(leaf)
-    return out
-
-
-def domain_skill_names(url=None, limit=10):
-    """Return up to `limit` Markdown filenames for the current page's matching domain skill directory."""
-    target = url or page_info().get("url", "")
-    host = urlparse(target).hostname
-    root = Path(__file__).parent / "domain-skills"
-    for candidate in _domain_skill_candidates(host):
-        folder = root / candidate
-        if not folder.is_dir():
-            continue
-        files = sorted(p.name for p in folder.rglob("*.md") if p.is_file())
-        return files[:limit]
-    return []
-
 
 # --- input ---
 def click(x, y, button="left", clicks=1):

--- a/helpers.py
+++ b/helpers.py
@@ -1,6 +1,7 @@
 """Browser control via CDP. Read, edit, extend -- this file is yours."""
 import base64, json, os, socket, time, urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 def _load_env():
@@ -54,6 +55,39 @@ def page_info():
             expression="JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})",
             returnByValue=True)
     return json.loads(r["result"]["value"])
+
+
+def _domain_skill_candidates(hostname):
+    host = (hostname or "").lower().strip(".")
+    if not host:
+        return []
+    parts = [p for p in host.split(".") if p and p != "www"]
+    if not parts:
+        return []
+    seen, out = set(), []
+    for i in range(len(parts) - 1):
+        candidate = ".".join(parts[i:])
+        if candidate not in seen:
+            seen.add(candidate)
+            out.append(candidate)
+    leaf = parts[0]
+    if leaf not in seen:
+        out.append(leaf)
+    return out
+
+
+def domain_skill_names(url=None, limit=10):
+    """Return up to `limit` Markdown filenames for the current page's matching domain skill directory."""
+    target = url or page_info().get("url", "")
+    host = urlparse(target).hostname
+    root = Path(__file__).parent / "domain-skills"
+    for candidate in _domain_skill_candidates(host):
+        folder = root / candidate
+        if not folder.is_dir():
+            continue
+        files = sorted(p.name for p in folder.rglob("*.md") if p.is_file())
+        return files[:limit]
+    return []
 
 
 # --- input ---


### PR DESCRIPTION
## What changed
- added `domain_skill_names(url=None, limit=10)` to `helpers.py`
- the helper derives the current page's hostname, matches it against `domain-skills/` folders using simple fallback candidates, and returns up to 10 Markdown filenames
- the helper returns only skill names, not file contents

## Why
Agents need a quick way to check whether site-specific domain skills already exist for the current page before doing custom work, without dumping full skill files into the workflow.

## Validation
- verified `domain_skill_names('https://thetechgeeks.com.au/products/x')` returns `['pricing.md']`
- verified `domain_skill_names('https://www.tiktok.com/tiktokstudio/upload')` returns `['upload.md']`
- verified unknown or placeholder-only domains return an empty list

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend goto(url) to include a domain_skills list with up to 10 Markdown skill filenames for the page’s domain, so agents can quickly see site-specific skills. It parses the hostname (removes "www."), checks `domain-skills/<domain-prefix>/`, and returns the list when the directory exists.

<sup>Written for commit ec50d9244efbbe101e0407eed5c932711d4961c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

