### PR TITLE
Add domain skills: GitHub, HN, Product Hunt, Amazon, News, Job Boards

### DIFF
--- a/domain-skills/amazon/product-search.md
+++ b/domain-skills/amazon/product-search.md
@@ -1,0 +1,442 @@
+# Amazon — Product Search & Data Extraction
+
+`https://www.amazon.com` (also `.co.uk`, `.fr`, `.de`, `.co.jp`, `.ca`, `.com.au`)
+
+---
+
+## Do this first: construct URLs directly, don't click the search box
+
+Amazon search URLs are stable and predictable. Build them directly — it's faster and avoids bot-detection on the home page UI.
+
+```python
+query = "mechanical keyboard"
+goto(f"https://www.amazon.com/s?k={query.replace(' ', '+')}")
+wait_for_load()
+```
+
+For product detail pages, go straight to the `/dp/` URL:
+
+```python
+asin = "B08N5WRWNW"
+goto(f"https://www.amazon.com/dp/{asin}")
+wait_for_load()
+```
+
+---
+
+## URL patterns
+
+| Goal | URL pattern |
+|---|---|
+| Keyword search | `/s?k=wireless+earbuds` |
+| Search in department | `/s?k=chair&i=garden` (i= is the department node) |
+| Price range | `/s?k=standing+desk&rh=p_36%3A1000-30000` (cents, e.g. 1000=\$10, 30000=\$300) |
+| Min rating filter | `/s?k=headphones&rh=p_72%3A1248957011` (4+ stars node) |
+| Prime-only | `/s?k=coffee+maker&rh=p_85%3A2470955011` |
+| Combine filters | `/s?k=standing+desk&rh=p_36%3A1000-30000%2Cp_72%3A1248957011` |
+| Product detail | `/dp/{ASIN}` |
+| Best Sellers (root) | `/Best-Sellers/zgbs/` |
+| Best Sellers (category) | `/Best-Sellers/zgbs/electronics/` |
+| Best Sellers (subcategory) | `/Best-Sellers/zgbs/electronics/172541/` (node ID) |
+
+Price range encoding: multiply dollar amount by 100 and encode as `p_36%3A{min}-{max}`. Example: \$50–\$300 → `p_36%3A5000-30000`.
+
+---
+
+## Workflow 1: Search results extraction
+
+### Reliable extraction via `data-asin`
+
+Amazon marks every real result card with `data-asin`. Sponsored results get `data-component-type="sp-sponsored-result"` — filter them out.
+
+```python
+import json
+
+goto("https://www.amazon.com/s?k=mechanical+keyboard")
+wait_for_load()
+wait(2)  # let lazy-loaded price data settle
+
+results = js("""
+(function() {
+  var cards = document.querySelectorAll(
+    '[data-component-type="s-search-result"]:not([data-component-type="sp-sponsored-result"])'
+  );
+  var out = [];
+  for (var i = 0; i < Math.min(cards.length, 10); i++) {
+    var c = cards[i];
+    var asin = c.getAttribute('data-asin') || '';
+    var titleEl = c.querySelector('h2 a span, h2 span');
+    var title = titleEl ? titleEl.innerText.trim() : '';
+    // Price: whole + fraction
+    var whole = c.querySelector('.a-price-whole');
+    var frac  = c.querySelector('.a-price-fraction');
+    var price = (whole && frac)
+      ? ('$' + whole.innerText.replace(',','').replace('.','') + '.' + frac.innerText)
+      : (c.querySelector('.a-price .a-offscreen') || {innerText:''}).innerText.trim();
+    var ratingEl = c.querySelector('i.a-icon-star-small span, i[class*="a-star"] span');
+    var rating = ratingEl ? ratingEl.innerText.trim() : '';
+    var reviewEl = c.querySelector('[aria-label*="stars"] + span, .a-size-base.s-underline-text');
+    var reviews = reviewEl ? reviewEl.innerText.replace(/,/g,'').trim() : '';
+    var prime = !!c.querySelector('[aria-label="Amazon Prime"], .s-prime');
+    out.push({asin, title, price, rating, reviews, prime});
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+products = json.loads(results)
+for p in products:
+    print(p)
+```
+
+### ASIN from URL (search results page)
+
+Each result card's "a" link encodes the ASIN:
+
+```python
+asins = js("""
+JSON.stringify(
+  Array.from(document.querySelectorAll('[data-asin]'))
+    .map(el => el.getAttribute('data-asin'))
+    .filter(a => a && a.length === 10)
+    .filter((a, i, arr) => arr.indexOf(a) === i)  // dedupe
+)
+""")
+# e.g. ["B09XLNBM3B", "B07WRXDH2P", ...]
+```
+
+---
+
+## Workflow 2: Product detail page extraction (`/dp/{ASIN}`)
+
+```python
+import json, re
+
+asin = "B07XJ8C8F7"
+goto(f"https://www.amazon.com/dp/{asin}")
+wait_for_load()
+wait(2)
+
+detail = js("""
+(function() {
+  // Title
+  var titleEl = document.getElementById('productTitle');
+  var title = titleEl ? titleEl.innerText.trim() : '';
+
+  // Price — multiple possible locations
+  var priceEl = (
+    document.getElementById('priceblock_ourprice') ||
+    document.getElementById('priceblock_dealprice') ||
+    document.querySelector('.a-price .a-offscreen') ||
+    document.querySelector('#corePriceDisplay_desktop_feature_div .a-price .a-offscreen') ||
+    document.querySelector('#apex_offerDisplay_desktop .a-price .a-offscreen')
+  );
+  var price = priceEl ? priceEl.innerText.trim() : '';
+
+  // Rating
+  var ratingEl = document.getElementById('acrPopover');
+  var rating = ratingEl ? (ratingEl.getAttribute('title') || '').trim() : '';
+
+  // Review count
+  var reviewEl = document.getElementById('acrCustomerReviewText');
+  var reviews = reviewEl ? reviewEl.innerText.replace(/[^0-9]/g,'') : '';
+
+  // Availability
+  var availEl = document.getElementById('availability');
+  var availability = availEl ? availEl.innerText.trim() : '';
+
+  // Bullet points (feature list)
+  var bullets = Array.from(document.querySelectorAll('#feature-bullets li span.a-list-item'))
+    .map(el => el.innerText.trim())
+    .filter(t => t.length > 0);
+
+  return JSON.stringify({title, price, rating, reviews: parseInt(reviews)||0, availability, bullets});
+})()
+""")
+
+info = json.loads(detail)
+print(info)
+```
+
+### Availability string patterns
+
+```python
+avail = info["availability"]
+if "In Stock" in avail:
+    status = "in_stock"
+elif re.search(r"Only \d+ left", avail):
+    n = re.search(r"(\d+)", avail).group(1)
+    status = f"low_stock_{n}"
+elif "Usually ships" in avail:
+    status = "ships_delayed"
+elif "Unavailable" in avail or "Currently unavailable" in avail:
+    status = "out_of_stock"
+else:
+    status = "unknown"
+```
+
+---
+
+## Workflow 3: Price checking by ASIN (fast, no browser)
+
+For a single known ASIN, `http_get` is usually sufficient and avoids CAPTCHA risk:
+
+```python
+import re
+
+asin = "B08N5WRWNW"
+html = http_get(
+    f"https://www.amazon.com/dp/{asin}",
+    headers={"Accept-Language": "en-US,en;q=0.9"}
+)
+
+# Extract title
+title_m = re.search(r'id="productTitle"[^>]*>\s*([^<]+)', html)
+title = title_m.group(1).strip() if title_m else "N/A"
+
+# Extract price (offscreen span is most reliable in raw HTML)
+price_m = re.search(r'class="a-offscreen">([^<]+)</span>', html)
+price = price_m.group(1).strip() if price_m else "N/A"
+
+print(f"{asin}: {title} — {price}")
+```
+
+If `http_get` returns a CAPTCHA page (check `"captcha" in html.lower()`), fall back to the browser path (goto + wait_for_load + js extraction above).
+
+```python
+if "captcha" in html.lower() or "Type the characters" in html:
+    # Fall back to browser
+    goto(f"https://www.amazon.com/dp/{asin}")
+    wait_for_load()
+    wait(2)
+    # ... use js() extraction from Workflow 2
+```
+
+---
+
+## Workflow 4: Best Sellers extraction
+
+```python
+import json
+
+category_path = "electronics"   # or "computers", "books", etc.
+goto(f"https://www.amazon.com/Best-Sellers/zgbs/{category_path}/")
+wait_for_load()
+wait(2)
+
+bestsellers = js("""
+(function() {
+  var items = document.querySelectorAll(
+    '#zg-ordered-list li, .zg-item-immersion'
+  );
+  var out = [];
+  for (var i = 0; i < Math.min(items.length, 10); i++) {
+    var el = items[i];
+    var rank = i + 1;
+    var titleEl = el.querySelector('.zg-bdg-text, ._cDEzb_p13n-sc-css-line-clamp-3_g3dy1, .p13n-sc-truncated');
+    var title = titleEl ? titleEl.innerText.trim() : '';
+    var priceEl = el.querySelector('.p13n-sc-price, ._cDEzb_p13n-sc-price_3mJ9Z');
+    var price = priceEl ? priceEl.innerText.trim() : '';
+    var ratingEl = el.querySelector('.a-icon-star-small span, .a-icon-star span');
+    var rating = ratingEl ? ratingEl.innerText.trim() : '';
+    var linkEl = el.querySelector('a.a-link-normal[href*="/dp/"]');
+    var href = linkEl ? linkEl.href : '';
+    var asinM = href.match(/\/dp\/([A-Z0-9]{10})/);
+    var asin = asinM ? asinM[1] : '';
+    if (title) out.push({rank, asin, title, price, rating});
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+items = json.loads(bestsellers)
+for item in items:
+    print(item)
+```
+
+Best Sellers pages paginate in two columns — if `items` is empty, the page may use a different layout. Take a screenshot to confirm:
+
+```python
+screenshot()  # inspect layout before tuning selectors
+```
+
+---
+
+## Workflow 5: Multi-page search (pagination)
+
+Amazon search results have a "Next" button. Extract the URL from it rather than incrementing a page counter (page numbers can be non-linear after filter application):
+
+```python
+import json
+
+all_results = []
+goto("https://www.amazon.com/s?k=standing+desk&rh=p_36%3A1000-30000")
+wait_for_load()
+wait(2)
+
+for page_num in range(1, 6):  # up to 5 pages
+    # extract current page results (same JS as Workflow 1)
+    batch = json.loads(js("""
+    (function() {
+      var cards = document.querySelectorAll('[data-component-type="s-search-result"]');
+      var out = [];
+      cards.forEach(function(c) {
+        var asin = c.getAttribute('data-asin') || '';
+        var titleEl = c.querySelector('h2 a span');
+        var title = titleEl ? titleEl.innerText.trim() : '';
+        var priceEl = c.querySelector('.a-price .a-offscreen');
+        var price = priceEl ? priceEl.innerText.trim() : '';
+        if (asin && title) out.push({asin, title, price});
+      });
+      return JSON.stringify(out);
+    })()
+    """))
+    all_results.extend(batch)
+
+    # get next page URL
+    next_url = js("""
+      var n = document.querySelector('.s-pagination-next:not(.s-pagination-disabled)');
+      n ? n.href : null
+    """)
+    if not next_url:
+        break
+
+    goto(next_url)
+    wait_for_load()
+    wait(2)  # respect rate limit between pages
+
+print(f"Total results collected: {len(all_results)}")
+```
+
+---
+
+## Workflow 6: Add to cart (requires logged-in session)
+
+This only works when Chrome already has an active Amazon session.
+
+```python
+asin = "B09XLNBM3B"
+goto(f"https://www.amazon.com/dp/{asin}")
+wait_for_load()
+wait(2)
+
+# Verify not a CAPTCHA or login redirect
+url = page_info()["url"]
+if "signin" in url or "ap/signin" in url:
+    raise RuntimeError("Not logged in — open Amazon and sign in first")
+
+# Take screenshot to find Add to Cart button location
+screenshot()
+
+# Click "Add to Cart" (coordinate from screenshot — typically center of page, ~y=400-600)
+# Use JS to click it reliably if coordinates are uncertain
+added = js("""
+(function() {
+  var btn = (
+    document.getElementById('add-to-cart-button') ||
+    document.querySelector('input[name="submit.add-to-cart"]') ||
+    document.querySelector('input[id*="add-to-cart"]')
+  );
+  if (!btn) return 'not_found';
+  btn.click();
+  return 'clicked';
+})()
+""")
+
+wait(3)
+wait_for_load()
+
+# Confirm: cart overlay or redirect to cart page
+url_after = page_info()["url"]
+confirmation = js("document.querySelector('#NATC_SMART_WAGON_CONF_MSG_SUCCESS, #sw-atc-confirmation') ? 'success' : 'check_page'")
+print(f"Result: {added}, {confirmation}, URL: {url_after}")
+```
+
+---
+
+## ASIN extraction patterns
+
+ASINs are always 10 characters, uppercase letters and digits. Three reliable sources:
+
+```python
+import re
+
+# 1. From the current page URL
+asin_from_url = re.search(r'/dp/([A-Z0-9]{10})', page_info()["url"])
+asin = asin_from_url.group(1) if asin_from_url else None
+
+# 2. From a card's data-asin attribute
+asin = js("document.querySelector('[data-asin]').getAttribute('data-asin')")
+
+# 3. From raw HTML or href text
+asins_in_html = re.findall(r'/dp/([A-Z0-9]{10})', some_html_string)
+```
+
+---
+
+## Price format handling
+
+Amazon serves prices in several formats — handle all of them:
+
+```python
+import re
+
+def parse_price(raw: str) -> float | None:
+    """Normalize any Amazon price string to a float, or None if missing."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    # "from $12.99" → strip "from"
+    raw = re.sub(r'(?i)^from\s+', '', raw)
+    # "$1,299.00" or "$12.99" or "$12" (no cents)
+    m = re.search(r'\$?([\d,]+)\.?(\d{0,2})', raw.replace(',', ''))
+    if not m:
+        return None
+    dollars = m.group(1).replace(',', '')
+    cents = m.group(2).ljust(2, '0') if m.group(2) else '00'
+    try:
+        return float(f"{dollars}.{cents}")
+    except ValueError:
+        return None
+
+# Price can also come split across two DOM elements:
+#   .a-price-whole = "12." (trailing dot)
+#   .a-price-fraction = "99"
+# In that case: float(whole.rstrip('.') + '.' + frac)
+```
+
+---
+
+## Gotchas
+
+- **CAPTCHA wall** — Amazon detects rapid automated requests. Symptoms: page title is "Robot Check" or "CAPTCHA", body contains "Type the characters". Always `wait(2)` between page loads. If hit, take a `screenshot()` — sometimes the CAPTCHA is solvable visually. For bulk scraping, use `http_get` in a `ThreadPoolExecutor` with at most 3-5 concurrent requests.
+
+  ```python
+  def is_captcha(html: str) -> bool:
+      return "Type the characters" in html or "captcha" in html.lower() or "Robot Check" in html
+  ```
+
+- **Login-gated prices** — Some prices only show after sign-in (Prime pricing, business pricing, Warehouse Deals). If `price == ""` but the product exists, you are seeing the logged-out view. The `http_get` path is more likely to hit this than the browser path.
+
+- **Split dollar/cents DOM structure** — The `.a-price` container splits into `.a-price-whole` (e.g. `"299."`) and `.a-price-fraction` (e.g. `"99"`). The `.a-offscreen` child has the full combined string and is the most reliable single target.
+
+- **"Sponsored" results at the top** — Filter with `:not([data-component-type="sp-sponsored-result"])`. Sponsored cards still have `data-asin` set, so ASIN-only extraction picks them up unless filtered.
+
+- **Third-party seller prices absent until cart** — For listings fulfilled by third-party sellers, the price element may be empty. The page shows "See price in cart" — this is intentional, not a scraping failure.
+
+- **Review count formatting** — Amazon renders `"1,234 ratings"`. Strip commas before `int()`:
+  ```python
+  count = int(review_text.replace(",", "").split()[0])
+  ```
+
+- **Best Sellers layout shift** — The Best Sellers page has redesigned its layout multiple times. If the `#zg-ordered-list` selector misses, fall back to `.zg-item-immersion` or take a screenshot and re-inspect. The ASIN is always extractable from `href` links containing `/dp/`.
+
+- **TLD differences** — Prices, availability text, and some DOM IDs differ by country. The `.a-price .a-offscreen` pattern is reliable cross-TLD. For `.co.uk`, `.de`, `.fr`, `.co.jp` — replace the base URL; product data structure is the same. Currency symbols change (`£`, `€`, `¥`).
+
+- **Dynamic price loading** — Some product pages load price via XHR after DOMContentLoaded. `wait_for_load()` alone is not enough — add `wait(2)` after it before running JS extraction.
+
+- **Page variants** — Amazon A/B tests layouts constantly. If extraction returns empty strings, `screenshot()` immediately to see actual page state. Selectors documented here reflect the most common variant as of early 2026.
+
+- **Robot detection escalation** — If requests succeed but return increasingly sparse data (no prices, empty titles), Amazon may be in a soft-block state serving degraded content. Take a screenshot, check the actual page, and add more `wait()` between requests.
+
+- **`data-component-type` is not always present** — On some search result pages (especially category browse pages reached via `/s?i=...`), `data-component-type` is absent. Fall back to `[data-asin]` directly and tolerate empty fields.

--- a/domain-skills/github/scraping.md
+++ b/domain-skills/github/scraping.md
@@ -1,0 +1,294 @@
+# GitHub — Scraping public data
+
+`https://github.com` and `https://api.github.com` — public repo metadata, user profiles, trending pages, releases, and README content.
+
+## Do this first
+
+**Use the REST API with `http_get`, not the browser.** For anything that has an API endpoint (repo metadata, user profiles, releases, tags, README), a single `http_get` call replaces `goto + wait_for_load + screenshot + js`. The browser is only needed for pages that render client-side without a JSON equivalent (trending page, search results with JS filtering).
+
+```python
+import json, os
+
+def gh_get(path, token=None):
+    headers = {"Accept": "application/vnd.github+json"}
+    tok = token or os.environ.get("GITHUB_TOKEN")
+    if tok:
+        headers["Authorization"] = f"token {tok}"
+    return json.loads(http_get(f"https://api.github.com{path}", headers=headers))
+
+# Repo metadata — stars, forks, description, topics, language, license
+repo = gh_get("/repos/browser-use/browser-use")
+print(repo["stargazers_count"], repo["forks_count"], repo["description"])
+```
+
+Unauthenticated: **60 requests/hour** per IP. With a token: **5000/hour**. Always check `X-RateLimit-Remaining` before looping.
+
+---
+
+## Common workflows
+
+### 1. Trending repositories (browser required)
+
+The trending page (`https://github.com/trending`) is rendered client-side — `http_get` returns a skeleton with no repo data. Use the browser.
+
+```python
+goto("https://github.com/trending")
+wait_for_load()
+
+# Optional: filter by language and period via URL params
+# goto("https://github.com/trending/python?since=weekly")
+# goto("https://github.com/trending/typescript?since=daily")
+
+repos = js("""
+(function() {
+  var rows = document.querySelectorAll('article.Box-row');
+  return Array.from(rows).map(function(row) {
+    var nameEl = row.querySelector('h2 a');
+    var descEl = row.querySelector('p');
+    var starsEl = row.querySelector('a[href$="/stargazers"]');
+    var forksEl = row.querySelector('a[href$="/forks"]');
+    var langEl  = row.querySelector('[itemprop="programmingLanguage"]');
+    var todayEl = row.querySelector('.float-sm-right');
+    return {
+      full_name:   nameEl ? nameEl.getAttribute('href').slice(1) : null,
+      url:         nameEl ? 'https://github.com' + nameEl.getAttribute('href') : null,
+      description: descEl ? descEl.textContent.trim() : null,
+      stars:       starsEl ? starsEl.textContent.trim() : null,
+      forks:       forksEl ? forksEl.textContent.trim() : null,
+      language:    langEl  ? langEl.textContent.trim() : null,
+      stars_today: todayEl ? todayEl.textContent.trim() : null,
+    };
+  });
+})()
+""")
+print(repos[:10])
+```
+
+**Note:** `stars` from the DOM will be "1.2k" not `1234`. Use the API for exact counts if you need them:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+def enrich(repo):
+    data = gh_get(f"/repos/{repo['full_name']}")
+    repo["stars_exact"] = data["stargazers_count"]
+    repo["forks_exact"] = data["forks_count"]
+    return repo
+
+with ThreadPoolExecutor(max_workers=8) as ex:
+    enriched = list(ex.map(enrich, repos))
+```
+
+---
+
+### 2. User profile — followers, bio, public repos
+
+```python
+# API (preferred)
+user = gh_get("/users/Archish27")
+print(user["followers"])       # int, exact
+print(user["following"])
+print(user["public_repos"])
+print(user["bio"])
+print(user["avatar_url"])
+print(user["blog"])            # personal site if set
+print(user["company"])
+print(user["location"])
+```
+
+Fields always present: `login`, `id`, `avatar_url`, `html_url`, `type`, `public_repos`, `public_gists`, `followers`, `following`, `created_at`, `updated_at`.
+
+---
+
+### 3. Repository metadata — stars, forks, topics, language
+
+```python
+repo = gh_get("/repos/n4ze3m/page-assist")
+
+print({
+    "stars":       repo["stargazers_count"],
+    "forks":       repo["forks_count"],
+    "watchers":    repo["watchers_count"],
+    "open_issues": repo["open_issues_count"],
+    "language":    repo["language"],          # primary language
+    "topics":      repo["topics"],            # list[str]
+    "license":     repo["license"]["name"] if repo["license"] else None,
+    "description": repo["description"],
+    "created_at":  repo["created_at"],
+    "pushed_at":   repo["pushed_at"],         # last commit time
+    "default_branch": repo["default_branch"],
+    "archived":    repo["archived"],
+})
+```
+
+---
+
+### 4. README content
+
+```python
+import base64
+
+readme = gh_get("/repos/browser-use/browser-use/readme")
+# content is base64-encoded
+text = base64.b64decode(readme["content"]).decode("utf-8")
+print(text[:2000])
+```
+
+Alternatively, raw markdown (no auth needed, no rate limit from the API quota):
+
+```python
+raw = http_get("https://raw.githubusercontent.com/browser-use/browser-use/main/README.md")
+print(raw[:2000])
+```
+
+`raw.githubusercontent.com` is a plain CDN — not rate-limited like the API. Prefer it for README-only tasks.
+
+---
+
+### 5. Latest releases and tags
+
+```python
+# Latest release (published, non-prerelease)
+release = gh_get("/repos/owner/repo/releases/latest")
+print(release["tag_name"])      # e.g. "v1.2.3"
+print(release["name"])          # release title
+print(release["body"])          # release notes (markdown)
+print(release["published_at"])
+print(release["html_url"])
+
+# Assets (download URLs)
+for asset in release["assets"]:
+    print(asset["name"], asset["browser_download_url"])
+
+# All releases (paginated)
+releases = gh_get("/repos/owner/repo/releases?per_page=10")
+for r in releases:
+    print(r["tag_name"], r["published_at"], r["prerelease"])
+
+# Tags (lighter — no release notes)
+tags = gh_get("/repos/owner/repo/tags?per_page=10")
+for t in tags:
+    print(t["name"], t["commit"]["sha"])
+```
+
+---
+
+### 6. Parallel multi-repo fetch
+
+```python
+import json, os
+from concurrent.futures import ThreadPoolExecutor
+
+repos_to_check = [
+    "browser-use/browser-use",
+    "n4ze3m/page-assist",
+    "microsoft/vscode",
+]
+
+def fetch_repo(full_name):
+    try:
+        return gh_get(f"/repos/{full_name}")
+    except Exception as e:
+        return {"full_name": full_name, "error": str(e)}
+
+with ThreadPoolExecutor(max_workers=10) as ex:
+    results = list(ex.map(fetch_repo, repos_to_check))
+
+for r in results:
+    if "error" not in r:
+        print(r["full_name"], r["stargazers_count"])
+```
+
+---
+
+### 7. Most starred repos for a language (Search API)
+
+```python
+# Top Python repos by stars from the past week
+import urllib.parse
+
+q = urllib.parse.quote("language:python created:>2026-04-11")
+results = gh_get(f"/search/repositories?q={q}&sort=stars&order=desc&per_page=10")
+for item in results["items"]:
+    print(item["full_name"], item["stargazers_count"])
+```
+
+Search API counts against rate limits more aggressively — **30 requests/min** unauthenticated, **30/min** authenticated (same for search). Add a `GITHUB_TOKEN` to avoid 422/403 on busy loops.
+
+---
+
+## When to use the browser vs pure HTTP
+
+| Task | Method |
+|---|---|
+| Repo metadata (stars, forks, desc, topics) | `http_get` → API |
+| User profile (followers, bio, avatar) | `http_get` → API |
+| README text | `http_get` → raw CDN |
+| Latest release / tags | `http_get` → API |
+| Trending page (all languages) | Browser (`goto` + `js`) |
+| Trending page filtered by language | Browser (`goto` + `js`) |
+| Search results with JS-driven filters | Browser |
+| Paginated issue / PR lists | `http_get` → API (`?page=N&per_page=100`) |
+| File contents in a repo | `http_get` → `raw.githubusercontent.com` |
+| Private repos | Browser (authenticated session) OR API with token |
+
+---
+
+## Gotchas
+
+- **Unauthenticated rate limit is 60 req/hr total per IP** — not per endpoint. A loop over 70 repos will hit it. Set `GITHUB_TOKEN` in `.env` or the environment:
+
+  ```python
+  import os
+  # Set once; gh_get() picks it up automatically via os.environ.get("GITHUB_TOKEN")
+  # Don't hardcode the token in scripts
+  ```
+
+- **Trending page needs the browser, not `http_get`.** `http_get("https://github.com/trending")` returns the HTML skeleton; the repo list is injected by a React bundle after `DOMContentLoaded`. Always use `goto` + `wait_for_load` + `js(...)`.
+
+- **Star counts in the trending DOM are formatted strings ("1.2k", "23.4k"), not integers.** Use the API if you need exact numbers. Quick parser if you only have DOM values:
+
+  ```python
+  def parse_stars(s):
+      s = s.strip().replace(",", "")
+      if s.endswith("k"):
+          return int(float(s[:-1]) * 1000)
+      return int(s)
+  ```
+
+- **The trending page `article.Box-row` selector is stable as of 2026-04** but GitHub redesigns without notice. If `js(...)` returns an empty list, `screenshot()` to see the current DOM structure and update the selector.
+
+- **`/repos/{owner}/{repo}` 404s if the repo is private or deleted** — wrap in try/except and check `response["message"]`.
+
+- **Search API has a separate lower rate limit (30/min) and requires queries to have at least one qualifier.** `q=stars:>1000` works; `q=` alone returns a 422.
+
+- **`raw.githubusercontent.com` is NOT rate-limited by the GitHub API quota** — use it freely for file content, README, and configs. It's a CDN, not the API gateway.
+
+- **Pagination:** API endpoints default to `per_page=30`, max `per_page=100`. For full lists:
+
+  ```python
+  def paginate(path):
+      results, page = [], 1
+      while True:
+          sep = "&" if "?" in path else "?"
+          batch = gh_get(f"{path}{sep}per_page=100&page={page}")
+          if not batch:
+              break
+          results.extend(batch)
+          if len(batch) < 100:
+              break
+          page += 1
+      return results
+
+  all_releases = paginate("/repos/owner/repo/releases")
+  ```
+
+- **GraphQL API** (not shown above) at `https://api.github.com/graphql` supports batching many repos in one request — worth it if you're pulling data for 50+ repos and want to stay under rate limits. Requires a token with appropriate scopes.
+
+- **Lazy loading on long repo lists in the browser:** GitHub infinite-scrolls contributor lists and file trees. If `js(...)` returns fewer items than expected, scroll first:
+
+  ```python
+  scroll(760, 400, dy=3000)
+  wait(1.5)
+  # then re-run the js() extraction
+  ```

--- a/domain-skills/hackernews/scraping.md
+++ b/domain-skills/hackernews/scraping.md
@@ -1,0 +1,274 @@
+# Hacker News — Scraping Stories, Comments & Search
+
+`https://news.ycombinator.com` — Classic server-rendered HTML tables. No JS required to render content.
+
+## Do this first
+
+**Use HTTP, not the browser.** HN is pure server-rendered HTML — all story data is in the raw source. `http_get` is 10–20x faster than `goto + wait_for_load`, and there is no rate-limited API to worry about for basic reads.
+
+```python
+html = http_get("https://news.ycombinator.com")
+# Full front-page HTML — stories are in <tr class="athing"> rows
+```
+
+Never open the browser for front-page or listing reads. Reserve `goto` for interactive tasks only (e.g. submitting a comment, logging in).
+
+---
+
+## Approach 1 — Front-page and listing pages (JS extraction)
+
+HN's DOM is a plain HTML table. After `http_get`, evaluate JS selectors against the raw HTML via `js()` **if you're already in a browser session**, or parse with a lightweight regex approach for pure-HTTP tasks.
+
+### Using `js()` after `goto` (when a browser session is already open)
+
+```python
+goto("https://news.ycombinator.com")
+wait_for_load()
+
+stories = js("""
+(() => {
+  const rows = document.querySelectorAll('tr.athing');
+  return Array.from(rows).map(row => {
+    const titleAnchor = row.querySelector('span.titleline > a');
+    const subRow      = row.nextElementSibling;
+    const scoreEl     = subRow && subRow.querySelector('span.score');
+    const authorEl    = subRow && subRow.querySelector('a.hnuser');
+    const ageEl       = subRow && subRow.querySelector('span.age a');
+    const commentsEl  = subRow && [...subRow.querySelectorAll('a')]
+                          .find(a => a.textContent.includes('comment'));
+    return {
+      id:       row.getAttribute('id'),
+      title:    titleAnchor ? titleAnchor.textContent.trim() : '',
+      url:      titleAnchor ? titleAnchor.href : '',
+      points:   scoreEl    ? parseInt(scoreEl.textContent)  : 0,
+      author:   authorEl   ? authorEl.textContent.trim()    : '',
+      age:      ageEl      ? ageEl.textContent.trim()       : '',
+      comments: commentsEl ? parseInt(commentsEl.textContent) : 0,
+    };
+  });
+})()
+""")
+# returns a list of dicts, one per story (up to 30 per page)
+```
+
+### Using pure `http_get` + Python regex (no browser needed)
+
+```python
+import re, json
+
+def parse_hn_page(url):
+    html = http_get(url)
+
+    # Each story block: <tr class="athing" id="STORY_ID">
+    athing_ids = re.findall(r'<tr class="athing" id="(\d+)">', html)
+
+    # Title + URL: <span class="titleline"><a href="URL">TITLE</a>
+    title_urls = re.findall(
+        r'<span class="titleline"><a href="([^"]*)"[^>]*>([^<]+)</a>', html
+    )
+
+    # Points: <span class="score" id="score_STORYID">N points</span>
+    scores = re.findall(r'<span class="score"[^>]*>(\d+) points?</span>', html)
+
+    # Author: <a class="hnuser" href="user?id=USERNAME">USERNAME</a>
+    authors = re.findall(r'<a class="hnuser"[^>]*>([^<]+)</a>', html)
+
+    # Comment counts: last <a> in subrow, text like "42\xa0comments"
+    comments = re.findall(
+        r'(\d+)&nbsp;comment', html
+    )
+
+    stories = []
+    for i, sid in enumerate(athing_ids):
+        url_raw, title = title_urls[i] if i < len(title_urls) else ('', '')
+        # HN "text posts" have relative URLs like "item?id=..."
+        full_url = (
+            url_raw if url_raw.startswith('http')
+            else f"https://news.ycombinator.com/{url_raw}"
+        )
+        stories.append({
+            'id':       sid,
+            'title':    title,
+            'url':      full_url,
+            'points':   int(scores[i])   if i < len(scores)   else 0,
+            'author':   authors[i]       if i < len(authors)   else '',
+            'comments': int(comments[i]) if i < len(comments) else 0,
+        })
+    return stories
+
+top_stories = parse_hn_page("https://news.ycombinator.com")
+```
+
+---
+
+## Approach 2 — Algolia HN Search API (best for search + date filtering)
+
+The Algolia API is the fastest way to search HN by keyword, filter by date, or get stories above a points threshold. No HTML parsing needed.
+
+Base URL: `http://hn.algolia.com/api/v1/search`
+
+```python
+import json, time
+
+def hn_search(query, tags="story", min_points=0, since_hours=24, num=10):
+    """
+    Search HN stories via Algolia.
+    tags: "story" | "ask_hn" | "show_hn" | "comment" | "poll"
+    """
+    since_ts = int(time.time()) - since_hours * 3600
+    params = (
+        f"query={query}"
+        f"&tags={tags}"
+        f"&numericFilters=points>{min_points},created_at_i>{since_ts}"
+        f"&hitsPerPage={num}"
+    )
+    resp = http_get(f"http://hn.algolia.com/api/v1/search?{params}")
+    data = json.loads(resp)
+    return [
+        {
+            'objectID': h['objectID'],           # story ID
+            'title':    h.get('title', ''),
+            'url':      h.get('url') or f"https://news.ycombinator.com/item?id={h['objectID']}",
+            'points':   h.get('points', 0),
+            'author':   h.get('author', ''),
+            'comments': h.get('num_comments', 0),
+            'created':  h.get('created_at', ''),  # ISO 8601 string
+            'created_ts': h.get('created_at_i', 0),  # Unix timestamp
+        }
+        for h in data.get('hits', [])
+    ]
+
+# Examples:
+results = hn_search("AI agents", since_hours=24, min_points=10, num=20)
+results = hn_search("", tags="show_hn", since_hours=48, num=10)  # top Show HN last 48h
+results = hn_search("Rust", tags="story", min_points=100, num=5)  # high-signal Rust posts
+```
+
+Use `search_by_date` endpoint instead of `search` to sort by recency rather than relevance:
+
+```python
+resp = http_get(
+    "http://hn.algolia.com/api/v1/search_by_date"
+    "?query=python&tags=story&hitsPerPage=10"
+)
+```
+
+---
+
+## Common workflows
+
+### Top N stories from front page
+
+```python
+stories = parse_hn_page("https://news.ycombinator.com")
+top3 = stories[:3]
+# Each dict: {id, title, url, points, author, comments}
+```
+
+### Show HN extraction
+
+```python
+stories = parse_hn_page("https://news.ycombinator.com/show")
+top10 = stories[:10]
+```
+
+### Ask HN extraction
+
+```python
+stories = parse_hn_page("https://news.ycombinator.com/ask")
+top5 = stories[:5]
+```
+
+### Page 2 (stories 31–60)
+
+```python
+page2 = parse_hn_page("https://news.ycombinator.com/?p=2")
+```
+
+### Monitor for topic in last 24 hours
+
+```python
+# Preferred: Algolia API — no scraping, timestamp-accurate
+hits = hn_search("postgres", since_hours=24, min_points=0, num=30)
+matching = [h for h in hits if h['points'] > 5]  # filter noise
+```
+
+### Get comments from a thread
+
+```python
+import re
+
+def get_hn_comments(item_id, max_comments=20):
+    html = http_get(f"https://news.ycombinator.com/item?id={item_id}")
+
+    # Comment text is inside <span class="commtext ...">
+    texts = re.findall(
+        r'<span class="commtext[^"]*">(.*?)</span>\s*</div>',
+        html, re.DOTALL
+    )
+    # Strip inline HTML tags for plain text
+    def strip_tags(s):
+        return re.sub(r'<[^>]+>', '', s).strip()
+
+    # Authors per comment: <a class="hnuser" ...>USERNAME</a>
+    authors = re.findall(r'<a class="hnuser"[^>]*>([^<]+)</a>', html)
+    # First author is story submitter — skip it for comment authors
+    comment_authors = authors[1:]
+
+    comments = []
+    for i, text in enumerate(texts[:max_comments]):
+        comments.append({
+            'author': comment_authors[i] if i < len(comment_authors) else '',
+            'text':   strip_tags(text),
+        })
+    return comments
+
+comments = get_hn_comments("43567890")
+```
+
+For deep thread extraction (nested replies, vote counts), use the Algolia Items API — it returns the full thread as JSON:
+
+```python
+import json
+
+def get_thread_algolia(item_id):
+    resp = http_get(f"http://hn.algolia.com/api/v1/items/{item_id}")
+    return json.loads(resp)
+    # Top-level keys: id, title, url, points, author, children (list of comment dicts)
+
+thread = get_thread_algolia("43567890")
+top_comments = thread.get('children', [])[:10]
+```
+
+### Export to CSV
+
+```python
+import csv, io
+
+def stories_to_csv(stories):
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=['title', 'url', 'points', 'author', 'comments'])
+    w.writeheader()
+    w.writerows(stories)
+    return buf.getvalue()
+
+csv_text = stories_to_csv(top10)
+# Write to file:
+with open("/tmp/hn_show.csv", "w") as f:
+    f.write(csv_text)
+```
+
+---
+
+## Gotchas
+
+- **30 items per page** — HN hard-caps each listing to 30 stories. Use `?p=2`, `?p=3` etc. to paginate. The next-page link also carries a `?fnid=` token on some endpoints (Best, Active), which changes each page load — safer to use `?p=N` where it works.
+- **Story URLs can be relative** — "Ask HN" and "text posts" set `href="item?id=XXXXXXX"` (no leading slash). Always check `url.startswith('http')` and prepend `https://news.ycombinator.com/` if not.
+- **Points vs score** — the `<span class="score">` element shows "N points" (plural even for 1). Parse with `int(re.search(r'(\d+)', score_text).group(1))`. Jobs posts and some flagged posts have no score element at all.
+- **Comment count text** — uses a non-breaking space (`\xa0` / `&nbsp;`): `"42\xa0comments"`. Use `int(re.search(r'(\d+)', text).group(1))` to parse safely. Posts with zero comments show "discuss" not "0 comments" — handle that case.
+- **Algolia timestamps are Unix integers** — `created_at_i` is a Unix timestamp (seconds). `created_at` is ISO 8601. Convert: `datetime.utcfromtimestamp(h['created_at_i'])`.
+- **Algolia `url` field is None for text posts** — `h.get('url')` returns `None` for Ask/Show HN posts that have no external link. Always fall back: `h.get('url') or f"https://news.ycombinator.com/item?id={h['objectID']}"`.
+- **Rate limiting** — HN has no official rate limit for reads, but aggressive scraping will get you temporarily 503'd. One request per second is safe. For bulk work, the Algolia API is more tolerant than scraping HN directly.
+- **Dead/flagged stories** — `[dead]` or `[flagged]` stories appear in the HTML but have no score element and no author link. They show up as empty fields in regex parses — filter with `if s['title']` before returning results.
+- **"More" link at page bottom is not reliable for automation** — it uses `?fnid=` tokens that expire. Use explicit `?p=N` pagination instead.
+- **Browser not needed** — HN has zero JS-rendered content. Every story, comment, and score is in the initial HTML. Never use `goto + wait_for_load + screenshot` for read-only HN tasks.

--- a/domain-skills/job-boards/indeed-glassdoor.md
+++ b/domain-skills/job-boards/indeed-glassdoor.md
@@ -1,0 +1,1021 @@
+# Job Boards — Indeed, Glassdoor, Stepstone
+
+Covers: `indeed.com`, `glassdoor.com`, `stepstone.de`
+
+---
+
+## Do this first: construct search URLs directly
+
+Never type into the search box on the homepage — bot detection triggers immediately. Build search URLs directly and navigate straight to results.
+
+```python
+from urllib.parse import quote_plus
+
+# Indeed — English (US)
+query, location = "Python developer", "San Francisco"
+goto(f"https://www.indeed.com/jobs?q={quote_plus(query)}&l={quote_plus(location)}")
+wait_for_load()
+wait(2)
+
+# Indeed — last 24 hours
+goto(f"https://www.indeed.com/jobs?q={quote_plus(query)}&l={quote_plus(location)}&fromage=1")
+wait_for_load()
+wait(2)
+
+# Glassdoor — public search (no login required for result cards)
+goto(f"https://www.glassdoor.com/Job/jobs.htm?sc.keyword={quote_plus(query)}")
+wait_for_load()
+wait(2)
+
+# Stepstone (Germany)
+keyword, city = "Data Scientist", "Berlin"
+goto(f"https://www.stepstone.de/jobs/{quote_plus(keyword)}/in-{quote_plus(city)}.html")
+wait_for_load()
+wait(2)
+```
+
+---
+
+## URL patterns
+
+### Indeed
+
+| Goal | URL pattern |
+|---|---|
+| Keyword + location | `/jobs?q={title}&l={location}` |
+| Last 24 hours | `/jobs?q={title}&l={location}&fromage=1` |
+| Last 3 days | `/jobs?q={title}&l={location}&fromage=3` |
+| Last week | `/jobs?q={title}&l={location}&fromage=7` |
+| Remote only | `/jobs?q={title}&remotejob=032b3046-06a3-4876-8dfd-474eb5e7ed11` |
+| Full-time only | `/jobs?q={title}&l={location}&jt=fulltime` |
+| Part-time | `/jobs?q={title}&l={location}&jt=parttime` |
+| With salary | `/jobs?q={title}&l={location}&rbl=%24{min}%2B` |
+| Page 2 (results 11-20) | append `&start=10` |
+| Page 3 (results 21-30) | append `&start=20` |
+| Job detail page | `https://www.indeed.com/viewjob?jk={job_key}` |
+
+**Indeed country variants**: `.co.uk`, `.de`, `.fr`, `.com.au` — same URL structure, different base domain.
+
+### Glassdoor
+
+| Goal | URL pattern |
+|---|---|
+| Keyword search | `/Job/jobs.htm?sc.keyword={title}` |
+| Keyword + city name | `/Job/jobs.htm?sc.keyword={title}&locT=C&locKeyword={city}` |
+| Remote filter | `/Job/jobs.htm?sc.keyword={title}&remoteWorkType=1` |
+| Next page | append `&p=2`, `&p=3` |
+
+### Stepstone (Germany)
+
+| Goal | URL pattern |
+|---|---|
+| Keyword in city | `/jobs/{keyword}/in-{city}.html` |
+| Page 2 | `/jobs/{keyword}/in-{city}/page-2.html` |
+| Page 3 | `/jobs/{keyword}/in-{city}/page-3.html` |
+| Full-time | `/jobs/{keyword}/in-{city}.html?of=1` |
+
+For Stepstone, keyword and city go directly in the path — encode spaces as `-`:
+```python
+kw_path = keyword.replace(" ", "-")
+city_path = city.replace(" ", "-")
+goto(f"https://www.stepstone.de/jobs/{kw_path}/in-{city_path}.html")
+```
+
+---
+
+## Cookie / consent banner dismissal
+
+Indeed (EU/UK) and Glassdoor show GDPR consent overlays. Dismiss before extraction.
+
+```python
+def dismiss_cookie_banner():
+    """Try common consent button patterns. Safe to call even if no banner is present."""
+    dismissed = js("""
+    (function() {
+      // Indeed: "Accept all cookies" button
+      var selectors = [
+        'button[id*="onetrust-accept"]',
+        'button[id*="accept-all"]',
+        '#onetrust-accept-btn-handler',
+        'button[data-testid="cookie-consent-accept"]',
+        // Glassdoor: consent modal
+        'button[data-test="accept-cookies"]',
+        // Generic patterns
+        'button[class*="accept"]',
+        'button[class*="consent"]',
+      ];
+      for (var i = 0; i < selectors.length; i++) {
+        var btn = document.querySelector(selectors[i]);
+        if (btn && btn.offsetParent !== null) {
+          btn.click();
+          return selectors[i];
+        }
+      }
+      return null;
+    })()
+    """)
+    if dismissed:
+        wait(1)
+    return dismissed
+```
+
+Call immediately after `wait_for_load()` on `.co.uk`, `.de`, or `glassdoor.com`:
+
+```python
+goto("https://www.indeed.co.uk/jobs?q=Python+developer&l=London")
+wait_for_load()
+wait(2)
+dismiss_cookie_banner()
+wait(1)
+```
+
+---
+
+## Workflow 1: Indeed — search result card extraction
+
+Each result card on Indeed carries a `data-jk` attribute (the job key). Use it to construct direct URLs.
+
+```python
+import json
+from urllib.parse import quote_plus
+
+query, location = "machine learning engineer", "New York"
+goto(f"https://www.indeed.com/jobs?q={quote_plus(query)}&l={quote_plus(location)}")
+wait_for_load()
+wait(2)
+dismiss_cookie_banner()
+
+jobs = js("""
+(function() {
+  // Cards live in <div data-jk="..."> or <li> with data-jk attribute
+  var cards = document.querySelectorAll('[data-jk]');
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+    var jk = c.getAttribute('data-jk') || '';
+    if (!jk) continue;
+
+    // Title
+    var titleEl = c.querySelector('h2.jobTitle span[title], h2.jobTitle span:not(.visually-hidden), [data-testid="job-title"]');
+    var title = titleEl ? titleEl.innerText.trim() : '';
+
+    // Company name
+    var compEl = c.querySelector('[data-testid="company-name"], .companyName, span[data-testid="company-name"]');
+    var company = compEl ? compEl.innerText.trim() : '';
+
+    // Location
+    var locEl = c.querySelector('[data-testid="text-location"], .companyLocation');
+    var location = locEl ? locEl.innerText.trim() : '';
+
+    // Salary — may not always be present in the card
+    var salEl = c.querySelector('[data-testid="attribute_snippet_testid"], .salary-snippet-container, .metadata.salary-snippet');
+    var salary = salEl ? salEl.innerText.trim() : '';
+
+    // Posting date / age
+    var dateEl = c.querySelector('[data-testid="myJobsStateDate"], span.date, .result-link-bar-container .date');
+    var posted = dateEl ? dateEl.innerText.trim() : '';
+
+    // Direct URL via job key
+    var url = 'https://www.indeed.com/viewjob?jk=' + jk;
+
+    if (title) {
+      out.push({jk, title, company, location, salary, posted, url});
+    }
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+results = json.loads(jobs)
+for r in results:
+    print(r)
+# Typically returns 10–15 cards per page
+```
+
+---
+
+## Workflow 2: Indeed — pagination (multi-page extraction)
+
+Indeed paginates using `&start=N` where N increments by 10 per page.
+
+```python
+import json
+from urllib.parse import quote_plus
+
+query, location = "data scientist", "remote"
+base_url = f"https://www.indeed.com/jobs?q={quote_plus(query)}&l={quote_plus(location)}"
+
+all_jobs = []
+
+for page in range(3):   # 3 pages = up to ~30 results
+    start = page * 10
+    url = base_url if start == 0 else f"{base_url}&start={start}"
+    goto(url)
+    wait_for_load()
+    wait(2)   # mandatory — bot detection is aggressive on rapid loads
+
+    if page == 0:
+        dismiss_cookie_banner()
+
+    batch_json = js("""
+    (function() {
+      var cards = document.querySelectorAll('[data-jk]');
+      var out = [];
+      for (var i = 0; i < cards.length; i++) {
+        var c = cards[i];
+        var jk = c.getAttribute('data-jk') || '';
+        if (!jk) continue;
+        var titleEl = c.querySelector('h2.jobTitle span[title], [data-testid="job-title"]');
+        var compEl  = c.querySelector('[data-testid="company-name"], .companyName');
+        var locEl   = c.querySelector('[data-testid="text-location"], .companyLocation');
+        var salEl   = c.querySelector('[data-testid="attribute_snippet_testid"], .salary-snippet-container');
+        var dateEl  = c.querySelector('[data-testid="myJobsStateDate"], span.date');
+        out.push({
+          jk,
+          title:   titleEl ? titleEl.innerText.trim() : '',
+          company: compEl  ? compEl.innerText.trim()  : '',
+          location: locEl  ? locEl.innerText.trim()   : '',
+          salary:  salEl   ? salEl.innerText.trim()   : '',
+          posted:  dateEl  ? dateEl.innerText.trim()  : '',
+          url: 'https://www.indeed.com/viewjob?jk=' + jk,
+        });
+      }
+      return JSON.stringify(out.filter(j => j.title));
+    })()
+    """)
+
+    batch = json.loads(batch_json)
+    if not batch:
+        break   # no results on this page — stop
+    all_jobs.extend(batch)
+
+print(f"Collected {len(all_jobs)} jobs across {page+1} pages")
+```
+
+**For `fromage` (date filter) + pagination**: keep the `fromage` param in the base URL:
+```python
+base_url = f"https://www.indeed.com/jobs?q={quote_plus(query)}&l={quote_plus(location)}&fromage=1"
+```
+
+---
+
+## Workflow 3: Indeed — job detail page extraction
+
+Fetch the full job description from the detail page. The `viewjob?jk=` URL is canonical and stable.
+
+```python
+import json, re
+
+def get_indeed_job_detail(jk: str) -> dict:
+    """Fetch full job details from an Indeed job key."""
+    goto(f"https://www.indeed.com/viewjob?jk={jk}")
+    wait_for_load()
+    wait(2)
+
+    detail = js("""
+    (function() {
+      // Title
+      var titleEl = document.querySelector('[data-testid="jobsearch-JobInfoHeader-title"], h1.jobsearch-JobInfoHeader-title');
+      var title = titleEl ? titleEl.innerText.trim() : '';
+
+      // Company
+      var compEl = document.querySelector('[data-testid="inlineHeader-companyName"] a, [data-company-name="true"]');
+      var company = compEl ? compEl.innerText.trim() : '';
+
+      // Location
+      var locEl = document.querySelector('[data-testid="inlineHeader-companyLocation"], [data-testid="job-location"]');
+      var location = locEl ? locEl.innerText.trim() : '';
+
+      // Salary — shown when available in header
+      var salEl = document.querySelector('[data-testid="jobsearch-OtherJobDetailsContainer"] [aria-label*="alary"], #salaryInfoAndJobType span');
+      var salary = salEl ? salEl.innerText.trim() : '';
+
+      // Full job description text
+      var descEl = document.getElementById('jobDescriptionText');
+      var description = descEl ? descEl.innerText.trim() : '';
+
+      // Job type (Full-time, Part-time, Contract, etc.)
+      var typeEl = document.querySelector('[data-testid="attribute_snippet_testid"]');
+      var jobType = typeEl ? typeEl.innerText.trim() : '';
+
+      // "Apply on company site" link — external application URL
+      var externalBtn = document.querySelector('[data-jk][href*="indeed.com/applystart"], a[href*="indeed.com/applystart"]');
+      var externalUrl = externalBtn ? externalBtn.href : '';
+
+      return JSON.stringify({title, company, location, salary, jobType, description, externalUrl});
+    })()
+    """)
+    return json.loads(detail)
+
+# Example
+detail = get_indeed_job_detail("abc123def456xyz")
+print(detail["title"], "—", detail["salary"])
+print(detail["description"][:500])  # first 500 chars
+```
+
+---
+
+## Workflow 4: Glassdoor — search result extraction
+
+Glassdoor shows a login modal after a few scrolls. Extract cards from the first visible load before triggering that wall.
+
+```python
+import json
+from urllib.parse import quote_plus
+
+query = "product manager"
+goto(f"https://www.glassdoor.com/Job/jobs.htm?sc.keyword={quote_plus(query)}")
+wait_for_load()
+wait(3)   # Glassdoor JS rendering takes longer
+
+# Dismiss cookie banner if present
+dismiss_cookie_banner()
+
+# Extract cards before any scroll (avoid triggering login modal)
+jobs = js("""
+(function() {
+  // Glassdoor job cards: li[data-jobid] or article[data-id]
+  var cards = document.querySelectorAll('li[data-jobid], li[class*="JobsList_jobListItem"]');
+  if (!cards.length) {
+    // Fallback: try generic article cards
+    cards = document.querySelectorAll('[data-test="jobListing"], [id^="job-listing-"]');
+  }
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+
+    // Job ID (used for canonical URL)
+    var jobId = c.getAttribute('data-jobid') || c.getAttribute('data-id') || '';
+
+    // Title
+    var titleEl = c.querySelector('[data-test="job-title"], a[class*="JobCard_jobTitle"], .job-title');
+    var title = titleEl ? titleEl.innerText.trim() : '';
+
+    // Company
+    var compEl = c.querySelector('[data-test="employer-name"], [class*="JobCard_employer"], .employer-name');
+    var company = compEl ? compEl.innerText.trim() : '';
+
+    // Location
+    var locEl = c.querySelector('[data-test="emp-location"], [class*="JobCard_location"], .location');
+    var location = locEl ? locEl.innerText.trim() : '';
+
+    // Salary estimate (not always shown in card)
+    var salEl = c.querySelector('[data-test="detailSalary"], [class*="salary"], .salaryEstimate');
+    var salary = salEl ? salEl.innerText.trim() : '';
+
+    // Company rating
+    var ratingEl = c.querySelector('[data-test="rating"], [class*="ratingNumber"], .rating');
+    var rating = ratingEl ? ratingEl.innerText.trim() : '';
+
+    // Canonical URL
+    var linkEl = c.querySelector('a[href*="/job-listing/"], a[href*="glassdoor.com/job"]');
+    var url = linkEl ? linkEl.href : (jobId ? 'https://www.glassdoor.com/job-listing/glassdoor-jl' + jobId + '.htm' : '');
+
+    if (title) out.push({jobId, title, company, location, salary, rating, url});
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+results = json.loads(jobs)
+for r in results:
+    print(r)
+```
+
+**If `jobs` returns an empty list**, Glassdoor has changed its DOM structure. Take a screenshot and inspect:
+
+```python
+screenshot()
+# Look for the actual card selector, then update the querySelectorAll above
+```
+
+---
+
+## Workflow 5: Glassdoor — handling the login wall
+
+Glassdoor increasingly shows a login modal after viewing a few listings. Detect and dismiss it.
+
+```python
+def dismiss_glassdoor_login_modal():
+    """Close the Glassdoor sign-in / register modal if it appears."""
+    closed = js("""
+    (function() {
+      // Close button on the modal
+      var closeBtn = document.querySelector(
+        '[alt="Close"], button[class*="modal_closeIcon"], [data-test="close-modal"]'
+      );
+      if (closeBtn && closeBtn.offsetParent !== null) {
+        closeBtn.click();
+        return 'closed';
+      }
+      // Sometimes the modal has an X with aria-label
+      var ariaClose = document.querySelector('[aria-label="Close"]');
+      if (ariaClose && ariaClose.offsetParent !== null) {
+        ariaClose.click();
+        return 'aria-closed';
+      }
+      return null;
+    })()
+    """)
+    if closed:
+        wait(1)
+    return closed
+
+# Strategy: extract as much as possible before the modal appears
+# If the modal blocks results, dismiss it and try again
+result = dismiss_glassdoor_login_modal()
+if result:
+    wait(1)
+    # Re-run extraction after dismissal
+```
+
+If the modal is persistent and cannot be closed, switch to Indeed for the same search — it has more accessible public results.
+
+---
+
+## Workflow 6: Stepstone (German) — job extraction
+
+Stepstone is server-rendered. Most data can be extracted with `http_get` for speed, or via `goto` + `js()` for dynamic content.
+
+```python
+import json, re
+from urllib.parse import quote_plus
+
+keyword = "Sachbearbeiter Einkauf"
+city = "Regensburg"
+
+# Stepstone encodes keyword/city in the path
+kw_path = keyword.replace(" ", "-")
+city_path = city.replace(" ", "-")
+
+goto(f"https://www.stepstone.de/jobs/{kw_path}/in-{city_path}.html")
+wait_for_load()
+wait(2)
+dismiss_cookie_banner()
+
+jobs = js("""
+(function() {
+  // Stepstone result cards
+  var cards = document.querySelectorAll(
+    'article[data-at="job-item"], [data-genesis-element="JOB_CARD"], article.sc-fhzFiK'
+  );
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+
+    // Title
+    var titleEl = c.querySelector('h2[data-at="job-item-title"] a, [data-at="job-title"], .listing__title a');
+    var title   = titleEl ? titleEl.innerText.trim() : '';
+    var url     = titleEl ? (titleEl.href || '') : '';
+
+    // Company
+    var compEl = c.querySelector('[data-at="job-item-company-name"], [data-at="company-name"], .listing__company');
+    var company = compEl ? compEl.innerText.trim() : '';
+
+    // Location
+    var locEl = c.querySelector('[data-at="job-item-location"], .listing__location');
+    var location = locEl ? locEl.innerText.trim() : '';
+
+    // Posting date
+    var dateEl = c.querySelector('[data-at="job-posting-date"], time, .listing__date');
+    var posted = dateEl ? (dateEl.getAttribute('datetime') || dateEl.innerText.trim()) : '';
+
+    if (title) out.push({title, company, location, posted, url});
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+results = json.loads(jobs)
+for r in results:
+    print(r)
+```
+
+### Stepstone pagination
+
+```python
+import json
+
+all_jobs = []
+for page in range(1, 4):   # pages 1-3
+    if page == 1:
+        url = f"https://www.stepstone.de/jobs/{kw_path}/in-{city_path}.html"
+    else:
+        url = f"https://www.stepstone.de/jobs/{kw_path}/in-{city_path}/page-{page}.html"
+
+    goto(url)
+    wait_for_load()
+    wait(2)
+
+    if page == 1:
+        dismiss_cookie_banner()
+
+    batch_json = js("""
+    (function() {
+      var cards = document.querySelectorAll('article[data-at="job-item"], [data-genesis-element="JOB_CARD"]');
+      var out = [];
+      for (var i = 0; i < cards.length; i++) {
+        var c = cards[i];
+        var titleEl = c.querySelector('[data-at="job-item-title"] a, [data-at="job-title"]');
+        var compEl  = c.querySelector('[data-at="job-item-company-name"]');
+        var locEl   = c.querySelector('[data-at="job-item-location"]');
+        var dateEl  = c.querySelector('time');
+        out.push({
+          title:    titleEl ? titleEl.innerText.trim() : '',
+          company:  compEl  ? compEl.innerText.trim()  : '',
+          location: locEl   ? locEl.innerText.trim()   : '',
+          posted:   dateEl  ? dateEl.getAttribute('datetime') || dateEl.innerText.trim() : '',
+          url:      titleEl ? titleEl.href : '',
+        });
+      }
+      return JSON.stringify(out.filter(j => j.title));
+    })()
+    """)
+
+    batch = json.loads(batch_json)
+    if not batch:
+        break
+    all_jobs.extend(batch)
+
+print(f"Stepstone: {len(all_jobs)} jobs collected")
+```
+
+---
+
+## Indeed job key (jk) — direct URL construction
+
+Indeed search result links go through a tracking redirect. **Do not use those redirect URLs.** Instead, extract the `data-jk` attribute directly for the stable canonical URL.
+
+```python
+# Correct approach: extract data-jk from the card
+job_keys = js("""
+JSON.stringify(
+  Array.from(document.querySelectorAll('[data-jk]'))
+    .map(el => el.getAttribute('data-jk'))
+    .filter(jk => jk && jk.length > 0)
+    .filter((jk, i, arr) => arr.indexOf(jk) === i)  // dedupe
+)
+""")
+import json
+jks = json.loads(job_keys)
+
+# Canonical job detail URL for any job key:
+for jk in jks:
+    direct_url = f"https://www.indeed.com/viewjob?jk={jk}"
+    print(direct_url)
+```
+
+If you already have a redirect URL and need to extract the `jk` from it:
+
+```python
+import re
+def extract_jk(url: str) -> str | None:
+    m = re.search(r'[?&]jk=([a-f0-9]+)', url)
+    return m.group(1) if m else None
+```
+
+---
+
+## Salary extraction and normalization
+
+Salary appears in different places and formats depending on the job and site.
+
+### Indeed salary patterns
+
+```python
+import re
+
+def parse_indeed_salary(raw: str) -> dict:
+    """
+    Parse Indeed salary strings like:
+      "$85,000 - $110,000 a year"
+      "Up to $65 an hour"
+      "$25 - $30 an hour"
+      "From $120,000 a year"
+      "Employer est.: $90,000 - $120,000 a year"
+    Returns: {low, high, period, source}
+    """
+    if not raw:
+        return {"raw": raw, "low": None, "high": None, "period": None, "source": None}
+
+    source = None
+    if "Employer est." in raw:
+        source = "employer"
+        raw = raw.replace("Employer est.:", "").strip()
+    elif "Glassdoor est." in raw:
+        source = "glassdoor"
+        raw = raw.replace("Glassdoor est.:", "").strip()
+
+    raw_clean = raw.replace(",", "")
+
+    # Period
+    period = None
+    if "a year" in raw or "per year" in raw or "/yr" in raw:
+        period = "year"
+    elif "an hour" in raw or "per hour" in raw or "/hr" in raw:
+        period = "hour"
+    elif "a month" in raw or "per month" in raw:
+        period = "month"
+
+    # Range: two dollar amounts
+    range_m = re.findall(r'\$?([\d]+(?:\.\d+)?)', raw_clean)
+    low  = float(range_m[0]) if len(range_m) >= 1 else None
+    high = float(range_m[1]) if len(range_m) >= 2 else low
+
+    return {"raw": raw, "low": low, "high": high, "period": period, "source": source}
+
+# Examples
+parse_indeed_salary("$85,000 - $110,000 a year")
+# -> {"low": 85000.0, "high": 110000.0, "period": "year", "source": None}
+
+parse_indeed_salary("Employer est.: $90,000 - $120,000 a year")
+# -> {"low": 90000.0, "high": 120000.0, "period": "year", "source": "employer"}
+
+parse_indeed_salary("Up to $65 an hour")
+# -> {"low": 65.0, "high": 65.0, "period": "hour", "source": None}
+```
+
+### Glassdoor salary note
+
+Glassdoor shows two types of salary estimates:
+- **"Employer est."** — the company provided a range in the job post
+- **"Glassdoor est."** — Glassdoor estimated based on similar roles; shown with "(est.)" in the card
+
+Both are shown as text inside the card. Parse the same way as Indeed.
+
+If the salary is absent in the search result card, it is only available on the job detail page (requires a click through to the individual listing).
+
+---
+
+## Date normalization ("3 days ago" → actual date)
+
+All three sites use relative timestamps. Convert to absolute dates when needed.
+
+```python
+import re
+from datetime import datetime, timedelta
+
+def parse_relative_date(text: str, reference_date: datetime = None) -> datetime | None:
+    """
+    Convert relative job posting dates to datetime objects.
+    Handles: "Just posted", "Today", "1 day ago", "3 days ago", "30+ days ago"
+    """
+    if reference_date is None:
+        reference_date = datetime.utcnow()
+
+    text = text.strip().lower()
+
+    if not text or text in ("", "unknown"):
+        return None
+    if text in ("just posted", "today", "active today"):
+        return reference_date
+    if "hour" in text:
+        m = re.search(r'(\d+)', text)
+        hours = int(m.group(1)) if m else 1
+        return reference_date - timedelta(hours=hours)
+    if "day" in text:
+        m = re.search(r'(\d+)', text)
+        days = int(m.group(1)) if m else 1
+        return reference_date - timedelta(days=days)
+    if "week" in text:
+        m = re.search(r'(\d+)', text)
+        weeks = int(m.group(1)) if m else 1
+        return reference_date - timedelta(weeks=weeks)
+    if "month" in text:
+        m = re.search(r'(\d+)', text)
+        months = int(m.group(1)) if m else 1
+        return reference_date - timedelta(days=months * 30)
+    if "30+" in text:
+        return reference_date - timedelta(days=30)
+
+    return None  # unparseable
+
+# Examples
+parse_relative_date("3 days ago")    # datetime ~3 days before now
+parse_relative_date("Just posted")  # datetime.utcnow()
+parse_relative_date("30+ days ago") # datetime 30 days ago
+```
+
+---
+
+## Workflow 7: Fast bulk extraction with `http_get` (no browser)
+
+For Indeed, the raw HTML of search results contains structured JSON in a `window.mosaic.providerData` script tag. This is faster and more reliable than DOM extraction.
+
+```python
+import json, re
+from urllib.parse import quote_plus
+
+def indeed_http_search(query: str, location: str = "", fromage: int = 0, start: int = 0) -> list[dict]:
+    """
+    Extract Indeed jobs via HTTP (no browser). Parses the embedded JSON payload.
+    Returns up to ~15 jobs per call.
+    """
+    params = f"q={quote_plus(query)}&l={quote_plus(location)}&start={start}"
+    if fromage:
+        params += f"&fromage={fromage}"
+
+    html = http_get(
+        f"https://www.indeed.com/jobs?{params}",
+        headers={
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept": "text/html,application/xhtml+xml",
+        }
+    )
+
+    # Check for CAPTCHA before parsing
+    if "captcha" in html.lower() or "robot check" in html.lower():
+        return []  # fall back to browser-based extraction
+
+    # Indeed embeds job data in window.mosaic.providerData["mosaic-provider-jobcards"]
+    m = re.search(
+        r'window\.mosaic\.providerData\["mosaic-provider-jobcards"\]\s*=\s*(\{.*?\});',
+        html, re.DOTALL
+    )
+    if not m:
+        return []
+
+    try:
+        data = json.loads(m.group(1))
+    except json.JSONDecodeError:
+        return []
+
+    results_list = (
+        data
+        .get("metaData", {})
+        .get("mosaicProviderJobCardsModel", {})
+        .get("results", [])
+    )
+
+    jobs = []
+    for r in results_list:
+        jk = r.get("jobkey", "")
+        jobs.append({
+            "jk":       jk,
+            "title":    r.get("title", ""),
+            "company":  r.get("company", ""),
+            "location": r.get("formattedLocation", ""),
+            "salary":   r.get("salarySnippet", {}).get("text", ""),
+            "posted":   r.get("formattedRelativeTime", ""),
+            "url":      f"https://www.indeed.com/viewjob?jk={jk}",
+            "snippet":  r.get("snippet", ""),  # short description preview
+        })
+    return jobs
+
+# Example — last 24h remote jobs
+jobs = indeed_http_search("software engineer", "remote", fromage=1)
+for j in jobs:
+    print(j["title"], "|", j["company"], "|", j["salary"])
+```
+
+If `http_get` returns 0 results (CAPTCHA or structure change), fall back to the `goto` + `js()` browser workflow above.
+
+---
+
+## Workflow 8: "Easy Apply" vs external application detection
+
+Some Indeed listings apply on Indeed directly ("Easy Apply") while others redirect to the company site. Detect which type before deciding what to do.
+
+```python
+def get_application_type(jk: str) -> dict:
+    """Returns {type: 'easy_apply'|'external'|'unknown', external_url: str|None}"""
+    goto(f"https://www.indeed.com/viewjob?jk={jk}")
+    wait_for_load()
+    wait(2)
+
+    return js("""
+    (function() {
+      // "Apply now" button pointing to /applystart = indeed-hosted Easy Apply
+      var easyBtn = document.querySelector(
+        'button[data-testid="applyButton"], [id="indeedApplyButton"], button[class*="IndeedApplyButton"]'
+      );
+      // "Apply on company site" button
+      var extBtn = document.querySelector(
+        'a[data-testid="applyButton"][href*="indeed.com/applystart"], a[href*="indeed.com/applystart"]'
+      );
+      // External redirect — check the main CTA
+      var mainCta = document.querySelector('[data-testid="applyButton"]');
+      var ctaHref = mainCta ? mainCta.href : '';
+
+      if (easyBtn && !ctaHref.includes('apply.indeed')) {
+        return {type: 'easy_apply', externalUrl: null};
+      }
+      if (extBtn || (ctaHref && !ctaHref.includes('indeed.com/viewjob'))) {
+        return {type: 'external', externalUrl: ctaHref || null};
+      }
+      return {type: 'unknown', externalUrl: null};
+    })()
+    """)
+```
+
+---
+
+## Bot detection and rate limiting
+
+Indeed and Glassdoor have active bot detection. Violating these limits leads to CAPTCHA walls, IP blocks, or silently degraded results (cards with empty fields).
+
+### Safe request cadence
+
+```python
+# Minimum wait between page loads
+INTER_PAGE_WAIT = 2.5   # seconds — don't go below 2
+
+# Between job detail page fetches
+INTER_DETAIL_WAIT = 3.0  # seconds
+
+# http_get concurrency limit
+MAX_HTTP_CONCURRENT = 2  # never more than 2 at once for Indeed/Glassdoor
+```
+
+### CAPTCHA detection
+
+```python
+def is_captcha_page() -> bool:
+    """Check if the current page is a CAPTCHA or block page."""
+    url = page_info()["url"]
+    title = js("document.title") or ""
+    body_text = js("document.body ? document.body.innerText.substring(0, 500) : ''") or ""
+
+    signals = [
+        "captcha" in url.lower(),
+        "robot" in title.lower(),
+        "are you a human" in body_text.lower(),
+        "verify you are human" in body_text.lower(),
+        "unusual traffic" in body_text.lower(),
+        "indeed.com/error" in url,
+        "sorry" in title.lower() and "indeed" in url,
+    ]
+    return any(signals)
+
+# Use after every goto:
+goto(some_url)
+wait_for_load()
+wait(2)
+if is_captcha_page():
+    screenshot()
+    # Wait longer and retry once
+    wait(10)
+    goto(some_url)
+    wait_for_load()
+    wait(3)
+```
+
+### Glassdoor session hygiene
+
+Glassdoor's bot detection is more fingerprint-based. If results stop loading:
+
+1. Take a `screenshot()` — confirm whether it is a login modal vs a block page
+2. Dismiss any login modal first (`dismiss_glassdoor_login_modal()`)
+3. If a block page appears, pause 30+ seconds before retrying
+4. Switch to Indeed for the same query — results are similar and bot tolerance is higher
+
+---
+
+## Filtering by date, job type, and salary
+
+### Indeed URL filter parameters
+
+```python
+from urllib.parse import quote_plus
+
+def build_indeed_url(
+    query: str,
+    location: str = "",
+    fromage: int = 0,       # days: 1=last 24h, 3=last 3 days, 7=last week
+    job_type: str = "",     # "fulltime", "parttime", "contract", "internship", "temporary"
+    remote: bool = False,
+    start: int = 0,
+) -> str:
+    base = f"https://www.indeed.com/jobs?q={quote_plus(query)}&l={quote_plus(location)}"
+    if fromage:
+        base += f"&fromage={fromage}"
+    if job_type:
+        base += f"&jt={job_type}"
+    if remote:
+        base += "&remotejob=032b3046-06a3-4876-8dfd-474eb5e7ed11"
+    if start:
+        base += f"&start={start}"
+    return base
+
+# Examples
+url = build_indeed_url("backend engineer", "Austin, TX", fromage=7, job_type="fulltime")
+url = build_indeed_url("data analyst", remote=True, fromage=1)
+```
+
+---
+
+## Collecting N results across pages
+
+```python
+import json
+from urllib.parse import quote_plus
+
+def collect_indeed_jobs(query: str, location: str = "", max_results: int = 20,
+                        fromage: int = 0, job_type: str = "") -> list[dict]:
+    """
+    Collect up to max_results jobs from Indeed across multiple pages.
+    Waits between pages to avoid bot detection.
+    """
+    all_jobs = []
+    seen_jks = set()
+    page = 0
+
+    while len(all_jobs) < max_results:
+        start = page * 10
+        url = build_indeed_url(query, location, fromage=fromage, job_type=job_type, start=start)
+        goto(url)
+        wait_for_load()
+        wait(2.5)
+
+        if page == 0:
+            dismiss_cookie_banner()
+
+        if is_captcha_page():
+            print(f"CAPTCHA on page {page+1}, stopping")
+            break
+
+        batch_json = js("""
+        (function() {
+          var cards = document.querySelectorAll('[data-jk]');
+          var out = [];
+          for (var i = 0; i < cards.length; i++) {
+            var c = cards[i];
+            var jk = c.getAttribute('data-jk') || '';
+            if (!jk) continue;
+            var titleEl = c.querySelector('h2.jobTitle span[title], [data-testid="job-title"]');
+            var compEl  = c.querySelector('[data-testid="company-name"], .companyName');
+            var locEl   = c.querySelector('[data-testid="text-location"], .companyLocation');
+            var salEl   = c.querySelector('[data-testid="attribute_snippet_testid"], .salary-snippet-container');
+            var dateEl  = c.querySelector('[data-testid="myJobsStateDate"], span.date');
+            out.push({
+              jk,
+              title:    titleEl ? titleEl.innerText.trim() : '',
+              company:  compEl  ? compEl.innerText.trim()  : '',
+              location: locEl   ? locEl.innerText.trim()   : '',
+              salary:   salEl   ? salEl.innerText.trim()   : '',
+              posted:   dateEl  ? dateEl.innerText.trim()  : '',
+              url: 'https://www.indeed.com/viewjob?jk=' + jk,
+            });
+          }
+          return JSON.stringify(out.filter(j => j.title && j.jk));
+        })()
+        """)
+
+        batch = json.loads(batch_json)
+        if not batch:
+            break  # no more results
+
+        new_jobs = [j for j in batch if j["jk"] not in seen_jks]
+        seen_jks.update(j["jk"] for j in new_jobs)
+        all_jobs.extend(new_jobs)
+        page += 1
+
+    return all_jobs[:max_results]
+
+# Examples
+jobs = collect_indeed_jobs("Python developer", "San Francisco", max_results=20)
+jobs = collect_indeed_jobs("remote software engineer", fromage=1, max_results=10)
+jobs = collect_indeed_jobs("machine learning engineer", max_results=30, fromage=7, job_type="fulltime")
+```
+
+---
+
+## Gotchas
+
+- **`data-jk` is the job key, not a DOM id** — Always use `[data-jk]` to select cards, not `#job-...` ids which vary by page layout and A/B test variant.
+
+- **Indeed redirect links are NOT stable URLs** — Anchor `href` values in search results go through `https://www.indeed.com/rc/clk?...` tracking redirects which expire. Always extract `data-jk` from the card and construct `https://www.indeed.com/viewjob?jk={jk}` yourself.
+
+- **Salary is on the detail page, not the card** — Many listings show no salary in the search result card. If salary is required, fetch the individual `viewjob?jk=` page and extract it there. Budget `wait(3)` per detail page and do not fetch more than 5 detail pages per minute.
+
+- **"Employer est." vs "Glassdoor est."** — These are two distinct data signals. Employer estimates come from the job post itself; Glassdoor estimates are crowd-sourced. The distinction matters when reporting salary accuracy to users.
+
+- **Glassdoor login modal appears after 2-3 scrolls** — Extract all visible cards immediately on load before scrolling. If you need to load more results via scroll/infinite scroll, dismiss the modal first.
+
+- **Glassdoor public results are limited** — Without login, Glassdoor shows ~10-15 cards. If the task requires 30+ results, use Indeed instead (no login required, up to ~15 per page with full pagination).
+
+- **Stepstone uses path-based URL routing, not query params** — Spaces in keyword or city must be replaced with `-` for the path, not `%20` or `+`. `quote_plus()` is wrong for path segments. Use `.replace(" ", "-")`.
+
+- **Stepstone pagination is in the path** — `/page-2.html`, `/page-3.html` — not `?page=2`. There is no `&start=N` param as in Indeed.
+
+- **`http_get` for Glassdoor fails more often** — Glassdoor requires JS to render job cards. Use the browser path for Glassdoor. `http_get` only works reliably for Indeed and Stepstone where server-rendered HTML contains structured data.
+
+- **Indeed embeds JSON in a `<script>` tag** — The `window.mosaic.providerData` block in the HTML source is the fastest extraction path but it can break if Indeed changes the key. Always have the DOM-based `js()` approach as a fallback.
+
+- **Date strings are relative, not absolute** — "3 days ago", "30+ days ago", "Just posted" — none of these are machine-parseable dates without a reference point. Use `datetime.utcnow()` as the reference. "30+" means at least 30 days ago; treat as stale.
+
+- **`fromage=1` on Indeed means "last 24 hours" but uses the listing creation date, not the apply-by date** — Fresh listings can appear in `fromage=3` results a day later due to indexing lag.
+
+- **Indeed CAPTCHA appears as a clean-looking page** with an image puzzle or just a "continue" button — it will not raise an error. Always check `is_captcha_page()` before assuming extraction results are valid.
+
+- **Glassdoor location IDs for `locT=C&locId=`** — Programmatic location filtering by ID requires a separate city-ID lookup (Glassdoor's internal city registry). For basic scraping, omit `locId` and use `locKeyword=` with the city name instead — results are less precise but don't require a lookup step.
+
+- **User-agent matters** — `http_get` uses `Mozilla/5.0` by default (see `helpers.py`). For Indeed `http_get`, also set `Accept-Language: en-US,en;q=0.9` to avoid getting German or localized results based on IP geolocation.
+
+- **Stepstone cookie modal is fullscreen** — On first load, Stepstone shows a fullscreen consent overlay that blocks the entire page. Always call `dismiss_cookie_banner()` before any extraction. If the overlay cannot be dismissed with the generic pattern, use a coordinate click: `screenshot()` first to find the "Alle akzeptieren" (Accept all) button position, then `click(x, y)`.
+
+- **Glassdoor salary in card vs detail** — Salary text in the card may be truncated ("$90K - $120K (Glassdoor est.)"). The full salary breakdown (base, bonus, total comp) is only on the job detail page, which requires a click through.
+
+- **"Easy Apply" listings may not have an external URL** — If the job only has an Indeed-hosted application, there is no company site URL. The `externalUrl` will be `null` — this is expected, not a scraping failure.
+
+- **Empty cards on Indeed mobile breakpoints** — If the browser viewport is very narrow, Indeed may render a different card layout with different selectors. Keep viewport at normal desktop width (1280px+) to get consistent `[data-jk]` card rendering.

--- a/domain-skills/news-aggregation/multi-source.md
+++ b/domain-skills/news-aggregation/multi-source.md
@@ -1,0 +1,702 @@
+# News Aggregation — Multi-Source Fetching
+
+Covers TechCrunch, The Verge, Ars Technica, BBC, Reuters, VentureBeat, and similar editorial news sites. For Hacker News specifically, see `hackernews/scraping.md`.
+
+## Do this first
+
+**Use RSS feeds, not the browser.** Almost every major news publication exposes RSS. A single `http_get` on an RSS URL gives you titles, URLs, summaries, authors, and publish dates as structured XML — no screenshots, no JS rendering, no cookie banners. This is 10–20x faster than browser-based scraping and works reliably even on sites that heavily JS-render their front pages.
+
+```python
+# Known RSS feeds (verified 2026-04):
+RSS_FEEDS = {
+    "techcrunch":    "https://techcrunch.com/feed/",
+    "verge":         "https://www.theverge.com/rss/index.xml",
+    "ars_technica":  "https://feeds.arstechnica.com/arstechnica/index",
+    "bbc":           "http://feeds.bbci.co.uk/news/rss.xml",
+    "reuters":       "https://feeds.reuters.com/reuters/topNews",
+    "venturebeat":   "https://venturebeat.com/feed/",
+}
+
+# Category/topic feeds:
+TOPIC_FEEDS = {
+    "techcrunch_ai":   "https://techcrunch.com/category/artificial-intelligence/feed/",
+    "techcrunch_startups": "https://techcrunch.com/category/startups/feed/",
+    "verge_ai":        "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml",
+    "verge_tech":      "https://www.theverge.com/rss/tech/index.xml",
+    "ars_tech":        "https://feeds.arstechnica.com/arstechnica/technology-lab",
+    "ars_science":     "https://feeds.arstechnica.com/arstechnica/science",
+    "bbc_tech":        "http://feeds.bbci.co.uk/news/technology/rss.xml",
+    "bbc_world":       "http://feeds.bbci.co.uk/news/world/rss.xml",
+    "reuters_world":   "https://feeds.reuters.com/reuters/worldnews",
+    "reuters_tech":    "https://feeds.reuters.com/reuters/technologynews",
+}
+```
+
+---
+
+## Parsing RSS — the core utility
+
+RSS is XML. Parse it with Python's built-in `xml.etree.ElementTree` — no third-party libraries needed.
+
+```python
+import xml.etree.ElementTree as ET
+import re
+from email.utils import parsedate_to_datetime   # handles RFC 822 dates
+from datetime import datetime, timezone
+
+def parse_rss(xml_text, source_name=""):
+    """Parse an RSS 2.0 feed. Returns a list of article dicts."""
+    # Some feeds include XML namespace declarations that break plain ET parsing.
+    # Strip them first so we can use simple tag names.
+    xml_text = re.sub(r' xmlns[^"]*"[^"]*"', '', xml_text)
+    xml_text = re.sub(r'<\?xml[^?]*\?>', '', xml_text).strip()
+
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        # Malformed XML — last resort, grab titles with regex
+        titles = re.findall(r'<title><!\[CDATA\[(.*?)\]\]></title>', xml_text)
+        links  = re.findall(r'<link>(https?://[^<]+)</link>', xml_text)
+        return [{"title": t, "url": l, "source": source_name}
+                for t, l in zip(titles, links)]
+
+    items = root.findall(".//item")  # RSS 2.0
+    if not items:
+        items = root.findall(".//{http://www.w3.org/2005/Atom}entry")  # Atom
+
+    articles = []
+    for item in items:
+        def text(tag, default=""):
+            el = item.find(tag)
+            if el is None:
+                return default
+            t = el.text or ""
+            # Strip CDATA wrapper if present (some feeds inline it as text)
+            t = re.sub(r'<!\[CDATA\[(.*?)\]\]>', r'\1', t, flags=re.DOTALL)
+            return t.strip()
+
+        title   = text("title")
+        url     = text("link") or text("guid")
+        summary = text("description") or text("summary") or text("{http://www.w3.org/2005/Atom}summary")
+        author  = text("author") or text("{http://purl.org/dc/elements/1.1/}creator")
+        pub_raw = text("pubDate") or text("published") or text("updated")
+
+        # Normalise publish date to a UTC datetime (or None)
+        pub_dt = _parse_date(pub_raw)
+
+        if not title and not url:
+            continue
+
+        articles.append({
+            "title":   title,
+            "url":     url,
+            "summary": re.sub(r'<[^>]+>', '', summary).strip(),  # strip HTML tags
+            "author":  author,
+            "source":  source_name,
+            "pub_raw": pub_raw,
+            "pub_dt":  pub_dt,
+        })
+
+    return articles
+
+
+def _parse_date(s):
+    """Try multiple date formats. Returns a UTC-aware datetime or None."""
+    if not s:
+        return None
+    s = s.strip()
+    # RFC 822 (most RSS feeds): "Fri, 18 Apr 2026 10:30:00 +0000"
+    try:
+        return parsedate_to_datetime(s).astimezone(timezone.utc)
+    except Exception:
+        pass
+    # ISO 8601 (Atom, some modern feeds): "2026-04-18T10:30:00Z"
+    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(s, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+        except ValueError:
+            continue
+    return None
+```
+
+---
+
+## Parallel fetch — multiple feeds simultaneously
+
+Use `ThreadPoolExecutor` to fetch all feeds in parallel. With 6 feeds each taking ~300ms, sequential fetching takes ~1.8s; parallel takes ~350ms.
+
+```python
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+def fetch_feed(name, url):
+    """Fetch and parse one RSS feed. Returns (name, articles) or (name, []) on error."""
+    try:
+        xml = http_get(url, headers={"Accept": "application/rss+xml, application/xml, text/xml"})
+        return name, parse_rss(xml, source_name=name)
+    except Exception as e:
+        print(f"[{name}] fetch failed: {e}")
+        return name, []
+
+
+def fetch_all_feeds(feed_dict, max_workers=8):
+    """Fetch multiple RSS feeds in parallel. Returns merged list of articles."""
+    all_articles = []
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        futures = {ex.submit(fetch_feed, name, url): name
+                   for name, url in feed_dict.items()}
+        for fut in as_completed(futures):
+            name, articles = fut.result()
+            all_articles.extend(articles)
+    return all_articles
+
+
+# Example: top AI news across TechCrunch + The Verge + Ars Technica
+articles = fetch_all_feeds({
+    "techcrunch_ai": TOPIC_FEEDS["techcrunch_ai"],
+    "verge_ai":      TOPIC_FEEDS["verge_ai"],
+    "ars_tech":      TOPIC_FEEDS["ars_tech"],
+})
+print(f"Fetched {len(articles)} articles from 3 sources")
+```
+
+---
+
+## Common workflows
+
+### Fetch top N articles from a single site
+
+```python
+xml = http_get("https://techcrunch.com/feed/")
+articles = parse_rss(xml, source_name="techcrunch")
+top5 = articles[:5]
+for a in top5:
+    print(f"[{a['source']}] {a['title']}")
+    print(f"  {a['url']}")
+    print(f"  {a['pub_raw']}")
+```
+
+### Multi-source aggregation with deduplication
+
+Different feeds sometimes carry the same wire story (e.g. Reuters articles reprinted elsewhere). Dedup by URL before presenting results.
+
+```python
+def aggregate_and_dedup(feed_dict, max_per_source=None):
+    """Fetch feeds, dedup by URL, return sorted by publish date (newest first)."""
+    all_articles = fetch_all_feeds(feed_dict)
+
+    # Dedup by URL — keep first occurrence (arbitrary ordering from parallel fetch)
+    seen_urls = set()
+    unique = []
+    for a in all_articles:
+        url = a["url"].rstrip("/")   # normalise trailing slash
+        if url and url not in seen_urls:
+            seen_urls.add(url)
+            unique.append(a)
+
+    # Sort: articles with a known pub_dt first (newest), unknown dates last
+    def sort_key(a):
+        dt = a.get("pub_dt")
+        return dt if dt else datetime.min.replace(tzinfo=timezone.utc)
+
+    unique.sort(key=sort_key, reverse=True)
+
+    if max_per_source:
+        # Cap per-source contribution so no single feed dominates
+        counts = {}
+        capped = []
+        for a in unique:
+            src = a["source"]
+            counts[src] = counts.get(src, 0)
+            if counts[src] < max_per_source:
+                capped.append(a)
+                counts[src] += 1
+        return capped
+
+    return unique
+
+
+# Top 5 AI stories across 3 sources in last 24 hours
+from datetime import timedelta
+
+results = aggregate_and_dedup({
+    "techcrunch_ai": TOPIC_FEEDS["techcrunch_ai"],
+    "verge_ai":      TOPIC_FEEDS["verge_ai"],
+    "ars_tech":      TOPIC_FEEDS["ars_tech"],
+}, max_per_source=10)
+
+cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+recent = [a for a in results if a["pub_dt"] and a["pub_dt"] >= cutoff]
+print(f"Found {len(recent)} articles in last 24h")
+for a in recent[:5]:
+    print(f"\n[{a['source']}] {a['title']}")
+    print(f"  Published: {a['pub_dt'].strftime('%Y-%m-%d %H:%M UTC')}")
+    print(f"  URL: {a['url']}")
+    print(f"  Summary: {a['summary'][:200]}")
+```
+
+### Filter by keyword in title or summary
+
+```python
+def filter_by_keyword(articles, keywords, case_sensitive=False):
+    """Return articles where any keyword appears in title or summary."""
+    results = []
+    for a in articles:
+        haystack = a["title"] + " " + a["summary"]
+        if not case_sensitive:
+            haystack = haystack.lower()
+            checks = [k.lower() for k in keywords]
+        else:
+            checks = keywords
+        if any(k in haystack for k in checks):
+            results.append(a)
+    return results
+
+
+# All articles mentioning GPT-4, Claude, or Gemini from the last 48 hours
+all_articles = fetch_all_feeds(RSS_FEEDS)
+cutoff = datetime.now(timezone.utc) - timedelta(hours=48)
+recent = [a for a in all_articles if a["pub_dt"] and a["pub_dt"] >= cutoff]
+ai_articles = filter_by_keyword(recent, ["GPT-4", "Claude", "Gemini", "LLM", "AI model"])
+for a in ai_articles:
+    print(f"[{a['source']}] {a['title']}")
+```
+
+### Filter by publish date window
+
+```python
+def filter_by_age(articles, hours=24):
+    """Return articles published within the last N hours. Articles with no date are excluded."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    return [a for a in articles if a["pub_dt"] and a["pub_dt"] >= cutoff]
+
+
+# "Top tech news from today" — all feeds, last 24 hours
+all_tech = fetch_all_feeds({
+    "techcrunch": RSS_FEEDS["techcrunch"],
+    "verge":      RSS_FEEDS["verge"],
+    "ars":        RSS_FEEDS["ars_technica"],
+})
+today = filter_by_age(all_tech, hours=24)
+today.sort(key=lambda a: a["pub_dt"], reverse=True)
+print(f"Today: {len(today)} articles")
+```
+
+### Search for a company or topic across all sources
+
+```python
+def company_news(company_name, hours=168, feeds=None):
+    """
+    Get all articles mentioning `company_name` from the last N hours (default: 7 days).
+    Uses general feeds — for better coverage, also search Algolia HN (see hackernews/scraping.md).
+    """
+    feeds = feeds or RSS_FEEDS
+    all_articles = fetch_all_feeds(feeds)
+    recent = filter_by_age(all_articles, hours=hours)
+    matches = filter_by_keyword(recent, [company_name])
+    matches.sort(key=lambda a: a["pub_dt"], reverse=True)
+    return matches
+
+
+# "Get all articles about OpenAI from the last week"
+openai_news = company_news("OpenAI", hours=168)
+for a in openai_news:
+    print(f"[{a['pub_dt'].strftime('%m-%d')}] [{a['source']}] {a['title']}")
+```
+
+### Extract full article text from a URL
+
+RSS feeds truncate body text (often 50–200 words max). To get full text, follow the article URL. Works on sites without paywalls.
+
+```python
+def fetch_article_text(url):
+    """
+    Fetch full article text from a URL via HTTP (no browser).
+    Returns plain text, stripping nav/footer boilerplate.
+    Works for: TechCrunch, Ars Technica, Reuters, VentureBeat, BBC.
+    Does NOT work for: FT, NYT, Bloomberg, WSJ (paywalls), The Verge (JS-rendered body).
+    """
+    html = http_get(url)
+
+    # Extract <article> content if present (most modern sites)
+    article_match = re.search(r'<article[^>]*>(.*?)</article>', html, re.DOTALL)
+    if article_match:
+        body_html = article_match.group(1)
+    else:
+        # Fall back to <main>
+        main_match = re.search(r'<main[^>]*>(.*?)</main>', html, re.DOTALL)
+        body_html = main_match.group(1) if main_match else html
+
+    # Strip scripts, styles, and HTML tags
+    body_html = re.sub(r'<(script|style)[^>]*>.*?</(script|style)>', '', body_html, flags=re.DOTALL)
+    text = re.sub(r'<[^>]+>', ' ', body_html)
+    text = re.sub(r'\s+', ' ', text).strip()
+
+    return text
+
+
+# Get full text of the top TechCrunch AI article
+xml = http_get(TOPIC_FEEDS["techcrunch_ai"])
+articles = parse_rss(xml, "techcrunch")
+if articles:
+    full_text = fetch_article_text(articles[0]["url"])
+    print(full_text[:1000])
+```
+
+### Scrape The Verge front page (all articles, title + author + timestamp + URL)
+
+The Verge's front page is JS-rendered, so `http_get` returns a skeleton. Use the browser. But note: the RSS feed is faster if you just need the top articles.
+
+```python
+# Option A — RSS (fast, no browser, top articles only)
+xml = http_get("https://www.theverge.com/rss/index.xml")
+articles = parse_rss(xml, "verge")
+# Returns up to 20 articles with title, URL, summary, pub_dt
+
+# Option B — Browser (when you need author bylines or full front-page layout)
+goto("https://www.theverge.com")
+wait_for_load()
+_dismiss_consent_banner()   # see Cookie/Consent section below
+
+articles = js("""
+(() => {
+  const cards = document.querySelectorAll('h2 a, h3 a');
+  const seen = new Set();
+  const out = [];
+  for (const a of cards) {
+    const url = a.href;
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    const title = a.textContent.trim();
+    if (!title) continue;
+    // Author is often in a sibling or parent context — walk up
+    const article = a.closest('article') || a.closest('[data-chorus-optimize-field]');
+    const authorEl = article && article.querySelector('a[data-analytics-link="author"]');
+    const timeEl   = article && article.querySelector('time');
+    out.push({
+      title:     title,
+      url:       url,
+      author:    authorEl ? authorEl.textContent.trim() : '',
+      timestamp: timeEl   ? timeEl.getAttribute('datetime') : '',
+    });
+    if (out.length >= 30) break;
+  }
+  return out;
+})()
+""")
+```
+
+---
+
+## Cookie / consent banner handling
+
+BBC, The Verge, and all EU-facing properties show GDPR consent banners on first visit. The banner intercepts clicks — dismiss it before any other interaction.
+
+### Generic approach (works on most sites)
+
+```python
+def _dismiss_consent_banner(wait_seconds=2.0):
+    """
+    Try to dismiss a cookie/consent banner by clicking 'Accept all', 'Accept', or 'Agree' buttons.
+    Call after goto() + wait_for_load(). Safe to call even if no banner is present.
+    """
+    wait(wait_seconds)   # banners often inject asynchronously
+
+    dismissed = js("""
+    (() => {
+      const phrases = [
+        'accept all', 'accept cookies', 'agree to all', 'i agree',
+        'allow all', 'allow cookies', 'ok', 'got it',
+      ];
+      const els = [
+        ...document.querySelectorAll('button'),
+        ...document.querySelectorAll('a[role="button"]'),
+        ...document.querySelectorAll('[class*="consent"] button'),
+        ...document.querySelectorAll('[id*="consent"] button'),
+        ...document.querySelectorAll('[class*="cookie"] button'),
+        ...document.querySelectorAll('[id*="cookie"] button'),
+        ...document.querySelectorAll('[class*="gdpr"] button'),
+        ...document.querySelectorAll('[class*="banner"] button'),
+      ];
+      for (const el of els) {
+        const text = (el.textContent || el.value || '').toLowerCase().trim();
+        if (phrases.some(p => text.includes(p))) {
+          el.click();
+          return el.textContent.trim();
+        }
+      }
+      return null;
+    })()
+    """)
+
+    if dismissed:
+        wait(1.0)  # let the banner animate out
+    return dismissed
+```
+
+### BBC-specific consent
+
+BBC uses a dedicated consent domain (`bbc.co.uk/usp/prd/gdpr`). The consent banner renders inside the page as a full-screen overlay — a regular `button` click via JS usually works. If the JS click doesn't register, fall back to a coordinate click after taking a screenshot to locate the button.
+
+```python
+def _dismiss_bbc_consent():
+    """Dismiss the BBC consent overlay. Call after goto() + wait_for_load()."""
+    wait(2.0)
+    # Try JS click first
+    result = js("""
+    (() => {
+      // BBC consent button selector (stable as of 2026-04)
+      const btn = document.querySelector('button[data-testid="accept-button"]')
+               || document.querySelector('.tp-close')
+               || document.querySelector('[class*="ConsentBanner"] button');
+      if (btn) { btn.click(); return true; }
+      // Fallback: any button with 'Yes' or 'Accept' in a modal/dialog
+      for (const b of document.querySelectorAll('dialog button, [role="dialog"] button')) {
+        if (/yes|accept|agree/i.test(b.textContent)) { b.click(); return true; }
+      }
+      return false;
+    })()
+    """)
+    if not result:
+        # Fallback: screenshot and coordinate-click the accept button
+        screenshot("/tmp/bbc_banner.png")
+        # Typical BBC accept button is near top-center on a full-screen overlay
+        click(760, 450)
+    wait(1.0)
+```
+
+**BBC domain note:** `bbc.co.uk/news` serves UK content; `bbc.com/news` serves international. They are different editorial selections. The RSS feed (`feeds.bbci.co.uk`) gives a merged top-stories view. After you dismiss the consent banner once, BBC sets a cookie that persists for the session — subsequent `goto` calls on the same session won't show it again.
+
+---
+
+## When browser IS needed vs pure HTTP
+
+| Task | Use |
+|---|---|
+| TechCrunch articles (listing + metadata) | RSS `http_get` |
+| TechCrunch full article body | `http_get(article_url)` — clean HTML |
+| The Verge articles (listing + metadata) | RSS `http_get` |
+| The Verge full article body | Browser — body is JS-rendered after hydration |
+| Ars Technica articles | RSS `http_get` |
+| Ars Technica full article body | `http_get(article_url)` — full HTML |
+| BBC articles (listing + metadata) | RSS `http_get` |
+| BBC full article body | `http_get(article_url)` usually works |
+| Reuters articles | RSS `http_get` |
+| Reuters full article body | `http_get(article_url)` — clean HTML |
+| VentureBeat articles | RSS `http_get` |
+| FT / NYT / Bloomberg / WSJ | Do not use — paywalled |
+| "Get the lead article link from bbc.co.uk/news right now" | Browser (need live DOM, not cached RSS) |
+| Search results / filtered views with JS | Browser |
+| Pagination beyond first RSS page | Browser or site-specific API |
+
+---
+
+## Site-specific notes
+
+### TechCrunch
+
+- General feed: `https://techcrunch.com/feed/` (latest across all categories)
+- Category feeds: `https://techcrunch.com/category/<slug>/feed/`
+  - AI: `/category/artificial-intelligence/feed/`
+  - Startups: `/category/startups/feed/`
+  - Venture: `/category/venture/feed/`
+  - Security: `/category/security/feed/`
+- RSS returns full article summaries (2–4 sentences). No paywall on article pages.
+- Author names are in `<dc:creator>` not `<author>` — already handled by `parse_rss`.
+
+### The Verge
+
+- General feed: `https://www.theverge.com/rss/index.xml`
+- Topic feeds: `https://www.theverge.com/rss/<topic>/index.xml`
+  - AI: `rss/ai-artificial-intelligence/index.xml`
+  - Tech: `rss/tech/index.xml`
+  - Science: `rss/science/index.xml`
+  - Games: `rss/games/index.xml`
+- RSS is Atom format (not RSS 2.0) — `parse_rss` handles both.
+- Full article body is JS-rendered (React/Chorus). `http_get` on article URLs gives you a skeleton. Use the browser or accept the RSS summary.
+
+### Ars Technica
+
+- General feed: `https://feeds.arstechnica.com/arstechnica/index`
+- Topic feeds: `https://feeds.arstechnica.com/arstechnica/<section>`
+  - Technology: `technology-lab`
+  - Science: `science`
+  - Gaming: `gaming`
+  - Policy: `tech-policy`
+  - Security: `security`
+- RSS includes article summaries (first 1–2 paragraphs). Article pages are clean HTML.
+- No consent banner in most regions. No paywall.
+
+### BBC
+
+- Top stories: `http://feeds.bbci.co.uk/news/rss.xml`
+- World: `http://feeds.bbci.co.uk/news/world/rss.xml`
+- Technology: `http://feeds.bbci.co.uk/news/technology/rss.xml`
+- Science: `http://feeds.bbci.co.uk/news/science_and_environment/rss.xml`
+- RSS descriptions are short (1 sentence). Article HTML is clean and readable.
+- Consent banner shows on first browser visit — see BBC-specific handling above.
+- `bbc.co.uk/news` = UK-focused editorial; `bbc.com/news` = international. Geo-varies on some stories.
+
+### Reuters
+
+- Top news: `https://feeds.reuters.com/reuters/topNews`
+- World: `https://feeds.reuters.com/reuters/worldnews`
+- Technology: `https://feeds.reuters.com/reuters/technologynews`
+- Business: `https://feeds.reuters.com/reuters/businessNews`
+- Article pages are clean HTML with no paywall for standard articles.
+- Reuters wire stories are often reproduced verbatim on BBC, AP News, etc. — dedup by URL is important when mixing Reuters with other feeds.
+
+### VentureBeat
+
+- General feed: `https://venturebeat.com/feed/`
+- AI feed: `https://venturebeat.com/category/ai/feed/`
+- RSS summaries are generous (3–5 sentences). Full articles are clean HTML.
+- Some articles behind a "VB Transform" event sign-up modal — usually dismissible, but the article body is present in the raw HTML.
+
+---
+
+## Putting it all together — complete task examples
+
+### "Get top 5 AI stories in last 24 hours from TechCrunch, The Verge, VentureBeat"
+
+```python
+import xml.etree.ElementTree as ET
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone, timedelta
+from email.utils import parsedate_to_datetime
+
+# (paste parse_rss, _parse_date, fetch_feed, fetch_all_feeds, filter_by_age from above)
+
+feeds = {
+    "techcrunch_ai": "https://techcrunch.com/category/artificial-intelligence/feed/",
+    "verge_ai":      "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml",
+    "venturebeat_ai":"https://venturebeat.com/category/ai/feed/",
+}
+
+all_articles = fetch_all_feeds(feeds)
+last_24h = filter_by_age(all_articles, hours=24)
+last_24h.sort(key=lambda a: a["pub_dt"], reverse=True)
+top5 = last_24h[:5]
+
+for a in top5:
+    print(f"\nTitle:   {a['title']}")
+    print(f"Source:  {a['source']}")
+    print(f"URL:     {a['url']}")
+    print(f"Date:    {a['pub_dt'].strftime('%Y-%m-%d %H:%M UTC') if a['pub_dt'] else 'unknown'}")
+    print(f"Summary: {a['summary'][:300]}")
+```
+
+### "Visit BBC World, dismiss cookie banner, get first lead article link"
+
+```python
+goto("https://www.bbc.co.uk/news")
+wait_for_load()
+_dismiss_bbc_consent()  # must run before any other interaction
+
+# Get lead article link from DOM (more reliable than RSS for "right now" front page)
+lead_url = js("""
+(() => {
+  // BBC lead story is usually an <a> inside the first <article> or [data-testid="dundee-card"]
+  const selectors = [
+    'article h3 a',
+    '[data-testid="dundee-card"] a',
+    'h3 a[href*="/news/"]',
+    'h2 a[href*="/news/"]',
+  ];
+  for (const sel of selectors) {
+    const el = document.querySelector(sel);
+    if (el && el.href && !el.href.includes('#')) return el.href;
+  }
+  return null;
+})()
+""")
+print("Lead article:", lead_url)
+```
+
+### "Get today's top tech news from TechCrunch, Ars Technica, and The Verge"
+
+```python
+feeds = {
+    "techcrunch": "https://techcrunch.com/feed/",
+    "ars":        "https://feeds.arstechnica.com/arstechnica/index",
+    "verge":      "https://www.theverge.com/rss/index.xml",
+}
+all_articles = fetch_all_feeds(feeds)
+today = filter_by_age(all_articles, hours=24)
+today.sort(key=lambda a: a["pub_dt"], reverse=True)
+
+print(f"Today's top tech news ({len(today)} articles):\n")
+for i, a in enumerate(today[:15], 1):
+    ts = a["pub_dt"].strftime("%H:%M UTC") if a["pub_dt"] else "?"
+    print(f"{i:2}. [{a['source']:12}] {ts}  {a['title']}")
+```
+
+### "Extract AI/ML news from the last 48 hours across multiple tech publications"
+
+```python
+ai_feeds = {
+    "techcrunch_ai":   "https://techcrunch.com/category/artificial-intelligence/feed/",
+    "verge_ai":        "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml",
+    "venturebeat_ai":  "https://venturebeat.com/category/ai/feed/",
+    "ars_tech":        "https://feeds.arstechnica.com/arstechnica/technology-lab",
+}
+# Also pull from general tech feeds and keyword-filter
+general_feeds = {
+    "bbc_tech":    "http://feeds.bbci.co.uk/news/technology/rss.xml",
+    "reuters_tech":"https://feeds.reuters.com/reuters/technologynews",
+}
+
+dedicated = fetch_all_feeds(ai_feeds)
+general   = fetch_all_feeds(general_feeds)
+ai_keywords = ["AI", "machine learning", "LLM", "neural network", "GPT", "Claude",
+               "Gemini", "artificial intelligence", "deep learning", "model", "agent"]
+filtered_general = filter_by_keyword(general, ai_keywords)
+
+all_ai = dedicated + filtered_general
+last_48h = filter_by_age(all_ai, hours=48)
+
+# Dedup by URL
+seen = set()
+deduped = []
+for a in last_48h:
+    u = a["url"].rstrip("/")
+    if u not in seen:
+        seen.add(u)
+        deduped.append(a)
+
+deduped.sort(key=lambda a: a["pub_dt"], reverse=True)
+print(f"Found {len(deduped)} unique AI/ML articles in last 48h")
+```
+
+---
+
+## Gotchas
+
+- **User-Agent required.** Some CDNs (Cloudflare on VentureBeat, Fastly on some Reuters endpoints) return 403 or 429 to Python's default `urllib` agent. `http_get` in this harness already sends `Mozilla/5.0` — don't override it with an empty string. If you hit a 403, try adding an `Accept` header: `{"Accept": "application/rss+xml, text/xml"}`.
+
+- **Publish date formats vary wildly.** RFC 822 (`Fri, 18 Apr 2026 10:30:00 +0000`) is most common in RSS 2.0. Atom feeds use ISO 8601 (`2026-04-18T10:30:00Z`). BBC sometimes omits the seconds. Some feeds use timezone abbreviations (`EST`, `PST`) that are not valid RFC 822 but `email.utils.parsedate_to_datetime` handles them. The `_parse_date` helper above handles all known variants.
+
+- **RSS truncates article body.** RSS `<description>` is at most a few sentences. For full text, `http_get(article_url)` — but this doubles request count. Batch with `ThreadPoolExecutor` if you need full text for many articles.
+
+- **Paywalls.** Do not attempt to scrape FT, NYT, Bloomberg, or WSJ without a subscription. Their articles are behind hard paywalls and bot-detection. Stick to the sources listed above which are freely readable.
+
+- **Cookie consent intercepts clicks.** If you do need to use the browser on BBC or The Verge, always call the dismiss helper before interacting with any link or button. If you click before the banner is dismissed, the click goes to the banner overlay, not the page.
+
+- **BBC geo-serving.** `bbc.co.uk/news` and `bbc.com/news` serve different story selections. The RSS feed `feeds.bbci.co.uk/news/rss.xml` is a merged view and less affected by geo. If a user asks for "BBC World News", use `http://feeds.bbci.co.uk/news/world/rss.xml`.
+
+- **The Verge full article body requires the browser.** Unlike TechCrunch and Ars, The Verge renders article text client-side via React hydration. `http_get(article_url)` gives you only the title and metadata, not the body paragraphs. Accept the RSS summary (which is 2–4 sentences) or use `goto` + `wait_for_load` + `js(...)` to extract the body.
+
+- **Reuters feed freshness.** Reuters top-news feed updates frequently (every few minutes). For real-time news, Reuters is often 10–30 minutes ahead of other outlets.
+
+- **Atom vs RSS 2.0 namespaces.** The Verge and some modern feeds use Atom (`<feed>` root, `<entry>` items). The `parse_rss` helper above detects and handles both formats. If you write your own parser, check the root tag: `feed` = Atom, `rss` = RSS 2.0.
+
+- **`<guid>` vs `<link>`.** In some feeds (particularly Reuters), `<link>` is the feed URL itself and `<guid>` carries the article URL. The `parse_rss` helper tries `link` first and falls back to `guid`. Always verify the URL points to an article, not the feed root.
+
+- **Relative URLs in RSS.** Uncommon but it happens on some smaller publications. Always check `url.startswith('http')` after parsing and prepend the base domain if needed.
+
+- **XML namespace stripping.** Some feeds include namespace declarations like `xmlns:dc="http://purl.org/dc/elements/1.1/"` which cause `ET.fromstring` to require namespace-prefixed tag names. The `re.sub` at the top of `parse_rss` strips these so plain tag names like `dc:creator` are parsed as `"dc:creator"` (colon in tag name) — which ET handles fine.
+
+- **"Relative time" strings.** Some sites (Medium, Substack) put "2 hours ago" in the `<pubDate>` field instead of an absolute timestamp. `_parse_date` will return `None` for these — treat `pub_dt=None` as "recently published" or use the article's position in the feed (item 0 = newest).

--- a/domain-skills/producthunt/scraping.md
+++ b/domain-skills/producthunt/scraping.md
@@ -1,0 +1,477 @@
+# Product Hunt — Daily Launches & Topic Scraping
+
+`https://www.producthunt.com` — React SPA, requires browser (not `http_get`)
+
+## Important: This site needs a browser
+
+Product Hunt is a fully client-rendered React application. `http_get("https://www.producthunt.com")` returns an HTML shell with almost no product data — the launch list, vote counts, and taglines are all injected by the JS bundle after hydration.
+
+Always use `goto` + `wait_for_load` + a short `wait` for React to hydrate, then `js()` to extract.
+
+```python
+goto("https://www.producthunt.com")
+wait_for_load()
+wait(2)  # let React hydrate product cards
+```
+
+---
+
+## Common workflows
+
+### 1. Today's daily leaderboard — top N products
+
+This is the homepage default view. Products are sorted by vote count and rendered in `<li>` elements inside the main feed.
+
+```python
+goto("https://www.producthunt.com")
+wait_for_load()
+wait(2)
+
+products = js("""
+(function() {
+  // Each product card sits inside a <li> with a data-test attribute
+  var items = document.querySelectorAll('li[class*="item"]');
+
+  // Fallback selector if the above is empty — PH uses Tailwind, not stable class names.
+  // The most reliable anchor is the section heading that says "Today" or a date.
+  if (!items || items.length === 0) {
+    items = document.querySelectorAll('section[class*="posts"] li');
+  }
+
+  return Array.from(items).slice(0, 20).map(function(li) {
+    // Product name: inside an <a> that links to /posts/...
+    var nameEl = li.querySelector('a[href*="/posts/"] strong, a[href*="/posts/"] span[class*="title"]');
+    if (!nameEl) nameEl = li.querySelector('a[href*="/posts/"]');
+
+    // Tagline: second text block inside the card
+    var tagEl  = li.querySelector('a[href*="/posts/"] + * span, [class*="tagline"], [class*="description"]');
+
+    // Vote count: the orange/red upvote button
+    var voteEl = li.querySelector('[class*="voteButton"] span, button[class*="vote"] span, [data-test*="vote"] span');
+
+    // PH URL (relative)
+    var linkEl = li.querySelector('a[href*="/posts/"]');
+
+    return {
+      name:     nameEl ? nameEl.innerText.trim() : null,
+      tagline:  tagEl  ? tagEl.innerText.trim()  : null,
+      votes:    voteEl ? voteEl.innerText.trim()  : null,
+      ph_url:   linkEl ? 'https://www.producthunt.com' + linkEl.getAttribute('href') : null,
+    };
+  }).filter(function(p) { return p.name; });
+})()
+""")
+
+print(products[:10])
+```
+
+**If the selector returns an empty list:** call `screenshot()` to see the current DOM, then inspect what wraps the product cards. PH's class names are Tailwind hashes that occasionally change on deploys. The most stable fallback is to pivot to `a[href*="/posts/"]` anchors:
+
+```python
+products = js("""
+(function() {
+  var seen = new Set();
+  var out  = [];
+  document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
+    var href = a.getAttribute('href');
+    if (seen.has(href)) return;
+    seen.add(href);
+
+    // Walk up to find the card root
+    var card = a.closest('li') || a.closest('article') || a.parentElement;
+    var text  = a.innerText.trim().split('\\n');
+
+    out.push({
+      name:    text[0] || null,
+      tagline: text[1] || null,
+      ph_url:  'https://www.producthunt.com' + href,
+    });
+  });
+  return out.filter(function(p) { return p.name && p.name.length > 0; });
+})()
+""")
+```
+
+---
+
+### 2. Scroll to load more products (lazy loading)
+
+The homepage loads ~10 products initially. Scrolling fires an intersection observer that appends more. Repeat until you have enough or hit the end of today's launches.
+
+```python
+goto("https://www.producthunt.com")
+wait_for_load()
+wait(2)
+
+info = page_info()
+viewport_h = info["h"]
+
+all_products = []
+seen_urls = set()
+
+for batch in range(5):  # 5 scrolls × ~10 products = up to ~50
+    # Extract currently visible products
+    batch_data = js("""
+    (function() {
+      var seen = new Set();
+      var out  = [];
+      document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
+        var href = a.getAttribute('href');
+        if (seen.has(href) || !href.match(/^\\/posts\\/[^/]+$/)) return;
+        seen.add(href);
+        var card = a.closest('li') || a.parentElement;
+        var texts = a.innerText.trim().split('\\n').filter(function(s){ return s.trim(); });
+        // Vote button is a sibling of the link
+        var voteEl = card ? card.querySelector('button[class*="vote"] span, [class*="voteButton"] span') : null;
+        out.push({
+          name:    texts[0] || null,
+          tagline: texts[1] || null,
+          votes:   voteEl ? voteEl.innerText.trim() : null,
+          ph_url:  'https://www.producthunt.com' + href,
+        });
+      });
+      return out;
+    })()
+    """)
+
+    for p in (batch_data or []):
+        if p.get("ph_url") and p["ph_url"] not in seen_urls:
+            seen_urls.add(p["ph_url"])
+            all_products.append(p)
+
+    print(f"Batch {batch+1}: {len(all_products)} total products so far")
+
+    # Scroll toward the bottom of the page to trigger lazy loading
+    ph = page_info()["ph"]  # current page height
+    scroll(760, viewport_h // 2, dy=-(ph // 3))
+    wait(2)  # wait for the next batch to render
+
+print(f"Final: {len(all_products)} products")
+```
+
+---
+
+### 3. Topic / category pages
+
+Product Hunt organises products by topic at `/topics/<slug>`. These pages list the highest-ranked products for that topic across all time (not just today). They are also client-rendered — use the browser.
+
+Common topic slugs: `developer-tools`, `ai`, `marketing`, `design-tools`, `productivity`, `open-source`, `chrome-extensions`, `no-code`.
+
+```python
+topic = "developer-tools"  # or "ai", "marketing", etc.
+goto(f"https://www.producthunt.com/topics/{topic}")
+wait_for_load()
+wait(2)
+
+products = js("""
+(function() {
+  var seen = new Set();
+  var out  = [];
+  document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
+    var href = a.getAttribute('href');
+    if (seen.has(href) || !href.match(/^\\/posts\\/[^/]+$/)) return;
+    seen.add(href);
+    var card   = a.closest('li') || a.closest('article') || a.parentElement;
+    var texts  = a.innerText.trim().split('\\n').filter(function(s){ return s.trim(); });
+    var voteEl = card ? card.querySelector('[class*="vote"] span, button span') : null;
+    out.push({
+      name:    texts[0] || null,
+      tagline: texts[1] || null,
+      votes:   voteEl ? voteEl.innerText.trim() : null,
+      ph_url:  'https://www.producthunt.com' + href,
+    });
+  });
+  return out;
+})()
+""")
+
+print(products[:20])
+```
+
+To scroll and load more results on a topic page (same mechanics as the homepage):
+
+```python
+for _ in range(4):
+    scroll(760, 400, dy=-1200)
+    wait(1.5)
+# then re-run the js() extraction above
+```
+
+---
+
+### 4. Product detail page — description, pricing, maker info, external URL
+
+The detail page at `https://www.producthunt.com/posts/{slug}` contains the full description, the external website URL, tags, gallery images, and maker profiles.
+
+```python
+slug = "cursor-the-ai-code-editor"   # replace with actual slug from the leaderboard
+goto(f"https://www.producthunt.com/posts/{slug}")
+wait_for_load()
+wait(2)
+
+detail = js("""
+(function() {
+  // External website URL — the "Visit website" button points to /redirect/posts/...
+  // which redirects to the real external URL. Grab it from the href directly.
+  var visitBtn = document.querySelector('a[href*="/redirect/posts/"], a[href*="website"]');
+  var extUrl   = visitBtn ? visitBtn.getAttribute('href') : null;
+
+  // Description block — typically a <div> or <p> under the tagline
+  var descEl = document.querySelector('[class*="description"], [class*="about"], section p');
+  var desc   = descEl ? descEl.innerText.trim() : null;
+
+  // Tags / topics
+  var tags = Array.from(
+    document.querySelectorAll('a[href*="/topics/"]')
+  ).map(function(a){ return a.innerText.trim(); })
+   .filter(function(t){ return t.length > 0 && t.length < 40; });
+
+  // Pricing — if there's a pricing section (not all products show one)
+  var pricingEl = document.querySelector('[class*="pricing"], [class*="price"]');
+  var pricing   = pricingEl ? pricingEl.innerText.trim() : null;
+
+  // Vote count on the detail page
+  var voteEl = document.querySelector('[class*="voteButton"] span, button[class*="vote"] span');
+
+  // Maker info — links to /user/... profiles
+  var makers = Array.from(
+    document.querySelectorAll('a[href*="/user/"]')
+  ).map(function(a){
+    return {
+      name:     a.innerText.trim(),
+      ph_url:   'https://www.producthunt.com' + a.getAttribute('href'),
+    };
+  }).filter(function(m){ return m.name.length > 0; });
+
+  // Gallery image URLs
+  var images = Array.from(
+    document.querySelectorAll('img[class*="gallery"], [class*="media"] img, [class*="screenshot"] img')
+  ).map(function(img){ return img.src; })
+   .filter(function(src){ return src && !src.includes('avatar') && !src.includes('logo'); });
+
+  return {
+    external_url: extUrl,
+    description:  desc,
+    tags:         [...new Set(tags)].slice(0, 10),
+    pricing:      pricing,
+    votes:        voteEl ? voteEl.innerText.trim() : null,
+    makers:       makers.slice(0, 5),
+    gallery:      images.slice(0, 8),
+  };
+})()
+""")
+
+print(detail)
+```
+
+**Getting the real external URL (not the PH redirect):** PH wraps outbound links in `/redirect/posts/{id}?url=...`. The `url` query param contains the actual destination. Parse it without clicking:
+
+```python
+import urllib.parse
+
+redirect_href = detail.get("external_url", "")   # e.g. "/redirect/posts/123?url=https%3A%2F%2F..."
+if redirect_href and "url=" in redirect_href:
+    qs = urllib.parse.parse_qs(urllib.parse.urlparse(redirect_href).query)
+    real_url = qs.get("url", [None])[0]
+    print("External site:", real_url)
+```
+
+---
+
+### 5. First 20 products with full details (name, website, description, tags, votes, logo)
+
+This combines the leaderboard scroll with per-product detail fetching. It is slow (one `goto` per product) — use only when you genuinely need description + external URL for every product.
+
+```python
+goto("https://www.producthunt.com")
+wait_for_load()
+wait(2)
+
+# Step 1: collect slugs from the leaderboard
+slugs = js("""
+(function() {
+  var seen = new Set();
+  var out  = [];
+  document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
+    var href = a.getAttribute('href');
+    if (seen.has(href) || !href.match(/^\\/posts\\/[^/]+$/)) return;
+    seen.add(href);
+    out.push(href);
+  });
+  return out.slice(0, 20);
+})()
+""")
+
+# Step 2: visit each product page and extract details
+import time, urllib.parse
+
+results = []
+for ph_path in slugs:
+    goto(f"https://www.producthunt.com{ph_path}")
+    wait_for_load()
+    wait(1.5)
+
+    row = js("""
+    (function() {
+      var visitBtn  = document.querySelector('a[href*="/redirect/posts/"]');
+      var logoEl    = document.querySelector('img[alt*="logo"], [class*="logo"] img, header img');
+      var nameEl    = document.querySelector('h1');
+      var taglineEl = document.querySelector('h2, [class*="tagline"]');
+      var descEl    = document.querySelector('[class*="description"] p, section > p, [class*="about"] p');
+      var voteEl    = document.querySelector('[class*="voteButton"] span, button[class*="vote"] span');
+      var tags      = Array.from(document.querySelectorAll('a[href*="/topics/"]'))
+                          .map(function(a){ return a.innerText.trim(); })
+                          .filter(function(t){ return t && t.length < 40; });
+      return {
+        name:         nameEl    ? nameEl.innerText.trim()    : null,
+        tagline:      taglineEl ? taglineEl.innerText.trim() : null,
+        description:  descEl   ? descEl.innerText.trim()    : null,
+        votes:        voteEl   ? voteEl.innerText.trim()    : null,
+        redirect_url: visitBtn  ? visitBtn.getAttribute('href') : null,
+        logo_url:     logoEl   ? logoEl.src : null,
+        tags:         [...new Set(tags)].slice(0, 8),
+      };
+    })()
+    """)
+
+    # Resolve external URL from redirect href
+    if row and row.get("redirect_url") and "url=" in row["redirect_url"]:
+        qs = urllib.parse.parse_qs(urllib.parse.urlparse(row["redirect_url"]).query)
+        row["website"] = qs.get("url", [None])[0]
+    else:
+        row["website"] = None
+
+    row["ph_url"] = f"https://www.producthunt.com{ph_path}"
+    results.append(row)
+    time.sleep(0.5)  # polite pacing
+
+print(results)
+```
+
+---
+
+### 6. GraphQL API (advanced — fragile)
+
+Product Hunt exposes a GraphQL endpoint at `https://www.producthunt.com/frontend/graphql`. It is used by the SPA itself and returns structured JSON without DOM parsing. The catch: it requires a `_ph_puuid` cookie and an `Authorization: Bearer <token>` that is minted client-side and rotates on each session.
+
+**Grab the live token from the running browser session:**
+
+```python
+# 1. Make sure producthunt.com is open in the browser
+goto("https://www.producthunt.com")
+wait_for_load()
+wait(2)
+
+# 2. Extract the bearer token from localStorage / window.__APOLLO_STATE__
+token = js("""
+(function() {
+  // PH stores auth in a localStorage key like "ph_access_token" or via Apollo headers
+  // Try common locations:
+  var t = localStorage.getItem('ph_access_token')
+       || localStorage.getItem('access_token');
+  if (t) return t;
+
+  // Fallback: intercept from the last XHR — not easy without Network.enable.
+  // Return null if not found; use the cookie approach below instead.
+  return null;
+})()
+""")
+
+# 3. Get cookies to send with the request
+cookies_raw = js("document.cookie")
+# cookies_raw is "key=val; key2=val2; ..."
+
+print("Token:", token)
+print("Cookies:", cookies_raw[:200])
+```
+
+**Issue a GraphQL query using the token:**
+
+```python
+import json
+
+# Today's top posts (posts endpoint)
+query = """
+query TodaysPosts($first: Int) {
+  posts(order: VOTES, first: $first, postedAfter: "today") {
+    edges {
+      node {
+        id
+        name
+        tagline
+        votesCount
+        website
+        slug
+        topics {
+          edges { node { name } }
+        }
+        thumbnail { url }
+      }
+    }
+  }
+}
+"""
+
+headers = {
+    "Content-Type": "application/json",
+    "Accept":       "application/json",
+    "Origin":       "https://www.producthunt.com",
+    "Referer":      "https://www.producthunt.com/",
+}
+if token:
+    headers["Authorization"] = f"Bearer {token}"
+if cookies_raw:
+    headers["Cookie"] = cookies_raw
+
+body = json.dumps({"query": query, "variables": {"first": 20}}).encode()
+
+# http_get only does GET — use a raw CDP network request for POST
+response = js(f"""
+(async function() {{
+  const r = await fetch('https://www.producthunt.com/frontend/graphql', {{
+    method: 'POST',
+    headers: {json.dumps(headers)},
+    body: JSON.stringify({{query: {json.dumps(query)}, variables: {{first: 20}}}})
+  }});
+  return await r.text();
+}})()
+""")
+
+data = json.loads(response)
+posts = data["data"]["posts"]["edges"]
+for edge in posts:
+    node = edge["node"]
+    print(node["name"], "|", node["tagline"], "|", node["votesCount"], "|", node["website"])
+```
+
+**Why this is fragile:**
+- The bearer token changes every session and cannot be hardcoded.
+- PH may add CSRF checks (`x-csrf-token`, `x-request-id`) that break the fetch.
+- The GraphQL schema has changed several times — field names like `postsConnection` vs `posts` vary by PH's deployment.
+- Use DOM scraping as the primary method; treat GraphQL as a faster alternative to verify or enrich data when it works.
+
+---
+
+## Gotchas
+
+- **Products load in batches — scroll and wait between batches.** The first `wait_for_load()` only signals the HTML shell is ready. React renders the first ~10 products, then more are appended as you scroll. Each `scroll()` should be followed by `wait(1.5)` to `wait(2)` to let the fetch-and-render cycle finish.
+
+- **Vote counts update in real-time.** Product Hunt uses WebSockets (Pusher) to push live vote increments. A vote count you read at T+0 may differ from one read at T+30s. Treat them as point-in-time snapshots, not authoritative totals.
+
+- **`/topics/` pages rank by all-time votes, not today.** If the task says "today's top developer tools," use the homepage and filter by topic tags on the detail page — don't use `/topics/developer-tools`, which will return products from past years.
+
+- **The external website URL is never directly in the link text.** PH wraps all outbound links in `/redirect/posts/{id}?url=<encoded>`. Parse the `url=` query param from the redirect `href` attribute — do NOT click it (that opens a new tab and loses context). See the `urllib.parse` snippet in workflow 4.
+
+- **PH uses Tailwind — class names are hashed and not stable across deploys.** Never use a class name like `styles_voteButton__xK9q2` as a selector. Always target structural attributes (`href`, `data-test*`, `aria-*`) or element type + hierarchy. The `a[href^="/posts/"]` anchor is the most stable entry point.
+
+- **Login is not required for reading** — vote counts, product names, taglines, descriptions, and maker profiles are all publicly accessible. Login is required only to upvote, comment, or access private launches.
+
+- **The `#1 product` on the homepage** is ranked by votes within the current day (midnight UTC reset). The ordering is stable by mid-day but can change rapidly in the first few hours after midnight as votes accumulate.
+
+- **Pagination on topic pages** works via infinite scroll, same as the homepage. There is no `?page=N` URL parameter for the browser-rendered view. Scroll to get more.
+
+- **`screenshot()` is your best debugging tool.** If any `js()` extraction returns empty or `None`, always call `screenshot()` before trying alternative selectors — the page may still be loading, a login modal may have appeared, or PH may have A/B-tested a new layout.
+
+- **Date boundary:** PH resets the daily leaderboard at **midnight UTC**, not midnight in the user's local timezone. If you're scraping just after midnight UTC, the new day's list may have zero or very few products.
+
+- **Product Hunt CDN assets** (logos, gallery images) are served from `ph-files.imgix.net`. These are publicly accessible without auth and can be fetched with `http_get`.


### PR DESCRIPTION
## Summary

Adds 6 new domain skill guides for public, no-login-required sites, derived from real user task patterns.

- **github/scraping.md** — GitHub API + trending page, rate limiting, parallel fetch
- **hackernews/scraping.md** — http_get + Algolia API for search/date filtering
- **producthunt/scraping.md** — React SPA browser scraping, lazy-load, redirect unwrapping
- **amazon/product-search.md** — ASIN extraction, price normalization, CAPTCHA handling
- **news-aggregation/multi-source.md** — RSS-first, parallel fetch, consent banners
- **job-boards/indeed-glassdoor.md** — URL construction, job key extraction, salary normalization

All skills cover publicly accessible content only. No credentials or login-gated workflows.

## Test plan
- [ ] Review each skill file for accuracy
- [ ] Verify code snippets are valid Python
- [ ] Check selectors against current live site DOM
- [ ] Run at least one workflow per skill to validate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six domain-skill guides for public, no-login sites with clear patterns and Python snippets. This improves reliability and speed by favoring APIs/RSS and direct URLs, using the browser only when needed.

- **New Features**
  - GitHub: Use REST `http_get` for repo/users/releases; handle rate limits; browser for Trending; parallel fetch.
  - Hacker News: `http_get` and simple parsing for lists/comments; Algolia API for search/date filters.
  - Product Hunt: React SPA; use browser with hydrate wait; extract daily leaderboard and topics; handle lazy-load.
  - Amazon: Build search and `/dp/` URLs; extract ASINs; normalize prices; basic CAPTCHA/backoff guidance.
  - News aggregation: RSS-first across major sites; parallel fetch with TTLs; handle consent banners and canonical links.
  - Job boards (Indeed/Glassdoor/Stepstone): Construct search URLs; extract job IDs/keys; normalize salary; paginate safely.

<sup>Written for commit f0f70e73629de08f0b8ad5c8f209385063547dc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

