### PR TITLE
[codex] Add more spacing between README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ When this page appears tick the checkbox so the agent can connect to the real br
 
 <img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />
 
+<br><br><br>
 
 ## Example task
 
@@ -25,6 +26,7 @@ Star this repository.
 
 See [domain-skills/](domain-skills/) for examples on other websites.
 
+<br><br><br>
 
 ## Code Structure
 
@@ -35,6 +37,7 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 - `admin.py` (~139 lines) holds daemon bootstrap and optional remote-browser helpers.
 - `daemon.py` (~220 lines) keeps the CDP websocket and socket bridge alive.
 
+<br><br><br>
 
 ## Optional: Remote browsers
 


### PR DESCRIPTION
## What changed
- added larger visual spacing between the main README sections with explicit HTML line breaks
- left the README content unchanged

## Why
The existing section breaks were still too tight visually. This makes the main sections breathe more when rendered on GitHub.

## Validation
- reviewed the README diff locally


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `<br><br><br>` between main README sections to increase vertical spacing and make the document easier to scan on GitHub. No content changes.

<sup>Written for commit 98ed52c11559b891d3343b0cb015e7c9a10a2b06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

