### PR TITLE
[codex] Reduce README section spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When this page appears tick the checkbox so the agent can connect to the real br
 
 <img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />
 
-<br><br><br>
+<br><br>
 
 ## Example task
 
@@ -26,7 +26,7 @@ Star this repository.
 
 See [domain-skills/](domain-skills/) for examples on other websites.
 
-<br><br><br>
+<br><br>
 
 ## Code Structure
 
@@ -37,7 +37,7 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 - `admin.py` (~139 lines) holds daemon bootstrap and optional remote-browser helpers.
 - `daemon.py` (~220 lines) keeps the CDP websocket and socket bridge alive.
 
-<br><br><br>
+<br><br>
 
 ## Optional: Remote browsers
 


### PR DESCRIPTION
## What changed
- reduced the extra README section spacing from three `<br>` tags to two between the main sections
- left the rest of the README unchanged

## Why
The previous spacing was a bit too loose. This keeps the sections visually separated without creating as much vertical whitespace.

## Validation
- reviewed the README diff locally


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced vertical spacing in the README by changing section dividers from three `<br>` tags to two. Keeps sections clearly separated while cutting excess whitespace.

<sup>Written for commit 5783f4b935c3925f8f0bb9280a458d30e21e9130. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

