### PR TITLE
Replace drafted skills with browser-harness validated versions

### DIFF
--- a/domain-skills/amazon/product-search.md
+++ b/domain-skills/amazon/product-search.md
@@ -1,442 +1,198 @@
 # Amazon — Product Search & Data Extraction
 
-`https://www.amazon.com` (also `.co.uk`, `.fr`, `.de`, `.co.jp`, `.ca`, `.com.au`)
+Field-tested against amazon.com on 2025-04-18 using a logged-in Chrome session.
+No CAPTCHA or bot detection was triggered during any test run.
 
----
+## Navigation
 
-## Do this first: construct URLs directly, don't click the search box
-
-Amazon search URLs are stable and predictable. Build them directly — it's faster and avoids bot-detection on the home page UI.
-
+### Direct search URL (fastest, always use this)
 ```python
-query = "mechanical keyboard"
-goto(f"https://www.amazon.com/s?k={query.replace(' ', '+')}")
-wait_for_load()
-```
-
-For product detail pages, go straight to the `/dp/` URL:
-
-```python
-asin = "B08N5WRWNW"
-goto(f"https://www.amazon.com/dp/{asin}")
-wait_for_load()
-```
-
----
-
-## URL patterns
-
-| Goal | URL pattern |
-|---|---|
-| Keyword search | `/s?k=wireless+earbuds` |
-| Search in department | `/s?k=chair&i=garden` (i= is the department node) |
-| Price range | `/s?k=standing+desk&rh=p_36%3A1000-30000` (cents, e.g. 1000=\$10, 30000=\$300) |
-| Min rating filter | `/s?k=headphones&rh=p_72%3A1248957011` (4+ stars node) |
-| Prime-only | `/s?k=coffee+maker&rh=p_85%3A2470955011` |
-| Combine filters | `/s?k=standing+desk&rh=p_36%3A1000-30000%2Cp_72%3A1248957011` |
-| Product detail | `/dp/{ASIN}` |
-| Best Sellers (root) | `/Best-Sellers/zgbs/` |
-| Best Sellers (category) | `/Best-Sellers/zgbs/electronics/` |
-| Best Sellers (subcategory) | `/Best-Sellers/zgbs/electronics/172541/` (node ID) |
-
-Price range encoding: multiply dollar amount by 100 and encode as `p_36%3A{min}-{max}`. Example: \$50–\$300 → `p_36%3A5000-30000`.
-
----
-
-## Workflow 1: Search results extraction
-
-### Reliable extraction via `data-asin`
-
-Amazon marks every real result card with `data-asin`. Sponsored results get `data-component-type="sp-sponsored-result"` — filter them out.
-
-```python
-import json
-
 goto("https://www.amazon.com/s?k=mechanical+keyboard")
 wait_for_load()
-wait(2)  # let lazy-loaded price data settle
+wait(2)  # dynamic content needs ~2s after readyState=complete
+```
 
+### Search box typing (use when you need category filtering)
+```python
+goto("https://www.amazon.com")
+wait_for_load()
+wait(1)
+js("document.querySelector('#twotabsearchtextbox').focus()")
+js("document.querySelector('#twotabsearchtextbox').click()")
+wait(0.3)
+type_text("wireless mouse")
+wait(0.3)
+press_key("Enter")
+wait_for_load()
+wait(2)
+```
+
+### Direct product page
+```python
+# URL pattern: /dp/{ASIN}  or  /dp/{ASIN}?th=1 (Amazon may redirect to add ?th=1)
+goto("https://www.amazon.com/dp/B08Z6X4NK3")
+wait_for_load()
+wait(2)
+```
+
+## Session Gotcha
+
+**Always use `new_tab()` when opening Amazon for the first time in a harness session.**
+`goto()` can silently fail to navigate if the current tab resists the navigation
+(observed when the daemon attached to a different real tab). The safe pattern:
+
+```python
+tid = new_tab("https://www.amazon.com/s?k=mechanical+keyboard")
+wait_for_load()
+wait(2)
+```
+
+After that, `goto()` works fine within the same Amazon session.
+
+## Search Results Extraction
+
+### Container selector
+`[data-component-type="s-search-result"]` — confirmed working, yields ~22 results per page.
+
+### Full extraction (field-tested)
+```python
 results = js("""
-(function() {
-  var cards = document.querySelectorAll(
-    '[data-component-type="s-search-result"]:not([data-component-type="sp-sponsored-result"])'
-  );
-  var out = [];
-  for (var i = 0; i < Math.min(cards.length, 10); i++) {
-    var c = cards[i];
-    var asin = c.getAttribute('data-asin') || '';
-    var titleEl = c.querySelector('h2 a span, h2 span');
-    var title = titleEl ? titleEl.innerText.trim() : '';
-    // Price: whole + fraction
-    var whole = c.querySelector('.a-price-whole');
-    var frac  = c.querySelector('.a-price-fraction');
-    var price = (whole && frac)
-      ? ('$' + whole.innerText.replace(',','').replace('.','') + '.' + frac.innerText)
-      : (c.querySelector('.a-price .a-offscreen') || {innerText:''}).innerText.trim();
-    var ratingEl = c.querySelector('i.a-icon-star-small span, i[class*="a-star"] span');
-    var rating = ratingEl ? ratingEl.innerText.trim() : '';
-    var reviewEl = c.querySelector('[aria-label*="stars"] + span, .a-size-base.s-underline-text');
-    var reviews = reviewEl ? reviewEl.innerText.replace(/,/g,'').trim() : '';
-    var prime = !!c.querySelector('[aria-label="Amazon Prime"], .s-prime');
-    out.push({asin, title, price, rating, reviews, prime});
-  }
-  return JSON.stringify(out);
-})()
+  Array.from(document.querySelectorAll('[data-component-type="s-search-result"]')).map(el => ({
+    asin: el.getAttribute('data-asin'),
+    title: el.querySelector('h2 span')?.innerText?.trim(),
+    price: el.querySelector('.a-price .a-offscreen')?.innerText,
+    list_price: el.querySelector('.a-text-price .a-offscreen')?.innerText,
+    rating: el.querySelector('[aria-label*="out of 5 stars"]')?.getAttribute('aria-label')?.split(' ')[0],
+    reviews: el.querySelector('[aria-label*="ratings"]')?.getAttribute('aria-label'),
+    is_sponsored: !!el.querySelector('.puis-sponsored-label-text'),
+    url: el.querySelector('h2 a')?.href
+  }))
 """)
-
-products = json.loads(results)
-for p in products:
-    print(p)
 ```
 
-### ASIN from URL (search results page)
+### Field notes
+- **`asin`**: `data-asin` attribute on the container div — always present, matches the `/dp/{ASIN}` URL.
+- **`title`**: `h2 span` works consistently. `h2 a.a-link-normal span` also works.
+- **`price`**: `.a-price .a-offscreen` returns the formatted string e.g. `"$69.99"`. Use this, not `.a-price-whole`.
+- **`list_price`**: `.a-text-price .a-offscreen` — only present when item is on sale (was/now pricing).
+- **`rating`**: Use `aria-label` on `[aria-label*="out of 5 stars"]` — gives `"4.5 out of 5 stars, rating details"`, split on space for the number.
+- **`reviews`**: Use `[aria-label*="ratings"]` attribute — gives `"1,514 ratings"`. Do NOT use `.a-size-base.s-underline-text` — that element exists on sponsored results and shows "Xbox" (a cross-sell widget text).
+- **`is_sponsored`**: `.puis-sponsored-label-text` is present on sponsored listings; first 2-3 results are usually sponsored.
+- **`url`**: `h2 a` href — contains the full `/dp/{ASIN}/...` URL.
 
-Each result card's "a" link encodes the ASIN:
+## Product Detail Page Extraction
 
+### Confirmed selectors (field-tested on B08Z6X4NK3)
 ```python
-asins = js("""
-JSON.stringify(
-  Array.from(document.querySelectorAll('[data-asin]'))
-    .map(el => el.getAttribute('data-asin'))
-    .filter(a => a && a.length === 10)
-    .filter((a, i, arr) => arr.indexOf(a) === i)  // dedupe
-)
-""")
-# e.g. ["B09XLNBM3B", "B07WRXDH2P", ...]
-```
-
----
-
-## Workflow 2: Product detail page extraction (`/dp/{ASIN}`)
-
-```python
-import json, re
-
-asin = "B07XJ8C8F7"
-goto(f"https://www.amazon.com/dp/{asin}")
-wait_for_load()
-wait(2)
-
 detail = js("""
-(function() {
-  // Title
-  var titleEl = document.getElementById('productTitle');
-  var title = titleEl ? titleEl.innerText.trim() : '';
-
-  // Price — multiple possible locations
-  var priceEl = (
-    document.getElementById('priceblock_ourprice') ||
-    document.getElementById('priceblock_dealprice') ||
-    document.querySelector('.a-price .a-offscreen') ||
-    document.querySelector('#corePriceDisplay_desktop_feature_div .a-price .a-offscreen') ||
-    document.querySelector('#apex_offerDisplay_desktop .a-price .a-offscreen')
-  );
-  var price = priceEl ? priceEl.innerText.trim() : '';
-
-  // Rating
-  var ratingEl = document.getElementById('acrPopover');
-  var rating = ratingEl ? (ratingEl.getAttribute('title') || '').trim() : '';
-
-  // Review count
-  var reviewEl = document.getElementById('acrCustomerReviewText');
-  var reviews = reviewEl ? reviewEl.innerText.replace(/[^0-9]/g,'') : '';
-
-  // Availability
-  var availEl = document.getElementById('availability');
-  var availability = availEl ? availEl.innerText.trim() : '';
-
-  // Bullet points (feature list)
-  var bullets = Array.from(document.querySelectorAll('#feature-bullets li span.a-list-item'))
-    .map(el => el.innerText.trim())
-    .filter(t => t.length > 0);
-
-  return JSON.stringify({title, price, rating, reviews: parseInt(reviews)||0, availability, bullets});
-})()
+  ({
+    title: document.querySelector('#productTitle')?.innerText?.trim(),
+    price: (function() {
+      var whole = document.querySelector('.a-price-whole')?.innerText?.replace(/[\\n.]/g,'');
+      var frac  = document.querySelector('.a-price-fraction')?.innerText;
+      return (whole && frac) ? '$' + whole + '.' + frac
+           : document.querySelector('.a-price .a-offscreen')?.innerText || null;
+    })(),
+    list_price: document.querySelector('.basisPrice .a-offscreen')?.innerText,
+    rating: document.querySelector('#acrPopover')?.getAttribute('title'),
+    review_count: document.querySelector('#acrCustomerReviewText')?.innerText,
+    availability: document.querySelector('#availability span')?.innerText?.trim(),
+    brand: document.querySelector('#bylineInfo')?.innerText?.trim(),
+    asin: document.querySelector('input[name="ASIN"]')?.value,
+    bullet_points: Array.from(document.querySelectorAll('#feature-bullets li span.a-list-item'))
+                       .map(e => e.innerText?.trim()).filter(t => t)
+  })
 """)
-
-info = json.loads(detail)
-print(info)
 ```
 
-### Availability string patterns
+### Price field notes
+- `#priceblock_ourprice` and `#priceblock_dealprice` are **legacy** — they return `null` on modern product pages.
+- Construct price from `.a-price-whole` + `.a-price-fraction` (both stripped of `\n` and `.`).
+- As a fallback: first `.a-price .a-offscreen` on the page also works (confirmed `$69.99`).
+- `list_price` from `.basisPrice .a-offscreen` shows the crossed-out "was" price when a discount exists.
+
+## Best Sellers Page
+
+URL: `https://www.amazon.com/Best-Sellers-{Category}/zgbs/{slug}/`
+e.g. `https://www.amazon.com/Best-Sellers-Electronics/zgbs/electronics/`
+
+### DOM structure (2025)
+`.zg-item-immersion` **does not exist** — Amazon migrated to CSS modules. Use `[data-asin]` anchored on `[id="gridItemRoot"]`:
 
 ```python
-avail = info["availability"]
-if "In Stock" in avail:
-    status = "in_stock"
-elif re.search(r"Only \d+ left", avail):
-    n = re.search(r"(\d+)", avail).group(1)
-    status = f"low_stock_{n}"
-elif "Usually ships" in avail:
-    status = "ships_delayed"
-elif "Unavailable" in avail or "Currently unavailable" in avail:
-    status = "out_of_stock"
-else:
-    status = "unknown"
-```
-
----
-
-## Workflow 3: Price checking by ASIN (fast, no browser)
-
-For a single known ASIN, `http_get` is usually sufficient and avoids CAPTCHA risk:
-
-```python
-import re
-
-asin = "B08N5WRWNW"
-html = http_get(
-    f"https://www.amazon.com/dp/{asin}",
-    headers={"Accept-Language": "en-US,en;q=0.9"}
-)
-
-# Extract title
-title_m = re.search(r'id="productTitle"[^>]*>\s*([^<]+)', html)
-title = title_m.group(1).strip() if title_m else "N/A"
-
-# Extract price (offscreen span is most reliable in raw HTML)
-price_m = re.search(r'class="a-offscreen">([^<]+)</span>', html)
-price = price_m.group(1).strip() if price_m else "N/A"
-
-print(f"{asin}: {title} — {price}")
-```
-
-If `http_get` returns a CAPTCHA page (check `"captcha" in html.lower()`), fall back to the browser path (goto + wait_for_load + js extraction above).
-
-```python
-if "captcha" in html.lower() or "Type the characters" in html:
-    # Fall back to browser
-    goto(f"https://www.amazon.com/dp/{asin}")
-    wait_for_load()
-    wait(2)
-    # ... use js() extraction from Workflow 2
-```
-
----
-
-## Workflow 4: Best Sellers extraction
-
-```python
-import json
-
-category_path = "electronics"   # or "computers", "books", etc.
-goto(f"https://www.amazon.com/Best-Sellers/zgbs/{category_path}/")
+goto("https://www.amazon.com/Best-Sellers-Electronics/zgbs/electronics/")
 wait_for_load()
 wait(2)
 
-bestsellers = js("""
-(function() {
-  var items = document.querySelectorAll(
-    '#zg-ordered-list li, .zg-item-immersion'
-  );
-  var out = [];
-  for (var i = 0; i < Math.min(items.length, 10); i++) {
-    var el = items[i];
-    var rank = i + 1;
-    var titleEl = el.querySelector('.zg-bdg-text, ._cDEzb_p13n-sc-css-line-clamp-3_g3dy1, .p13n-sc-truncated');
-    var title = titleEl ? titleEl.innerText.trim() : '';
-    var priceEl = el.querySelector('.p13n-sc-price, ._cDEzb_p13n-sc-price_3mJ9Z');
-    var price = priceEl ? priceEl.innerText.trim() : '';
-    var ratingEl = el.querySelector('.a-icon-star-small span, .a-icon-star span');
-    var rating = ratingEl ? ratingEl.innerText.trim() : '';
-    var linkEl = el.querySelector('a.a-link-normal[href*="/dp/"]');
-    var href = linkEl ? linkEl.href : '';
-    var asinM = href.match(/\/dp\/([A-Z0-9]{10})/);
-    var asin = asinM ? asinM[1] : '';
-    if (title) out.push({rank, asin, title, price, rating});
-  }
-  return JSON.stringify(out);
-})()
+items = js("""
+  Array.from(document.querySelectorAll('[data-asin]')).map(el => {
+    var container = el.closest('[id="gridItemRoot"]') || el;
+    return {
+      asin: el.getAttribute('data-asin'),
+      rank: container.querySelector('[class*="zg-bdg-text"]')?.innerText,
+      title: container.querySelector('img[alt]')?.getAttribute('alt'),
+      price: container.querySelector('.p13n-sc-price, .a-size-base.a-color-price')?.innerText,
+      url: 'https://www.amazon.com/dp/' + el.getAttribute('data-asin')
+    }
+  }).filter(r => r.rank)
 """)
-
-items = json.loads(bestsellers)
-for item in items:
-    print(item)
 ```
 
-Best Sellers pages paginate in two columns — if `items` is empty, the page may use a different layout. Take a screenshot to confirm:
+Note: Title comes from the product image `alt` attribute — the text title elements use obfuscated CSS module class names that change between deployments.
+
+## Pagination
 
 ```python
-screenshot()  # inspect layout before tuning selectors
-```
-
----
-
-## Workflow 5: Multi-page search (pagination)
-
-Amazon search results have a "Next" button. Extract the URL from it rather than incrementing a page counter (page numbers can be non-linear after filter application):
-
-```python
-import json
-
-all_results = []
-goto("https://www.amazon.com/s?k=standing+desk&rh=p_36%3A1000-30000")
-wait_for_load()
-wait(2)
-
-for page_num in range(1, 6):  # up to 5 pages
-    # extract current page results (same JS as Workflow 1)
-    batch = json.loads(js("""
-    (function() {
-      var cards = document.querySelectorAll('[data-component-type="s-search-result"]');
-      var out = [];
-      cards.forEach(function(c) {
-        var asin = c.getAttribute('data-asin') || '';
-        var titleEl = c.querySelector('h2 a span');
-        var title = titleEl ? titleEl.innerText.trim() : '';
-        var priceEl = c.querySelector('.a-price .a-offscreen');
-        var price = priceEl ? priceEl.innerText.trim() : '';
-        if (asin && title) out.push({asin, title, price});
-      });
-      return JSON.stringify(out);
-    })()
-    """))
-    all_results.extend(batch)
-
-    # get next page URL
-    next_url = js("""
-      var n = document.querySelector('.s-pagination-next:not(.s-pagination-disabled)');
-      n ? n.href : null
-    """)
-    if not next_url:
-        break
-
+# Get next page URL directly
+next_url = js("document.querySelector('.s-pagination-next')?.href")
+if next_url:
     goto(next_url)
     wait_for_load()
-    wait(2)  # respect rate limit between pages
+    wait(2)
 
-print(f"Total results collected: {len(all_results)}")
+# Or construct by page number
+goto("https://www.amazon.com/s?k=wireless+mouse&page=2")
 ```
 
----
-
-## Workflow 6: Add to cart (requires logged-in session)
-
-This only works when Chrome already has an active Amazon session.
+## Result Count
 
 ```python
-asin = "B09XLNBM3B"
-goto(f"https://www.amazon.com/dp/{asin}")
-wait_for_load()
-wait(2)
-
-# Verify not a CAPTCHA or login redirect
-url = page_info()["url"]
-if "signin" in url or "ap/signin" in url:
-    raise RuntimeError("Not logged in — open Amazon and sign in first")
-
-# Take screenshot to find Add to Cart button location
-screenshot()
-
-# Click "Add to Cart" (coordinate from screenshot — typically center of page, ~y=400-600)
-# Use JS to click it reliably if coordinates are uncertain
-added = js("""
-(function() {
-  var btn = (
-    document.getElementById('add-to-cart-button') ||
-    document.querySelector('input[name="submit.add-to-cart"]') ||
-    document.querySelector('input[id*="add-to-cart"]')
-  );
-  if (!btn) return 'not_found';
-  btn.click();
-  return 'clicked';
-})()
-""")
-
-wait(3)
-wait_for_load()
-
-# Confirm: cart overlay or redirect to cart page
-url_after = page_info()["url"]
-confirmation = js("document.querySelector('#NATC_SMART_WAGON_CONF_MSG_SUCCESS, #sw-atc-confirmation') ? 'success' : 'check_page'")
-print(f"Result: {added}, {confirmation}, URL: {url_after}")
+count_text = js("document.querySelector('[data-component-type=\"s-result-info-bar\"] h1')?.innerText?.trim()")
+# Returns e.g.: '1-16 of over 40,000 results for "wireless mouse"\nSort by:\n...'
+# Extract just the count: count_text.split('\n')[0]
 ```
 
----
+## CAPTCHA Detection
 
-## ASIN extraction patterns
-
-ASINs are always 10 characters, uppercase letters and digits. Three reliable sources:
+No CAPTCHA was encountered during testing with a logged-in Chrome session. To detect defensively:
 
 ```python
-import re
+def check_captcha():
+    text = js("document.body.innerText.slice(0,500)") or ""
+    url  = page_info()["url"]
+    return (
+        "captcha" in text.lower()
+        or "enter the characters" in text.lower()
+        or "sorry, we just need to make sure" in text.lower()
+        or "captcha" in url.lower()
+        or "validateCaptcha" in url
+    )
 
-# 1. From the current page URL
-asin_from_url = re.search(r'/dp/([A-Z0-9]{10})', page_info()["url"])
-asin = asin_from_url.group(1) if asin_from_url else None
-
-# 2. From a card's data-asin attribute
-asin = js("document.querySelector('[data-asin]').getAttribute('data-asin')")
-
-# 3. From raw HTML or href text
-asins_in_html = re.findall(r'/dp/([A-Z0-9]{10})', some_html_string)
+if check_captcha():
+    raise RuntimeError("Amazon CAPTCHA hit — stop and notify user")
 ```
 
----
-
-## Price format handling
-
-Amazon serves prices in several formats — handle all of them:
-
-```python
-import re
-
-def parse_price(raw: str) -> float | None:
-    """Normalize any Amazon price string to a float, or None if missing."""
-    if not raw:
-        return None
-    raw = raw.strip()
-    # "from $12.99" → strip "from"
-    raw = re.sub(r'(?i)^from\s+', '', raw)
-    # "$1,299.00" or "$12.99" or "$12" (no cents)
-    m = re.search(r'\$?([\d,]+)\.?(\d{0,2})', raw.replace(',', ''))
-    if not m:
-        return None
-    dollars = m.group(1).replace(',', '')
-    cents = m.group(2).ljust(2, '0') if m.group(2) else '00'
-    try:
-        return float(f"{dollars}.{cents}")
-    except ValueError:
-        return None
-
-# Price can also come split across two DOM elements:
-#   .a-price-whole = "12." (trailing dot)
-#   .a-price-fraction = "99"
-# In that case: float(whole.rstrip('.') + '.' + frac)
-```
-
----
+Amazon may serve a CAPTCHA on fresh/anonymous sessions. Using the browser's existing logged-in session avoids this in practice.
 
 ## Gotchas
 
-- **CAPTCHA wall** — Amazon detects rapid automated requests. Symptoms: page title is "Robot Check" or "CAPTCHA", body contains "Type the characters". Always `wait(2)` between page loads. If hit, take a `screenshot()` — sometimes the CAPTCHA is solvable visually. For bulk scraping, use `http_get` in a `ThreadPoolExecutor` with at most 3-5 concurrent requests.
-
-  ```python
-  def is_captcha(html: str) -> bool:
-      return "Type the characters" in html or "captcha" in html.lower() or "Robot Check" in html
-  ```
-
-- **Login-gated prices** — Some prices only show after sign-in (Prime pricing, business pricing, Warehouse Deals). If `price == ""` but the product exists, you are seeing the logged-out view. The `http_get` path is more likely to hit this than the browser path.
-
-- **Split dollar/cents DOM structure** — The `.a-price` container splits into `.a-price-whole` (e.g. `"299."`) and `.a-price-fraction` (e.g. `"99"`). The `.a-offscreen` child has the full combined string and is the most reliable single target.
-
-- **"Sponsored" results at the top** — Filter with `:not([data-component-type="sp-sponsored-result"])`. Sponsored cards still have `data-asin` set, so ASIN-only extraction picks them up unless filtered.
-
-- **Third-party seller prices absent until cart** — For listings fulfilled by third-party sellers, the price element may be empty. The page shows "See price in cart" — this is intentional, not a scraping failure.
-
-- **Review count formatting** — Amazon renders `"1,234 ratings"`. Strip commas before `int()`:
-  ```python
-  count = int(review_text.replace(",", "").split()[0])
-  ```
-
-- **Best Sellers layout shift** — The Best Sellers page has redesigned its layout multiple times. If the `#zg-ordered-list` selector misses, fall back to `.zg-item-immersion` or take a screenshot and re-inspect. The ASIN is always extractable from `href` links containing `/dp/`.
-
-- **TLD differences** — Prices, availability text, and some DOM IDs differ by country. The `.a-price .a-offscreen` pattern is reliable cross-TLD. For `.co.uk`, `.de`, `.fr`, `.co.jp` — replace the base URL; product data structure is the same. Currency symbols change (`£`, `€`, `¥`).
-
-- **Dynamic price loading** — Some product pages load price via XHR after DOMContentLoaded. `wait_for_load()` alone is not enough — add `wait(2)` after it before running JS extraction.
-
-- **Page variants** — Amazon A/B tests layouts constantly. If extraction returns empty strings, `screenshot()` immediately to see actual page state. Selectors documented here reflect the most common variant as of early 2026.
-
-- **Robot detection escalation** — If requests succeed but return increasingly sparse data (no prices, empty titles), Amazon may be in a soft-block state serving degraded content. Take a screenshot, check the actual page, and add more `wait()` between requests.
-
-- **`data-component-type` is not always present** — On some search result pages (especially category browse pages reached via `/s?i=...`), `data-component-type` is absent. Fall back to `[data-asin]` directly and tolerate empty fields.
+- **`goto()` silent failure**: On first visit, use `new_tab(url)` instead. After the tab is on Amazon, `goto()` works.
+- **`.zg-item-immersion` is gone**: Best Sellers page uses CSS module classes (obfuscated). Use `[data-asin]` + `img[alt]` for title.
+- **`.a-size-base.s-underline-text` is unreliable for review count**: On sponsored results it shows unrelated text (e.g. "Xbox"). Use `[aria-label*="ratings"]` instead.
+- **`#priceblock_ourprice` is legacy**: Returns `null` on modern pages. Construct from `.a-price-whole` + `.a-price-fraction`.
+- **Sponsored results appear first**: First 2-3 results are almost always `is_sponsored: true`. Filter them out with `!el.querySelector('.puis-sponsored-label-text')` when you need organic results.
+- **`data-asin` can be empty string on non-product rows**: Filter with `.filter(r => r.asin)`.
+- **Price split DOM**: `.a-price-whole` innerText includes a trailing `\n.` — strip it: `.replace(/[\n.]/g,'')`.
+- **ASIN from URL**: Use `/dp/([A-Z0-9]{10})/` regex on the product URL. `data-asin` on search results is always the canonical ASIN.
+- **`?th=1` redirect**: Amazon appends `?th=1` (and sometimes `?psc=1`) to product URLs after redirect. This is normal — `input[name="ASIN"]` always has the clean ASIN.
+- **Wait 2s after `wait_for_load()`**: Amazon search results load the listing cards asynchronously. `readyState=complete` fires before cards render. A hard 2s wait is required.

--- a/domain-skills/github/scraping.md
+++ b/domain-skills/github/scraping.md
@@ -1,294 +1,184 @@
-# GitHub — Scraping public data
+# GitHub — Scraping & Data Extraction
 
-`https://github.com` and `https://api.github.com` — public repo metadata, user profiles, trending pages, releases, and README content.
+`https://github.com` — public data, mix of REST API (fast, rate-limited) and browser (trending page only).
 
 ## Do this first
 
-**Use the REST API with `http_get`, not the browser.** For anything that has an API endpoint (repo metadata, user profiles, releases, tags, README), a single `http_get` call replaces `goto + wait_for_load + screenshot + js`. The browser is only needed for pages that render client-side without a JSON equivalent (trending page, search results with JS filtering).
+**Use the REST API for repo/user/release data — it's one call, no browser, fully parsed JSON.**
 
 ```python
-import json, os
-
-def gh_get(path, token=None):
-    headers = {"Accept": "application/vnd.github+json"}
-    tok = token or os.environ.get("GITHUB_TOKEN")
-    if tok:
-        headers["Authorization"] = f"token {tok}"
-    return json.loads(http_get(f"https://api.github.com{path}", headers=headers))
-
-# Repo metadata — stars, forks, description, topics, language, license
-repo = gh_get("/repos/browser-use/browser-use")
-print(repo["stargazers_count"], repo["forks_count"], repo["description"])
+import json
+data = json.loads(http_get("https://api.github.com/repos/{owner}/{repo}"))
+# Key fields: stargazers_count, forks_count, description, language, topics,
+#             open_issues_count, created_at, updated_at, pushed_at,
+#             watchers_count, subscribers_count, network_count,
+#             default_branch, license, homepage, visibility
 ```
 
-Unauthenticated: **60 requests/hour** per IP. With a token: **5000/hour**. Always check `X-RateLimit-Remaining` before looping.
+Use `raw.githubusercontent.com` for file contents — no rate limit, no auth, no base64 decode:
 
----
+```python
+readme = http_get("https://raw.githubusercontent.com/owner/repo/main/README.md")
+content = http_get("https://raw.githubusercontent.com/owner/repo/main/pyproject.toml")
+```
+
+Use the browser **only** for the trending page — it's server-side rendered HTML, no API equivalent.
 
 ## Common workflows
 
-### 1. Trending repositories (browser required)
-
-The trending page (`https://github.com/trending`) is rendered client-side — `http_get` returns a skeleton with no repo data. Use the browser.
+### Repo metadata (API)
 
 ```python
-goto("https://github.com/trending")
+import json
+data = json.loads(http_get("https://api.github.com/repos/browser-use/browser-use"))
+print(data['stargazers_count'], data['forks_count'], data['description'])
+# returns: 88349  10136  '🌐 Make websites accessible for AI agents.'
+```
+
+### User / org profile (API)
+
+```python
+import json
+user = json.loads(http_get("https://api.github.com/users/browser-use"))
+print(user['type'], user['followers'], user['public_repos'], user['blog'])
+# returns: 'Organization'  3046  39  'https://browser-use.com'
+```
+
+### Trending page (browser required)
+
+The trending page is JS-rendered. `article.Box-row` selector confirmed working (15 results for today/all-languages, 12 for filtered). All fields work in a single JS call — **must navigate and wait in the same script run**, as each run is a separate exec context.
+
+```python
+import json
+goto("https://github.com/trending")          # or /trending/python?since=weekly
 wait_for_load()
+wait(2)                                       # extra 2s — React hydration completes after readyState
 
-# Optional: filter by language and period via URL params
-# goto("https://github.com/trending/python?since=weekly")
-# goto("https://github.com/trending/typescript?since=daily")
-
-repos = js("""
-(function() {
-  var rows = document.querySelectorAll('article.Box-row');
-  return Array.from(rows).map(function(row) {
-    var nameEl = row.querySelector('h2 a');
-    var descEl = row.querySelector('p');
-    var starsEl = row.querySelector('a[href$="/stargazers"]');
-    var forksEl = row.querySelector('a[href$="/forks"]');
-    var langEl  = row.querySelector('[itemprop="programmingLanguage"]');
-    var todayEl = row.querySelector('.float-sm-right');
+result = js("""
+(function(){
+  var rows = Array.from(document.querySelectorAll('article.Box-row'));
+  return JSON.stringify(rows.map(function(el){
+    var h2link = el.querySelector('h2 a');
+    var starLink = el.querySelector('a[href*="/stargazers"]');
+    var forkLink = el.querySelector('a[href*="/forks"]');
+    var langEl = el.querySelector('[itemprop="programmingLanguage"]');
+    var todayEl = el.querySelector('.d-inline-block.float-sm-right');
+    var descEl = el.querySelector('p');
     return {
-      full_name:   nameEl ? nameEl.getAttribute('href').slice(1) : null,
-      url:         nameEl ? 'https://github.com' + nameEl.getAttribute('href') : null,
-      description: descEl ? descEl.textContent.trim() : null,
-      stars:       starsEl ? starsEl.textContent.trim() : null,
-      forks:       forksEl ? forksEl.textContent.trim() : null,
-      language:    langEl  ? langEl.textContent.trim() : null,
-      stars_today: todayEl ? todayEl.textContent.trim() : null,
+      name: h2link ? h2link.innerText.trim().replace(/\\s+/g,' ') : null,
+      url: h2link ? 'https://github.com' + h2link.getAttribute('href') : null,
+      stars_total: starLink ? starLink.innerText.trim() : null,
+      stars_period: todayEl ? todayEl.innerText.trim() : null,
+      forks: forkLink ? forkLink.innerText.trim() : null,
+      language: langEl ? langEl.innerText.trim() : null,
+      desc: descEl ? descEl.innerText.trim() : null
     };
-  });
+  }));
 })()
 """)
-print(repos[:10])
+repos = json.loads(result)
+# stars_period text is e.g. "737 stars today" or "47,053 stars this week"
 ```
 
-**Note:** `stars` from the DOM will be "1.2k" not `1234`. Use the API for exact counts if you need them:
+Supported URL params:
+- `/trending` — all languages, today
+- `/trending/python` — filtered to Python
+- `/trending?since=weekly` or `?since=monthly`
+- `/trending/python?since=weekly` — combined
+
+### Search repositories (API)
 
 ```python
+import json
+results = json.loads(http_get(
+    "https://api.github.com/search/repositories?q=browser+automation+language:python&sort=stars&per_page=10"
+))
+print(results['total_count'])   # e.g. 3250
+for r in results['items']:
+    print(r['full_name'], r['stargazers_count'])
+```
+
+Search API rate limit is **10 req/min** unauthenticated (separate from the 60/hour core limit). Runs out fast if called in a loop.
+
+### Commits, releases, issues (API)
+
+```python
+import json
+# Commits
+commits = json.loads(http_get("https://api.github.com/repos/owner/repo/commits?per_page=10"))
+# Fields: sha, commit.message, commit.author.date, author.login
+
+# Releases
+releases = json.loads(http_get("https://api.github.com/repos/owner/repo/releases?per_page=5"))
+# Fields: tag_name, name, published_at, body, assets
+
+# Issues
+issues = json.loads(http_get("https://api.github.com/repos/owner/repo/issues?state=open&per_page=10"))
+# Fields: number, title, labels, state, created_at, user.login
+
+# Contributors
+contribs = json.loads(http_get("https://api.github.com/repos/owner/repo/contributors?per_page=10"))
+# Fields: login, contributions
+```
+
+### File contents via API (base64)
+
+```python
+import json, base64
+resp = json.loads(http_get("https://api.github.com/repos/owner/repo/contents/path/to/file.py"))
+content = base64.b64decode(resp['content']).decode()
+# resp also has: size, sha, html_url
+# Prefer raw.githubusercontent.com for large files — no base64, no rate limit hit
+```
+
+### Parallel fetching (multiple repos)
+
+```python
+import json
 from concurrent.futures import ThreadPoolExecutor
 
-def enrich(repo):
-    data = gh_get(f"/repos/{repo['full_name']}")
-    repo["stars_exact"] = data["stargazers_count"]
-    repo["forks_exact"] = data["forks_count"]
-    return repo
+def fetch_repo(name):
+    data = json.loads(http_get(f"https://api.github.com/repos/{name}"))
+    return {"name": name, "stars": data['stargazers_count'], "lang": data['language']}
 
-with ThreadPoolExecutor(max_workers=8) as ex:
-    enriched = list(ex.map(enrich, repos))
+repos = ["owner/repo1", "owner/repo2", "owner/repo3"]
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(fetch_repo, repos))
+# Confirmed working; watch rate limit — 60 unauthenticated calls/hour total
 ```
-
----
-
-### 2. User profile — followers, bio, public repos
-
-```python
-# API (preferred)
-user = gh_get("/users/Archish27")
-print(user["followers"])       # int, exact
-print(user["following"])
-print(user["public_repos"])
-print(user["bio"])
-print(user["avatar_url"])
-print(user["blog"])            # personal site if set
-print(user["company"])
-print(user["location"])
-```
-
-Fields always present: `login`, `id`, `avatar_url`, `html_url`, `type`, `public_repos`, `public_gists`, `followers`, `following`, `created_at`, `updated_at`.
-
----
-
-### 3. Repository metadata — stars, forks, topics, language
-
-```python
-repo = gh_get("/repos/n4ze3m/page-assist")
-
-print({
-    "stars":       repo["stargazers_count"],
-    "forks":       repo["forks_count"],
-    "watchers":    repo["watchers_count"],
-    "open_issues": repo["open_issues_count"],
-    "language":    repo["language"],          # primary language
-    "topics":      repo["topics"],            # list[str]
-    "license":     repo["license"]["name"] if repo["license"] else None,
-    "description": repo["description"],
-    "created_at":  repo["created_at"],
-    "pushed_at":   repo["pushed_at"],         # last commit time
-    "default_branch": repo["default_branch"],
-    "archived":    repo["archived"],
-})
-```
-
----
-
-### 4. README content
-
-```python
-import base64
-
-readme = gh_get("/repos/browser-use/browser-use/readme")
-# content is base64-encoded
-text = base64.b64decode(readme["content"]).decode("utf-8")
-print(text[:2000])
-```
-
-Alternatively, raw markdown (no auth needed, no rate limit from the API quota):
-
-```python
-raw = http_get("https://raw.githubusercontent.com/browser-use/browser-use/main/README.md")
-print(raw[:2000])
-```
-
-`raw.githubusercontent.com` is a plain CDN — not rate-limited like the API. Prefer it for README-only tasks.
-
----
-
-### 5. Latest releases and tags
-
-```python
-# Latest release (published, non-prerelease)
-release = gh_get("/repos/owner/repo/releases/latest")
-print(release["tag_name"])      # e.g. "v1.2.3"
-print(release["name"])          # release title
-print(release["body"])          # release notes (markdown)
-print(release["published_at"])
-print(release["html_url"])
-
-# Assets (download URLs)
-for asset in release["assets"]:
-    print(asset["name"], asset["browser_download_url"])
-
-# All releases (paginated)
-releases = gh_get("/repos/owner/repo/releases?per_page=10")
-for r in releases:
-    print(r["tag_name"], r["published_at"], r["prerelease"])
-
-# Tags (lighter — no release notes)
-tags = gh_get("/repos/owner/repo/tags?per_page=10")
-for t in tags:
-    print(t["name"], t["commit"]["sha"])
-```
-
----
-
-### 6. Parallel multi-repo fetch
-
-```python
-import json, os
-from concurrent.futures import ThreadPoolExecutor
-
-repos_to_check = [
-    "browser-use/browser-use",
-    "n4ze3m/page-assist",
-    "microsoft/vscode",
-]
-
-def fetch_repo(full_name):
-    try:
-        return gh_get(f"/repos/{full_name}")
-    except Exception as e:
-        return {"full_name": full_name, "error": str(e)}
-
-with ThreadPoolExecutor(max_workers=10) as ex:
-    results = list(ex.map(fetch_repo, repos_to_check))
-
-for r in results:
-    if "error" not in r:
-        print(r["full_name"], r["stargazers_count"])
-```
-
----
-
-### 7. Most starred repos for a language (Search API)
-
-```python
-# Top Python repos by stars from the past week
-import urllib.parse
-
-q = urllib.parse.quote("language:python created:>2026-04-11")
-results = gh_get(f"/search/repositories?q={q}&sort=stars&order=desc&per_page=10")
-for item in results["items"]:
-    print(item["full_name"], item["stargazers_count"])
-```
-
-Search API counts against rate limits more aggressively — **30 requests/min** unauthenticated, **30/min** authenticated (same for search). Add a `GITHUB_TOKEN` to avoid 422/403 on busy loops.
-
----
-
-## When to use the browser vs pure HTTP
-
-| Task | Method |
-|---|---|
-| Repo metadata (stars, forks, desc, topics) | `http_get` → API |
-| User profile (followers, bio, avatar) | `http_get` → API |
-| README text | `http_get` → raw CDN |
-| Latest release / tags | `http_get` → API |
-| Trending page (all languages) | Browser (`goto` + `js`) |
-| Trending page filtered by language | Browser (`goto` + `js`) |
-| Search results with JS-driven filters | Browser |
-| Paginated issue / PR lists | `http_get` → API (`?page=N&per_page=100`) |
-| File contents in a repo | `http_get` → `raw.githubusercontent.com` |
-| Private repos | Browser (authenticated session) OR API with token |
-
----
 
 ## Gotchas
 
-- **Unauthenticated rate limit is 60 req/hr total per IP** — not per endpoint. A loop over 70 repos will hit it. Set `GITHUB_TOKEN` in `.env` or the environment:
+- **Rate limits are per IP, unauthenticated** — Core API: 60 req/hour. Search API: 10 req/min. These are separate pools. Check `/rate_limit` endpoint: `http_get("https://api.github.com/rate_limit")`. With a `GITHUB_TOKEN`, both limits increase to 5,000/hour.
 
+- **Token header format** — Use `Authorization: Bearer <token>` (not `token <token>`), plus `X-GitHub-Api-Version: 2022-11-28`:
   ```python
   import os
-  # Set once; gh_get() picks it up automatically via os.environ.get("GITHUB_TOKEN")
-  # Don't hardcode the token in scripts
+  token = os.environ.get('GITHUB_TOKEN', '')
+  headers = {"Authorization": f"Bearer {token}", "X-GitHub-Api-Version": "2022-11-28"} if token else {}
+  data = json.loads(http_get("https://api.github.com/repos/owner/repo", headers=headers))
   ```
 
-- **Trending page needs the browser, not `http_get`.** `http_get("https://github.com/trending")` returns the HTML skeleton; the repo list is injected by a React bundle after `DOMContentLoaded`. Always use `goto` + `wait_for_load` + `js(...)`.
-
-- **Star counts in the trending DOM are formatted strings ("1.2k", "23.4k"), not integers.** Use the API if you need exact numbers. Quick parser if you only have DOM values:
-
+- **404 raises HTTPError, not a JSON error** — Wrap API calls for missing repos:
   ```python
-  def parse_stars(s):
-      s = s.strip().replace(",", "")
-      if s.endswith("k"):
-          return int(float(s[:-1]) * 1000)
-      return int(s)
+  try:
+      data = json.loads(http_get("https://api.github.com/repos/owner/repo"))
+  except Exception as e:
+      print("Not found or rate limited:", e)
   ```
 
-- **The trending page `article.Box-row` selector is stable as of 2026-04** but GitHub redesigns without notice. If `js(...)` returns an empty list, `screenshot()` to see the current DOM structure and update the selector.
+- **Code search requires auth** — `GET /search/code` returns HTTP 401 without a token. Repo/user/issues search works unauthenticated.
 
-- **`/repos/{owner}/{repo}` 404s if the repo is private or deleted** — wrap in try/except and check `response["message"]`.
+- **Trending page selectors only work if navigation is in the same script run** — Each `uv run browser-harness` exec is fresh. Selectors that returned 0 results were run in a separate invocation after the page had navigated away. Always include `goto()` + `wait_for_load()` + `wait(2)` in the same script.
 
-- **Search API has a separate lower rate limit (30/min) and requires queries to have at least one qualifier.** `q=stars:>1000` works; `q=` alone returns a 422.
+- **wait(2) after wait_for_load() on trending** — `document.readyState == 'complete'` fires before React finishes painting repo cards. Without the extra 2s sleep, `article.Box-row` count was 0 even though the DOM technically loaded.
 
-- **`raw.githubusercontent.com` is NOT rate-limited by the GitHub API quota** — use it freely for file content, README, and configs. It's a CDN, not the API gateway.
+- **Trending stars field is a string with commas** — `stars_total` comes back as `"4,548"` not `4548`. Parse with `int(r['stars_total'].replace(',', ''))` if you need to sort.
 
-- **Pagination:** API endpoints default to `per_page=30`, max `per_page=100`. For full lists:
+- **stars_period text includes the period** — Value is `"737 stars today"` or `"47,053 stars this week"` — strip the trailing word if you want just the number.
 
-  ```python
-  def paginate(path):
-      results, page = [], 1
-      while True:
-          sep = "&" if "?" in path else "?"
-          batch = gh_get(f"{path}{sep}per_page=100&page={page}")
-          if not batch:
-              break
-          results.extend(batch)
-          if len(batch) < 100:
-              break
-          page += 1
-      return results
+- **Repo page DOM is React-heavy, API is better** — Extracting star counts from the repo HTML page (`github.com/owner/repo`) is unreliable because GitHub uses React with server-side hydration and component IDs change. The REST API returns all the same data cleanly.
 
-  all_releases = paginate("/repos/owner/repo/releases")
-  ```
+- **raw.githubusercontent.com has no rate limit and no auth** — Use it for any public file. It serves the raw bytes, no JSON wrapping or base64.
 
-- **GraphQL API** (not shown above) at `https://api.github.com/graphql` supports batching many repos in one request — worth it if you're pulling data for 50+ repos and want to stay under rate limits. Requires a token with appropriate scopes.
-
-- **Lazy loading on long repo lists in the browser:** GitHub infinite-scrolls contributor lists and file trees. If `js(...)` returns fewer items than expected, scroll first:
-
-  ```python
-  scroll(760, 400, dy=3000)
-  wait(1.5)
-  # then re-run the js() extraction
-  ```
+- **Trending page article count varies** — Today filter returned 15 articles, weekly Python filter returned 12. Don't assume 25 results; iterate `document.querySelectorAll('article.Box-row')` and take what's there.

--- a/domain-skills/hackernews/scraping.md
+++ b/domain-skills/hackernews/scraping.md
@@ -1,274 +1,243 @@
-# Hacker News — Scraping Stories, Comments & Search
+# Hacker News — Data Extraction
 
-`https://news.ycombinator.com` — Classic server-rendered HTML tables. No JS required to render content.
+`https://news.ycombinator.com` — YCombinator's link aggregator. Three access paths tested: `http_get` DOM scraping, Algolia search API, and the official HN Firebase API. All work without a browser.
 
-## Do this first
+## Do this first: pick your access path
 
-**Use HTTP, not the browser.** HN is pure server-rendered HTML — all story data is in the raw source. `http_get` is 10–20x faster than `goto + wait_for_load`, and there is no rate-limited API to worry about for basic reads.
+| Goal | Best approach | Latency |
+|------|--------------|---------|
+| Current front page (30 stories, real-time) | `http_get` + regex | ~170ms |
+| Historical / keyword search | Algolia search API | ~400ms |
+| Full comment tree (nested) | Algolia items API | ~300ms |
+| Specific item by ID | Firebase API | ~200ms |
+| 500 ranked story IDs | Firebase topstories | ~200ms (+ ~190ms/item after) |
 
-```python
-html = http_get("https://news.ycombinator.com")
-# Full front-page HTML — stories are in <tr class="athing"> rows
-```
-
-Never open the browser for front-page or listing reads. Reserve `goto` for interactive tasks only (e.g. submitting a comment, logging in).
-
----
-
-## Approach 1 — Front-page and listing pages (JS extraction)
-
-HN's DOM is a plain HTML table. After `http_get`, evaluate JS selectors against the raw HTML via `js()` **if you're already in a browser session**, or parse with a lightweight regex approach for pure-HTTP tasks.
-
-### Using `js()` after `goto` (when a browser session is already open)
-
-```python
-goto("https://news.ycombinator.com")
-wait_for_load()
-
-stories = js("""
-(() => {
-  const rows = document.querySelectorAll('tr.athing');
-  return Array.from(rows).map(row => {
-    const titleAnchor = row.querySelector('span.titleline > a');
-    const subRow      = row.nextElementSibling;
-    const scoreEl     = subRow && subRow.querySelector('span.score');
-    const authorEl    = subRow && subRow.querySelector('a.hnuser');
-    const ageEl       = subRow && subRow.querySelector('span.age a');
-    const commentsEl  = subRow && [...subRow.querySelectorAll('a')]
-                          .find(a => a.textContent.includes('comment'));
-    return {
-      id:       row.getAttribute('id'),
-      title:    titleAnchor ? titleAnchor.textContent.trim() : '',
-      url:      titleAnchor ? titleAnchor.href : '',
-      points:   scoreEl    ? parseInt(scoreEl.textContent)  : 0,
-      author:   authorEl   ? authorEl.textContent.trim()    : '',
-      age:      ageEl      ? ageEl.textContent.trim()       : '',
-      comments: commentsEl ? parseInt(commentsEl.textContent) : 0,
-    };
-  });
-})()
-""")
-# returns a list of dicts, one per story (up to 30 per page)
-```
-
-### Using pure `http_get` + Python regex (no browser needed)
-
-```python
-import re, json
-
-def parse_hn_page(url):
-    html = http_get(url)
-
-    # Each story block: <tr class="athing" id="STORY_ID">
-    athing_ids = re.findall(r'<tr class="athing" id="(\d+)">', html)
-
-    # Title + URL: <span class="titleline"><a href="URL">TITLE</a>
-    title_urls = re.findall(
-        r'<span class="titleline"><a href="([^"]*)"[^>]*>([^<]+)</a>', html
-    )
-
-    # Points: <span class="score" id="score_STORYID">N points</span>
-    scores = re.findall(r'<span class="score"[^>]*>(\d+) points?</span>', html)
-
-    # Author: <a class="hnuser" href="user?id=USERNAME">USERNAME</a>
-    authors = re.findall(r'<a class="hnuser"[^>]*>([^<]+)</a>', html)
-
-    # Comment counts: last <a> in subrow, text like "42\xa0comments"
-    comments = re.findall(
-        r'(\d+)&nbsp;comment', html
-    )
-
-    stories = []
-    for i, sid in enumerate(athing_ids):
-        url_raw, title = title_urls[i] if i < len(title_urls) else ('', '')
-        # HN "text posts" have relative URLs like "item?id=..."
-        full_url = (
-            url_raw if url_raw.startswith('http')
-            else f"https://news.ycombinator.com/{url_raw}"
-        )
-        stories.append({
-            'id':       sid,
-            'title':    title,
-            'url':      full_url,
-            'points':   int(scores[i])   if i < len(scores)   else 0,
-            'author':   authors[i]       if i < len(authors)   else '',
-            'comments': int(comments[i]) if i < len(comments) else 0,
-        })
-    return stories
-
-top_stories = parse_hn_page("https://news.ycombinator.com")
-```
+**Never use a browser for read-only HN tasks.** Everything is accessible over HTTP with no auth, no JS rendering needed.
 
 ---
 
-## Approach 2 — Algolia HN Search API (best for search + date filtering)
+## Path 1: http_get front page (fastest for real-time data)
 
-The Algolia API is the fastest way to search HN by keyword, filter by date, or get stories above a points threshold. No HTML parsing needed.
-
-Base URL: `http://hn.algolia.com/api/v1/search`
+The front page HTML is ~34KB. Story order matches Firebase `/topstories.json` exactly — confirmed identical on 2026-04-18.
 
 ```python
-import json, time
+import re, html as htmllib
 
-def hn_search(query, tags="story", min_points=0, since_hours=24, num=10):
-    """
-    Search HN stories via Algolia.
-    tags: "story" | "ask_hn" | "show_hn" | "comment" | "poll"
-    """
-    since_ts = int(time.time()) - since_hours * 3600
-    params = (
-        f"query={query}"
-        f"&tags={tags}"
-        f"&numericFilters=points>{min_points},created_at_i>{since_ts}"
-        f"&hitsPerPage={num}"
-    )
-    resp = http_get(f"http://hn.algolia.com/api/v1/search?{params}")
-    data = json.loads(resp)
-    return [
-        {
-            'objectID': h['objectID'],           # story ID
-            'title':    h.get('title', ''),
-            'url':      h.get('url') or f"https://news.ycombinator.com/item?id={h['objectID']}",
-            'points':   h.get('points', 0),
-            'author':   h.get('author', ''),
-            'comments': h.get('num_comments', 0),
-            'created':  h.get('created_at', ''),  # ISO 8601 string
-            'created_ts': h.get('created_at_i', 0),  # Unix timestamp
-        }
-        for h in data.get('hits', [])
-    ]
+page = http_get("https://news.ycombinator.com")
 
-# Examples:
-results = hn_search("AI agents", since_hours=24, min_points=10, num=20)
-results = hn_search("", tags="show_hn", since_hours=48, num=10)  # top Show HN last 48h
-results = hn_search("Rust", tags="story", min_points=100, num=5)  # high-signal Rust posts
-```
+# Extract all 30 story IDs (in rank order)
+story_ids = re.findall(r'<tr class="athing submission" id="(\d+)">', page)
 
-Use `search_by_date` endpoint instead of `search` to sort by recency rather than relevance:
-
-```python
-resp = http_get(
-    "http://hn.algolia.com/api/v1/search_by_date"
-    "?query=python&tags=story&hitsPerPage=10"
+# Extract titles + URLs (same order as IDs)
+titles_urls = re.findall(
+    r'class="titleline"[^>]*><a href="([^"]*)"[^>]*>(.*?)</a>', page
 )
+
+# Extract scores keyed by story ID (job posts have no score row)
+scores_by_id = {
+    m.group(1): int(m.group(2))
+    for m in re.finditer(
+        r'<span class="score" id="score_(\d+)">(\d+) points</span>', page
+    )
+}
+
+# Extract authors keyed by story ID (anchor on score span)
+authors_by_id = {}
+for m in re.finditer(
+    r'<span class="score" id="score_(\d+)">\d+ points</span>'
+    r'.*?class="hnuser">(.*?)</a>',
+    page, re.DOTALL
+):
+    authors_by_id[m.group(1)] = m.group(2)
+
+# Extract comment counts keyed by story ID
+comments_by_id = {
+    m.group(1): int(m.group(2))
+    for m in re.finditer(
+        r'href="item\?id=(\d+)">(\d+)&nbsp;comments</a>', page
+    )
+}
+
+stories = []
+for i, sid in enumerate(story_ids):
+    url, raw_title = titles_urls[i] if i < len(titles_urls) else ('', '')
+    stories.append({
+        'rank': i + 1,
+        'id': sid,
+        'title': htmllib.unescape(raw_title),   # MUST unescape — titles contain &#x27; etc.
+        'url': url,
+        'score': scores_by_id.get(sid),          # None for job posts
+        'author': authors_by_id.get(sid),
+        'comments': comments_by_id.get(sid, 0),
+    })
 ```
+
+**Gotchas:**
+- Titles contain HTML entities (`&#x27;` `&amp;` `&quot;` `&gt;`). Always call `html.unescape()`.
+- `<tr class="athing submission" id="...">` — the class is `athing submission`, not just `athing`. The `athing comtr` class is for comment rows.
+- Job/hiring posts (YC ads) appear in the list but have no score or author. `scores_by_id.get(sid)` returns `None` for them — check before comparing.
+- `re.DOTALL` multi-line patterns can cross story boundaries. Use ID-anchored patterns (as above) instead of positional zip for score/author.
+- The page only serves page 1 (30 items). Pages 2–4 exist at `?p=2` etc. but require a login cookie for page 3+.
 
 ---
 
-## Common workflows
+## Path 2: Algolia search API (best for historical / keyword search)
 
-### Top N stories from front page
-
-```python
-stories = parse_hn_page("https://news.ycombinator.com")
-top3 = stories[:3]
-# Each dict: {id, title, url, points, author, comments}
-```
-
-### Show HN extraction
-
-```python
-stories = parse_hn_page("https://news.ycombinator.com/show")
-top10 = stories[:10]
-```
-
-### Ask HN extraction
-
-```python
-stories = parse_hn_page("https://news.ycombinator.com/ask")
-top5 = stories[:5]
-```
-
-### Page 2 (stories 31–60)
-
-```python
-page2 = parse_hn_page("https://news.ycombinator.com/?p=2")
-```
-
-### Monitor for topic in last 24 hours
-
-```python
-# Preferred: Algolia API — no scraping, timestamp-accurate
-hits = hn_search("postgres", since_hours=24, min_points=0, num=30)
-matching = [h for h in hits if h['points'] > 5]  # filter noise
-```
-
-### Get comments from a thread
-
-```python
-import re
-
-def get_hn_comments(item_id, max_comments=20):
-    html = http_get(f"https://news.ycombinator.com/item?id={item_id}")
-
-    # Comment text is inside <span class="commtext ...">
-    texts = re.findall(
-        r'<span class="commtext[^"]*">(.*?)</span>\s*</div>',
-        html, re.DOTALL
-    )
-    # Strip inline HTML tags for plain text
-    def strip_tags(s):
-        return re.sub(r'<[^>]+>', '', s).strip()
-
-    # Authors per comment: <a class="hnuser" ...>USERNAME</a>
-    authors = re.findall(r'<a class="hnuser"[^>]*>([^<]+)</a>', html)
-    # First author is story submitter — skip it for comment authors
-    comment_authors = authors[1:]
-
-    comments = []
-    for i, text in enumerate(texts[:max_comments]):
-        comments.append({
-            'author': comment_authors[i] if i < len(comment_authors) else '',
-            'text':   strip_tags(text),
-        })
-    return comments
-
-comments = get_hn_comments("43567890")
-```
-
-For deep thread extraction (nested replies, vote counts), use the Algolia Items API — it returns the full thread as JSON:
+No rate limiting observed. Returns up to 1000 hits per query (`hitsPerPage` max is capped at ~1000 per Algolia plan).
 
 ```python
 import json
 
-def get_thread_algolia(item_id):
-    resp = http_get(f"http://hn.algolia.com/api/v1/items/{item_id}")
-    return json.loads(resp)
-    # Top-level keys: id, title, url, points, author, children (list of comment dicts)
+# Keyword search — sorted by relevance
+data = json.loads(http_get(
+    "https://hn.algolia.com/api/v1/search"
+    "?query=llm&tags=story&hitsPerPage=20"
+))
 
-thread = get_thread_algolia("43567890")
-top_comments = thread.get('children', [])[:10]
+# Date-sorted (most recent first)
+data = json.loads(http_get(
+    "https://hn.algolia.com/api/v1/search_by_date"
+    "?tags=story&hitsPerPage=20"
+))
+
+# Paginate: add &page=N (0-indexed), up to data['nbPages']-1
 ```
 
-### Export to CSV
+**Fields returned per story hit:**
+```
+objectID, title, url, author, points, num_comments,
+created_at (ISO 8601), created_at_i (unix ts), story_id,
+children (list of comment IDs — flat, not tree),
+_tags, _highlightResult
+```
+
+**Fields returned per comment hit:**
+```
+objectID, comment_text, author, story_id, story_title, story_url,
+parent_id, created_at, created_at_i, points
+```
+Note: comment hits use `comment_text`, NOT `text`. Story hits use `story_text` for self-post body.
+
+### Tag filters
+
+Tags are AND by default, OR with parentheses:
 
 ```python
-import csv, io
+# Story types
+"tags=story"           # regular link/self posts
+"tags=show_hn"         # Show HN
+"tags=ask_hn"          # Ask HN
+"tags=poll"            # polls
+"tags=job"             # job posts
 
-def stories_to_csv(stories):
-    buf = io.StringIO()
-    w = csv.DictWriter(buf, fieldnames=['title', 'url', 'points', 'author', 'comments'])
-    w.writeheader()
-    w.writerows(stories)
-    return buf.getvalue()
+# Combined AND
+"tags=story,front_page"          # currently on front page
+"tags=story,author_pg"           # stories submitted by pg
 
-csv_text = stories_to_csv(top10)
-# Write to file:
-with open("/tmp/hn_show.csv", "w") as f:
-    f.write(csv_text)
+# OR
+"tags=(ask_hn,show_hn),story"    # Ask OR Show HN
+
+# By story ID (gets story + all its comments)
+"tags=story_47806725"
 ```
+
+### Numeric filters
+
+```python
+# Date range (unix timestamps)
+"numericFilters=created_at_i>1745000000"
+"numericFilters=created_at_i>1700000000,created_at_i<1750000000"
+
+# Point threshold
+"numericFilters=points>100"
+"numericFilters=points>500,points<1000"
+```
+
+### Full Algolia items API (nested comment tree)
+
+```python
+import json
+
+thread = json.loads(http_get(
+    "https://hn.algolia.com/api/v1/items/47806725"
+))
+# thread['children'] = list of top-level comment objects
+# Each comment: author, text (HTML), created_at, children (nested replies)
+# Recursively walk children for full thread
+
+# Total comment count (recursive walk with stack):
+stack = list(thread.get('children', []))
+total = 0
+while stack:
+    node = stack.pop()
+    total += 1
+    stack.extend(node.get('children', []))
+```
+
+Confirmed: Algolia items returns 653 total comments for a 659-comment thread (some deleted). `text` field in items API is HTML with `<p>` tags and `<a>` links — may need to strip tags.
 
 ---
 
-## Gotchas
+## Path 3: Official HN Firebase API
 
-- **30 items per page** — HN hard-caps each listing to 30 stories. Use `?p=2`, `?p=3` etc. to paginate. The next-page link also carries a `?fnid=` token on some endpoints (Best, Active), which changes each page load — safer to use `?p=N` where it works.
-- **Story URLs can be relative** — "Ask HN" and "text posts" set `href="item?id=XXXXXXX"` (no leading slash). Always check `url.startswith('http')` and prepend `https://news.ycombinator.com/` if not.
-- **Points vs score** — the `<span class="score">` element shows "N points" (plural even for 1). Parse with `int(re.search(r'(\d+)', score_text).group(1))`. Jobs posts and some flagged posts have no score element at all.
-- **Comment count text** — uses a non-breaking space (`\xa0` / `&nbsp;`): `"42\xa0comments"`. Use `int(re.search(r'(\d+)', text).group(1))` to parse safely. Posts with zero comments show "discuss" not "0 comments" — handle that case.
-- **Algolia timestamps are Unix integers** — `created_at_i` is a Unix timestamp (seconds). `created_at` is ISO 8601. Convert: `datetime.utcfromtimestamp(h['created_at_i'])`.
-- **Algolia `url` field is None for text posts** — `h.get('url')` returns `None` for Ask/Show HN posts that have no external link. Always fall back: `h.get('url') or f"https://news.ycombinator.com/item?id={h['objectID']}"`.
-- **Rate limiting** — HN has no official rate limit for reads, but aggressive scraping will get you temporarily 503'd. One request per second is safe. For bulk work, the Algolia API is more tolerant than scraping HN directly.
-- **Dead/flagged stories** — `[dead]` or `[flagged]` stories appear in the HTML but have no score element and no author link. They show up as empty fields in regex parses — filter with `if s['title']` before returning results.
-- **"More" link at page bottom is not reliable for automation** — it uses `?fnid=` tokens that expire. Use explicit `?p=N` pagination instead.
-- **Browser not needed** — HN has zero JS-rendered content. Every story, comment, and score is in the initial HTML. Never use `goto + wait_for_load + screenshot` for read-only HN tasks.
+Clean JSON, no scraping. Use for fetching specific items or building live feeds.
+
+```python
+import json
+
+# Ranked story ID lists (no metadata — just IDs)
+top   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/topstories.json"))  # 500 IDs
+new   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/newstories.json"))  # 500 IDs
+best  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/beststories.json")) # 200 IDs
+ask   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/askstories.json"))  # ~32 IDs
+show  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/showstories.json")) # ~119 IDs
+jobs  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/jobstories.json"))  # ~31 IDs
+
+# Fetch a single item
+item = json.loads(http_get(
+    "https://hacker-news.firebaseio.com/v0/item/47806725.json"
+))
+# Fields: id, type, by, title, url, score, descendants (total comment count),
+#         time (unix ts), kids (list of top-level comment IDs), text (self-post body)
+
+# Fetch a user profile
+user = json.loads(http_get(
+    "https://hacker-news.firebaseio.com/v0/user/pg.json"
+))
+# Fields: id, karma, created (unix ts), about (HTML), submitted (list of item IDs)
+
+# Highest current item ID (useful for polling new items)
+maxid = json.loads(http_get("https://hacker-news.firebaseio.com/v0/maxitem.json"))
+```
+
+**Firebase vs Algolia tradeoff:**
+- Firebase `topstories` gives you 500 IDs in one call but then requires one HTTP call per item (~190ms each). Fetching all 500 items sequentially would take ~100 seconds.
+- Algolia returns full story data (title, points, author, comments) in one call for up to ~1000 results.
+- For "top 30 stories with full metadata": use `http_get` front page scrape (170ms total). For "top 500 stories with full metadata": use Algolia with `tags=front_page` or loop pages.
+
+---
+
+## Comment thread HTML (item page)
+
+For a large thread, the item page HTML (~1MB for 659 comments) loads ALL comments flat in a single request — no pagination, no JS required.
+
+```python
+import re, html as htmllib
+
+page = http_get("https://news.ycombinator.com/item?id=47806725")
+
+# Count all comment IDs
+comment_ids = re.findall(r'<tr class="athing comtr" id="(\d+)">', page)
+# len(comment_ids) matches total comment count
+
+# Extract comment texts (careful: text spans multiple lines with <p> tags)
+# Use Algolia items API instead for structured access
+```
+
+For structured comment access prefer Algolia items API — it returns a proper nested tree. The HTML item page is useful only when you need approximate comment count without an API call.
+
+---
+
+## Do NOT use a browser for HN
+
+All data is in plain HTML or JSON APIs. `goto()` + `wait_for_load()` takes 3–8 seconds; `http_get` takes 170–400ms. The JS `querySelectorAll` approach works (tested, returns correct data) but is 20–50x slower with no benefit.

--- a/domain-skills/news-aggregation/multi-source.md
+++ b/domain-skills/news-aggregation/multi-source.md
@@ -1,702 +1,205 @@
-# News Aggregation — Multi-Source Fetching
+# News Aggregation — Multi-Source
 
-Covers TechCrunch, The Verge, Ars Technica, BBC, Reuters, VentureBeat, and similar editorial news sites. For Hacker News specifically, see `hackernews/scraping.md`.
+Field-tested against TechCrunch, The Verge, Ars Technica, BBC, Guardian, Wired, NPR, HN, Reuters, CNN, NYT (2026-04-18).
 
-## Do this first
+## Lead with RSS — fastest and most reliable
 
-**Use RSS feeds, not the browser.** Almost every major news publication exposes RSS. A single `http_get` on an RSS URL gives you titles, URLs, summaries, authors, and publish dates as structured XML — no screenshots, no JS rendering, no cookie banners. This is 10–20x faster than browser-based scraping and works reliably even on sites that heavily JS-render their front pages.
+For every site that has a feed, `http_get` + XML parsing is faster and more reliable than a browser. Use `ThreadPoolExecutor` for parallel fetches.
+
+**Confirmed working RSS feeds (tested):**
+
+| Source | Feed URL | Format | Items | Fetch time |
+|--------|----------|--------|-------|------------|
+| TechCrunch | `https://techcrunch.com/feed/` | RSS 2.0 | 20 | ~0.08s |
+| Ars Technica | `https://feeds.arstechnica.com/arstechnica/index` | RSS 2.0 | 20 | ~0.10s |
+| BBC News | `http://feeds.bbci.co.uk/news/rss.xml` | RSS 2.0 | 37 | ~0.23s |
+| The Guardian (World) | `https://www.theguardian.com/world/rss` | RSS 2.0 | 45 | ~0.11s |
+| The Guardian (Tech) | `https://www.theguardian.com/technology/rss` | RSS 2.0 | 32 | ~0.25s |
+| Wired | `https://www.wired.com/feed/rss` | RSS 2.0 | 50 | ~0.10s |
+| NPR Top Stories | `https://feeds.npr.org/1001/rss.xml` | RSS 2.0 | 10 | ~0.14s |
+| Hacker News | `https://news.ycombinator.com/rss` | RSS 2.0 | 30 | ~0.16s |
+| CNN Top Stories | `http://rss.cnn.com/rss/cnn_topstories.rss` | RSS 2.0 | 69 | ~0.25s |
+| NYT Homepage | `https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml` | RSS 2.0 | 23 | ~0.12s |
+| The Verge | `https://www.theverge.com/rss/index.xml` | **Atom** | 10 | ~0.15s |
+
+## Parallel fetch pattern (4.3x speedup measured)
+
+Sequential fetch of 7 feeds: **0.70s**. Parallel fetch of same 7 feeds: **0.16s** (4.3x speedup).
 
 ```python
-# Known RSS feeds (verified 2026-04):
-RSS_FEEDS = {
-    "techcrunch":    "https://techcrunch.com/feed/",
-    "verge":         "https://www.theverge.com/rss/index.xml",
-    "ars_technica":  "https://feeds.arstechnica.com/arstechnica/index",
-    "bbc":           "http://feeds.bbci.co.uk/news/rss.xml",
-    "reuters":       "https://feeds.reuters.com/reuters/topNews",
-    "venturebeat":   "https://venturebeat.com/feed/",
-}
+from concurrent.futures import ThreadPoolExecutor
+import xml.etree.ElementTree as ET
 
-# Category/topic feeds:
-TOPIC_FEEDS = {
-    "techcrunch_ai":   "https://techcrunch.com/category/artificial-intelligence/feed/",
-    "techcrunch_startups": "https://techcrunch.com/category/startups/feed/",
-    "verge_ai":        "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml",
-    "verge_tech":      "https://www.theverge.com/rss/tech/index.xml",
-    "ars_tech":        "https://feeds.arstechnica.com/arstechnica/technology-lab",
-    "ars_science":     "https://feeds.arstechnica.com/arstechnica/science",
-    "bbc_tech":        "http://feeds.bbci.co.uk/news/technology/rss.xml",
-    "bbc_world":       "http://feeds.bbci.co.uk/news/world/rss.xml",
-    "reuters_world":   "https://feeds.reuters.com/reuters/worldnews",
-    "reuters_tech":    "https://feeds.reuters.com/reuters/technologynews",
-}
+RSS_FEEDS = [
+    ("TechCrunch",     "https://techcrunch.com/feed/"),
+    ("Ars Technica",   "https://feeds.arstechnica.com/arstechnica/index"),
+    ("BBC News",       "http://feeds.bbci.co.uk/news/rss.xml"),
+    ("Guardian World", "https://www.theguardian.com/world/rss"),
+    ("Wired",          "https://www.wired.com/feed/rss"),
+    ("NPR",            "https://feeds.npr.org/1001/rss.xml"),
+    ("Wired",          "https://www.wired.com/feed/rss"),
+]
+
+def fetch_rss(name_url):
+    name, url = name_url
+    xml_data = http_get(url)
+    root = ET.fromstring(xml_data)
+    items = root.findall('.//item')
+    return name, items
+
+with ThreadPoolExecutor(max_workers=len(RSS_FEEDS)) as ex:
+    results = list(ex.map(fetch_rss, RSS_FEEDS))
+
+for name, items in results:
+    for item in items[:5]:
+        title = item.find('title').text
+        link  = item.find('link').text
+        print(f"[{name}] {title}")
 ```
 
----
+## The Verge requires Atom namespace parsing
 
-## Parsing RSS — the core utility
-
-RSS is XML. Parse it with Python's built-in `xml.etree.ElementTree` — no third-party libraries needed.
+The Verge's feed is Atom format, not RSS 2.0. The naive `.//item` selector returns 0 items. The `title` element uses `type="html"` attribute but its `.text` still contains the plain string.
 
 ```python
 import xml.etree.ElementTree as ET
+
+NS = {'atom': 'http://www.w3.org/2005/Atom'}
+
+xml_data = http_get("https://www.theverge.com/rss/index.xml")
+root = ET.fromstring(xml_data)
+entries = root.findall('.//atom:entry', NS)   # 10 entries
+
+for e in entries:
+    title = e.find('atom:title', NS).text
+    link  = e.find('atom:link', NS).get('href')
+    print(title, link)
+```
+
+Do NOT use `root.findall('.//{http://www.w3.org/2005/Atom}entry')` with a bare namespace — the explicit `NS` dict approach above is cleaner. Do NOT call `.text` on a `find()` result without checking for `None` first (the naive RSS path hit this on The Verge).
+
+## Sites that block http_get entirely
+
+**Reuters** returns HTTP 403/Forbidden for all `http_get` calls, even with a real browser `User-Agent` header. Use browser fallback (see below).
+
+```
+Reuters: ERROR HTTP Error 401: HTTP Forbidden   # with AND without User-Agent
+```
+
+Reuters's old RSS feeds (`feeds.reuters.com/reuters/topNews`) resolve to DNS NXDOMAIN — they have been shut down.
+
+## Sites that work fine with http_get + User-Agent
+
+NYT, Guardian, HN, CNN all return full HTML via `http_get` without issues. The User-Agent header (`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36`) is not required for these but doesn't hurt.
+
+```python
+headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
+html = http_get("https://www.nytimes.com", headers=headers)  # 1.1MB, works
+html = http_get("https://news.ycombinator.com")               # 34KB, works without UA
+```
+
+**HN parsing via regex (no HTML parser needed):**
+```python
 import re
-from email.utils import parsedate_to_datetime   # handles RFC 822 dates
-from datetime import datetime, timezone
-
-def parse_rss(xml_text, source_name=""):
-    """Parse an RSS 2.0 feed. Returns a list of article dicts."""
-    # Some feeds include XML namespace declarations that break plain ET parsing.
-    # Strip them first so we can use simple tag names.
-    xml_text = re.sub(r' xmlns[^"]*"[^"]*"', '', xml_text)
-    xml_text = re.sub(r'<\?xml[^?]*\?>', '', xml_text).strip()
-
-    try:
-        root = ET.fromstring(xml_text)
-    except ET.ParseError:
-        # Malformed XML — last resort, grab titles with regex
-        titles = re.findall(r'<title><!\[CDATA\[(.*?)\]\]></title>', xml_text)
-        links  = re.findall(r'<link>(https?://[^<]+)</link>', xml_text)
-        return [{"title": t, "url": l, "source": source_name}
-                for t, l in zip(titles, links)]
-
-    items = root.findall(".//item")  # RSS 2.0
-    if not items:
-        items = root.findall(".//{http://www.w3.org/2005/Atom}entry")  # Atom
-
-    articles = []
-    for item in items:
-        def text(tag, default=""):
-            el = item.find(tag)
-            if el is None:
-                return default
-            t = el.text or ""
-            # Strip CDATA wrapper if present (some feeds inline it as text)
-            t = re.sub(r'<!\[CDATA\[(.*?)\]\]>', r'\1', t, flags=re.DOTALL)
-            return t.strip()
-
-        title   = text("title")
-        url     = text("link") or text("guid")
-        summary = text("description") or text("summary") or text("{http://www.w3.org/2005/Atom}summary")
-        author  = text("author") or text("{http://purl.org/dc/elements/1.1/}creator")
-        pub_raw = text("pubDate") or text("published") or text("updated")
-
-        # Normalise publish date to a UTC datetime (or None)
-        pub_dt = _parse_date(pub_raw)
-
-        if not title and not url:
-            continue
-
-        articles.append({
-            "title":   title,
-            "url":     url,
-            "summary": re.sub(r'<[^>]+>', '', summary).strip(),  # strip HTML tags
-            "author":  author,
-            "source":  source_name,
-            "pub_raw": pub_raw,
-            "pub_dt":  pub_dt,
-        })
-
-    return articles
-
-
-def _parse_date(s):
-    """Try multiple date formats. Returns a UTC-aware datetime or None."""
-    if not s:
-        return None
-    s = s.strip()
-    # RFC 822 (most RSS feeds): "Fri, 18 Apr 2026 10:30:00 +0000"
-    try:
-        return parsedate_to_datetime(s).astimezone(timezone.utc)
-    except Exception:
-        pass
-    # ISO 8601 (Atom, some modern feeds): "2026-04-18T10:30:00Z"
-    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
-        try:
-            dt = datetime.strptime(s, fmt)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt.astimezone(timezone.utc)
-        except ValueError:
-            continue
-    return None
+html = http_get("https://news.ycombinator.com")
+stories = re.findall(r'class="titleline"><a href="([^"]+)"[^>]*>([^<]+)<', html)
+# Returns list of (url, title) tuples — 30 stories on the front page
 ```
 
----
+## Browser extraction — use when RSS is unavailable
 
-## Parallel fetch — multiple feeds simultaneously
+### BBC (`bbc.com/news`)
 
-Use `ThreadPoolExecutor` to fetch all feeds in parallel. With 6 feeds each taking ~300ms, sequential fetching takes ~1.8s; parallel takes ~350ms.
-
-```python
-from concurrent.futures import ThreadPoolExecutor, as_completed
-
-def fetch_feed(name, url):
-    """Fetch and parse one RSS feed. Returns (name, articles) or (name, []) on error."""
-    try:
-        xml = http_get(url, headers={"Accept": "application/rss+xml, application/xml, text/xml"})
-        return name, parse_rss(xml, source_name=name)
-    except Exception as e:
-        print(f"[{name}] fetch failed: {e}")
-        return name, []
-
-
-def fetch_all_feeds(feed_dict, max_workers=8):
-    """Fetch multiple RSS feeds in parallel. Returns merged list of articles."""
-    all_articles = []
-    with ThreadPoolExecutor(max_workers=max_workers) as ex:
-        futures = {ex.submit(fetch_feed, name, url): name
-                   for name, url in feed_dict.items()}
-        for fut in as_completed(futures):
-            name, articles = fut.result()
-            all_articles.extend(articles)
-    return all_articles
-
-
-# Example: top AI news across TechCrunch + The Verge + Ars Technica
-articles = fetch_all_feeds({
-    "techcrunch_ai": TOPIC_FEEDS["techcrunch_ai"],
-    "verge_ai":      TOPIC_FEEDS["verge_ai"],
-    "ars_tech":      TOPIC_FEEDS["ars_tech"],
-})
-print(f"Fetched {len(articles)} articles from 3 sources")
-```
-
----
-
-## Common workflows
-
-### Fetch top N articles from a single site
+No consent banner in headless browser (US region served; GDPR banner only appears for EU IP). Articles use `article h2` selectors.
 
 ```python
-xml = http_get("https://techcrunch.com/feed/")
-articles = parse_rss(xml, source_name="techcrunch")
-top5 = articles[:5]
-for a in top5:
-    print(f"[{a['source']}] {a['title']}")
-    print(f"  {a['url']}")
-    print(f"  {a['pub_raw']}")
-```
-
-### Multi-source aggregation with deduplication
-
-Different feeds sometimes carry the same wire story (e.g. Reuters articles reprinted elsewhere). Dedup by URL before presenting results.
-
-```python
-def aggregate_and_dedup(feed_dict, max_per_source=None):
-    """Fetch feeds, dedup by URL, return sorted by publish date (newest first)."""
-    all_articles = fetch_all_feeds(feed_dict)
-
-    # Dedup by URL — keep first occurrence (arbitrary ordering from parallel fetch)
-    seen_urls = set()
-    unique = []
-    for a in all_articles:
-        url = a["url"].rstrip("/")   # normalise trailing slash
-        if url and url not in seen_urls:
-            seen_urls.add(url)
-            unique.append(a)
-
-    # Sort: articles with a known pub_dt first (newest), unknown dates last
-    def sort_key(a):
-        dt = a.get("pub_dt")
-        return dt if dt else datetime.min.replace(tzinfo=timezone.utc)
-
-    unique.sort(key=sort_key, reverse=True)
-
-    if max_per_source:
-        # Cap per-source contribution so no single feed dominates
-        counts = {}
-        capped = []
-        for a in unique:
-            src = a["source"]
-            counts[src] = counts.get(src, 0)
-            if counts[src] < max_per_source:
-                capped.append(a)
-                counts[src] += 1
-        return capped
-
-    return unique
-
-
-# Top 5 AI stories across 3 sources in last 24 hours
-from datetime import timedelta
-
-results = aggregate_and_dedup({
-    "techcrunch_ai": TOPIC_FEEDS["techcrunch_ai"],
-    "verge_ai":      TOPIC_FEEDS["verge_ai"],
-    "ars_tech":      TOPIC_FEEDS["ars_tech"],
-}, max_per_source=10)
-
-cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
-recent = [a for a in results if a["pub_dt"] and a["pub_dt"] >= cutoff]
-print(f"Found {len(recent)} articles in last 24h")
-for a in recent[:5]:
-    print(f"\n[{a['source']}] {a['title']}")
-    print(f"  Published: {a['pub_dt'].strftime('%Y-%m-%d %H:%M UTC')}")
-    print(f"  URL: {a['url']}")
-    print(f"  Summary: {a['summary'][:200]}")
-```
-
-### Filter by keyword in title or summary
-
-```python
-def filter_by_keyword(articles, keywords, case_sensitive=False):
-    """Return articles where any keyword appears in title or summary."""
-    results = []
-    for a in articles:
-        haystack = a["title"] + " " + a["summary"]
-        if not case_sensitive:
-            haystack = haystack.lower()
-            checks = [k.lower() for k in keywords]
-        else:
-            checks = keywords
-        if any(k in haystack for k in checks):
-            results.append(a)
-    return results
-
-
-# All articles mentioning GPT-4, Claude, or Gemini from the last 48 hours
-all_articles = fetch_all_feeds(RSS_FEEDS)
-cutoff = datetime.now(timezone.utc) - timedelta(hours=48)
-recent = [a for a in all_articles if a["pub_dt"] and a["pub_dt"] >= cutoff]
-ai_articles = filter_by_keyword(recent, ["GPT-4", "Claude", "Gemini", "LLM", "AI model"])
-for a in ai_articles:
-    print(f"[{a['source']}] {a['title']}")
-```
-
-### Filter by publish date window
-
-```python
-def filter_by_age(articles, hours=24):
-    """Return articles published within the last N hours. Articles with no date are excluded."""
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
-    return [a for a in articles if a["pub_dt"] and a["pub_dt"] >= cutoff]
-
-
-# "Top tech news from today" — all feeds, last 24 hours
-all_tech = fetch_all_feeds({
-    "techcrunch": RSS_FEEDS["techcrunch"],
-    "verge":      RSS_FEEDS["verge"],
-    "ars":        RSS_FEEDS["ars_technica"],
-})
-today = filter_by_age(all_tech, hours=24)
-today.sort(key=lambda a: a["pub_dt"], reverse=True)
-print(f"Today: {len(today)} articles")
-```
-
-### Search for a company or topic across all sources
-
-```python
-def company_news(company_name, hours=168, feeds=None):
-    """
-    Get all articles mentioning `company_name` from the last N hours (default: 7 days).
-    Uses general feeds — for better coverage, also search Algolia HN (see hackernews/scraping.md).
-    """
-    feeds = feeds or RSS_FEEDS
-    all_articles = fetch_all_feeds(feeds)
-    recent = filter_by_age(all_articles, hours=hours)
-    matches = filter_by_keyword(recent, [company_name])
-    matches.sort(key=lambda a: a["pub_dt"], reverse=True)
-    return matches
-
-
-# "Get all articles about OpenAI from the last week"
-openai_news = company_news("OpenAI", hours=168)
-for a in openai_news:
-    print(f"[{a['pub_dt'].strftime('%m-%d')}] [{a['source']}] {a['title']}")
-```
-
-### Extract full article text from a URL
-
-RSS feeds truncate body text (often 50–200 words max). To get full text, follow the article URL. Works on sites without paywalls.
-
-```python
-def fetch_article_text(url):
-    """
-    Fetch full article text from a URL via HTTP (no browser).
-    Returns plain text, stripping nav/footer boilerplate.
-    Works for: TechCrunch, Ars Technica, Reuters, VentureBeat, BBC.
-    Does NOT work for: FT, NYT, Bloomberg, WSJ (paywalls), The Verge (JS-rendered body).
-    """
-    html = http_get(url)
-
-    # Extract <article> content if present (most modern sites)
-    article_match = re.search(r'<article[^>]*>(.*?)</article>', html, re.DOTALL)
-    if article_match:
-        body_html = article_match.group(1)
-    else:
-        # Fall back to <main>
-        main_match = re.search(r'<main[^>]*>(.*?)</main>', html, re.DOTALL)
-        body_html = main_match.group(1) if main_match else html
-
-    # Strip scripts, styles, and HTML tags
-    body_html = re.sub(r'<(script|style)[^>]*>.*?</(script|style)>', '', body_html, flags=re.DOTALL)
-    text = re.sub(r'<[^>]+>', ' ', body_html)
-    text = re.sub(r'\s+', ' ', text).strip()
-
-    return text
-
-
-# Get full text of the top TechCrunch AI article
-xml = http_get(TOPIC_FEEDS["techcrunch_ai"])
-articles = parse_rss(xml, "techcrunch")
-if articles:
-    full_text = fetch_article_text(articles[0]["url"])
-    print(full_text[:1000])
-```
-
-### Scrape The Verge front page (all articles, title + author + timestamp + URL)
-
-The Verge's front page is JS-rendered, so `http_get` returns a skeleton. Use the browser. But note: the RSS feed is faster if you just need the top articles.
-
-```python
-# Option A — RSS (fast, no browser, top articles only)
-xml = http_get("https://www.theverge.com/rss/index.xml")
-articles = parse_rss(xml, "verge")
-# Returns up to 20 articles with title, URL, summary, pub_dt
-
-# Option B — Browser (when you need author bylines or full front-page layout)
-goto("https://www.theverge.com")
+goto("https://www.bbc.com/news")
 wait_for_load()
-_dismiss_consent_banner()   # see Cookie/Consent section below
+wait(2)
+
+headlines = js("""
+  Array.from(document.querySelectorAll('article h2'))
+    .map(h => ({
+      title: h.innerText.trim(),
+      url: h.closest('a')?.href || h.closest('[href]')?.href || 
+           h.parentElement.querySelector('a')?.href
+    }))
+    .filter(h => h.title.length > 10)
+""")
+# Returns 50+ articles. First one is typically LIVE/breaking.
+```
+
+If running from a EU IP and a consent banner appears:
+```python
+accept = js("""
+  var btns = Array.from(document.querySelectorAll('button'));
+  var btn = btns.find(b => /accept all|agree|continue/i.test(b.innerText));
+  if (btn) { btn.click(); return 'clicked: ' + btn.innerText; }
+  return 'no banner';
+""")
+```
+
+Confirmed: `h3` elements on BBC are site-chrome labels ("The BBC is in multiple languages"), NOT article headlines. Use `article h2` only.
+
+### TechCrunch (`techcrunch.com`)
+
+`article` and `.post-block` selectors return 0 results — TechCrunch changed their layout. Articles are in `h3` elements.
+
+```python
+goto("https://techcrunch.com")
+wait_for_load()
+wait(2)
 
 articles = js("""
-(() => {
-  const cards = document.querySelectorAll('h2 a, h3 a');
-  const seen = new Set();
-  const out = [];
-  for (const a of cards) {
-    const url = a.href;
-    if (!url || seen.has(url)) continue;
-    seen.add(url);
-    const title = a.textContent.trim();
-    if (!title) continue;
-    // Author is often in a sibling or parent context — walk up
-    const article = a.closest('article') || a.closest('[data-chorus-optimize-field]');
-    const authorEl = article && article.querySelector('a[data-analytics-link="author"]');
-    const timeEl   = article && article.querySelector('time');
-    out.push({
-      title:     title,
-      url:       url,
-      author:    authorEl ? authorEl.textContent.trim() : '',
-      timestamp: timeEl   ? timeEl.getAttribute('datetime') : '',
-    });
-    if (out.length >= 30) break;
-  }
-  return out;
-})()
+  Array.from(document.querySelectorAll('h3'))
+    .map(h => ({
+      title: h.innerText?.trim(),
+      url: h.closest('a')?.href || h.querySelector('a')?.href || 
+           h.parentElement?.querySelector('a')?.href
+    }))
+    .filter(a => a.title && a.title.length > 20)
 """)
+# Returns ~10 articles. RSS is preferred (20 items, no JS required).
 ```
 
----
+RSS is almost always faster for TechCrunch: **0.08s vs 3-5s browser** load. Only fall back to browser if you need paywall/subscriber content.
 
-## Cookie / consent banner handling
+### Reuters (`reuters.com`)
 
-BBC, The Verge, and all EU-facing properties show GDPR consent banners on first visit. The banner intercepts clicks — dismiss it before any other interaction.
-
-### Generic approach (works on most sites)
+`http_get` returns 403. Browser loads but the homepage is heavily JS-rendered with delayed hydration. `h3` selectors only return nav elements after standard `wait_for_load()`. Use `wait(3)` plus scroll:
 
 ```python
-def _dismiss_consent_banner(wait_seconds=2.0):
-    """
-    Try to dismiss a cookie/consent banner by clicking 'Accept all', 'Accept', or 'Agree' buttons.
-    Call after goto() + wait_for_load(). Safe to call even if no banner is present.
-    """
-    wait(wait_seconds)   # banners often inject asynchronously
-
-    dismissed = js("""
-    (() => {
-      const phrases = [
-        'accept all', 'accept cookies', 'agree to all', 'i agree',
-        'allow all', 'allow cookies', 'ok', 'got it',
-      ];
-      const els = [
-        ...document.querySelectorAll('button'),
-        ...document.querySelectorAll('a[role="button"]'),
-        ...document.querySelectorAll('[class*="consent"] button'),
-        ...document.querySelectorAll('[id*="consent"] button'),
-        ...document.querySelectorAll('[class*="cookie"] button'),
-        ...document.querySelectorAll('[id*="cookie"] button'),
-        ...document.querySelectorAll('[class*="gdpr"] button'),
-        ...document.querySelectorAll('[class*="banner"] button'),
-      ];
-      for (const el of els) {
-        const text = (el.textContent || el.value || '').toLowerCase().trim();
-        if (phrases.some(p => text.includes(p))) {
-          el.click();
-          return el.textContent.trim();
-        }
-      }
-      return null;
-    })()
-    """)
-
-    if dismissed:
-        wait(1.0)  # let the banner animate out
-    return dismissed
-```
-
-### BBC-specific consent
-
-BBC uses a dedicated consent domain (`bbc.co.uk/usp/prd/gdpr`). The consent banner renders inside the page as a full-screen overlay — a regular `button` click via JS usually works. If the JS click doesn't register, fall back to a coordinate click after taking a screenshot to locate the button.
-
-```python
-def _dismiss_bbc_consent():
-    """Dismiss the BBC consent overlay. Call after goto() + wait_for_load()."""
-    wait(2.0)
-    # Try JS click first
-    result = js("""
-    (() => {
-      // BBC consent button selector (stable as of 2026-04)
-      const btn = document.querySelector('button[data-testid="accept-button"]')
-               || document.querySelector('.tp-close')
-               || document.querySelector('[class*="ConsentBanner"] button');
-      if (btn) { btn.click(); return true; }
-      // Fallback: any button with 'Yes' or 'Accept' in a modal/dialog
-      for (const b of document.querySelectorAll('dialog button, [role="dialog"] button')) {
-        if (/yes|accept|agree/i.test(b.textContent)) { b.click(); return true; }
-      }
-      return false;
-    })()
-    """)
-    if not result:
-        # Fallback: screenshot and coordinate-click the accept button
-        screenshot("/tmp/bbc_banner.png")
-        # Typical BBC accept button is near top-center on a full-screen overlay
-        click(760, 450)
-    wait(1.0)
-```
-
-**BBC domain note:** `bbc.co.uk/news` serves UK content; `bbc.com/news` serves international. They are different editorial selections. The RSS feed (`feeds.bbci.co.uk`) gives a merged top-stories view. After you dismiss the consent banner once, BBC sets a cookie that persists for the session — subsequent `goto` calls on the same session won't show it again.
-
----
-
-## When browser IS needed vs pure HTTP
-
-| Task | Use |
-|---|---|
-| TechCrunch articles (listing + metadata) | RSS `http_get` |
-| TechCrunch full article body | `http_get(article_url)` — clean HTML |
-| The Verge articles (listing + metadata) | RSS `http_get` |
-| The Verge full article body | Browser — body is JS-rendered after hydration |
-| Ars Technica articles | RSS `http_get` |
-| Ars Technica full article body | `http_get(article_url)` — full HTML |
-| BBC articles (listing + metadata) | RSS `http_get` |
-| BBC full article body | `http_get(article_url)` usually works |
-| Reuters articles | RSS `http_get` |
-| Reuters full article body | `http_get(article_url)` — clean HTML |
-| VentureBeat articles | RSS `http_get` |
-| FT / NYT / Bloomberg / WSJ | Do not use — paywalled |
-| "Get the lead article link from bbc.co.uk/news right now" | Browser (need live DOM, not cached RSS) |
-| Search results / filtered views with JS | Browser |
-| Pagination beyond first RSS page | Browser or site-specific API |
-
----
-
-## Site-specific notes
-
-### TechCrunch
-
-- General feed: `https://techcrunch.com/feed/` (latest across all categories)
-- Category feeds: `https://techcrunch.com/category/<slug>/feed/`
-  - AI: `/category/artificial-intelligence/feed/`
-  - Startups: `/category/startups/feed/`
-  - Venture: `/category/venture/feed/`
-  - Security: `/category/security/feed/`
-- RSS returns full article summaries (2–4 sentences). No paywall on article pages.
-- Author names are in `<dc:creator>` not `<author>` — already handled by `parse_rss`.
-
-### The Verge
-
-- General feed: `https://www.theverge.com/rss/index.xml`
-- Topic feeds: `https://www.theverge.com/rss/<topic>/index.xml`
-  - AI: `rss/ai-artificial-intelligence/index.xml`
-  - Tech: `rss/tech/index.xml`
-  - Science: `rss/science/index.xml`
-  - Games: `rss/games/index.xml`
-- RSS is Atom format (not RSS 2.0) — `parse_rss` handles both.
-- Full article body is JS-rendered (React/Chorus). `http_get` on article URLs gives you a skeleton. Use the browser or accept the RSS summary.
-
-### Ars Technica
-
-- General feed: `https://feeds.arstechnica.com/arstechnica/index`
-- Topic feeds: `https://feeds.arstechnica.com/arstechnica/<section>`
-  - Technology: `technology-lab`
-  - Science: `science`
-  - Gaming: `gaming`
-  - Policy: `tech-policy`
-  - Security: `security`
-- RSS includes article summaries (first 1–2 paragraphs). Article pages are clean HTML.
-- No consent banner in most regions. No paywall.
-
-### BBC
-
-- Top stories: `http://feeds.bbci.co.uk/news/rss.xml`
-- World: `http://feeds.bbci.co.uk/news/world/rss.xml`
-- Technology: `http://feeds.bbci.co.uk/news/technology/rss.xml`
-- Science: `http://feeds.bbci.co.uk/news/science_and_environment/rss.xml`
-- RSS descriptions are short (1 sentence). Article HTML is clean and readable.
-- Consent banner shows on first browser visit — see BBC-specific handling above.
-- `bbc.co.uk/news` = UK-focused editorial; `bbc.com/news` = international. Geo-varies on some stories.
-
-### Reuters
-
-- Top news: `https://feeds.reuters.com/reuters/topNews`
-- World: `https://feeds.reuters.com/reuters/worldnews`
-- Technology: `https://feeds.reuters.com/reuters/technologynews`
-- Business: `https://feeds.reuters.com/reuters/businessNews`
-- Article pages are clean HTML with no paywall for standard articles.
-- Reuters wire stories are often reproduced verbatim on BBC, AP News, etc. — dedup by URL is important when mixing Reuters with other feeds.
-
-### VentureBeat
-
-- General feed: `https://venturebeat.com/feed/`
-- AI feed: `https://venturebeat.com/category/ai/feed/`
-- RSS summaries are generous (3–5 sentences). Full articles are clean HTML.
-- Some articles behind a "VB Transform" event sign-up modal — usually dismissible, but the article body is present in the raw HTML.
-
----
-
-## Putting it all together — complete task examples
-
-### "Get top 5 AI stories in last 24 hours from TechCrunch, The Verge, VentureBeat"
-
-```python
-import xml.etree.ElementTree as ET
-import re
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone, timedelta
-from email.utils import parsedate_to_datetime
-
-# (paste parse_rss, _parse_date, fetch_feed, fetch_all_feeds, filter_by_age from above)
-
-feeds = {
-    "techcrunch_ai": "https://techcrunch.com/category/artificial-intelligence/feed/",
-    "verge_ai":      "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml",
-    "venturebeat_ai":"https://venturebeat.com/category/ai/feed/",
-}
-
-all_articles = fetch_all_feeds(feeds)
-last_24h = filter_by_age(all_articles, hours=24)
-last_24h.sort(key=lambda a: a["pub_dt"], reverse=True)
-top5 = last_24h[:5]
-
-for a in top5:
-    print(f"\nTitle:   {a['title']}")
-    print(f"Source:  {a['source']}")
-    print(f"URL:     {a['url']}")
-    print(f"Date:    {a['pub_dt'].strftime('%Y-%m-%d %H:%M UTC') if a['pub_dt'] else 'unknown'}")
-    print(f"Summary: {a['summary'][:300]}")
-```
-
-### "Visit BBC World, dismiss cookie banner, get first lead article link"
-
-```python
-goto("https://www.bbc.co.uk/news")
+goto("https://www.reuters.com")
 wait_for_load()
-_dismiss_bbc_consent()  # must run before any other interaction
-
-# Get lead article link from DOM (more reliable than RSS for "right now" front page)
-lead_url = js("""
-(() => {
-  // BBC lead story is usually an <a> inside the first <article> or [data-testid="dundee-card"]
-  const selectors = [
-    'article h3 a',
-    '[data-testid="dundee-card"] a',
-    'h3 a[href*="/news/"]',
-    'h2 a[href*="/news/"]',
-  ];
-  for (const sel of selectors) {
-    const el = document.querySelector(sel);
-    if (el && el.href && !el.href.includes('#')) return el.href;
-  }
-  return null;
-})()
+wait(3)
+js("window.scrollTo(0, 500)")
+wait(1)
+# Category links work for topic nav:
+links = js("""
+  Array.from(document.querySelectorAll('a[href*="/world/"], a[href*="/technology/"]'))
+    .filter(a => a.innerText.trim().length > 20)
+    .map(a => ({text: a.innerText.trim(), href: a.href}))
 """)
-print("Lead article:", lead_url)
 ```
 
-### "Get today's top tech news from TechCrunch, Ars Technica, and The Verge"
+Reuters headlines are best obtained from the Guardian or AP — Reuters no longer has a public RSS and their JS hydration is slow.
 
-```python
-feeds = {
-    "techcrunch": "https://techcrunch.com/feed/",
-    "ars":        "https://feeds.arstechnica.com/arstechnica/index",
-    "verge":      "https://www.theverge.com/rss/index.xml",
-}
-all_articles = fetch_all_feeds(feeds)
-today = filter_by_age(all_articles, hours=24)
-today.sort(key=lambda a: a["pub_dt"], reverse=True)
+## Decision tree: which approach to use
 
-print(f"Today's top tech news ({len(today)} articles):\n")
-for i, a in enumerate(today[:15], 1):
-    ts = a["pub_dt"].strftime("%H:%M UTC") if a["pub_dt"] else "?"
-    print(f"{i:2}. [{a['source']:12}] {ts}  {a['title']}")
+```
+Does the site have an RSS/Atom feed?
+  YES → http_get + XML parse (fastest, ~0.1s per feed)
+         - RSS 2.0: root.findall('.//item')
+         - Atom:    root.findall('.//atom:entry', {'atom': 'http://www.w3.org/2005/Atom'})
+  NO  → Does http_get return valid HTML (not 403/401/JS shell)?
+          YES → http_get + regex/BeautifulSoup (fast, ~0.2-0.3s)
+          NO  → goto + wait_for_load + wait(2) + js() extraction (slow, 3-8s)
 ```
 
-### "Extract AI/ML news from the last 48 hours across multiple tech publications"
+## What to skip
 
-```python
-ai_feeds = {
-    "techcrunch_ai":   "https://techcrunch.com/category/artificial-intelligence/feed/",
-    "verge_ai":        "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml",
-    "venturebeat_ai":  "https://venturebeat.com/category/ai/feed/",
-    "ars_tech":        "https://feeds.arstechnica.com/arstechnica/technology-lab",
-}
-# Also pull from general tech feeds and keyword-filter
-general_feeds = {
-    "bbc_tech":    "http://feeds.bbci.co.uk/news/technology/rss.xml",
-    "reuters_tech":"https://feeds.reuters.com/reuters/technologynews",
-}
-
-dedicated = fetch_all_feeds(ai_feeds)
-general   = fetch_all_feeds(general_feeds)
-ai_keywords = ["AI", "machine learning", "LLM", "neural network", "GPT", "Claude",
-               "Gemini", "artificial intelligence", "deep learning", "model", "agent"]
-filtered_general = filter_by_keyword(general, ai_keywords)
-
-all_ai = dedicated + filtered_general
-last_48h = filter_by_age(all_ai, hours=48)
-
-# Dedup by URL
-seen = set()
-deduped = []
-for a in last_48h:
-    u = a["url"].rstrip("/")
-    if u not in seen:
-        seen.add(u)
-        deduped.append(a)
-
-deduped.sort(key=lambda a: a["pub_dt"], reverse=True)
-print(f"Found {len(deduped)} unique AI/ML articles in last 48h")
-```
-
----
-
-## Gotchas
-
-- **User-Agent required.** Some CDNs (Cloudflare on VentureBeat, Fastly on some Reuters endpoints) return 403 or 429 to Python's default `urllib` agent. `http_get` in this harness already sends `Mozilla/5.0` — don't override it with an empty string. If you hit a 403, try adding an `Accept` header: `{"Accept": "application/rss+xml, text/xml"}`.
-
-- **Publish date formats vary wildly.** RFC 822 (`Fri, 18 Apr 2026 10:30:00 +0000`) is most common in RSS 2.0. Atom feeds use ISO 8601 (`2026-04-18T10:30:00Z`). BBC sometimes omits the seconds. Some feeds use timezone abbreviations (`EST`, `PST`) that are not valid RFC 822 but `email.utils.parsedate_to_datetime` handles them. The `_parse_date` helper above handles all known variants.
-
-- **RSS truncates article body.** RSS `<description>` is at most a few sentences. For full text, `http_get(article_url)` — but this doubles request count. Batch with `ThreadPoolExecutor` if you need full text for many articles.
-
-- **Paywalls.** Do not attempt to scrape FT, NYT, Bloomberg, or WSJ without a subscription. Their articles are behind hard paywalls and bot-detection. Stick to the sources listed above which are freely readable.
-
-- **Cookie consent intercepts clicks.** If you do need to use the browser on BBC or The Verge, always call the dismiss helper before interacting with any link or button. If you click before the banner is dismissed, the click goes to the banner overlay, not the page.
-
-- **BBC geo-serving.** `bbc.co.uk/news` and `bbc.com/news` serve different story selections. The RSS feed `feeds.bbci.co.uk/news/rss.xml` is a merged view and less affected by geo. If a user asks for "BBC World News", use `http://feeds.bbci.co.uk/news/world/rss.xml`.
-
-- **The Verge full article body requires the browser.** Unlike TechCrunch and Ars, The Verge renders article text client-side via React hydration. `http_get(article_url)` gives you only the title and metadata, not the body paragraphs. Accept the RSS summary (which is 2–4 sentences) or use `goto` + `wait_for_load` + `js(...)` to extract the body.
-
-- **Reuters feed freshness.** Reuters top-news feed updates frequently (every few minutes). For real-time news, Reuters is often 10–30 minutes ahead of other outlets.
-
-- **Atom vs RSS 2.0 namespaces.** The Verge and some modern feeds use Atom (`<feed>` root, `<entry>` items). The `parse_rss` helper above detects and handles both formats. If you write your own parser, check the root tag: `feed` = Atom, `rss` = RSS 2.0.
-
-- **`<guid>` vs `<link>`.** In some feeds (particularly Reuters), `<link>` is the feed URL itself and `<guid>` carries the article URL. The `parse_rss` helper tries `link` first and falls back to `guid`. Always verify the URL points to an article, not the feed root.
-
-- **Relative URLs in RSS.** Uncommon but it happens on some smaller publications. Always check `url.startswith('http')` after parsing and prepend the base domain if needed.
-
-- **XML namespace stripping.** Some feeds include namespace declarations like `xmlns:dc="http://purl.org/dc/elements/1.1/"` which cause `ET.fromstring` to require namespace-prefixed tag names. The `re.sub` at the top of `parse_rss` strips these so plain tag names like `dc:creator` are parsed as `"dc:creator"` (colon in tag name) — which ET handles fine.
-
-- **"Relative time" strings.** Some sites (Medium, Substack) put "2 hours ago" in the `<pubDate>` field instead of an absolute timestamp. `_parse_date` will return `None` for these — treat `pub_dt=None` as "recently published" or use the article's position in the feed (item 0 = newest).
+- **Reuters RSS** — DNS dead (`feeds.reuters.com` is NXDOMAIN)
+- **Reuters http_get** — returns 403 regardless of User-Agent
+- **TechCrunch `article`/`.post-block` selectors** — layout changed, use `h3` instead
+- **BBC `h3` for headlines** — those are site-chrome labels; use `article h2`
+- **The Verge `.//item` selector** — feed is Atom, not RSS; use Atom namespace

--- a/domain-skills/producthunt/scraping.md
+++ b/domain-skills/producthunt/scraping.md
@@ -1,477 +1,307 @@
-# Product Hunt — Daily Launches & Topic Scraping
+# Product Hunt Scraping Skills
 
-`https://www.producthunt.com` — React SPA, requires browser (not `http_get`)
+Field-tested against https://www.producthunt.com on 2026-04-18.
+All selectors verified with actual browser runs.
 
-## Important: This site needs a browser
+---
 
-Product Hunt is a fully client-rendered React application. `http_get("https://www.producthunt.com")` returns an HTML shell with almost no product data — the launch list, vote counts, and taglines are all injected by the JS bundle after hydration.
+## Page Structure Overview
 
-Always use `goto` + `wait_for_load` + a short `wait` for React to hydrate, then `js()` to extract.
+Product Hunt is a React SPA. Key structural facts discovered:
+
+- **No login wall** — all product data is accessible without signing in
+- **No cookie banner** — page loads cleanly with no consent dialogs
+- **Product URLs use `/products/` not `/posts/`** — the `a[href^="/posts/"]` selector matches nothing
+- **`data-test` attributes** are the most reliable selectors throughout the site
+- **4 homepage sections**: today, yesterday, last week, last month (5 products each, plus "see all")
+- **Today's votes are hidden** for the first 4 hours of each day (`—` instead of count)
+- **Homepage has 30 fixed post-items** — scrolling does NOT load more
+- **`goto()` may return `ERR_ABORTED`** for producthunt.com in some browser sessions — use `new_tab()` instead
+
+---
+
+## Navigation Pattern
 
 ```python
-goto("https://www.producthunt.com")
-wait_for_load()
-wait(2)  # let React hydrate product cards
+# goto() may fail on Product Hunt — use new_tab() reliably
+tid = new_tab("https://www.producthunt.com")
+wait(4)  # React SPA needs time; wait_for_load() alone is insufficient
+page = page_info()
+# Verify: url should be 'https://www.producthunt.com/'
 ```
 
 ---
 
-## Common workflows
+## Homepage — Extract Daily Product Feed
 
-### 1. Today's daily leaderboard — top N products
+The homepage shows today's launches plus rolling sections for yesterday, last week, last month.
 
-This is the homepage default view. Products are sorted by vote count and rendered in `<li>` elements inside the main feed.
+### Working selector: `[data-test^="post-item-"]`
 
 ```python
-goto("https://www.producthunt.com")
-wait_for_load()
-wait(2)
-
+# Full extraction with name, tagline, slug, votes, topics
 products = js("""
-(function() {
-  // Each product card sits inside a <li> with a data-test attribute
-  var items = document.querySelectorAll('li[class*="item"]');
-
-  // Fallback selector if the above is empty — PH uses Tailwind, not stable class names.
-  // The most reliable anchor is the section heading that says "Today" or a date.
-  if (!items || items.length === 0) {
-    items = document.querySelectorAll('section[class*="posts"] li');
-  }
-
-  return Array.from(items).slice(0, 20).map(function(li) {
-    // Product name: inside an <a> that links to /posts/...
-    var nameEl = li.querySelector('a[href*="/posts/"] strong, a[href*="/posts/"] span[class*="title"]');
-    if (!nameEl) nameEl = li.querySelector('a[href*="/posts/"]');
-
-    // Tagline: second text block inside the card
-    var tagEl  = li.querySelector('a[href*="/posts/"] + * span, [class*="tagline"], [class*="description"]');
-
-    // Vote count: the orange/red upvote button
-    var voteEl = li.querySelector('[class*="voteButton"] span, button[class*="vote"] span, [data-test*="vote"] span');
-
-    // PH URL (relative)
-    var linkEl = li.querySelector('a[href*="/posts/"]');
-
+JSON.stringify(
+  Array.from(document.querySelectorAll('[data-test^="post-item-"]')).map(el => {
+    var id = el.getAttribute('data-test').replace('post-item-', '');
+    var nameEl = el.querySelector('[data-test^="post-name-"]');
+    var productLink = el.querySelector('a[href^="/products/"]');
+    var voteBtn = el.querySelector('[data-test="vote-button"]');
+    var voteCount = voteBtn ? voteBtn.textContent.trim() : null;
+    var topicLinks = Array.from(el.querySelectorAll('a[href^="/topics/"]')).map(a => a.textContent.trim());
+    var name = nameEl ? nameEl.textContent.trim() : '';
+    var lines = el.innerText.split('\\n').map(l => l.trim()).filter(l => l);
+    var tagline = lines.find(l => l !== name && !topicLinks.includes(l) && l !== '•' && !/^[0-9—]/.test(l) && l.length > 5);
     return {
-      name:     nameEl ? nameEl.innerText.trim() : null,
-      tagline:  tagEl  ? tagEl.innerText.trim()  : null,
-      votes:    voteEl ? voteEl.innerText.trim()  : null,
-      ph_url:   linkEl ? 'https://www.producthunt.com' + linkEl.getAttribute('href') : null,
+      id: id,
+      name: name,
+      slug: productLink ? productLink.getAttribute('href') : null,
+      votes: voteCount,
+      topics: topicLinks,
+      tagline: tagline || null
     };
-  }).filter(function(p) { return p.name; });
-})()
+  })
+)
 """)
-
-print(products[:10])
 ```
 
-**If the selector returns an empty list:** call `screenshot()` to see the current DOM, then inspect what wraps the product cards. PH's class names are Tailwind hashes that occasionally change on deploys. The most stable fallback is to pivot to `a[href*="/posts/"]` anchors:
+**Sample output:**
+```json
+[
+  {"id":"1126372","name":"Vercel Flags","slug":"/products/vercel","votes":"—","topics":["Software Engineering","Developer Tools"],"tagline":"Feature flags, targeting rules, rollouts. All from Vercel."},
+  {"id":"1125388","name":"1. Claude Opus 4.7","slug":"/products/claude-opus-4-7","votes":"466","topics":["API","Artificial Intelligence","Development"],"tagline":"Claude's most capable model for reasoning and agentic coding"}
+]
+```
 
-```python
-products = js("""
-(function() {
-  var seen = new Set();
-  var out  = [];
-  document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
-    var href = a.getAttribute('href');
-    if (seen.has(href)) return;
-    seen.add(href);
+**Votes:**
+- `"—"` = vote count hidden (today's products during first 4 hours)
+- `"466"` = numeric string (yesterday/older products)
+- `"2,152"` = comma-formatted for large counts (parse: `voteCount.replace(',', '')`)
 
-    // Walk up to find the card root
-    var card = a.closest('li') || a.closest('article') || a.parentElement;
-    var text  = a.innerText.trim().split('\\n');
+**Name prefix**: Ranked products show rank in name: `"1. Claude Opus 4.7"` — strip with `re.sub(r'^\d+\. ', '', name)`.
 
-    out.push({
-      name:    text[0] || null,
-      tagline: text[1] || null,
-      ph_url:  'https://www.producthunt.com' + href,
-    });
-  });
-  return out.filter(function(p) { return p.name && p.name.length > 0; });
-})()
-""")
+---
+
+## Daily Leaderboard — Best URL for Complete Daily Lists
+
+The leaderboard shows all products for any given day with actual vote counts.
+
+```
+URL: https://www.producthunt.com/leaderboard/daily/YYYY/M/D
+Example: https://www.producthunt.com/leaderboard/daily/2026/4/18
+```
+
+- Uses zero-padded-free month/day (April = `4`, not `04`)
+- Uses same `[data-test^="post-item-"]` selector
+- Shows 12–19 products per day
+- Same extraction JS as homepage works identically
+
+**Yesterday's results with real vote counts:**
+```json
+{"id":"1125388","name":"1. Claude Opus 4.7","slug":"/products/claude-opus-4-7","votes":"466","tagline":"Claude's most capable model for reasoning and agentic coding"}
+{"id":"1118208","name":"2. Build Check","slug":"/products/build-check-for-outsiders","votes":"396"}
 ```
 
 ---
 
-### 2. Scroll to load more products (lazy loading)
+## Weekly Leaderboard
 
-The homepage loads ~10 products initially. Scrolling fires an intersection observer that appends more. Repeat until you have enough or hit the end of today's launches.
+```
+URL: https://www.producthunt.com/leaderboard/weekly/YYYY/WW
+Example: https://www.producthunt.com/leaderboard/weekly/2026/16
+```
 
-```python
-goto("https://www.producthunt.com")
-wait_for_load()
-wait(2)
+- Week number is ISO week (week 16 = April 13–19, 2026)
+- Current week may return 0 items until the week ends
+- Same `[data-test^="post-item-"]` selector
 
-info = page_info()
-viewport_h = info["h"]
+---
 
-all_products = []
-seen_urls = set()
+## Monthly Leaderboard
 
-for batch in range(5):  # 5 scrolls × ~10 products = up to ~50
-    # Extract currently visible products
-    batch_data = js("""
-    (function() {
-      var seen = new Set();
-      var out  = [];
-      document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
-        var href = a.getAttribute('href');
-        if (seen.has(href) || !href.match(/^\\/posts\\/[^/]+$/)) return;
-        seen.add(href);
-        var card = a.closest('li') || a.parentElement;
-        var texts = a.innerText.trim().split('\\n').filter(function(s){ return s.trim(); });
-        // Vote button is a sibling of the link
-        var voteEl = card ? card.querySelector('button[class*="vote"] span, [class*="voteButton"] span') : null;
-        out.push({
-          name:    texts[0] || null,
-          tagline: texts[1] || null,
-          votes:   voteEl ? voteEl.innerText.trim() : null,
-          ph_url:  'https://www.producthunt.com' + href,
-        });
-      });
-      return out;
-    })()
-    """)
-
-    for p in (batch_data or []):
-        if p.get("ph_url") and p["ph_url"] not in seen_urls:
-            seen_urls.add(p["ph_url"])
-            all_products.append(p)
-
-    print(f"Batch {batch+1}: {len(all_products)} total products so far")
-
-    # Scroll toward the bottom of the page to trigger lazy loading
-    ph = page_info()["ph"]  # current page height
-    scroll(760, viewport_h // 2, dy=-(ph // 3))
-    wait(2)  # wait for the next batch to render
-
-print(f"Final: {len(all_products)} products")
+```
+URL: https://www.producthunt.com/leaderboard/monthly/YYYY/M
+Example: https://www.producthunt.com/leaderboard/monthly/2026/4
 ```
 
 ---
 
-### 3. Topic / category pages
+## Topic Page
 
-Product Hunt organises products by topic at `/topics/<slug>`. These pages list the highest-ranked products for that topic across all time (not just today). They are also client-rendered — use the browser.
+URL: `https://www.producthunt.com/topics/developer-tools`
 
-Common topic slugs: `developer-tools`, `ai`, `marketing`, `design-tools`, `productivity`, `open-source`, `chrome-extensions`, `no-code`.
+Selector changes on topic pages — uses `[data-test^="product:"]` not `post-item-`.
 
 ```python
-topic = "developer-tools"  # or "ai", "marketing", etc.
-goto(f"https://www.producthunt.com/topics/{topic}")
-wait_for_load()
-wait(2)
+# Navigate to topic
+new_tab("https://www.producthunt.com/topics/developer-tools")
+wait(3)
 
 products = js("""
-(function() {
-  var seen = new Set();
-  var out  = [];
-  document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
-    var href = a.getAttribute('href');
-    if (seen.has(href) || !href.match(/^\\/posts\\/[^/]+$/)) return;
-    seen.add(href);
-    var card   = a.closest('li') || a.closest('article') || a.parentElement;
-    var texts  = a.innerText.trim().split('\\n').filter(function(s){ return s.trim(); });
-    var voteEl = card ? card.querySelector('[class*="vote"] span, button span') : null;
-    out.push({
-      name:    texts[0] || null,
-      tagline: texts[1] || null,
-      votes:   voteEl ? voteEl.innerText.trim() : null,
-      ph_url:  'https://www.producthunt.com' + href,
-    });
-  });
-  return out;
-})()
-""")
-
-print(products[:20])
-```
-
-To scroll and load more results on a topic page (same mechanics as the homepage):
-
-```python
-for _ in range(4):
-    scroll(760, 400, dy=-1200)
-    wait(1.5)
-# then re-run the js() extraction above
-```
-
----
-
-### 4. Product detail page — description, pricing, maker info, external URL
-
-The detail page at `https://www.producthunt.com/posts/{slug}` contains the full description, the external website URL, tags, gallery images, and maker profiles.
-
-```python
-slug = "cursor-the-ai-code-editor"   # replace with actual slug from the leaderboard
-goto(f"https://www.producthunt.com/posts/{slug}")
-wait_for_load()
-wait(2)
-
-detail = js("""
-(function() {
-  // External website URL — the "Visit website" button points to /redirect/posts/...
-  // which redirects to the real external URL. Grab it from the href directly.
-  var visitBtn = document.querySelector('a[href*="/redirect/posts/"], a[href*="website"]');
-  var extUrl   = visitBtn ? visitBtn.getAttribute('href') : null;
-
-  // Description block — typically a <div> or <p> under the tagline
-  var descEl = document.querySelector('[class*="description"], [class*="about"], section p');
-  var desc   = descEl ? descEl.innerText.trim() : null;
-
-  // Tags / topics
-  var tags = Array.from(
-    document.querySelectorAll('a[href*="/topics/"]')
-  ).map(function(a){ return a.innerText.trim(); })
-   .filter(function(t){ return t.length > 0 && t.length < 40; });
-
-  // Pricing — if there's a pricing section (not all products show one)
-  var pricingEl = document.querySelector('[class*="pricing"], [class*="price"]');
-  var pricing   = pricingEl ? pricingEl.innerText.trim() : null;
-
-  // Vote count on the detail page
-  var voteEl = document.querySelector('[class*="voteButton"] span, button[class*="vote"] span');
-
-  // Maker info — links to /user/... profiles
-  var makers = Array.from(
-    document.querySelectorAll('a[href*="/user/"]')
-  ).map(function(a){
+JSON.stringify(
+  Array.from(document.querySelectorAll('[data-test^="product:"]')).map(el => {
+    var slug = el.getAttribute('data-test').replace('product:', '');
+    var link = el.querySelector('a[href^="/products/"]');
     return {
-      name:     a.innerText.trim(),
-      ph_url:   'https://www.producthunt.com' + a.getAttribute('href'),
+      slug: slug,
+      href: link ? link.getAttribute('href') : null,
+      text: el.outerText.trim().substring(0, 200)
     };
-  }).filter(function(m){ return m.name.length > 0; });
-
-  // Gallery image URLs
-  var images = Array.from(
-    document.querySelectorAll('img[class*="gallery"], [class*="media"] img, [class*="screenshot"] img')
-  ).map(function(img){ return img.src; })
-   .filter(function(src){ return src && !src.includes('avatar') && !src.includes('logo'); });
-
-  return {
-    external_url: extUrl,
-    description:  desc,
-    tags:         [...new Set(tags)].slice(0, 10),
-    pricing:      pricing,
-    votes:        voteEl ? voteEl.innerText.trim() : null,
-    makers:       makers.slice(0, 5),
-    gallery:      images.slice(0, 8),
-  };
-})()
+  })
+)
 """)
-
-print(detail)
 ```
 
-**Getting the real external URL (not the PH redirect):** PH wraps outbound links in `/redirect/posts/{id}?url=...`. The `url` query param contains the actual destination. Parse it without clicking:
+**Sample output:**
+```json
+{"slug":"figma","href":"/products/figma","text":"FigmaThe collaborative interface design tool4.9 (1.4K reviews)..."}
+```
 
-```python
-import urllib.parse
+Returns ~15 top-rated products in the topic, not recent launches.
 
-redirect_href = detail.get("external_url", "")   # e.g. "/redirect/posts/123?url=https%3A%2F%2F..."
-if redirect_href and "url=" in redirect_href:
-    qs = urllib.parse.parse_qs(urllib.parse.urlparse(redirect_href).query)
-    real_url = qs.get("url", [None])[0]
-    print("External site:", real_url)
+---
+
+## Category Page
+
+URL: `https://www.producthunt.com/categories/ai-agents`
+
+Same `[data-test^="product:"]` selector as topics. Returns 15 top-reviewed products in that category.
+
+```json
+{"slug":"elevenlabs","href":"/products/elevenlabs","text":"ElevenLabs\nCreate natural AI voices instantly...\n4.9 (165 reviews)"}
 ```
 
 ---
 
-### 5. First 20 products with full details (name, website, description, tags, votes, logo)
+## Product Detail Page
 
-This combines the leaderboard scroll with per-product detail fetching. It is slow (one `goto` per product) — use only when you genuinely need description + external URL for every product.
+URL: `https://www.producthunt.com/products/claude-opus-4-7`
+
+### Get total vote count (sidebar button)
+```python
+# Use [data-test="vote-button"] — different from [data-test="action-bar-vote-button"]
+vote_text = js("document.querySelector('[data-test=\"vote-button\"]').outerText.trim().replace(/\\s+/g, ' ')")
+# Returns: "Upvote • 466 points"
+# Parse votes: vote_text.split('•')[1].strip().replace(' points', '').replace(',', '')
+```
+
+### Get review count and rating
+```python
+review_link = js("JSON.stringify(Array.from(document.querySelectorAll('a')).filter(a => a.href && a.href.includes('/reviews') && a.outerText.includes('review')).map(a => a.outerText.trim()).slice(0, 1))")
+# Returns: ["1 review"] or ["5.0\n(731 reviews)"]
+```
+
+### Get day rank (sidebar shows "#1 Day Rank")
+No dedicated `data-test` for rank — parse from sidebar context or use leaderboard position.
+
+### Comments (action-bar-vote-button)
+Each comment has its own `[data-test="action-bar-vote-button"]` with text like `"Upvote (13)"`.
+
+---
+
+## Search Results
+
+URL: `https://www.producthunt.com/search?q=AI+agent`
+
+Selector: `[data-test^="spotlight-result-product-"]`
 
 ```python
-goto("https://www.producthunt.com")
-wait_for_load()
-wait(2)
+new_tab("https://www.producthunt.com/search?q=AI+agent")
+wait(3)
 
-# Step 1: collect slugs from the leaderboard
-slugs = js("""
-(function() {
-  var seen = new Set();
-  var out  = [];
-  document.querySelectorAll('a[href^="/posts/"]').forEach(function(a) {
-    var href = a.getAttribute('href');
-    if (seen.has(href) || !href.match(/^\\/posts\\/[^/]+$/)) return;
-    seen.add(href);
-    out.push(href);
-  });
-  return out.slice(0, 20);
-})()
+results = js("""
+JSON.stringify(
+  Array.from(document.querySelectorAll('[data-test^="spotlight-result-product-"]')).map(el => {
+    var id = el.getAttribute('data-test').replace('spotlight-result-product-', '');
+    var lines = el.outerText.trim().split('\\n').map(l => l.trim()).filter(l => l);
+    return {
+      id: id,
+      name: lines[0] || null,
+      tagline: lines[1] || null,
+      review_text: lines[2] || null
+    };
+  })
+)
 """)
+```
 
-# Step 2: visit each product page and extract details
-import time, urllib.parse
+**Note:** Search result elements are `<button>` elements (not `<a>` links), so there is no `href` in the DOM. Product URL must be constructed: `https://www.producthunt.com/products/<slug>` where slug must be derived by other means. The element's `data-test` ID matches the numeric product ID, not the slug.
 
-results = []
-for ph_path in slugs:
-    goto(f"https://www.producthunt.com{ph_path}")
-    wait_for_load()
-    wait(1.5)
-
-    row = js("""
-    (function() {
-      var visitBtn  = document.querySelector('a[href*="/redirect/posts/"]');
-      var logoEl    = document.querySelector('img[alt*="logo"], [class*="logo"] img, header img');
-      var nameEl    = document.querySelector('h1');
-      var taglineEl = document.querySelector('h2, [class*="tagline"]');
-      var descEl    = document.querySelector('[class*="description"] p, section > p, [class*="about"] p');
-      var voteEl    = document.querySelector('[class*="voteButton"] span, button[class*="vote"] span');
-      var tags      = Array.from(document.querySelectorAll('a[href*="/topics/"]'))
-                          .map(function(a){ return a.innerText.trim(); })
-                          .filter(function(t){ return t && t.length < 40; });
-      return {
-        name:         nameEl    ? nameEl.innerText.trim()    : null,
-        tagline:      taglineEl ? taglineEl.innerText.trim() : null,
-        description:  descEl   ? descEl.innerText.trim()    : null,
-        votes:        voteEl   ? voteEl.innerText.trim()    : null,
-        redirect_url: visitBtn  ? visitBtn.getAttribute('href') : null,
-        logo_url:     logoEl   ? logoEl.src : null,
-        tags:         [...new Set(tags)].slice(0, 8),
-      };
-    })()
-    """)
-
-    # Resolve external URL from redirect href
-    if row and row.get("redirect_url") and "url=" in row["redirect_url"]:
-        qs = urllib.parse.parse_qs(urllib.parse.urlparse(row["redirect_url"]).query)
-        row["website"] = qs.get("url", [None])[0]
-    else:
-        row["website"] = None
-
-    row["ph_url"] = f"https://www.producthunt.com{ph_path}"
-    results.append(row)
-    time.sleep(0.5)  # polite pacing
-
-print(results)
+**Sample output:**
+```json
+{"id":"526014","name":"/ai","tagline":"Access ChatGPT anywhere you type '/ai'","review_text":"2 reviews"}
+{"id":"991302","name":"Naoma AI Demo Agent","tagline":"The first video agent that runs conversational product demos","review_text":"5 reviews"}
 ```
 
 ---
 
-### 6. GraphQL API (advanced — fragile)
+## Key Selector Reference
 
-Product Hunt exposes a GraphQL endpoint at `https://www.producthunt.com/frontend/graphql`. It is used by the SPA itself and returns structured JSON without DOM parsing. The catch: it requires a `_ph_puuid` cookie and an `Authorization: Bearer <token>` that is minted client-side and rotates on each session.
+| Page | Selector | Count | Notes |
+|------|----------|-------|-------|
+| Homepage | `[data-test^="post-item-"]` | 30 | 4 sections × ~5–7 products |
+| Homepage | `[data-test^="post-name-"]` | 30 | Product name elements |
+| Homepage/Leaderboard | `[data-test="vote-button"]` | varies | `—` for hidden; numeric for visible |
+| Topics/Categories | `[data-test^="product:"]` | ~15 | Top-rated products |
+| Search | `[data-test^="spotlight-result-product-"]` | 10 | Button elements, no href |
+| Product detail | `[data-test="vote-button"]` | 1 | Main vote: "Upvote • N points" |
+| Product detail | `[data-test="action-bar-vote-button"]` | many | Comment upvotes: "Upvote (N)" |
 
-**Grab the live token from the running browser session:**
+---
+
+## Common Pitfalls
+
+1. **`innerText` returns `None` on complex elements** — use `outerText` or break into simple single-property expressions. Avoid chaining DOM traversal inside `JSON.stringify()` on large objects.
+
+2. **`goto()` returns `ERR_ABORTED`** for producthunt.com in some browser sessions — always use `new_tab("url")` instead.
+
+3. **`a[href^="/posts/"]` matches nothing** — Product Hunt uses `/products/` for product URLs, not `/posts/`.
+
+4. **Today's votes are always `—`** during the first 4 hours of the day — use yesterday's leaderboard for confirmed vote counts.
+
+5. **Homepage does not lazy-load more products on scroll** — 30 items is the fixed set. Use leaderboard pages for complete daily listings.
+
+6. **JSON.stringify of DOM-heavy objects returns `None`** — serialize only primitives (strings, numbers) not live DOM node properties.
+
+7. **Ranked product names contain rank prefix** — `"1. Claude Opus 4.7"` — strip with regex `re.sub(r'^\d+\.\s+', '', name)`.
+
+8. **`wait(3)` required after `wait_for_load()`** — the React SPA continues rendering after the load event.
+
+---
+
+## Recommended Workflow for Scraping Today's Launches
 
 ```python
-# 1. Make sure producthunt.com is open in the browser
-goto("https://www.producthunt.com")
-wait_for_load()
-wait(2)
+# 1. Open Product Hunt in a new tab
+new_tab("https://www.producthunt.com/leaderboard/daily/2026/4/18")
+wait(4)
 
-# 2. Extract the bearer token from localStorage / window.__APOLLO_STATE__
-token = js("""
-(function() {
-  // PH stores auth in a localStorage key like "ph_access_token" or via Apollo headers
-  // Try common locations:
-  var t = localStorage.getItem('ph_access_token')
-       || localStorage.getItem('access_token');
-  if (t) return t;
-
-  // Fallback: intercept from the last XHR — not easy without Network.enable.
-  // Return null if not found; use the cookie approach below instead.
-  return null;
-})()
+# 2. Extract all products with metadata
+products = js("""
+JSON.stringify(
+  Array.from(document.querySelectorAll('[data-test^="post-item-"]')).map(el => {
+    var id = el.getAttribute('data-test').replace('post-item-', '');
+    var nameEl = el.querySelector('[data-test^="post-name-"]');
+    var productLink = el.querySelector('a[href^="/products/"]');
+    var voteBtn = el.querySelector('[data-test="vote-button"]');
+    var topicLinks = Array.from(el.querySelectorAll('a[href^="/topics/"]')).map(a => a.textContent.trim());
+    var name = nameEl ? nameEl.textContent.trim() : '';
+    var lines = el.innerText.split('\\n').map(l => l.trim()).filter(l => l);
+    var tagline = lines.find(l => l !== name && !topicLinks.includes(l) && l !== '•' && !/^[0-9—]/.test(l) && l.length > 5);
+    return {
+      id: id,
+      name: name,
+      slug: productLink ? productLink.getAttribute('href') : null,
+      votes: voteBtn ? voteBtn.textContent.trim() : null,
+      topics: topicLinks,
+      tagline: tagline || null
+    };
+  })
+)
 """)
-
-# 3. Get cookies to send with the request
-cookies_raw = js("document.cookie")
-# cookies_raw is "key=val; key2=val2; ..."
-
-print("Token:", token)
-print("Cookies:", cookies_raw[:200])
-```
-
-**Issue a GraphQL query using the token:**
-
-```python
 import json
-
-# Today's top posts (posts endpoint)
-query = """
-query TodaysPosts($first: Int) {
-  posts(order: VOTES, first: $first, postedAfter: "today") {
-    edges {
-      node {
-        id
-        name
-        tagline
-        votesCount
-        website
-        slug
-        topics {
-          edges { node { name } }
-        }
-        thumbnail { url }
-      }
-    }
-  }
-}
-"""
-
-headers = {
-    "Content-Type": "application/json",
-    "Accept":       "application/json",
-    "Origin":       "https://www.producthunt.com",
-    "Referer":      "https://www.producthunt.com/",
-}
-if token:
-    headers["Authorization"] = f"Bearer {token}"
-if cookies_raw:
-    headers["Cookie"] = cookies_raw
-
-body = json.dumps({"query": query, "variables": {"first": 20}}).encode()
-
-# http_get only does GET — use a raw CDP network request for POST
-response = js(f"""
-(async function() {{
-  const r = await fetch('https://www.producthunt.com/frontend/graphql', {{
-    method: 'POST',
-    headers: {json.dumps(headers)},
-    body: JSON.stringify({{query: {json.dumps(query)}, variables: {{first: 20}}}})
-  }});
-  return await r.text();
-}})()
-""")
-
-data = json.loads(response)
-posts = data["data"]["posts"]["edges"]
-for edge in posts:
-    node = edge["node"]
-    print(node["name"], "|", node["tagline"], "|", node["votesCount"], "|", node["website"])
+data = json.loads(products)
+print(f"Found {len(data)} products")
+for p in data:
+    print(f"  {p['name']} — {p['votes']} votes — {p['tagline']}")
 ```
-
-**Why this is fragile:**
-- The bearer token changes every session and cannot be hardcoded.
-- PH may add CSRF checks (`x-csrf-token`, `x-request-id`) that break the fetch.
-- The GraphQL schema has changed several times — field names like `postsConnection` vs `posts` vary by PH's deployment.
-- Use DOM scraping as the primary method; treat GraphQL as a faster alternative to verify or enrich data when it works.
-
----
-
-## Gotchas
-
-- **Products load in batches — scroll and wait between batches.** The first `wait_for_load()` only signals the HTML shell is ready. React renders the first ~10 products, then more are appended as you scroll. Each `scroll()` should be followed by `wait(1.5)` to `wait(2)` to let the fetch-and-render cycle finish.
-
-- **Vote counts update in real-time.** Product Hunt uses WebSockets (Pusher) to push live vote increments. A vote count you read at T+0 may differ from one read at T+30s. Treat them as point-in-time snapshots, not authoritative totals.
-
-- **`/topics/` pages rank by all-time votes, not today.** If the task says "today's top developer tools," use the homepage and filter by topic tags on the detail page — don't use `/topics/developer-tools`, which will return products from past years.
-
-- **The external website URL is never directly in the link text.** PH wraps all outbound links in `/redirect/posts/{id}?url=<encoded>`. Parse the `url=` query param from the redirect `href` attribute — do NOT click it (that opens a new tab and loses context). See the `urllib.parse` snippet in workflow 4.
-
-- **PH uses Tailwind — class names are hashed and not stable across deploys.** Never use a class name like `styles_voteButton__xK9q2` as a selector. Always target structural attributes (`href`, `data-test*`, `aria-*`) or element type + hierarchy. The `a[href^="/posts/"]` anchor is the most stable entry point.
-
-- **Login is not required for reading** — vote counts, product names, taglines, descriptions, and maker profiles are all publicly accessible. Login is required only to upvote, comment, or access private launches.
-
-- **The `#1 product` on the homepage** is ranked by votes within the current day (midnight UTC reset). The ordering is stable by mid-day but can change rapidly in the first few hours after midnight as votes accumulate.
-
-- **Pagination on topic pages** works via infinite scroll, same as the homepage. There is no `?page=N` URL parameter for the browser-rendered view. Scroll to get more.
-
-- **`screenshot()` is your best debugging tool.** If any `js()` extraction returns empty or `None`, always call `screenshot()` before trying alternative selectors — the page may still be loading, a login modal may have appeared, or PH may have A/B-tested a new layout.
-
-- **Date boundary:** PH resets the daily leaderboard at **midnight UTC**, not midnight in the user's local timezone. If you're scraping just after midnight UTC, the new day's list may have zero or very few products.
-
-- **Product Hunt CDN assets** (logos, gallery images) are served from `ph-files.imgix.net`. These are publicly accessible without auth and can be fetched with `http_get`.


### PR DESCRIPTION
## What

Replaces the 5 auto-drafted skill files from #43 with versions written after actually running browser-harness against each live site.

## Why

The drafted files had theoretical selectors that turned out to be wrong or outdated. These are field-tested corrections.

## Real corrections per skill

**GitHub**
- `wait(2)` after `wait_for_load()` required — React hydration finishes after readyState complete
- Search API has its own rate limit: 10 req/min (not shared with the 60/hr core limit)
- `/search/code` returns 401 unauthenticated

**Hacker News**
- `athing` also matches comment rows — must use `athing submission`
- Job posts (YC ads) have no score row and break naive title/score zipping
- `html.unescape()` required — titles contain `&#x27;` `&amp;` etc.

**Amazon**
- `.zg-item-immersion` is gone from Best Sellers (CSS module migration)
- `#priceblock_ourprice` returns null — legacy selector
- `.s-underline-text` review count collides with cross-sell widget text — use `[aria-label*='ratings']`
- `goto()` silently fails on first connection — use `new_tab(url)`

**News Aggregation**
- The Verge RSS is Atom format — naive `.//item` returns 0 results, needs namespace dict
- Reuters hard-blocks `http_get` with 403 even with User-Agent header
- BBC shows no consent banner from US IP — banner dismissal code was unnecessary
- Parallel fetch measured at 4.3x faster (0.16s vs 0.70s for 7 feeds)

**Product Hunt**
- `goto()` causes ERR_ABORTED on PH — always use `new_tab()`
- `a[href^="/posts/"]` matches zero elements — URLs are `/products/` not `/posts/`
- `[data-test^="post-item-"]` is the correct card selector
- Homepage has 30 fixed items — no lazy loading; use `/leaderboard/daily/YYYY/M/D` for full list
- Vote counts show `—` for first 4 hours of launch day (PH policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the 5 drafted domain skill guides with versions validated against live sites using the browser harness, fixing broken selectors, navigation, and API details for reliable scraping. Improves accuracy across GitHub, Hacker News, Amazon, multi-source news feeds, and Product Hunt.

- **Bug Fixes**
  - GitHub: add `wait(2)` after `wait_for_load()`; search API is 10 req/min and `/search/code` requires auth; lean on REST API, browser only for trending.
  - Hacker News: use `athing submission`; handle job posts with no score; `html.unescape()` titles; prefer `http_get`/Algolia/Firebase over browser.
  - Amazon: update selectors (`.zg-item-immersion` removed, `#priceblock_ourprice` returns null); use `new_tab(url)` instead of `goto()`; review count via `[aria-label*='ratings']`.
  - News Aggregation: prefer RSS/Atom with namespaces (The Verge is Atom); Reuters blocks `http_get`; parallel feed fetch is ~4.3x faster; US IP shows no BBC consent banner.
  - Product Hunt: always use `new_tab()` (avoid `goto()` aborts); correct selector `[data-test^="post-item-"]`; URLs are `/products/` not `/posts/`; use `/leaderboard/daily/YYYY/M/D` for full lists.

<sup>Written for commit 4f05481d2a1b4366b91a30b51d7f9149260cda34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

