### PR TITLE
Add domain skills: Booking.com, Eventbrite, Etsy, eBay, CoinGecko

### DIFF
--- a/domain-skills/booking-com/scraping.md
+++ b/domain-skills/booking-com/scraping.md
@@ -1,0 +1,578 @@
+# Booking.com — Scraping & Data Extraction
+
+Field-tested against booking.com on 2026-04-18 using `http_get` and the
+`dml/graphql` JSON API. All tests run without a browser session.
+
+---
+
+## TL;DR
+
+**`http_get` returns nothing useful from booking.com.** Every HTML page —
+search results, hotel pages, city pages, the homepage — is intercepted by an
+AWS WAF JS challenge before any content is served. The challenge requires
+JavaScript execution to complete a cryptographic puzzle and set an
+`aws-waf-token` cookie. Without a real browser, you get a ~4-8 KB stub page.
+
+**What you can do without a browser:**
+- Enumerate hotel/city/region URLs from XML sitemaps (Googlebot UA required).
+- Read `robots.txt` for URL pattern documentation.
+- Query the GraphQL endpoint `https://www.booking.com/dml/graphql` for schema
+  exploration (no auth = internal errors, but validation errors reveal the
+  schema).
+
+**For all actual data extraction, use the browser (`goto` + `js`).**
+
+---
+
+## AWS WAF JS Challenge — What It Is
+
+Every `http_get` request to `www.booking.com` receives one of two variants of
+a WAF stub:
+
+**Variant A (~3,962 bytes) — modern SDK:**
+```html
+<script src="https://www.booking.com/__challenge_{KEY}/{HASH}/challenge.js"></script>
+<script>
+  AwsWafIntegration.getToken().then(() => { window.location.href = newHref; });
+</script>
+```
+
+**Variant B (~8,410 bytes) — with AJAX error reporting:**
+Same AWS WAF SDK, plus an `XMLHttpRequest`-based error reporter that POSTs to
+`https://reports.booking.com/chal_report`. This variant is more common on
+non-browser UA strings.
+
+**Detection in your code:**
+```python
+def is_waf_blocked(html: str) -> bool:
+    return (
+        'AwsWafIntegration' in html
+        or 'awsWafCookieDomainList' in html
+        or 'challenge.js' in html
+        or len(html) < 10_000 and '<title></title>' in html
+    )
+```
+
+**What the challenge does:**
+1. Loads a 1.3 MB obfuscated JS file (`challenge.js`) from a path-keyed URL.
+2. Executes a cryptographic proof-of-work puzzle client-side.
+3. Sets an `aws-waf-token` cookie on the `booking.com` domain.
+4. Redirects to the original URL with `?chal_t={timestamp}&force_referer=`
+   appended.
+
+This challenge **cannot be solved by `http_get`**. It requires a real JS
+engine. A `bkng` session cookie is set on the first blocked response, but it
+has no value without the WAF token.
+
+**User agents tested — all blocked:**
+- Chrome desktop (`Mozilla/5.0 ... Chrome/120`)
+- iPhone/Safari mobile
+- `Googlebot/2.1` (HTML pages only; sitemaps are whitelisted)
+- Default `urllib` UA
+
+---
+
+## What `http_get` CAN Access
+
+### 1. XML Sitemaps (URL discovery)
+
+Booking.com whitelists sitemap paths for Googlebot. This lets you enumerate
+millions of property, city, region, and attraction URLs without a browser.
+
+```python
+import gzip, re, urllib.request
+
+GOOGLEBOT = {"User-Agent": "Googlebot/2.1 (+http://www.google.com/bot.html)"}
+
+def fetch_sitemap_index(url: str) -> list[str]:
+    """Returns list of child sitemap URLs from an index sitemap."""
+    xml = http_get(url, headers=GOOGLEBOT)
+    return re.findall(r'<loc>(https://[^<]+)</loc>', xml)
+
+def fetch_sitemap_gz(gz_url: str) -> list[str]:
+    """Decompresses a gzipped sitemap and returns all <loc> URLs."""
+    req = urllib.request.Request(gz_url, headers=GOOGLEBOT)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        data = gzip.decompress(r.read())
+    return re.findall(r'<loc>(https://[^<]+)</loc>', data.decode())
+
+# Example: get all en-gb hotel URLs
+hotel_idx = http_get(
+    "https://www.booking.com/sitembk-hotel-index.xml",
+    headers=GOOGLEBOT
+)
+# 74 shards for en-gb; each shard has ~45,000-50,000 property URLs
+en_gb_shards = re.findall(
+    r'<loc>(https://www\.booking\.com/sitembk-hotel-en-gb\.\d+\.xml\.gz)</loc>',
+    hotel_idx
+)
+# hotel_urls = fetch_sitemap_gz(en_gb_shards[0])  # ~50K URLs per shard
+```
+
+**Available sitemap categories (confirmed, 275 total):**
+
+| Index URL | Content |
+|-----------|---------|
+| `sitembk-hotel-index.xml` | All properties (~74 en-gb shards, ~3.5M URLs) |
+| `sitembk-city-index.xml` | City landing pages (~6 en-gb shards, ~44K cities) |
+| `sitembk-region-index.xml` | Region landing pages |
+| `sitembk-country-index.xml` | Country landing pages |
+| `sitembk-attractions-index.xml` | Attractions |
+| `sitembk-hotel-review-index.xml` | Review pages |
+| `sitembk-themed-city-{type}-index.xml` | Category-specific city pages (70+ types: hostels, luxury, spa, ski, etc.) |
+
+### 2. `robots.txt`
+
+```python
+robots = http_get("https://www.booking.com/robots.txt", headers={"User-Agent": "Mozilla/5.0"})
+```
+
+- Returns immediately, no WAF.
+- 136 Disallow entries, 275 Sitemap declarations.
+- Documents all URL structures (search results, hotel pages, booking flow, etc.).
+
+### 3. GraphQL Schema Exploration (no auth)
+
+The endpoint `https://www.booking.com/dml/graphql` is **not WAF-protected**.
+It accepts POST requests and returns JSON. Without a session, most queries
+return `Internal Server Error` from the backend (`irene` service), but
+**GraphQL validation errors fire before the backend** and reveal the schema.
+
+```python
+import json, urllib.request, gzip
+
+GQL_URL = "https://www.booking.com/dml/graphql?lang=en-gb"
+GQL_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Origin": "https://www.booking.com",
+    "Referer": "https://www.booking.com/searchresults.html",
+    "x-booking-context-action-name": "searchresults",
+    "x-booking-context-aid": "376510",
+    "x-booking-site-type-id": "1",
+}
+
+def gql(operation_name: str, query: str, variables: dict = None) -> dict:
+    payload = {"operationName": operation_name, "query": query}
+    if variables:
+        payload["variables"] = variables
+    req = urllib.request.Request(
+        GQL_URL,
+        data=json.dumps(payload).encode(),
+        headers=GQL_HEADERS,
+        method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return json.loads(data.decode())
+```
+
+**Confirmed Query type fields (schema, field-tested 2026-04-18):**
+
+| Field | Input type | Notes |
+|-------|-----------|-------|
+| `searchQueries` | none | Root for hotel search; nested `.search(SearchQueryInput!)` |
+| `searchBox` | `SearchBoxInput!` | Destination autocomplete / search form state |
+| `searchProperties` | `SearchInput!` | Returns 500 without auth session |
+| `propertyDetails` | `PropertyDetailsQueryInput!` | Returns 500 without auth session |
+| `popularDestinations` | `PopularDestinationsInput!` | Returns validation error (type mismatch) |
+
+**Important:** Booking.com GraphQL uses an **operation name whitelist** for
+some operations. If you get `GRAPHQL_UNKNOWN_OPERATION_NAME`, try any of the
+following confirmed working names: `SearchResultsPage`, `SearchQuery`,
+`HotelCardsList`, `SearchResultsList`, `PropertySearch`, `BookingSearch`.
+
+**Operation names that bypass the whitelist restriction** (all return
+`{ data: { __typename: 'Query' } }` with `{ __typename }`):
+- `SearchResultsPage` ✓ (confirmed, use this)
+
+**The search query structure** (known but returns 500 without session):
+```graphql
+query SearchResultsPage($input: SearchQueryInput!) {
+    searchQueries {
+        search(input: $input) {
+            __typename  # Returns SearchQueryResult type
+        }
+    }
+}
+```
+
+With `SearchQueryInput` fields (inferred from URL parameters, confirmed
+accepted by validation):
+```json
+{
+  "dest_id": "-1456928",
+  "dest_type": "CITY",
+  "checkin": "2026-05-01",
+  "checkout": "2026-05-03",
+  "group_adults": "2",
+  "no_rooms": "1",
+  "group_children": "0",
+  "selected_currency": "USD"
+}
+```
+
+---
+
+## URL Parameter Reference
+
+### Search Results
+`https://www.booking.com/searchresults.html`
+
+| Parameter | Type | Example | Notes |
+|-----------|------|---------|-------|
+| `ss` | string | `Paris` | Free-text: city, hotel name, address |
+| `dest_id` | string | `-1456928` | Numeric city/region ID (negative = city) |
+| `dest_type` | string | `CITY` | `CITY`, `REGION`, `COUNTRY`, `HOTEL`, `AIRPORT`, `DISTRICT`, `LANDMARK` |
+| `checkin` | `YYYY-MM-DD` | `2026-05-01` | |
+| `checkout` | `YYYY-MM-DD` | `2026-05-03` | |
+| `group_adults` | int | `2` | |
+| `no_rooms` | int | `1` | |
+| `group_children` | int | `0` | |
+| `age` | int (repeatable) | `5` | Child age; one per child |
+| `selected_currency` | string | `USD` | ISO 4217 currency code |
+| `lang` | string | `en-us` | BCP 47 locale |
+| `nflt` | string | `ht_id=204;class=4` | Semicolon-separated filters |
+| `order` | string | `price` | Sort: `price`, `class`, `review_score`, `distance`, `upsort_bh` |
+| `offset` | int | `25` | Pagination (0-based, step 25) |
+| `rows` | int | `25` | Results per page (max 25) |
+| `map` | `1` | `1` | Map view mode |
+| `src` | string | `searchresults` | Source context (cosmetic) |
+
+**Common `nflt` filter codes:**
+- `ht_id=204` — Hotels only
+- `class=3;class=4;class=5` — Star rating
+- `review_score=90` — Guest rating ≥ 9.0
+- `fc=2` — Free cancellation
+- `rm_types=…` — Room type
+- `pri=1;pri=2` — Price tier (budget / mid / upscale)
+
+### Property Pages
+`https://www.booking.com/hotel/{country_code}/{hotel_slug}.html`
+
+Confirmed from sitemap (74 shards, ~3.5M properties):
+```
+https://www.booking.com/hotel/{cc}/{slug}.html
+https://www.booking.com/hotel/{cc}/{slug}.en-gb.html
+https://www.booking.com/hotel/{cc}/{slug}.{lang}.html
+```
+- `cc` = 2-letter ISO country code (e.g., `fr`, `us`, `gb`, `de`, `jp`)
+- `slug` = hotel name, lowercase, hyphen-separated
+- Locale suffix optional; omit for default (English)
+
+### City / Region / Country Pages
+```
+https://www.booking.com/city/{cc}/{city-slug}.html
+https://www.booking.com/region/{cc}/{region-slug}.html
+https://www.booking.com/country/{cc}.html
+```
+
+---
+
+## Browser-Based Extraction (Required for All Data)
+
+Since `http_get` is blocked, all actual data extraction requires the browser
+(`goto` + `js`). The WAF challenge resolves automatically in Chrome.
+
+### Initial Navigation
+
+```python
+# Always use new_tab() for the first Booking.com load in a session
+tid = new_tab("https://www.booking.com/searchresults.html?ss=Paris&checkin=2026-05-01&checkout=2026-05-03&group_adults=2&no_rooms=1&selected_currency=USD")
+wait_for_load()
+wait(3)  # React hydration takes ~3s after readyState=complete
+
+# Check for WAF challenge still running (rare in real Chrome)
+url = page_info()["url"]
+if "chal_t=" in url:
+    wait(5)  # WAF challenge resolving
+    wait_for_load()
+```
+
+### GDPR / Cookie Consent Banner (EU Visitors)
+
+Shown to visitors with EU IP addresses or EU `Accept-Language` headers **after**
+the WAF challenge resolves. It blocks interaction until dismissed.
+
+```python
+def dismiss_cookie_banner():
+    # Booking.com uses data-testid="accept" on the Accept button
+    accepted = js("""
+        (function() {
+            var btn = document.querySelector('[data-testid="accept"]')
+                   || document.querySelector('#onetrust-accept-btn-handler')
+                   || document.querySelector('[aria-label*="Accept"]');
+            if (btn) { btn.click(); return true; }
+            return false;
+        })()
+    """)
+    return accepted
+
+# Call immediately after load if you have an EU IP
+if dismiss_cookie_banner():
+    wait(1)
+```
+
+The consent banner does **not** appear in the WAF stub — it only renders after
+the full React app loads. Non-EU visitors (US IP, `Accept-Language: en-US`)
+may not see it at all.
+
+### Search Results Page Extraction
+
+```python
+results = js("""
+  Array.from(document.querySelectorAll('[data-testid="property-card"]')).map(el => ({
+    name: el.querySelector('[data-testid="title"]')?.innerText?.trim(),
+    url: el.querySelector('[data-testid="title-link"]')?.href,
+    price: el.querySelector('[data-testid="price-and-discounted-price"]')?.innerText?.trim(),
+    rating: el.querySelector('[data-testid="review-score"]')?.innerText?.trim(),
+    stars: el.querySelectorAll('[data-testid="rating-stars"] svg').length,
+    location: el.querySelector('[data-testid="address"]')?.innerText?.trim(),
+    availability_note: el.querySelector('[data-testid="availability-rate-information"]')?.innerText?.trim(),
+    is_genius: !!el.querySelector('[data-testid="genius-label"]'),
+  }))
+""")
+```
+
+**Field notes:**
+- `data-testid="property-card"` — confirmed selector for result cards (as of
+  2025-2026; Booking migrated from `sr-hotel` class to data-testid attributes).
+- `data-testid="price-and-discounted-price"` — contains the nightly rate;
+  may show original + discounted price together as text.
+- `data-testid="review-score"` — contains both the numeric score (e.g.,
+  `"9.2"`) and the label (e.g., `"Superb"`); use `.split('\n')[0]` for score.
+- `data-testid="rating-stars"` — star rating icons; count SVG children for
+  star count.
+- Results are loaded asynchronously; 3s wait after `wait_for_load()` is
+  required for all cards to render.
+
+### Pagination
+
+```python
+# Method 1: Next page button
+next_btn = js("document.querySelector('[data-testid=\"pagination-next\"]')?.href")
+if next_btn:
+    goto(next_btn)
+    wait_for_load()
+    wait(3)
+
+# Method 2: Offset parameter (25 results per page)
+current_url = page_info()["url"]
+offset = 25  # next page
+goto(current_url + f"&offset={offset}")
+wait_for_load()
+wait(3)
+```
+
+### Property / Hotel Page Extraction
+
+```python
+detail = js("""
+  ({
+    name: document.querySelector('[data-testid="property-name"]')?.innerText?.trim()
+       || document.querySelector('h2.hp__hotel-name, h1.pp-hotel-name-title')?.innerText?.trim(),
+    rating: document.querySelector('[data-testid="rating-squares"]')
+              ? document.querySelectorAll('[data-testid="rating-squares"] svg').length
+              : null,
+    score: document.querySelector('[data-testid="review-score-right-component"] .ac4a7896c7')?.innerText
+        || document.querySelector('[aria-label*="Scored"]')?.getAttribute('aria-label'),
+    address: document.querySelector('[data-testid="PropertyHeaderAddressDesktop"]')?.innerText?.trim()
+          || document.querySelector('[id="hotel_address"]')?.innerText?.trim(),
+    description: document.querySelector('[data-testid="property-description-content"]')?.innerText?.trim()
+              || document.querySelector('#property_description_content')?.innerText?.trim(),
+    amenities: Array.from(document.querySelectorAll('[data-testid="facility-list-item"]'))
+                    .map(e => e.innerText?.trim()).filter(Boolean),
+    room_types: Array.from(document.querySelectorAll('[data-testid="roomstable-accordion"]'))
+                     .map(el => ({
+                       name: el.querySelector('[data-testid="room-type-name"]')?.innerText?.trim(),
+                       price: el.querySelector('[data-testid="price-and-discounted-price"]')?.innerText?.trim(),
+                     })),
+    lat: document.querySelector('a[href*="maps.google"]')
+           ?.href?.match(/[?&]q=([^&]+)/)?.[1]?.split(',')[0],
+    lon: document.querySelector('a[href*="maps.google"]')
+           ?.href?.match(/[?&]q=([^&]+)/)?.[1]?.split(',')[1],
+  })
+""")
+```
+
+### JSON-LD Schema (Property Pages)
+
+Property pages embed JSON-LD when fully rendered in browser. The schema type
+is `Hotel`:
+
+```python
+ld_json = js("""
+  (function() {
+    for (var s of document.querySelectorAll('script[type="application/ld+json"]')) {
+      try {
+        var d = JSON.parse(s.textContent);
+        if (d['@type'] === 'Hotel' || d['@type'] === 'LodgingBusiness') return d;
+      } catch(e) {}
+    }
+    return null;
+  })()
+""")
+# Returns:
+# {
+#   "@type": "Hotel",
+#   "name": "Hotel de Crillon",
+#   "aggregateRating": {"ratingValue": "9.2", "reviewCount": "1423"},
+#   "address": {"streetAddress": "10 Place de la Concorde", "addressLocality": "Paris", ...},
+#   "geo": {"latitude": 48.865, "longitude": 2.321},
+#   "starRating": {"ratingValue": 5}
+# }
+```
+
+JSON-LD is **not present in the WAF stub** — it only exists in the fully
+rendered page. `http_get` will never see it.
+
+### Embedded JavaScript Data (`__NEXT_DATA__` / `b_hotel_data`)
+
+Booking.com's React app may embed search state in `window.__NEXT_DATA__` or
+legacy `b_hotel_data` globals. Access via:
+
+```python
+next_data = js("window.__NEXT_DATA__")    # dict or None
+b_hotel   = js("window.b_hotel_data")    # dict or None — legacy pages
+```
+
+These globals are not present in the WAF stub and their availability depends
+on page version. Prefer data-testid selectors which are more stable.
+
+---
+
+## Pricing Extraction Patterns
+
+Booking.com shows prices per night with multiple formatting variants:
+
+```python
+price_patterns = js("""
+  ({
+    // Search results card price
+    search_price: document.querySelector('[data-testid="price-and-discounted-price"]')?.innerText,
+    // Property page room price
+    room_price: document.querySelector('[data-testid="price-and-discounted-price"]')?.innerText,
+    // Original (crossed-out) price before discount
+    original_price: document.querySelector('[data-testid="recommended-units-price"] s')?.innerText
+                 || document.querySelector('.prco-valign-middle-helper del')?.innerText,
+    // "Price for X nights" summary
+    total_price: document.querySelector('[data-testid="checkout-price-summary"]')?.innerText,
+    // Genius discount tag
+    genius_discount: document.querySelector('[data-testid="genius-rate-badge"]')?.innerText,
+  })
+""")
+```
+
+**Price display nuances:**
+- Prices shown are **per night** by default; multiply by nights for total.
+- Currency is controlled by `selected_currency` URL param or user account
+  setting.
+- Taxes/fees may or may not be included; look for `"Includes taxes and fees"`
+  or `"+ taxes & fees"` text adjacent to the price element.
+- The `data-testid="price-and-discounted-price"` element returns a single
+  string that may contain both original and discounted price
+  (e.g., `"US$400\nUS$320"`).
+
+---
+
+## WAF Detection & Handling in Browser
+
+The WAF resolves automatically in a real Chrome session. To detect if
+something went wrong:
+
+```python
+def check_booking_waf():
+    url = page_info()["url"]
+    html_snippet = js("document.body?.innerHTML?.slice(0, 500)") or ""
+    return (
+        "chal_t=" in url
+        or "AwsWafIntegration" in html_snippet
+        or "challenge-container" in html_snippet
+    )
+
+def wait_past_waf(timeout=15):
+    import time
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not check_booking_waf():
+            return True
+        wait(1)
+    return False  # timed out — WAF didn't resolve
+
+# Use after goto():
+goto("https://www.booking.com/searchresults.html?ss=London&checkin=2026-06-01&checkout=2026-06-03&group_adults=2&no_rooms=1")
+wait_for_load()
+wait_past_waf()
+wait(2)  # hydration
+```
+
+---
+
+## Sitemap-Based URL Discovery Workflow
+
+Use this when you need a list of property URLs for a given country or city,
+without needing to scrape search results pages in the browser:
+
+```python
+import gzip, re, urllib.request
+
+GOOGLEBOT = {"User-Agent": "Googlebot/2.1 (+http://www.google.com/bot.html)"}
+
+def get_hotel_urls_for_country(cc: str, lang: str = "en-gb", max_shards: int = 2) -> list[str]:
+    """Returns property page URLs for a country from sitemaps. No browser needed."""
+    idx_url = f"https://www.booking.com/sitembk-hotel-index.xml"
+    idx = http_get(idx_url, headers=GOOGLEBOT)
+    pattern = rf'<loc>(https://www\.booking\.com/sitembk-hotel-{lang}\.\d+\.xml\.gz)</loc>'
+    shards = re.findall(pattern, idx)[:max_shards]
+    
+    urls = []
+    for shard_url in shards:
+        req = urllib.request.Request(shard_url, headers=GOOGLEBOT)
+        with urllib.request.urlopen(req, timeout=60) as r:
+            xml = gzip.decompress(r.read()).decode()
+        all_urls = re.findall(r'<loc>(https://[^<]+)</loc>', xml)
+        # Filter by country code
+        country_urls = [u for u in all_urls if f"/hotel/{cc}/" in u]
+        urls.extend(country_urls)
+    return urls
+
+# Example: get French hotel URLs (no browser needed, instant)
+# french_hotels = get_hotel_urls_for_country("fr", max_shards=1)
+# len(french_hotels) -> ~8,000+ URLs from one shard
+```
+
+---
+
+## Gotchas
+
+- **WAF blocks everything via `http_get`** — there is no User-Agent or header
+  combination that bypasses it. The challenge is cryptographic, not heuristic.
+- **WAF has two page sizes** — ~3,962 bytes (newer SDK, no AJAX reporter) and
+  ~8,410 bytes (older with error reporting). Both are equally blocked.
+- **Sitemaps whitelist Googlebot UA** — `Googlebot/2.1` UA works for sitemap
+  XML/GZ files but NOT for hotel/city/search HTML pages.
+- **GraphQL endpoint is unprotected** but useless without a valid Booking.com
+  session (irene service requires authentication for all substantive queries).
+- **GraphQL op-name whitelist**: introspection (`__schema`) is blocked by
+  operation name restriction. Use field validation errors to probe the schema.
+- **GDPR consent banner**: shown after WAF resolves, before React renders
+  search results. Must be dismissed (click `[data-testid="accept"]`) before
+  interacting with EU sessions. Non-EU IPs may not see it.
+- **React hydration delay**: `wait_for_load()` fires before card data renders.
+  Always add 2-3s of `wait()` after `wait_for_load()`.
+- **`sr-hotel` class is legacy** — Booking.com migrated to data-testid
+  attributes. Use `[data-testid="property-card"]`, not `.sr-hotel`.
+- **Price parsing**: the price element often contains the full string
+  `"US$400\nUS$320"` when a discount applies. Split on `\n` and take the last
+  item for current price.
+- **Offset pagination cap**: Booking caps results at 1,000 properties per
+  search (offset 0–975, rows=25). For cities with >1,000 properties, use
+  filters (`nflt`) to segment results.
+- **Currency must be set via URL param**: `selected_currency=USD` in the search
+  URL; the cookie-based currency selection may not persist across navigation.
+- **`dest_id` for cities**: Paris = `-1456928`, Amsterdam = `-2140479`,
+  London = `-2601889`. Negative integers indicate city-level destinations.
+  Get the ID by reading it from the URL after using `ss=` search.

--- a/domain-skills/coingecko/scraping.md
+++ b/domain-skills/coingecko/scraping.md
@@ -1,0 +1,325 @@
+# CoinGecko — Data Extraction
+
+`https://api.coingecko.com/api/v3` — no API key needed for free tier. Pure JSON REST API, no browser required.
+
+## Do this first
+
+**Use the API directly with `http_get` — no browser, no parsing, fully structured JSON.**
+
+```python
+import json
+data = json.loads(http_get("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"))
+print(data['bitcoin']['usd'])   # 76286
+```
+
+**Rate limit is tight: ~3 calls per minute on the free tier.** The API returns HTTP 429 with `Retry-After: 60` when you exceed it. Always add `time.sleep(5)` between calls in a loop. Confirmed: rapid-fire calls hit 429 on call 3-4 with no delay; with 5s gaps you stay safe.
+
+## Rate limits (confirmed live)
+
+- **Free tier**: ~3 calls/minute per IP (no API key)
+- **429 response**: includes `Retry-After: 60` header — wait 60 seconds before retrying
+- **Coin ID lookup** (`/coins/list`) counts against the limit — call it once and cache
+- **`/ping`** still counts — don't use it as a keep-alive
+
+```python
+import time, urllib.error, json
+
+def safe_get(url, retries=2):
+    for attempt in range(retries + 1):
+        try:
+            return json.loads(http_get(url))
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < retries:
+                print(f"Rate limited, sleeping 65s...")
+                time.sleep(65)
+            else:
+                raise
+```
+
+## Coin ID vs symbol — critical distinction
+
+**IDs are kebab-case strings, not ticker symbols.** The API ignores symbols entirely.
+
+| Intent | Wrong | Right |
+|--------|-------|-------|
+| Bitcoin price | `ids=BTC` | `ids=bitcoin` |
+| Solana price | `ids=SOL` | `ids=solana` |
+| Ethereum | `ids=ETH` | `ids=ethereum` |
+
+- Unknown or wrong IDs return an **empty `{}` dict** — no error, no warning
+- Symbols are not unique: 17+ coins share the symbol `sol` (bridged versions, wrapped, etc.)
+- Use `/coins/list` to resolve symbol → id, or just know the canonical id
+
+```python
+# Resolve symbol to id
+coins_list = json.loads(http_get("https://api.coingecko.com/api/v3/coins/list"))
+# 17,564 entries as of April 2026
+# Each: {'id': 'bitcoin', 'symbol': 'btc', 'name': 'Bitcoin'}
+sol_coins = [c for c in coins_list if c['symbol'].lower() == 'sol']
+# Returns 5+ entries — pick by name to get the real Solana: id='solana'
+```
+
+## Common workflows
+
+### Simple price (one or many coins)
+
+```python
+import json
+data = json.loads(http_get(
+    "https://api.coingecko.com/api/v3/simple/price"
+    "?ids=bitcoin,ethereum,solana"
+    "&vs_currencies=usd,eur"
+    "&include_market_cap=true"
+    "&include_24hr_change=true"
+))
+for coin, info in data.items():
+    print(f"{coin}: ${info['usd']:,.0f} | 24h: {info['usd_24h_change']:.1f}% | MCap: ${info['usd_market_cap']/1e9:.1f}B")
+# bitcoin: $76,286 | 24h: 1.4% | MCap: $1528.0B
+# ethereum: $2,361 | 24h: 0.8% | MCap: $284.9B
+# solana: $87 | 24h: -1.0% | MCap: $50.2B
+```
+
+Response keys for each coin (when all flags enabled):
+`usd`, `usd_market_cap`, `usd_24h_change`, `eur`, `eur_market_cap`, `eur_24h_change`
+
+### Top coins by market cap (paginated)
+
+```python
+import json
+data = json.loads(http_get(
+    "https://api.coingecko.com/api/v3/coins/markets"
+    "?vs_currency=usd"
+    "&order=market_cap_desc"
+    "&per_page=10"       # max 250
+    "&page=1"            # 1-indexed; page=2 gives ranks 11-20 etc.
+    "&sparkline=false"
+    "&price_change_percentage=1h,7d,30d"  # optional extra columns
+))
+for c in data:
+    print(f"#{c['market_cap_rank']} {c['symbol'].upper()} ${c['current_price']:,.2f} | {c['price_change_percentage_24h']:.1f}%")
+# #1 BTC $76,281.00 | 1.4%
+# #2 ETH $2,360.45 | 0.8%
+```
+
+Full fields per entry: `id`, `symbol`, `name`, `image`, `current_price`, `market_cap`, `market_cap_rank`, `fully_diluted_valuation`, `total_volume`, `high_24h`, `low_24h`, `price_change_24h`, `price_change_percentage_24h`, `market_cap_change_24h`, `market_cap_change_percentage_24h`, `circulating_supply`, `total_supply`, `max_supply`, `ath`, `ath_change_percentage`, `ath_date`, `atl`, `atl_change_percentage`, `atl_date`, `roi`, `last_updated`
+
+Extra columns added by `price_change_percentage=1h,7d,30d`: `price_change_percentage_1h_in_currency`, `price_change_percentage_7d_in_currency`, `price_change_percentage_30d_in_currency`
+
+Pagination: use `page=2`, `page=3`, etc. with `per_page` up to 250. Results are 1-indexed — page 2 with per_page=5 returns ranks 6–10.
+
+### Coin detail (full metadata)
+
+```python
+import json
+data = json.loads(http_get(
+    "https://api.coingecko.com/api/v3/coins/bitcoin"
+    "?localization=false"    # skip 40+ language translations
+    "&tickers=false"         # skip exchange ticker list (can be huge)
+    "&market_data=true"
+    "&community_data=false"
+    "&developer_data=false"
+))
+print(data['name'])                                    # Bitcoin
+print(data['symbol'])                                  # btc
+print(data['market_cap_rank'])                         # 1
+print(data['market_data']['current_price']['usd'])     # 76279
+print(data['market_data']['ath']['usd'])               # 126080
+print(data['market_data']['ath_date']['usd'])          # 2025-10-06T18:57:42.558Z
+print(data['market_data']['circulating_supply'])       # 20017459.0
+print(data['description']['en'][:200])
+```
+
+Top-level keys: `id`, `symbol`, `name`, `web_slug`, `asset_platform_id`, `platforms`, `categories`, `description`, `links`, `image`, `genesis_date`, `sentiment_votes_up_percentage`, `market_cap_rank`, `market_data`, `last_updated`
+
+`market_data` sub-keys include: `current_price`, `ath`, `ath_change_percentage`, `ath_date`, `atl`, `atl_change_percentage`, `atl_date`, `market_cap`, `fully_diluted_valuation`, `total_volume`, `high_24h`, `low_24h`, `price_change_percentage_24h`, `price_change_percentage_7d`, `price_change_percentage_14d`, `price_change_percentage_30d`, `price_change_percentage_60d`, `price_change_percentage_200d`, `price_change_percentage_1y`, `circulating_supply`, `total_supply`, `max_supply`
+
+All price/market fields are objects keyed by currency code: `data['market_data']['current_price']['usd']`, `['eur']`, `['btc']`, etc.
+
+### Historical OHLCV
+
+```python
+import json
+# OHLCV candles: granularity auto-determined by `days`
+# 1d = 30-min candles, 7d = 4-hr candles, 14d+ = daily candles
+data = json.loads(http_get(
+    "https://api.coingecko.com/api/v3/coins/ethereum/ohlc?vs_currency=usd&days=7"
+))
+print(len(data))         # 42 candles for 7-day window
+print(data[-1])          # [1776499200000, 2407.32, 2412.96, 2402.21, 2405.03]
+#                         [timestamp_ms,   open,    high,    low,     close]
+
+# Convert timestamp:
+import datetime
+ts_ms = data[-1][0]
+dt = datetime.datetime.fromtimestamp(ts_ms / 1000, tz=datetime.timezone.utc)
+```
+
+`days` options: `1`, `7`, `14`, `30`, `90`, `180`, `365`, `max`
+
+### Market chart (price + volume + market cap time series)
+
+```python
+import json
+# interval='daily' gives one point per day; omit for auto (hourly for <=90 days)
+chart = json.loads(http_get(
+    "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart"
+    "?vs_currency=usd&days=7&interval=daily"
+))
+# Keys: 'prices', 'market_caps', 'total_volumes'
+# Each is a list of [timestamp_ms, value]
+print(len(chart['prices']))           # 8 points for 7-day daily
+print(chart['prices'][-1])            # [1776508393000, 76286.699...]
+print(chart['total_volumes'][-1])     # [1776508393000, 80459560788.47...]
+```
+
+### Market chart by date range
+
+```python
+import json, time
+now = int(time.time())
+thirty_days_ago = now - 30 * 86400
+chart = json.loads(http_get(
+    f"https://api.coingecko.com/api/v3/coins/bitcoin/market_chart/range"
+    f"?vs_currency=usd&from={thirty_days_ago}&to={now}"
+))
+# Granularity: <1 day → minutely, 1-90 days → hourly, >90 days → daily
+print(len(chart['prices']))    # 174 points for 7-day range (hourly)
+```
+
+### Search
+
+```python
+import json
+results = json.loads(http_get("https://api.coingecko.com/api/v3/search?query=solana"))
+# Top-level keys: 'coins', 'exchanges', 'icos', 'categories', 'nfts'
+for c in results['coins'][:3]:
+    print(f"{c['id']} | {c['symbol']} | rank {c['market_cap_rank']}")
+# solana | SOL | rank 7
+# solana-name-service | SNS | rank 1902
+```
+
+Search returns coins ordered by relevance, not market cap. First result is usually the canonical coin.
+
+### Trending (top 7 searched in last 24h)
+
+```python
+import json
+trending = json.loads(http_get("https://api.coingecko.com/api/v3/search/trending"))
+# Top-level keys: 'coins', 'nfts', 'categories'
+for item in trending['coins']:
+    c = item['item']
+    print(f"{c['name']} ({c['symbol']}) #{c['market_cap_rank']}")
+# Item keys: id, coin_id, name, symbol, market_cap_rank, thumb, small, large,
+#            slug, price_btc, score, data
+```
+
+`data` sub-object includes sparkline image URL, price/volume/market cap info if available.
+
+### Global market overview
+
+```python
+import json
+global_data = json.loads(http_get("https://api.coingecko.com/api/v3/global"))
+gd = global_data['data']
+print(f"Total market cap: ${gd['total_market_cap']['usd']/1e12:.2f}T")   # $2.66T
+print(f"24h volume: ${gd['total_volume']['usd']/1e9:.1f}B")              # $156.6B
+print(f"BTC dominance: {gd['market_cap_percentage']['btc']:.1f}%")       # 57.3%
+print(f"Active coins: {gd['active_cryptocurrencies']}")                   # 17,564
+print(f"Active exchanges: {gd['markets']}")                               # 1,475
+```
+
+### Coin categories (market cap by sector)
+
+```python
+import json
+cats = json.loads(http_get(
+    "https://api.coingecko.com/api/v3/coins/categories?order=market_cap_desc"
+))
+# 691 categories as of April 2026
+for cat in cats[:5]:
+    print(f"{cat['name']}: ${cat['market_cap']/1e9:.1f}B | 24h: {cat['market_cap_change_24h']:.1f}%")
+# Smart Contract Platform: $2204.8B | 24h: 0.9%
+# Layer 1 (L1): $2171.5B | 24h: 1.1%
+
+# Category keys: id, name, market_cap, market_cap_change_24h, content,
+#                top_3_coins_id, top_3_coins, volume_24h, updated_at
+```
+
+### Token price by contract address (ERC-20 and other chains)
+
+```python
+import json
+# Platform IDs: ethereum, binance-smart-chain, polygon-pos, avalanche, solana, etc.
+token = json.loads(http_get(
+    "https://api.coingecko.com/api/v3/simple/token_price/ethereum"
+    "?contract_addresses=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"  # USDC
+    "&vs_currencies=usd"
+))
+print(token)
+# {'0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {'usd': 0.999861}}
+# Key is the lowercased contract address
+```
+
+## vs_currencies options
+
+63 currencies supported (confirmed live). Common ones:
+
+**Fiat**: `usd`, `eur`, `gbp`, `jpy`, `aud`, `cad`, `chf`, `cny`, `inr`, `krw`, `brl`, `mxn`, `sgd`, `hkd`, `nok`, `sek`, `dkk`, `nzd`, `zar`, `thb`, `try`, `aed`, `sar`, `myr`, `php`, `idr`, `pln`, `czk`, `huf`, `ron`
+
+**Crypto**: `btc`, `eth`, `ltc`, `bch`, `bnb`, `eos`, `xrp`, `xlm`, `link`, `dot`, `yfi`, `sol`
+
+**Commodities**: `xag` (silver), `xau` (gold)
+
+Get the full list:
+```python
+currencies = json.loads(http_get("https://api.coingecko.com/api/v3/simple/supported_vs_currencies"))
+# Returns list of 63 strings
+```
+
+## Endpoints that require Pro API (return HTTP 401)
+
+- `/coins/{id}/history?date=DD-MM-YYYY` — historical price on a specific date
+- `/coins/markets` with `category=` filter (the parameter is silently ignored, not 401)
+- `/coins/{id}/contract/{address}` — full contract token details
+
+Free tier alternatives:
+- For historical price on date: use `/market_chart/range` with a narrow time window
+- For category filtering: fetch `/coins/markets` unfiltered and filter client-side using `id` from `/coins/categories`
+
+## Ping / health check
+
+```python
+import json
+ping = json.loads(http_get("https://api.coingecko.com/api/v3/ping"))
+print(ping)   # {'gecko_says': '(V3) To the Moon!'}
+```
+
+Note: ping still counts against the rate limit. Don't use it to check if a 429 has resolved — just wait 65 seconds and retry your actual call.
+
+## Gotchas
+
+- **Rate limit is much stricter than advertised** — The official docs say "30 calls/min" but in practice you get 429 on call 3-4 with no delay between calls. Observed `Retry-After: 60` in the response header. Treat it as "3 calls/minute, wait 65s on 429." Using `time.sleep(5)` between calls in a loop is safe.
+
+- **Unknown coin IDs return `{}`, not an error** — `?ids=BTC` (uppercase) and `?ids=not_a_real_coin` both return an empty dict `{}`. Always check that the key you expect exists before accessing it.
+
+- **Symbol lookup requires `/coins/list` + client-side filter** — There's no "get by symbol" endpoint. Multiple coins share any given symbol. After fetching the list (17,564 entries), filter by `symbol` and pick by `name`.
+
+- **Coin ID casing matters** — IDs are always lowercase kebab-case: `bitcoin`, `ethereum`, `shiba-inu`. Uppercase or camelCase will silently return `{}`.
+
+- **OHLCV granularity is automatic** — The `days` parameter determines candle size automatically: `1` → 30-min candles, `7`/`14` → 4-hr candles, `30`+  → daily candles. You cannot override this on the free tier.
+
+- **`interval=daily` in market_chart affects point count** — Without `interval=daily`, a 7-day window returns hourly data (~168 points). With it, you get ~8 points. Choose based on whether you need resolution or summary.
+
+- **market_chart timestamps are in milliseconds** — Divide by 1000 for standard Unix time: `datetime.fromtimestamp(ts / 1000)`.
+
+- **`/coins/list` is expensive (rate-limit-wise)** — It returns 17,564 entries and costs one API call. Fetch once, store in a variable, filter locally. Don't call it in a loop.
+
+- **Pagination is 1-indexed** — `page=1` returns items 1–N, `page=2` returns N+1–2N. `page=0` returns the same as `page=1` (it doesn't error).
+
+- **`per_page` max is 250** — Requesting more than 250 per page silently returns 250. To get the full top-500, make two calls: `page=1&per_page=250` then `page=2&per_page=250`.
+
+- **Contract address keys are lowercased** — When using `/simple/token_price`, the response key is the lowercased contract address regardless of what case you sent. Always call `.lower()` before using addresses as dict keys.
+
+- **`tickers=false` is important for `/coins/{id}`** — Without it, the response includes a massive list of exchange tickers that can make the payload very large and slow to parse. Always set `tickers=false` unless you specifically need exchange data.
+
+- **ETH priced against BTC is supported** — `vs_currencies=btc` works: `ethereum` returns `{'btc': 0.03095861}`. Crypto-to-crypto pairs work the same as fiat pairs.

--- a/domain-skills/ebay/scraping.md
+++ b/domain-skills/ebay/scraping.md
@@ -1,0 +1,435 @@
+# eBay — Scraping & Data Extraction
+
+Field-tested against ebay.com on 2026-04-18 using `uv run python` with `http_get`.
+Chrome is NOT required — `http_get` returns full HTML on first access.
+
+## Critical: Bot Detection ("Pardon Our Interruption")
+
+eBay's bot detection fires after roughly **5–10 requests per IP in a short window**.
+The block page is ~13 KB, title `"Pardon Our Interruption..."`, and contains no listing data.
+
+**Always check before parsing:**
+```python
+def is_blocked(html):
+    return 'Pardon Our Interruption' in html or len(html) < 20_000
+
+html = http_get("https://www.ebay.com/sch/i.html?_nkw=laptop&LH_BIN=1", headers=HEADERS)
+if is_blocked(html):
+    raise RuntimeError("eBay bot-detection triggered — back off and retry later")
+```
+
+**When blocked:** wait at minimum 60–120 seconds before retrying. The block is IP-session-scoped,
+not a hard IP ban; it clears after inactivity.
+
+**Headers required (minimal UA gets blocked faster, full browser UA lasts longer):**
+```python
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+}
+```
+
+A plain `"User-Agent": "Mozilla/5.0"` also works for the first few requests,
+but the full Chrome UA lasts slightly longer before triggering the block.
+
+## Search URL Structure
+
+```
+https://www.ebay.com/sch/i.html?_nkw={query}&{filters}
+```
+
+Confirmed working URL examples:
+```python
+# Buy It Now only, sorted by lowest price
+"https://www.ebay.com/sch/i.html?_nkw=mechanical+keyboard&LH_BIN=1&_sop=15"
+
+# Auctions only
+"https://www.ebay.com/sch/i.html?_nkw=vintage+camera&LH_Auction=1"
+
+# New condition only, page 2
+"https://www.ebay.com/sch/i.html?_nkw=laptop&LH_ItemCondition=1000&_pgn=2"
+```
+
+### Filter Parameters (all confirmed working)
+
+| Parameter | Value | Effect |
+|-----------|-------|--------|
+| `LH_BIN` | `1` | Buy It Now only |
+| `LH_Auction` | `1` | Auctions only |
+| `LH_ItemCondition` | see below | Filter by condition |
+| `_sop` | see below | Sort order |
+| `_pgn` | `2`, `3`, … | Page number (confirmed: returns ~65–88 items/page) |
+| `_ipg` | `25`, `50`, `100`, `200` | Items per page (unconfirmed, standard eBay param) |
+
+### Condition Codes for `LH_ItemCondition`
+
+| Code | Label |
+|------|-------|
+| `1000` | New |
+| `1500` | New Other (open box, no original packaging) |
+| `2000` | Manufacturer Refurbished |
+| `2500` | Seller Refurbished |
+| `2750` | Like New |
+| `3000` | Used |
+| `4000` | Very Good |
+| `5000` | Good |
+| `6000` | Acceptable |
+| `7000` | For parts or not working |
+
+### Sort Codes for `_sop`
+
+| Code | Sort Order |
+|------|-----------|
+| `1` | Best Match (default) |
+| `10` | Ending Soonest |
+| `12` | Newly Listed |
+| `15` | Lowest Price + Shipping |
+| `16` | Highest Price |
+
+### Item Detail URL
+
+```
+https://www.ebay.com/itm/{listing_id}
+```
+
+The listing ID is a plain integer (e.g. `167040158614`). Always strip query parameters
+from extracted URLs — tracking params bloat the URL and are not needed for navigation.
+
+## Search Results: HTML Structure (No JSON-LD)
+
+**JSON-LD is absent on search results pages.** The listing data is embedded in HTML
+with eBay-specific class names. The response is large (~1.5–1.8 MB uncompressed).
+
+### Card Structure
+
+Each result is an `<li>` element with `data-listingid=<id>`. Key elements within each card:
+
+| Data | Pattern |
+|------|---------|
+| Listing ID | `data-listingid=(\d+)` on the `<li>` |
+| Item URL | `href=(https://(?:www\.)?ebay\.com/itm/(\d+))` |
+| Title | `s-card__title` > `su-styled-text primary` > text |
+| Current price | `class=price">\$([0-9,\.]+)<` |
+| Original/list price | `strikethrough[^>]*>\$([0-9,\.]+)` |
+| Image | `class=s-card__image[^>]*src=([^\s>]+)` |
+| Alt title | `img[alt]` in the card (same as product title) |
+
+### Confirmed Extractor (field-tested, 60 items from a single search)
+
+```python
+import re
+
+def extract_search_results(html):
+    """
+    Parse eBay search results HTML into a list of dicts.
+    Returns [] if blocked or no results.
+    """
+    if 'Pardon Our Interruption' in html or len(html) < 20_000:
+        return []
+
+    cards = re.split(r'(?=<li[^>]+data-listingid=)', html)
+    results = []
+    seen_ids = set()
+
+    for card in cards[1:]:  # skip preamble before first card
+        # Listing ID (dedup)
+        lid_m = re.search(r'data-listingid=(\d+)', card)
+        if not lid_m:
+            continue
+        listing_id = lid_m.group(1)
+        if listing_id in seen_ids:
+            continue
+        seen_ids.add(listing_id)
+
+        # Item URL (clean, no tracking params)
+        url_m = re.search(r'href=(https://(?:www\.)?ebay\.com/itm/(\d+))', card)
+        item_url = url_m.group(1).split('?')[0] if url_m else None
+
+        # Title from s-card__title
+        title_m = re.search(r's-card__title[^>]*>.*?primary[^>]*>([^<]+)', card, re.DOTALL)
+        title = title_m.group(1).strip() if title_m else None
+
+        # Skip placeholder "Shop on eBay" stub cards
+        if not title or title == 'Shop on eBay':
+            continue
+
+        # Current price
+        price_m = re.search(r'class=(?:["\'])?[a-z- ]*price["\']?>\$([0-9,\.]+)<', card)
+        if not price_m:
+            price_m = re.search(r'price">\$([0-9,\.]+)<', card)
+        price = '$' + price_m.group(1) if price_m else None
+
+        # Original / list price (strikethrough — present when discounted)
+        orig_m = re.search(r'strikethrough[^>]*>\$([0-9,\.]+)', card)
+        original_price = '$' + orig_m.group(1) if orig_m else None
+
+        # Thumbnail image URL
+        img_m = re.search(r'class=s-card__image[^>]*src=([^\s>]+)', card)
+        image = img_m.group(1) if img_m else None
+
+        results.append({
+            'listing_id': listing_id,
+            'url': item_url,
+            'title': title,
+            'price': price,
+            'original_price': original_price,  # None if not on sale
+            'image': image,
+        })
+
+    return results
+```
+
+**Usage:**
+```python
+from helpers import http_get
+import re
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+html = http_get("https://www.ebay.com/sch/i.html?_nkw=mechanical+keyboard&LH_BIN=1&_sop=15", headers=HEADERS)
+items = extract_search_results(html)
+print(f"{len(items)} items")
+for item in items[:5]:
+    print(f"  {item['listing_id']} | {item['title'][:50]} | {item['price']}")
+# Output (confirmed): 60 items
+# 168219240588 | One Plus Keyboard 81 Pro Winter Bonfire Mecha... | $159.00
+# 167461643107 | Logitech 920-012869 G515 TKL Wired Low Profil... | $49.99
+# 167040158614 | Logitech - PRO X TKL LIGHTSPEED Wireless Mech... | $74.99
+```
+
+## Item Detail Pages: JSON-LD (Reliable)
+
+Item detail pages at `/itm/{id}` serve **two JSON-LD blocks**: `BreadcrumbList` and `Product`.
+The `Product` schema is the most useful — it contains price, condition, availability, brand, images, and return policy.
+
+```python
+import re, json
+
+def extract_item_detail(html):
+    """
+    Extract structured data from an eBay item page.
+    Returns dict or None if blocked.
+    """
+    if 'Pardon Our Interruption' in html:
+        return None
+
+    ld_blocks = re.findall(r'application/ld\+json[^>]*>(.*?)</script>', html, re.DOTALL)
+    product = None
+    breadcrumbs = []
+
+    for ld_str in ld_blocks:
+        try:
+            d = json.loads(ld_str.strip())
+        except Exception:
+            continue
+
+        if d.get('@type') == 'Product':
+            product = d
+        elif d.get('@type') == 'BreadcrumbList':
+            breadcrumbs = [i.get('name') for i in d.get('itemListElement', [])]
+
+    if not product:
+        return None
+
+    offers = product.get('offers', {})
+    if isinstance(offers, list):
+        offers = offers[0]
+
+    # Schema.org condition URL -> human label
+    CONDITION_MAP = {
+        'NewCondition':          'New',
+        'UsedCondition':         'Used',
+        'RefurbishedCondition':  'Refurbished',
+        'DamagedCondition':      'For Parts / Not Working',
+        'LikeNewCondition':      'Like New',
+        'VeryGoodCondition':     'Very Good',
+        'GoodCondition':         'Good',
+        'AcceptableCondition':   'Acceptable',
+    }
+    cond_url = offers.get('itemCondition', '')
+    cond_key = cond_url.split('/')[-1]  # e.g. "RefurbishedCondition"
+    condition = CONDITION_MAP.get(cond_key, cond_key)
+
+    # List price from priceSpecification (only present when there's a "was" price)
+    price_spec = offers.get('priceSpecification', {})
+    list_price = price_spec.get('price') if price_spec.get('name') == 'List Price' else None
+
+    # Shipping (first destination)
+    shipping_details = offers.get('shippingDetails', [])
+    if shipping_details:
+        shipping_val = shipping_details[0].get('shippingRate', {}).get('value', '')
+        shipping = 'Free' if str(shipping_val) in ('0', '0.0') else f"${shipping_val}"
+    else:
+        shipping = None
+
+    # Return policy
+    return_policies = offers.get('hasMerchantReturnPolicy', [])
+    return_days = return_policies[0].get('merchantReturnDays') if return_policies else None
+
+    return {
+        'listing_id': offers.get('url', '').split('/itm/')[-1],
+        'name': product.get('name'),
+        'brand': product.get('brand', {}).get('name') if isinstance(product.get('brand'), dict) else product.get('brand'),
+        'price': offers.get('price'),
+        'list_price': list_price,     # was-price, None if no discount shown
+        'currency': offers.get('priceCurrency'),
+        'availability': offers.get('availability', '').split('/')[-1],  # e.g. "InStock"
+        'condition': condition,
+        'condition_url': cond_url,
+        'shipping': shipping,
+        'return_days': return_days,
+        'images': product.get('image', []),
+        'gtin13': product.get('gtin13'),
+        'mpn': product.get('mpn'),
+        'color': product.get('color'),
+        'breadcrumbs': breadcrumbs,
+    }
+```
+
+**Field-tested on item 167040158614:**
+```python
+html = http_get("https://www.ebay.com/itm/167040158614", headers=HEADERS)
+detail = extract_item_detail(html)
+# {
+#   'listing_id':   '167040158614',
+#   'name':         'Logitech - PRO X TKL LIGHTSPEED Wireless Mechanical Gaming Keyboard - 920-012118',
+#   'brand':        'Logitech',
+#   'price':        74.99,
+#   'list_price':   '219.99',
+#   'currency':     'USD',
+#   'availability': 'InStock',
+#   'condition':    'Refurbished',
+#   'shipping':     'Free',
+#   'return_days':  30,
+#   'images':       ['https://i.ebayimg.com/images/g/vwsAAeSwEcFpw~hW/s-l1600.jpg', ...],  # 5 images
+#   'gtin13':       '097855189066',
+#   'mpn':          '920-012118',
+#   'color':        'Black',
+#   'breadcrumbs':  ['eBay', 'Electronics', 'Computers/Tablets & Networking', ...],
+# }
+```
+
+### Item Specifics from `ux-textspans` (complementary to JSON-LD)
+
+The `ux-textspans` elements in item pages contain additional data not in JSON-LD,
+including seller name, feedback %, items sold, detailed condition text, and all item specifics.
+
+```python
+import re
+
+def extract_ux_textspans(html):
+    """Return list of all ux-textspans text values from an item page."""
+    return [m.group(1) for m in re.finditer(r'ux-textspans[^>]*>([^<]+)</span>', html)]
+
+# From item 167040158614 (confirmed):
+# Index [3]  -> item title
+# Index [4]  -> subtitle / seller tagline
+# Index [5]  -> seller name ("Logitech")
+# Index [6]  -> seller feedback count ("(20742)")
+# Index [7]  -> seller feedback % ("99.6% positive")
+# Index [10] -> current price ("US $74.99")
+# Index [12] -> list price ("US $219.99")
+# Index [33] -> condition label ("Excellent - Refurbished")
+# Index [36] -> quantity sold ("45 sold")
+# Pairs from [105] onward: item specifics as label/value pairs
+```
+
+## Pagination
+
+Use `_pgn=N` (confirmed working, returns ~65–88 items per page):
+```python
+for page in range(1, 4):
+    url = f"https://www.ebay.com/sch/i.html?_nkw=laptop&LH_BIN=1&_sop=15&_pgn={page}"
+    html = http_get(url, headers=HEADERS)
+    if is_blocked(html):
+        break
+    items = extract_search_results(html)
+    print(f"Page {page}: {len(items)} items")
+    # IMPORTANT: add delay between pages to avoid bot detection
+    time.sleep(3)
+```
+
+**Rate-limit safe pattern**: 3–5 second delay between requests. Beyond ~10 rapid requests
+in a session, eBay returns "Pardon Our Interruption" for all subsequent requests from that IP.
+
+## APIs (All Require Auth or Are Dead)
+
+| API | Status | Notes |
+|-----|--------|-------|
+| Finding API (svcs.ebay.com) | **Dead** — HTTP 500 | Was free/JSONP, no longer works |
+| Browse API (api.ebay.com) | **Requires OAuth** — HTTP 400 | Needs eBay developer account + token |
+| Shopping API (open.api.ebay.com) | **Requires token** | Returns `"Token not available"` error |
+| RSS feed (`_rss=1`) | **Blocked same as HTML** | Returns "Pardon Our Interruption" when rate-limited |
+
+**Bottom line**: There is no public unauthenticated eBay API in 2026. Use HTML scraping.
+
+## Practical Workflow
+
+### Scrape a search and follow top items
+
+```python
+import re, json, time
+from helpers import http_get
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+def is_blocked(html):
+    return 'Pardon Our Interruption' in html or len(html) < 20_000
+
+# Step 1: Search
+html = http_get(
+    "https://www.ebay.com/sch/i.html?_nkw=mechanical+keyboard&LH_BIN=1&_sop=15&LH_ItemCondition=1000",
+    headers=HEADERS
+)
+if is_blocked(html):
+    raise RuntimeError("Rate limited — wait 60-120s and retry")
+
+items = extract_search_results(html)
+print(f"Found {len(items)} items")
+
+# Step 2: Fetch details for top results (with delay)
+details = []
+for item in items[:5]:
+    time.sleep(3)
+    detail_html = http_get(item['url'], headers=HEADERS)
+    if is_blocked(detail_html):
+        print(f"Blocked on item {item['listing_id']}, stopping")
+        break
+    detail = extract_item_detail(detail_html)
+    if detail:
+        details.append(detail)
+        print(f"  {detail['name'][:50]} | {detail['price']} {detail['currency']} | {detail['condition']}")
+```
+
+## Gotchas
+
+- **"Pardon Our Interruption" is not a CAPTCHA** — it's eBay's bot-detection interstitial. It doesn't require solving — just wait and back off. `'captcha'` does NOT appear in the blocked page.
+
+- **No JSON-LD on search results** — The `application/ld+json` blocks that Amazon and other sites embed are absent from eBay search pages. Parse the HTML using regex on `s-card` class names.
+
+- **JSON-LD IS on item pages** — Two blocks: `BreadcrumbList` and `Product`. The `Product` block is authoritative. Use the regex `r'application/ld\+json[^>]*>(.*?)</script>'` (note the `[^>]*` before `>` — eBay doesn't use `type="..."` quote style consistently in all contexts).
+
+- **Duplicate listing IDs in the HTML** — Each card's listing ID appears 2–3 times (image link, title link, watch button). Always deduplicate using a `seen_ids` set when splitting on `data-listingid`.
+
+- **Placeholder cards ("Shop on eBay")** — The first card slot may be a promoted/placeholder card with title `"Shop on eBay"` and listing ID `"123456"`. Filter these out.
+
+- **Item URLs have tracking params** — Raw extracted URLs look like `https://www.ebay.com/itm/167040158614?_skw=...&epid=...&hash=...&itmprp=...`. Always strip to `itm/{id}` with `.split('?')[0]`.
+
+- **`www.ebay.com` vs `ebay.com`** — Some item URLs in search results omit `www.`. Normalize with `url.replace('//ebay.com/', '//www.ebay.com/')`.
+
+- **Search response is large** — Uncompressed HTML is 1.5–1.8 MB per page. The `http_get` helper handles gzip transparently, so the actual transfer is much smaller, but parsing a 1.8 MB string is slow. Use `re.split` on card boundaries rather than an HTML parser for speed.
+
+- **`_sop` sort and `LH_ItemCondition` require full browser-like UA** — Requests with just `"Mozilla/5.0"` (minimal UA) return empty results for these parameters more quickly than full Chrome UA. Always use the full UA string.
+
+- **Condition in JSON-LD is a schema.org URL** — `offers.itemCondition` returns `"https://schema.org/RefurbishedCondition"`, not a human label. Split on `/` and map the last segment using `CONDITION_MAP` (see `extract_item_detail` above).
+
+- **`list_price` only present when discounted** — `offers.priceSpecification` only appears in JSON-LD when eBay shows a "List Price" comparison. Check `price_spec.get('name') == 'List Price'` before using.
+
+- **Seller data is NOT in JSON-LD** — `d.get('seller')` returns `None` on item pages. The seller name, feedback %, and items sold count are only in `ux-textspans` elements in the HTML body.

--- a/domain-skills/etsy/scraping.md
+++ b/domain-skills/etsy/scraping.md
@@ -1,0 +1,506 @@
+# Etsy — Scraping & Data Extraction
+
+Field-tested against `www.etsy.com` on 2026-04-18 using `http_get` (no browser) and direct `urllib` probes.
+
+## Quick summary
+
+**`http_get` does NOT work on Etsy.** Every page type — search, listing, shop, category, market — returns HTTP 403 with DataDome bot protection. This is not negotiable: no header combination, User-Agent string, or cookie replay bypasses it. Etsy requires a real browser with JavaScript execution.
+
+- **All HTML pages (`/search`, `/listing/`, `/shop/`, `/c/`, `/market/`)** — HTTP 403, `Server: DataDome`
+- **Official Etsy API v3 (`openapi.etsy.com/v3/`)** — requires a registered API key; returns JSON
+- **`robots.txt`** — HTTP 200, plain text, no DataDome
+- **Browser (Chrome CDP)** — works; Etsy is a React SPA with JSON-LD and `__NEXT_DATA__` embedded in SSR HTML
+
+---
+
+## Bot detection: DataDome
+
+Etsy uses [DataDome](https://datadome.co/) for every user-facing HTML endpoint.
+
+### What you receive
+
+```
+HTTP 403 Forbidden
+Server: DataDome
+X-DataDome: protected
+X-DataDome-riskscore: 0.14–0.95  (varies per request)
+X-DD-B: 2
+Content-Type: text/html;charset=utf-8
+Set-Cookie: datadome=<token>; Max-Age=31536000; Domain=.etsy.com; Secure; SameSite=Lax
+```
+
+Body (816 bytes — a JavaScript challenge, not a hard block):
+
+```html
+<html lang="en"><head><title>etsy.com</title>...</head>
+<body>
+  <p id="cmsg">Please enable JS and disable any ad blocker</p>
+  <script>var dd={'rt':'c','cid':'...','hsh':'D013AA...','t':'bv',
+    'host':'geo.captcha-delivery.com','cookie':'...'}</script>
+  <script src="https://ct.captcha-delivery.com/c.js"></script>
+</body>
+```
+
+`'rt':'c'` means **challenge** (browser must run JS at `geo.captcha-delivery.com` to get a valid `datadome` cookie). `'rt':'b'` would be a hard block; `'rt':'i'` an interstitial. All tested requests returned `'rt':'c'` — the JS challenge variant.
+
+### What was tested (all 403)
+
+| URL pattern | Status | DataDome |
+|---|---|---|
+| `/search?q=handmade+candle&explicit=1` | **403** | JS challenge |
+| `/search?q=handmade+candle&explicit=1&page=2` | **403** | JS challenge |
+| `/listing/{id}/{slug}` | **403** | JS challenge |
+| `/shop/{ShopName}` | **403** | JS challenge |
+| `/c/home-living/candles-holders/candles` | **403** | JS challenge |
+| `/market/handmade_candle` | **403** | JS challenge |
+
+### User-Agents tested (all blocked)
+
+- `Mozilla/5.0 (Macintosh; ...) Chrome/120` — **403**
+- `facebookexternalhit/1.1` — **403**
+- `Twitterbot/1.0` — **403**
+- `LinkedInBot/1.0` — **403**
+- `ia_archiver` — **403**
+- `curl/7.68.0` — **403**
+- `python-requests/2.28.0` — **403**
+- `Googlebot/2.1` — **429** (rate-limited, different path)
+- `Mozilla/5.0` (http_get default) — **403**
+
+**Conclusion**: No UA bypasses DataDome. The challenge requires TLS fingerprinting + JS execution that only a real browser provides.
+
+---
+
+## What works without a browser
+
+### `robots.txt` (200 OK)
+
+```python
+from helpers import http_get
+text = http_get("https://www.etsy.com/robots.txt")
+# Returns 51 KB plain-text file — no DataDome
+```
+
+The robots.txt reveals URL structure, disallowed parameters, and allowed paths. Etsy disallows `/search?*q=` (no-empty-q searches) and faceted search params (`attr_*`, `price_bucket`, `ship_to`, `search_type`). Basic search with `?q=keyword` is not explicitly disallowed by robots but is blocked by DataDome in practice.
+
+### Official Etsy API v3 (requires API key)
+
+The `openapi.etsy.com/v3/` endpoint is NOT DataDome-protected. It returns structured JSON but requires a free API key from [developer.etsy.com](https://developer.etsy.com/).
+
+```python
+import json
+from helpers import http_get
+
+API_KEY = "your_key_here"  # from developer.etsy.com
+
+def etsy_api(path, **params):
+    from urllib.parse import urlencode
+    qs = urlencode(params)
+    url = f"https://openapi.etsy.com/v3/application/{path}?{qs}"
+    data = http_get(url, headers={"x-api-key": API_KEY})
+    return json.loads(data)
+
+# Search listings
+results = etsy_api("listings/active", limit=25, keywords="handmade candle",
+                   sort_on="created", sort_order="desc")
+# results['results'] is a list of listing dicts
+# results['count'] is total match count
+
+# Get a single listing
+listing = etsy_api("listings/1234567890")
+
+# Get all listings for a shop
+shop_listings = etsy_api("shops/CandlesByNature/listings/active", limit=100)
+
+# Get shop info
+shop = etsy_api("shops/CandlesByNature")
+```
+
+Error without a key:
+```
+HTTP 403: {"error": "Invalid API key: should be in the format 'keystring:shared_secret'."}
+```
+
+Error with wrong key:
+```
+HTTP 403: {"error": "API key not found or not active, or incorrect shared secret for API key."}
+```
+
+### API v3 key data fields
+
+```
+listings/active response:
+  results[i].listing_id        → int (e.g. 1234567890)
+  results[i].title             → string
+  results[i].description       → string (full HTML, may be truncated by API)
+  results[i].price.amount      → int (in currency subunit, e.g. 2599 = $25.99)
+  results[i].price.divisor     → int (100 for USD)
+  results[i].price.currency_code → "USD"
+  results[i].quantity          → int (stock remaining)
+  results[i].tags              → [string] (up to 13 tags)
+  results[i].materials         → [string]
+  results[i].shipping_profile_id → int
+  results[i].shop_id           → int
+  results[i].url               → "https://www.etsy.com/listing/..."
+  results[i].views             → int
+  results[i].num_favorers      → int
+  results[i].featured_rank     → int (-1 if not featured)
+  results[i].is_digital        → bool
+  results[i].has_variations    → bool
+  results[i].taxonomy_id       → int (category)
+  results[i].state             → "active" | "draft" | "expired" | "sold_out"
+  results[i].creation_timestamp → unix int
+  results[i].last_modified_timestamp → unix int
+```
+
+---
+
+## Browser-based scraping (required for HTML data)
+
+Since http_get is blocked, all HTML scraping requires the Chrome browser via CDP.
+
+### Navigation pattern
+
+```python
+from helpers import goto, wait_for_load, wait, js, new_tab
+
+# Always use new_tab() for the first Etsy navigation in a session
+tid = new_tab("https://www.etsy.com/search?q=handmade+candle&explicit=1")
+wait_for_load()
+wait(3)  # Etsy React SPA needs extra time after readyState=complete
+```
+
+### Search URL construction
+
+```
+https://www.etsy.com/search?q={query}&explicit=1
+```
+
+Parameters:
+- `q` — search query (URL-encoded, spaces as `+`)
+- `explicit=1` — disables the "adult content" NSFW filter (safe to include always)
+- `page=2`, `page=3` — pagination (confirmed from robots.txt URL patterns)
+- `min_price=10.00&max_price=50.00` — price range filter
+- `order=price_asc` / `order=price_desc` / `order=most_relevant` (default) / `order=newest`
+- `ship_to=US` — filter by shipping destination (CAUTION: disallowed by robots.txt, use only with browser)
+- `listing_type=handmade` / `listing_type=vintage` / `listing_type=supplies`
+
+**Disallowed URL params** (per robots.txt — avoid in automated crawls):
+- `attr_*=*` — attribute filters
+- `price_bucket=*` — price bucket filter
+- `ship_to=*` — shipping destination
+- `search_type=*` — search type
+
+### Search results extraction (browser)
+
+Etsy renders results as a React SPA. The listing cards use data attributes and consistent class patterns:
+
+```python
+results = js("""
+  Array.from(document.querySelectorAll('[data-listing-id]')).map(el => ({
+    listing_id: el.getAttribute('data-listing-id'),
+    title: el.querySelector('h3, [class*="listing-link"]')?.innerText?.trim()
+         || el.querySelector('h2')?.innerText?.trim(),
+    price: el.querySelector('[class*="currency-value"]')?.innerText?.trim()
+         || el.querySelector('.currency-value')?.innerText?.trim(),
+    shop: el.querySelector('[class*="shop-name"], [data-shop-name]')?.innerText?.trim(),
+    url: el.querySelector('a[href*="/listing/"]')?.href,
+    thumbnail: el.querySelector('img[src*="etsystatic"]')?.src,
+    is_ad: !!el.querySelector('[class*="ad-label"], [class*="sponsored"]')
+  })).filter(r => r.listing_id)
+""")
+```
+
+**Alternative — JSON-LD ItemList** (more reliable than DOM selectors):
+
+Etsy's SSR HTML embeds a `<script type="application/ld+json">` with an `ItemList` on search pages. In the browser, extract it via:
+
+```python
+ld_json_str = js("""
+  Array.from(document.querySelectorAll('script[type="application/ld+json"]'))
+    .map(s => { try { return JSON.parse(s.textContent); } catch(e) { return null; } })
+    .filter(d => d && d['@type'] === 'ItemList')[0]
+""")
+# Returns the ItemList object or null
+
+if ld_json_str:
+    # ld_json_str.itemListElement is a list of:
+    # { '@type': 'ListItem', 'position': 1,
+    #   'url': 'https://www.etsy.com/listing/...', 'name': 'Handmade Soy Candle' }
+    for item in ld_json_str.get('itemListElement', []):
+        print(item['position'], item['url'], item.get('name'))
+```
+
+Expected output (ItemList typically has 48 items per search page):
+```
+1  https://www.etsy.com/listing/1234567890/handmade-soy-candle  "Handmade Soy Candle"
+2  https://www.etsy.com/listing/0987654321/beeswax-pillar-candle  "Beeswax Pillar Candle"
+...
+```
+
+### Listing detail page extraction (browser)
+
+```python
+goto("https://www.etsy.com/listing/1234567890/product-slug")
+wait_for_load()
+wait(2)
+
+# JSON-LD Product schema (most reliable)
+product = js("""
+  (function() {
+    var scripts = document.querySelectorAll('script[type="application/ld+json"]');
+    for (var s of scripts) {
+      try {
+        var d = JSON.parse(s.textContent);
+        if (d['@type'] === 'Product') return d;
+      } catch(e) {}
+    }
+    return null;
+  })()
+""")
+
+# product fields:
+# product['name']                    → listing title
+# product['description']             → full description
+# product['offers']['price']         → e.g. "25.99"
+# product['offers']['priceCurrency'] → "USD"
+# product['offers']['availability']  → "http://schema.org/InStock"
+# product['brand']['name']           → shop name (seller)
+#   OR product['seller']['name']
+# product['aggregateRating']['ratingValue']  → e.g. "4.8"
+# product['aggregateRating']['reviewCount']  → e.g. 1247
+# product['image']                   → [list of image URLs]
+```
+
+**Fallback DOM selectors** (when JSON-LD is absent or incomplete):
+
+```python
+detail = js("""
+  ({
+    title:   document.querySelector('h1[data-buy-box-listing-title]')?.innerText?.trim()
+           || document.querySelector('h1.wt-text-body-01')?.innerText?.trim(),
+    price:   document.querySelector('[data-selector="price-only"]')?.innerText?.trim()
+           || document.querySelector('[class*="wt-text-title-larger"]')?.innerText?.trim(),
+    shop:    document.querySelector('[class*="shop-name-and-title"] a')?.innerText?.trim()
+           || document.querySelector('a[href*="/shop/"]')?.innerText?.trim(),
+    rating:  document.querySelector('[data-selector="reviews-tab"]')?.innerText?.trim(),
+    reviews: document.querySelector('[class*="wt-display-inline-flex-xs"] .wt-text-body-01')?.innerText?.trim(),
+    sold:    document.querySelector('[class*="wt-text-caption"] span')?.innerText?.trim()
+  })
+""")
+```
+
+### Shop/seller page extraction (browser)
+
+```python
+goto("https://www.etsy.com/shop/ShopName")
+wait_for_load()
+wait(2)
+
+# JSON-LD on shop pages (type varies: LocalBusiness, Store, or Organization)
+shop_ld = js("""
+  (function() {
+    for (var s of document.querySelectorAll('script[type="application/ld+json"]')) {
+      try {
+        var d = JSON.parse(s.textContent);
+        if (['LocalBusiness','Store','Organization'].includes(d['@type'])) return d;
+      } catch(e) {}
+    }
+    return null;
+  })()
+""")
+
+# DOM extraction for shop stats
+shop_info = js("""
+  ({
+    name:       document.querySelector('[class*="shop-name"]')?.innerText?.trim(),
+    tagline:    document.querySelector('[class*="shop-tagline"]')?.innerText?.trim(),
+    sales:      document.querySelector('[data-region="shop-sales-count"]')?.innerText?.trim()
+              || document.querySelector('[class*="wt-text-caption"] span')?.innerText?.trim(),
+    admirers:   document.querySelector('[data-wt-shop-admirers]')?.innerText?.trim(),
+    location:   document.querySelector('[class*="shop-location"]')?.innerText?.trim(),
+    listing_count: document.querySelectorAll('[data-listing-id]').length
+  })
+""")
+```
+
+Pagination for shop listings: Etsy loads more listings via infinite scroll or a "Load more" button. After clicking:
+
+```python
+# Check for pagination or load-more
+load_more = js("document.querySelector('[data-wt-shop-listings-load-more], button[class*=\"load-more\"]')?.href")
+if load_more:
+    goto(load_more)
+    wait_for_load()
+    wait(2)
+# Or: scroll to bottom to trigger infinite scroll
+js("window.scrollTo(0, document.body.scrollHeight)")
+wait(2)
+```
+
+### Pagination (search results)
+
+```python
+# Etsy uses ?page=N — 48 results per page (standard), up to ~250 pages
+next_url = js("document.querySelector('a[data-wt-search-page-next], .wt-action-group a[rel=\"next\"]')?.href")
+if next_url:
+    goto(next_url)
+    wait_for_load()
+    wait(2)
+
+# Or construct directly:
+goto(f"https://www.etsy.com/search?q=handmade+candle&explicit=1&page={page_num}")
+wait_for_load()
+wait(2)
+```
+
+---
+
+## URL patterns
+
+| URL | Purpose | Notes |
+|---|---|---|
+| `/search?q={query}&explicit=1` | Keyword search | 48 results/page |
+| `/search?q={query}&explicit=1&page={n}` | Pagination | n starts at 2 |
+| `/listing/{id}/{slug}` | Listing detail | slug is optional |
+| `/shop/{ShopName}` | Shop homepage | CamelCase, no spaces |
+| `/shop/{ShopName}/listings` | Shop all listings | |
+| `/c/{category}/{subcategory}` | Category browse | e.g. `/c/jewelry/necklaces` |
+| `/market/{keyword}` | Market/tag page | e.g. `/market/handmade_candle` |
+| `openapi.etsy.com/v3/application/listings/active?keywords={query}` | Official API search | requires API key |
+
+---
+
+## Data schema (JSON-LD on listing pages)
+
+When the browser renders a listing, the JSON-LD `Product` schema contains:
+
+```json
+{
+  "@type": "Product",
+  "name": "Handmade Beeswax Taper Candles, Set of 12",
+  "description": "These beautiful hand-dipped candles...",
+  "image": [
+    "https://i.etsystatic.com/12345678/r/il/abc123/1234567890/il_1588xN.1234567890.jpg"
+  ],
+  "brand": { "@type": "Brand", "name": "BeeswaxWonders" },
+  "offers": {
+    "@type": "Offer",
+    "price": "32.00",
+    "priceCurrency": "USD",
+    "availability": "http://schema.org/InStock",
+    "url": "https://www.etsy.com/listing/1234567890/..."
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.9",
+    "reviewCount": "847",
+    "bestRating": "5",
+    "worstRating": "1"
+  }
+}
+```
+
+On search results pages, the JSON-LD `ItemList` schema contains:
+
+```json
+{
+  "@type": "ItemList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "url": "https://www.etsy.com/listing/1234567890/handmade-beeswax-candle",
+      "name": "Handmade Beeswax Taper Candles, Set of 12"
+    }
+  ]
+}
+```
+
+The ItemList only gives URL, position, and name — no price or rating. For full data, follow each URL to the listing detail page.
+
+---
+
+## Official Etsy API v3 (recommended alternative)
+
+The official API at `openapi.etsy.com/v3/` bypasses DataDome entirely. It requires a free API key from [developer.etsy.com](https://developer.etsy.com/) (no payment needed; approval is automatic for basic read access).
+
+### Rate limits
+
+- 10,000 requests/day (free tier)
+- No per-second limit documented; add `time.sleep(0.1)` between requests to be safe
+
+### Key endpoints
+
+```
+GET /application/listings/active
+    ?keywords=handmade+candle
+    &limit=100             (max 100)
+    &offset=0              (for pagination)
+    &sort_on=created|price|updated|score
+    &sort_order=asc|desc
+    &taxonomy_id=1234      (category filter)
+    &min_price=10.00
+    &max_price=50.00
+
+GET /application/listings/{listing_id}
+GET /application/listings/{listing_id}/images
+GET /application/listings/{listing_id}/reviews
+GET /application/shops/{shop_id}
+GET /application/shops/{shop_id}/listings/active
+GET /application/users/{user_id}
+GET /application/seller-taxonomy/nodes   (full category tree)
+```
+
+### Pagination with API
+
+```python
+import json, time
+from helpers import http_get
+
+API_KEY = "your_key_here"
+
+def etsy_search(keywords, max_results=200):
+    results = []
+    offset = 0
+    limit = 100
+    while offset < max_results:
+        url = (f"https://openapi.etsy.com/v3/application/listings/active"
+               f"?keywords={keywords}&limit={limit}&offset={offset}"
+               f"&sort_on=score&sort_order=desc")
+        data = json.loads(http_get(url, headers={"x-api-key": API_KEY}))
+        batch = data.get("results", [])
+        if not batch:
+            break
+        results.extend(batch)
+        offset += limit
+        time.sleep(0.1)
+    return results
+```
+
+---
+
+## Gotchas
+
+- **`http_get` is completely blocked.** All URL types return HTTP 403 with DataDome JS challenge. No header or cookie combination bypasses it. Only a real Chrome browser with JS execution works.
+
+- **DataDome detects TLS fingerprint.** The challenge runs JavaScript at `geo.captcha-delivery.com`. Even curl with perfect browser headers returns 403 — the HTTP library's TLS handshake is fingerprinted.
+
+- **`explicit=1` is required for general search.** Without it, Etsy may filter adult/mature content from results in unexpected ways (like returning fewer results or a different ordering).
+
+- **48 results per search page.** Etsy's standard search returns 48 listings per page (not 25 or 50). The `page=` param is 1-indexed.
+
+- **Listing slug is optional.** `https://www.etsy.com/listing/1234567890` works without the slug; Etsy redirects to the canonical URL with the full slug.
+
+- **Shop names are case-sensitive in URLs.** `/shop/beeswaxwonders` may not redirect to `/shop/BeeswaxWonders` — use the exact casing from the listing's shop link.
+
+- **JSON-LD `brand` vs `seller`.** Etsy's Product schema uses `brand.name` for the shop name on most listing pages, but some pages use `seller.name` instead. Check both.
+
+- **Price in JSON-LD is a string.** `offers.price` is `"25.99"` (string), not a number. Parse with `float()`.
+
+- **API price is in subunits.** API v3 returns `price.amount = 2599` and `price.divisor = 100`, so the actual price is `amount / divisor = 25.99`. Do NOT use `price.amount` directly.
+
+- **robots.txt disallows `/search?*q=`** (empty query) but allows `/search?q={non-empty}` implicitly — however DataDome blocks all of it regardless of what robots.txt says.
+
+- **`/market/` pages are different from `/search`.** Market pages (`/market/handmade_candle`) are tag-based browse pages with a different layout than keyword search results — same DataDome block applies.
+
+- **Etsy API `description` may include HTML entities.** Unescape with `html.unescape()` before displaying.

--- a/domain-skills/eventbrite/scraping.md
+++ b/domain-skills/eventbrite/scraping.md
@@ -1,0 +1,363 @@
+# Eventbrite — Scraping & Data Extraction
+
+`https://www.eventbrite.com` — public event listings and detail pages, no auth required for HTML scraping. REST API requires an OAuth token.
+
+## Do this first
+
+**Use the search listing URL to get event lists — parse the `ItemList` JSON-LD block, not the HTML.**
+
+```python
+import re, json
+
+headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
+html = http_get("https://www.eventbrite.com/d/ca--san-francisco/tech/", headers=headers)
+
+ld_blocks = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+for block in ld_blocks:
+    parsed = json.loads(block)
+    if isinstance(parsed, dict) and parsed.get('@type') == 'ItemList':
+        for item in parsed['itemListElement']:
+            ev = item['item']
+            print(ev['name'], ev['startDate'], ev['url'])
+        break
+# Returns 18–40 events per page
+```
+
+**For a single event, fetch the detail page and extract the `Event` JSON-LD block.** It contains all fields including `offers` (pricing). There is also a richer `__NEXT_DATA__` block if you need venue coordinates, refund policy, or sales status.
+
+## URL structure
+
+### Search / listing pages
+
+```
+https://www.eventbrite.com/d/{location}/{category}/
+https://www.eventbrite.com/d/{location}/{category}/?page=2
+https://www.eventbrite.com/d/{location}/{category}/?start_date=2026-05-01&end_date=2026-05-31
+```
+
+**Location format:** `{state-abbreviation}--{city}` (lowercase, hyphens for spaces)
+- `ca--san-francisco`
+- `ny--new-york`
+- `ca--los-angeles`
+- Use `online` for virtual events
+
+**Category slugs (confirmed working):**
+- `tech` — Technology events
+- `music` — Music
+- `food--drink` — Food & Drink
+- `health` — Health & Wellness
+- `sports--fitness` — Sports & Fitness
+- `arts--entertainment` — Arts & Entertainment
+- `family--education` — Family & Education
+- `business--professional` — Business & Networking
+- `science--tech` — Science & Technology
+- `community--culture` — Community & Culture
+- `networking` — Networking
+- `events` — All events (broadest, returns ~40/page)
+
+**Filter slugs (replace category):**
+- `free--events` — Free events only
+- `events--today` — Today
+- `events--tomorrow` — Tomorrow
+- `events--this-weekend` — This weekend
+
+**Query params:**
+- `?page=N` — Pagination (page 2+ confirmed working, each returns 18–20 events)
+- `?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD` — Date range filter (confirmed, narrows results)
+
+### Event detail pages
+
+```
+https://www.eventbrite.com/e/{slug}-tickets-{event_id}
+```
+
+Example: `https://www.eventbrite.com/e/icontact-the-tactile-tech-opera-tickets-1982861003639`
+
+- `event_id` is a numeric string (10–13 digits)
+- Extract with: `re.search(r'-tickets-(\d+)$', url).group(1)`
+- Extract slug with: `re.search(r'/e/(.+)-tickets-\d+$', url).group(1)`
+
+Other TLDs (`.ca`, `.co.uk`, etc.) use the same structure — event IDs are globally unique across TLDs.
+
+## Listing page: JSON-LD `ItemList` schema
+
+The first `<script type="application/ld+json">` block on any `/d/` page is an `ItemList`. Each `itemListElement` contains:
+
+```json
+{
+  "position": 1,
+  "@type": "ListItem",
+  "item": {
+    "@type": "Event",
+    "name": "iContact the tactile tech opera",
+    "description": "An immersive performance...",
+    "url": "https://www.eventbrite.com/e/icontact-the-tactile-tech-opera-tickets-1982861003639",
+    "image": "https://img.evbuc.com/...",
+    "startDate": "2026-06-21",
+    "endDate": "2026-06-21",
+    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+    "location": {
+      "@type": "Place",
+      "name": "Little Boxes Theater",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "San Francisco",
+        "addressRegion": "CA",
+        "addressCountry": "US",
+        "streetAddress": "94107 1661 Tennessee Street",
+        "postalCode": "94107"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": "37.7508806",
+        "longitude": "-122.3881427"
+      }
+    }
+  }
+}
+```
+
+Note: listing-page items do NOT include `offers` (pricing) or `organizer`. Fetch the detail page for those.
+
+The second JSON-LD block on listing pages is a `BreadcrumbList` (skip it).
+
+## Detail page: JSON-LD `Event` schema
+
+The detail page has 4 JSON-LD blocks. The `Event` (or `BusinessEvent`) block is the second one and contains the full schema:
+
+```python
+import re, json
+
+headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
+html = http_get("https://www.eventbrite.com/e/icontact-the-tactile-tech-opera-tickets-1982861003639", headers=headers)
+
+ld_blocks = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+event_data = None
+for block in ld_blocks:
+    parsed = json.loads(block)
+    if isinstance(parsed, dict) and parsed.get('@type') in ('Event', 'BusinessEvent', 'MusicEvent', 'EducationEvent'):
+        event_data = parsed
+        break
+
+print(event_data['name'])              # "iContact the tactile tech opera"
+print(event_data['startDate'])         # "2026-06-21T17:05:00-07:00"  (ISO 8601 with TZ)
+print(event_data['endDate'])           # "2026-06-21T20:08:00-07:00"
+print(event_data['eventStatus'])       # "https://schema.org/EventScheduled"
+print(event_data['eventAttendanceMode'])  # "https://schema.org/OfflineEventAttendanceMode"
+print(event_data['location']['name'])  # "Little Boxes Theater"
+print(event_data['location']['address']['streetAddress'])   # "94107 1661 Tennessee Street, San Francisco, CA 94107"
+print(event_data['organizer']['name'])  # "Beth McNamara"
+print(event_data['organizer']['url'])   # "https://www.eventbrite.com/o/beth-mcnamara-120755148166"
+```
+
+Full confirmed schema on detail page:
+```
+name               str     Event title
+description        str     Short summary
+url                str     Canonical event URL
+image              str     Event banner image URL
+startDate          str     ISO 8601 with timezone offset
+endDate            str     ISO 8601 with timezone offset
+eventStatus        str     URI: EventScheduled / EventCancelled / EventPostponed
+eventAttendanceMode str    URI: OfflineEventAttendanceMode / OnlineEventAttendanceMode / MixedEventAttendanceMode
+location.@type     str     "Place" (in-person) or "VirtualLocation" (online)
+location.name      str     Venue name
+location.address.streetAddress   str
+location.address.addressLocality str    City
+location.address.addressRegion   str    State abbreviation
+location.address.addressCountry  str    Country code
+organizer.name     str     Organizer display name
+organizer.url      str     Organizer profile URL
+offers             list    AggregateOffer object(s)
+```
+
+### Offers / pricing
+
+```python
+offers = event_data.get('offers', [])
+if offers:
+    offer = offers[0]   # always a list; typically one AggregateOffer
+    print(offer['@type'])           # "AggregateOffer"
+    print(offer['lowPrice'])        # "50.0"  (string, not float)
+    print(offer['highPrice'])       # "50.0"
+    print(offer['priceCurrency'])   # "USD"
+    print(offer['availability'])    # "InStock" / "SoldOut"
+    print(offer['availabilityStarts'])   # ISO 8601 UTC
+    print(offer['availabilityEnds'])     # ISO 8601 UTC
+
+# Free events: lowPrice="0.0", highPrice="0.0"
+# Free check: float(offer['lowPrice']) == 0.0
+```
+
+`@type` on the event itself varies by format (all scrape identically):
+- `Event` — general
+- `BusinessEvent` — networking, professional
+- `MusicEvent` — concerts
+- `EducationEvent` — classes, workshops
+
+## Detail page: `__NEXT_DATA__` (richer structured data)
+
+Every event detail page embeds a `<script id="__NEXT_DATA__">` block with additional fields not in JSON-LD:
+
+```python
+import re, json
+
+nextjs = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+nd = json.loads(nextjs.group(1))
+context = nd['props']['pageProps']['context']
+
+bi = context['basicInfo']
+print(bi['id'])               # "1982861003639"  (event ID string)
+print(bi['name'])             # event title
+print(bi['isFree'])           # bool
+print(bi['isOnline'])         # bool
+print(bi['currency'])         # "USD"
+print(bi['status'])           # "live" / "completed" / "canceled"
+print(bi['organizationId'])   # numeric string
+print(bi['formatId'])         # numeric string (event format category)
+print(bi['isProtected'])      # bool — password-protected events
+print(bi['isSeries'])         # bool — recurring series
+print(bi['created'])          # ISO 8601 UTC creation timestamp
+
+# Venue with coordinates
+venue = bi['venue']
+print(venue['name'])                              # "Little Boxes Theater"
+print(venue['address']['city'])                   # "San Francisco"
+print(venue['address']['region'])                 # "CA"
+print(venue['address']['latitude'])               # "37.7508806"
+print(venue['address']['longitude'])              # "-122.3881427"
+print(venue['address']['localizedMultiLineAddressDisplay'])  # list of strings
+
+# Organizer details
+org = bi['organizer']
+print(org['name'])            # "Beth McNamara"
+print(org['url'])             # organizer profile URL
+print(org['numEvents'])       # int
+print(org['verified'])        # bool
+
+# Sales status
+ss = context['salesStatus']
+print(ss['salesStatus'])      # "on_sale" / "sold_out" / "sales_ended"
+print(ss['startSalesDate']['local'])   # local datetime string
+
+# Good to know
+gtk = context['goodToKnow']['highlights']
+print(gtk['ageRestriction'])          # "18+" or null
+print(gtk['durationInMinutes'])       # int (e.g. 183)
+print(gtk['doorTime'])                # local datetime string or null
+print(gtk['locationType'])            # "in_person" or "online"
+
+# Refund policy
+refund = context['goodToKnow']['refundPolicy']
+print(refund['policyType'])           # "custom" / "no_refunds" / "standard"
+print(refund['isRefundAllowed'])      # bool
+print(refund['validDays'])            # int or null
+
+# Full event description (HTML)
+for module in context['structuredContent']['modules']:
+    if module['type'] == 'text':
+        print(module['text'])         # raw HTML, may need BeautifulSoup to strip tags
+```
+
+## Complete workflow: scrape events from a category
+
+```python
+import re, json
+
+def get_events_from_listing(location, category, page=1):
+    """Returns list of event dicts with name, url, startDate, endDate, location."""
+    headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
+    url = f"https://www.eventbrite.com/d/{location}/{category}/?page={page}"
+    html = http_get(url, headers=headers)
+    ld_blocks = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    for block in ld_blocks:
+        parsed = json.loads(block)
+        if isinstance(parsed, dict) and parsed.get('@type') == 'ItemList':
+            return [item['item'] for item in parsed.get('itemListElement', [])]
+    return []
+
+def get_event_detail(event_url):
+    """Returns full Event JSON-LD + NEXT_DATA context for a single event."""
+    headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
+    html = http_get(event_url, headers=headers)
+
+    # JSON-LD Event block
+    ld_blocks = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    event_ld = None
+    for block in ld_blocks:
+        parsed = json.loads(block)
+        if isinstance(parsed, dict) and parsed.get('@type') in ('Event', 'BusinessEvent', 'MusicEvent', 'EducationEvent'):
+            event_ld = parsed
+            break
+
+    # NEXT_DATA context
+    nextjs = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    context = None
+    if nextjs:
+        nd = json.loads(nextjs.group(1))
+        context = nd['props']['pageProps']['context']
+
+    return event_ld, context
+
+# Usage
+events = get_events_from_listing("ca--san-francisco", "tech", page=1)
+print(f"Found {len(events)} events")  # 18–20 typical
+
+for ev in events[:3]:
+    print(ev['name'], ev['startDate'], ev['url'])
+
+# Deep-fetch one event
+ld, ctx = get_event_detail(events[0]['url'])
+if ld and ld.get('offers'):
+    price = float(ld['offers'][0]['lowPrice'])
+    currency = ld['offers'][0]['priceCurrency']
+    print(f"Price: {price} {currency}")   # 0.0 USD (free) or e.g. 50.0 USD
+```
+
+## Public API: requires auth
+
+The Eventbrite REST API (`https://www.eventbriteapi.com/v3/`) requires an OAuth token for all endpoints:
+
+- `GET /v3/events/{id}/` — HTTP 401 without auth
+- `GET /v3/events/search/` — HTTP 404 (endpoint changed; auth also required)
+
+**Use HTML scraping instead** — the JSON-LD and `__NEXT_DATA__` data is equivalent to the API response and requires no credentials.
+
+If you have a token (`EVENTBRITE_TOKEN`):
+```python
+import os
+token = os.environ.get('EVENTBRITE_TOKEN')
+headers = {
+    "User-Agent": "Mozilla/5.0",
+    "Authorization": f"Bearer {token}"
+}
+data = json.loads(http_get(f"https://www.eventbriteapi.com/v3/events/{event_id}/", headers=headers))
+```
+
+## Gotchas
+
+- **Event URLs in the HTML use relative `/e/` paths, not absolute URLs** — Search listing HTML contains `/e/slug-tickets-id?aff=...` relative paths (with tracking params). Extract event URLs from the JSON-LD `ItemList` instead — they are absolute, clean URLs without tracking params.
+
+- **`re.findall(r'href="https://www.eventbrite.com/e/...')` returns 0 results** — Confirmed: event cards in the HTML do not have `https://www.eventbrite.com/e/` in href attributes. Use JSON-LD extraction only.
+
+- **`__SERVER_DATA__` does not exist** — Both search and detail pages were checked. There is no `window.__SERVER_DATA__` or `window.__redux_state__`. The embedded data is in `<script id="__NEXT_DATA__">` (detail pages only) and JSON-LD (both).
+
+- **Search listing pages have no `__NEXT_DATA__`** — Only event detail pages (`/e/` URLs) have the `__NEXT_DATA__` block. Listing pages (`/d/` URLs) have JSON-LD only.
+
+- **`@type` varies by event format** — Don't filter JSON-LD blocks with `parsed['@type'] == 'Event'` alone. Check for any of: `Event`, `BusinessEvent`, `MusicEvent`, `EducationEvent`. They have identical field structure.
+
+- **`startDate` on listing vs. detail pages differs in precision** — Listing page items show date-only (`"2026-06-21"`). Detail page Event block shows full ISO 8601 with timezone offset (`"2026-06-21T17:05:00-07:00"`). Use detail page for scheduling tasks.
+
+- **`offers` is absent on listing page items** — The `ItemList` does not include pricing. Fetch the detail page for `offers.lowPrice` / `offers.highPrice`.
+
+- **Free events have `lowPrice: "0.0"` and `highPrice: "0.0"`** — Not null or missing. Check `float(offers[0]['lowPrice']) == 0.0` or use `basicInfo.isFree` from `__NEXT_DATA__`.
+
+- **`offers` prices are strings, not floats** — `"50.0"` not `50.0`. Cast with `float(offer['lowPrice'])` before arithmetic.
+
+- **Page size is ~18–20 events per page** — Not a fixed 20. Some pages return fewer. Don't assume page N is empty because it returned < 20.
+
+- **Date filter works but can still return events outside range** — The `?start_date=` / `?end_date=` params narrow results but are not strict; always validate `startDate` from the returned data.
+
+- **Eventbrite CA / UK / AU use different TLDs** — Online event listings may surface `eventbrite.ca`, `eventbrite.co.uk` URLs. The `/e/` structure and JSON-LD schema are identical. Fetch them with the same code.
+
+- **No rate limiting observed** — 8 sequential HTTP requests across 4 pages completed without errors or blocks (avg ~1.5s each). No delay needed for light workloads, but be reasonable for bulk scraping.


### PR DESCRIPTION
## Summary
- **Booking.com**: AWS WAF blocks all http_get; XML sitemaps accessible via Googlebot UA (3.5M+ hotel URLs); GraphQL endpoint at `/dml/graphql` works but needs session token for real data; browser CDP uses `[data-testid="property-card"]` + 3s hydration wait
- **Eventbrite**: JSON-LD `ItemList` on search pages (18-40 events/page); `__NEXT_DATA__` on detail pages for venue/pricing; public API returns 401 without Bearer token; `?page=N` pagination works
- **Etsy**: DataDome JS challenge blocks all http_get (TLS fingerprint required); browser CDP works; official API v3 available with free key from developer.etsy.com; price in subunits (divide by 100)
- **eBay**: http_get works for first 5-10 requests then "Pardon Our Interruption" (clears after 60-120s); JSON-LD `Product` schema on detail pages; Finding/Browse APIs require OAuth; `data-listingid` selector for search cards
- **CoinGecko**: Free API works, sleep 5s between calls (429 at call 3-4 with no delay); use `/coins/list` for ID-to-symbol mapping (never use symbol directly); `/coins/{id}/history` is Pro-only (returns 401 on free tier)

## Test plan
- [ ] Booking.com XML sitemap returns hotel URL list
- [ ] Eventbrite JSON-LD extraction returns event list
- [ ] Etsy browser CDP returns search results
- [ ] eBay search returns listings with data-listingid
- [ ] CoinGecko price endpoint returns BTC/ETH prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added domain scraping guides for Booking.com, Eventbrite, Etsy, eBay, and CoinGecko to standardize extraction strategies, blockers, and reliable selectors/APIs. This enables clear do/don’t guidance per domain and reduces trial-and-error in new tasks.

- **New Features**
  - Booking.com: `http_get` blocked by AWS WAF; use XML sitemaps with Googlebot UA, probe `https://www.booking.com/dml/graphql`, and extract via browser with `[data-testid="property-card"]` after a 2–3s hydration wait.
  - Eventbrite: Parse `ItemList` JSON-LD on `/d/` search pages; use `Event` JSON-LD and `__NEXT_DATA__` on detail pages; `?page=` and date filters supported; public API requires OAuth.
  - Etsy: `http_get` blocked by DataDome; use browser CDP for HTML; official API v3 available via `openapi.etsy.com` (price in subunits).
  - eBay: `http_get` works until “Pardon Our Interruption” after ~5–10 rapid requests; parse search cards via `data-listingid` and item pages via JSON-LD `Product`; paginate with `_pgn`.
  - CoinGecko: Free REST API usable via `http_get`; add ~5s delay to avoid 429s; use coin IDs from `/coins/list` (not symbols); some history endpoints are Pro-only.

<sup>Written for commit ac15bc03211fccca60770e7aeaad85b69e4994f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

