### PR TITLE
Add domain skills: SEC EDGAR, Coursera, Goodreads, DuckDuckGo, TrustPilot

### DIFF
--- a/domain-skills/coursera/scraping.md
+++ b/domain-skills/coursera/scraping.md
@@ -1,0 +1,360 @@
+# Coursera — Course & Catalog Data Extraction
+
+Field-tested against coursera.org and api.coursera.org on 2026-04-18.
+No authentication required for the public catalog API.
+
+## TL;DR — Fastest Approach
+
+Use `http_get` against `api.coursera.org`. The public REST API returns clean JSON with no
+auth, no bot-detection, and sub-600ms latency. Use `q=search` with a keyword
+only when you need full-text search (requires a browser POST workaround — see below).
+For bulk enumeration, iterate the catalog list with `start` pagination.
+
+---
+
+## 1. Catalog List (http_get — always works)
+
+The default list query (`q=list` implied) returns ALL courses in Coursera's catalog —
+20,659 as of the test date.
+
+```python
+from helpers import http_get
+import json
+
+resp = http_get(
+    "https://api.coursera.org/api/courses.v1"
+    "?fields=name,slug,description,primaryLanguages,workload,"
+    "partnerIds,courseType,instructorIds,domainTypes,photoUrl,certificates"
+    "&limit=100&start=0"
+)
+data = json.loads(resp)
+courses = data["elements"]   # list of dicts
+next_start = data["paging"].get("next")   # e.g. "100", None when exhausted
+total = data["paging"].get("total")       # 20659
+```
+
+### Response structure (confirmed field names)
+
+```json
+{
+  "courseType": "v2.ondemand",
+  "description": "Gamification is the application of game elements...",
+  "domainTypes": [
+    {"domainId": "computer-science", "subdomainId": "design-and-product"},
+    {"domainId": "business",         "subdomainId": "marketing"}
+  ],
+  "photoUrl": "https://d3njjcbhbojbot.cloudfront.net/api/utilities/v1/imageproxy/https://coursera-course-photos.s3.amazonaws.com/...",
+  "id":             "69Bku0KoEeWZtA4u62x6lQ",
+  "slug":           "gamification",
+  "instructorIds":  ["226710"],
+  "specializations": [],
+  "workload":       "4-8 hours/week",
+  "primaryLanguages": ["en"],
+  "partnerIds":     ["6"],
+  "certificates":   ["VerifiedCert"],
+  "name":           "Gamification"
+}
+```
+
+Field notes:
+- `id` — opaque base64-ish string, stable identifier. Use for batch lookups and linking.
+- `slug` — URL-safe identifier. Course page: `https://www.coursera.org/learn/{slug}`
+- `courseType` — always `"v2.ondemand"` for self-paced courses in practice.
+- `workload` — free-text string, e.g. `"4-8 hours/week"`, `"1 hour 30 minutes"`, `"4 weeks of study, 1-2 hours/week"`. Not normalized.
+- `primaryLanguages` — ISO 639-1 list, e.g. `["en"]`, `["fr"]`.
+- `partnerIds` — list of partner (university/org) IDs. Join to `partners.v1` by id.
+- `instructorIds` — list of instructor IDs. Join to `instructors.v1` by id.
+- `domainTypes` — list of `{domainId, subdomainId}` objects. Domain IDs include `"data-science"`, `"computer-science"`, `"business"`, `"information-technology"`.
+- `certificates` — list of cert types, typically `["VerifiedCert"]`.
+- `photoUrl` — direct CDN URL to course image. Works without auth.
+- `specializations` — list of specialization IDs this course belongs to (often empty; not always populated here — use `onDemandSpecializations.v1` instead).
+- `previewLink` — field exists but was empty in all tested records; skip it.
+- `avgRating` — field does NOT appear in public API responses; not available.
+
+### Pagination
+
+```python
+def iter_all_courses(fields=None, page_size=100):
+    base_fields = "name,slug,description,primaryLanguages,workload,partnerIds,courseType,domainTypes,photoUrl"
+    if fields:
+        base_fields = fields
+    start = 0
+    while True:
+        url = (
+            f"https://api.coursera.org/api/courses.v1"
+            f"?fields={base_fields}&limit={page_size}&start={start}"
+        )
+        data = json.loads(http_get(url))
+        yield from data["elements"]
+        nxt = data["paging"].get("next")
+        if nxt is None:
+            break
+        start = int(nxt)
+```
+
+- `paging.next` is a string offset (e.g. `"100"`), or absent when exhausted.
+- `paging.total` is present on the first page (e.g. `20659`) but absent on subsequent pages.
+- `limit` up to at least 1000 works (tested: 1000 returned 1000 items). Use 100–500 for safe batches.
+
+---
+
+## 2. Partners API (http_get — works)
+
+422 partners (universities, companies) as of test date.
+
+```python
+resp = http_get(
+    "https://api.coursera.org/api/partners.v1"
+    "?fields=name,squareLogo,description,shortName&limit=50&start=0"
+)
+data = json.loads(resp)
+partners = data["elements"]
+# paging.next and paging.total follow same structure as courses
+```
+
+### Partner record structure
+
+```json
+{
+  "id":          "6",
+  "name":        "University of Pennsylvania",
+  "shortName":   "penn",
+  "description": "The University of Pennsylvania (commonly referred to as Penn)...",
+  "squareLogo":  "http://coursera-university-assets.s3.amazonaws.com/.../logo.png"
+}
+```
+
+### Partner by ID (with courseIds)
+
+```python
+resp = http_get(
+    "https://api.coursera.org/api/partners.v1"
+    "?ids=6&fields=name,squareLogo,description,shortName,courseIds"
+)
+data = json.loads(resp)
+partner = data["elements"][0]
+# partner["courseIds"] is a list of course ID strings (150+ for large universities)
+```
+
+---
+
+## 3. Specializations API (http_get — works)
+
+```python
+resp = http_get(
+    "https://api.coursera.org/api/onDemandSpecializations.v1"
+    "?fields=name,slug,description,partnerIds,courseIds,tagline&limit=100&start=0"
+)
+data = json.loads(resp)
+specs = data["elements"]
+```
+
+### Specialization record structure
+
+```json
+{
+  "id":          "AbCdEfGhIjKl",
+  "name":        "SIEM Splunk",
+  "slug":        "siem-splunk",
+  "tagline":     "Learn SIEM fundamentals with Splunk",
+  "description": "Course Overview:\n\nIn the \"SIEM Splunk\" specialization course...",
+  "partnerIds":  ["1441"],
+  "courseIds":   ["pu2XQCuEEe6qTBJCf71DPw", "Xc46mVFkEe6a4wrvTcwXPw", "YH1ok1FXEe62cBI5JZME2w"]
+}
+```
+
+Note: Specializations paging does NOT include `paging.total` — iterate until `paging.next` is absent.
+
+---
+
+## 4. Instructors API (http_get — works)
+
+Only useful for lookups by ID (from course `instructorIds`). The plain list endpoint
+returns many empty records (empty name/bio).
+
+```python
+# Lookup specific instructors by ID
+resp = http_get(
+    "https://api.coursera.org/api/instructors.v1"
+    "?ids=226710&fields=fullName,bio,department,title,photo"
+)
+data = json.loads(resp)
+instructor = data["elements"][0]
+```
+
+### Instructor record structure
+
+```json
+{
+  "id":         "226710",
+  "fullName":   "Kevin Werbach",
+  "title":      "Professor of Legal Studies and Business Ethics",
+  "department": "Legal Studies and Business Ethics",
+  "bio":        "Kevin Werbach is professor of Legal Studies...",
+  "photo":      "https://d3njjcbhbojbot.cloudfront.net/api/utilities/v1/imageproxy/..."
+}
+```
+
+---
+
+## 5. Batch ID Lookup
+
+Fetch multiple courses (or partners/instructors) in one request by passing a comma-separated `ids` list:
+
+```python
+ids = ",".join(["69Bku0KoEeWZtA4u62x6lQ", "hOzhxVNuEfCW8Q55q1kSNQ", "0HiU7Oe4EeWTAQ4yevf_oQ"])
+resp = http_get(
+    f"https://api.coursera.org/api/courses.v1"
+    f"?ids={ids}&fields=name,slug,description,primaryLanguages,workload,partnerIds"
+)
+data = json.loads(resp)
+# data["elements"] has exactly the courses you asked for
+```
+
+No observed limit on the number of IDs per request in testing (tried up to 3).
+
+---
+
+## 6. Keyword Search — BLOCKED for GET (405)
+
+`q=search&query=...` returns **HTTP 405 Method Not Allowed** on GET.
+This applies to all three resource types:
+- `courses.v1?q=search&query=python` → 405
+- `onDemandSpecializations.v1?q=search&query=data+science` → 405
+- `partners.v1?q=search&query=stanford` → 405
+
+The search endpoint requires a POST request (Coursera's public Autocomplete/Search
+service). For keyword-based discovery without a browser, use the catalog list and filter
+client-side, or use the browser approach below.
+
+### Browser fallback for keyword search
+
+```python
+new_tab("https://www.coursera.org/search?query=machine+learning")
+wait_for_load()
+wait(3)  # Results load asynchronously via React
+screenshot()
+```
+
+Note: The search results page (`/search?query=...`) is a client-rendered React app. The
+HTML returned by `http_get` does NOT contain course cards — it's a bare shell with no
+`__NEXT_DATA__` or embedded JSON. A live browser is required to see rendered results.
+
+---
+
+## 7. Course Detail HTML Page (http_get — works, limited data)
+
+```python
+html = http_get("https://www.coursera.org/learn/machine-learning")
+# html is ~980KB of server-rendered HTML (no NEXT_DATA, no Apollo state)
+```
+
+The course detail page IS served as full HTML (no JS-gate), but contains very
+little machine-readable course data. What you can extract:
+
+```python
+import re, json
+
+# Page title (includes course name)
+title = re.search(r'<title[^>]*>(.*?)</title>', html).group(1)
+# "Supervised Machine Learning: Regression and Classification  | Coursera"
+
+# JSON-LD blocks (2 present)
+jsonld_blocks = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+# Block 0: FAQPage schema (common Q&A about how courses work)
+# Block 1: BreadcrumbList (category path, e.g. Browse > Data Science > Machine Learning)
+faq   = json.loads(jsonld_blocks[0])   # {"@type": "FAQPage", "mainEntity": [...]}
+crumb = json.loads(jsonld_blocks[1])   # {"@type": "BreadcrumbList", "itemListElement": [...]}
+
+# Extract breadcrumb categories
+categories = [item["item"]["name"] for item in crumb["@graph"][0]["itemListElement"]]
+# e.g. ["Browse", "Data Science", "Machine Learning"]
+```
+
+The HTML does NOT embed: description, rating, instructor names, enrollment count,
+price, or any course-specific metadata as machine-readable fields.
+Use the API (`courses.v1?ids=...`) to get those from the slug.
+
+### Slug-to-ID lookup pattern
+
+```python
+# Get course data from slug (need ID first — get it from catalog or search)
+# Pattern: enumerate catalog, match by slug
+resp = http_get("https://api.coursera.org/api/courses.v1?fields=name,slug,description&limit=100&start=0")
+data = json.loads(resp)
+by_slug = {el["slug"]: el for el in data["elements"]}
+course = by_slug.get("machine-learning")
+```
+
+---
+
+## Endpoints Summary
+
+| Endpoint | Method | Result |
+|---|---|---|
+| `courses.v1` (list) | GET | 200 OK — full catalog, 20,659 courses |
+| `courses.v1?ids=...` | GET | 200 OK — batch lookup by ID |
+| `courses.v1?q=search&query=...` | GET | **405 Method Not Allowed** |
+| `partners.v1` (list) | GET | 200 OK — 422 partners |
+| `partners.v1?ids=...` | GET | 200 OK — with courseIds |
+| `partners.v1?q=search&query=...` | GET | **405 Method Not Allowed** |
+| `onDemandSpecializations.v1` (list) | GET | 200 OK — paginated (no total) |
+| `onDemandSpecializations.v1?q=search&query=...` | GET | **405 Method Not Allowed** |
+| `instructors.v1?ids=...` | GET | 200 OK — rich records by ID |
+| `instructors.v1` (list) | GET | 200 OK — mostly empty records |
+| `degrees.v1` | GET | 403 Forbidden |
+| `/search?query=...` page HTML | GET | 200 OK — React shell only, no data |
+| `/learn/{slug}` page HTML | GET | 200 OK — HTML with JSON-LD breadcrumb only |
+
+---
+
+## Rate Limits
+
+No rate limiting observed in testing:
+- 5 consecutive requests with no delay: all succeeded, avg 0.55s each.
+- No `X-RateLimit-*` or `Retry-After` headers in responses.
+- No auth headers needed for any working endpoint.
+
+Response headers that are present: `X-Coursera-Request-Id`, `X-Coursera-Trace-Id-Hex`,
+`x-envoy-upstream-service-time`. No rate-limit indicators.
+
+Use a small delay (0.5s) between requests if doing bulk enumeration of the full 20K+
+catalog as a courtesy, but no hard cap was observed.
+
+---
+
+## Gotchas
+
+- **`q=search` is POST-only**: All three resource types (courses, specializations,
+  partners) return 405 on GET when `q=search` is added. There is no documented public
+  POST endpoint. For keyword filtering, enumerate the catalog and filter client-side.
+
+- **`paging.total` absent after page 1**: Only the first page response includes
+  `paging.total`. Subsequent pages have only `paging.next`. Check for the `"next"` key
+  being absent to detect end-of-list.
+
+- **Specializations never include `paging.total`**: The `onDemandSpecializations.v1`
+  endpoint never returns `paging.total` in any page. Iterate until `"next"` is absent.
+
+- **`workload` is free-text, unnormalized**: Values include `"4-8 hours/week"`,
+  `"1 hour 30 minutes"`, `"4 weeks of study, 1-2 hours/week"`. Do not parse as a number
+  without normalization logic.
+
+- **`instructors.v1` list returns empty records**: The plain list endpoint returns many
+  instructors with empty `fullName`, `bio`, `title`. Always look up by `ids=` using
+  IDs from course records.
+
+- **`degrees.v1` is 403**: Degree programs are not accessible via the public API.
+
+- **HTML pages contain no embedded course data**: Both the search page and the course
+  detail page are React-rendered. `http_get` on `/search?query=...` returns an HTML
+  shell with no course listings. `http_get` on `/learn/{slug}` returns HTML with only
+  a FAQ JSON-LD and a breadcrumb JSON-LD — no course description, rating, price, or
+  enrollment data as machine-readable fields.
+
+- **`linked` resources don't populate**: Passing `includes=partners.v1` to the courses
+  endpoint returns an empty `linked: {}` object. Cross-resource joins require separate
+  requests by IDs.
+
+- **`previewLink` and `avgRating` fields**: These field names are accepted without error
+  but return no data in the response objects. Do not request them.

--- a/domain-skills/duckduckgo/scraping.md
+++ b/domain-skills/duckduckgo/scraping.md
@@ -1,0 +1,349 @@
+# DuckDuckGo — Instant Answer API
+
+`https://api.duckduckgo.com` — completely public, no auth, no API key. Returns Wikipedia-sourced abstracts, infoboxes, and instant answers for well-known entities, calculations, and utility queries. Not a search engine — it does not return a list of web results for arbitrary queries.
+
+## Do this first: pick your query type
+
+| Query type | Example | `Type` | Returns |
+|------------|---------|--------|---------|
+| Named entity (specific) | `apple inc` | A | Full abstract + infobox |
+| Ambiguous term | `python` | D | Disambiguation list in `RelatedTopics` |
+| Instant answer | `random number` | E | Direct answer in `Answer` field |
+| No match | `how to cook pasta` | `""` | All fields empty |
+
+**Use `skip_disambig=1` and `no_html=1` in almost every call.** `skip_disambig=1` upgrades D→A when there's an obvious primary result (e.g., `elon musk` goes from disambiguation to full article). `no_html=1` removes `<b>` tags from the `Answer` field and strips bold markup from `Result` HTML strings.
+
+**Never use a browser.** Everything is a single `http_get` JSON call, 183–320ms.
+
+---
+
+## Fastest path: entity lookup
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+def ddg_instant(query: str) -> dict:
+    q = urllib.parse.quote(query)
+    raw = http_get(
+        f"https://api.duckduckgo.com/?q={q}&format=json&no_html=1&skip_disambig=1"
+    )
+    return json.loads(raw)
+
+# Entity with Wikipedia abstract + infobox
+data = ddg_instant("openai")
+# data['Type'] == 'A'
+print(data['Heading'])        # 'OpenAI'
+print(data['AbstractText'])   # 'OpenAI is an American artificial intelligence research...'
+print(data['AbstractURL'])    # 'https://en.wikipedia.org/wiki/OpenAI'
+print(data['OfficialWebsite'])# 'https://openai.com/'
+print(data['Entity'])         # 'company'
+
+# Person lookup (skip_disambig resolves D→A automatically)
+data = ddg_instant("elon musk")
+print(data['Type'])           # 'A' (was 'D' without skip_disambig)
+print(data['AbstractText'][:100])  # 'Elon Reeve Musk is a businessman...'
+print(data['Image'])          # '/i/be2a8644.jpg' — prepend https://duckduckgo.com
+
+# Full image URL
+img_url = f"https://duckduckgo.com{data['Image']}" if data['Image'] else None
+```
+
+---
+
+## Instant answers (Type = E)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+def ddg_answer(query: str) -> tuple[str, str]:
+    """Returns (answer_text, answer_type). answer_text is '' if no result."""
+    q = urllib.parse.quote(query)
+    raw = http_get(
+        f"https://api.duckduckgo.com/?q={q}&format=json&no_html=1&no_redirect=1"
+    )
+    data = json.loads(raw)
+    ans = data.get('Answer', '')
+    # Answer can be a dict when it's a widget (calculator, converter) — only string Answers are usable
+    return (ans if isinstance(ans, str) else '', data.get('AnswerType', ''))
+
+# Confirmed working instant answers:
+text, kind = ddg_answer("random number")
+# text='0.245013228691281 (random number)', kind='rand'
+
+text, kind = ddg_answer("generate password")
+# text='ZCsbe8iY (random password)', kind='pw'
+
+text, kind = ddg_answer("ip address")
+# text='Your IP address is 73.158.74.222 in San Francisco, California, United States (94121)', kind='ip'
+
+text, kind = ddg_answer("base64 encode hello")
+# text='Base64 encode d: aGVsbG8=', kind='base64_conversion'
+
+text, kind = ddg_answer("md5 hash hello")
+# text='5d41402abc4b2a76b9719d911017c592', kind='md5'
+
+text, kind = ddg_answer("pi")
+# text='3.14159', kind='constants'
+
+text, kind = ddg_answer("today date")
+# text='\nS M T W T F S      April 2026\n...|18|...', kind='calendar'
+
+text, kind = ddg_answer("timer 5 minutes")
+# text='300', kind='timer'   — returns raw seconds
+
+text, kind = ddg_answer("lorem ipsum")
+# text='Ea hic quia corporis. Minus consequuntur...', kind='lorem_ipsum'
+
+# Color lookup — must URL-encode the # sign:
+text, kind = ddg_answer("color #FF5733")
+# text='Hex: #FF5733 ~ RGBA(255, 87, 51, 1) ~ RGB(100%, 34%, 20%) ~ HSL(11, 100%, 60%) ~ CMYB(0%, 66%, 80%, ...', kind='color_code'
+```
+
+**Widget answers return a dict, not a string** — `sqrt(144)`, `1 mile in km`, `100 USD in EUR`, and `stopwatch` all return `Answer` as a dict like `{'from': 'calculator', 'id': 'calculator', 'result': '', ...}`. The `result` key is empty — the actual computation happens client-side in a JS widget. Treat dict `Answer` values as "not usable via API".
+
+---
+
+## Full response schema
+
+Every response has exactly these 21 top-level keys (all always present):
+
+```
+Abstract         # same as AbstractText (redundant, use AbstractText)
+AbstractSource   # "Wikipedia" when present, "" otherwise
+AbstractText     # Wikipedia-sourced summary paragraph (up to ~1000 chars)
+AbstractURL      # Wikipedia article URL
+Answer           # string or dict — instant answer result (see above)
+AnswerType       # string key identifying the answer plugin (e.g. "rand", "ip")
+Definition       # almost always "" — not reliably populated
+DefinitionSource # almost always ""
+DefinitionURL    # almost always ""
+Entity           # entity type: "company", "programming language", "person", etc.
+Heading          # entity display name
+Image            # relative path e.g. "/i/4d83768732377cf3.png" — prepend https://duckduckgo.com
+ImageHeight      # int or "" when no image
+ImageIsLogo      # 0 or 1 integer when image present; "" otherwise
+ImageWidth       # int or "" when no image
+Infobox          # dict with "content" and "meta" lists, or "" if no infobox
+OfficialDomain   # e.g. "openai.com" — only for entities with a known website
+OfficialWebsite  # e.g. "https://openai.com/" — only when DDG knows it
+Redirect         # target URL when query is a bang (e.g. !g python) with no_redirect=1
+RelatedTopics    # list — see below
+Results          # list — official site links (usually 0 or 1 item)
+Type             # "A", "D", "C", "N", "E", or ""
+meta             # API plugin metadata — rarely needed
+```
+
+### `RelatedTopics` item structure
+
+Each item is one of two shapes:
+
+**Plain topic** (the common case):
+```python
+{
+    "FirstURL": "https://duckduckgo.com/Deep_learning",
+    "Icon": {"Height": "", "URL": "/i/abc123.png", "Width": ""},  # URL often ""
+    "Result": "<a href=\"...\">Deep learning</a>— branch of ML...",  # HTML
+    "Text": "Deep learning — branch of ML concerned with artificial neural networks."
+}
+```
+
+**Section** (disambiguation pages only — when `Type` is `D` without `skip_disambig`):
+```python
+{
+    "Name": "Science & Technology",   # section heading
+    "Topics": [                        # list of plain topic objects
+        {"FirstURL": "...", "Icon": {...}, "Result": "...", "Text": "..."},
+        ...
+    ]
+}
+```
+
+For A-type results, `RelatedTopics` are Wikipedia category links (e.g. `"American aerospace engineers"` pointing to `https://duckduckgo.com/c/...`). These are not web search results — they are DDG topic pages.
+
+### `Results` item structure
+
+Usually 0 or 1 item. When present, it's the official website:
+```python
+{
+    "FirstURL": "https://www.apple.com/",
+    "Icon": {"Height": 16, "URL": "/i/apple.com.ico", "Width": 16},
+    "Result": "<a href=\"https://www.apple.com/\">Official site</a>...",
+    "Text": "Official site"
+}
+```
+Icon URLs in `Results` are relative — prepend `https://duckduckgo.com`.
+
+### `Infobox` structure
+
+```python
+ib = data['Infobox']  # dict or "" (empty string when absent)
+if isinstance(ib, dict):
+    content = ib['content']  # list of structured fields
+    # Each content item:
+    # {"data_type": "string", "label": "Founded", "value": "December 08, 2015"}
+    # {"data_type": "string", "label": "Founders", "value": "Sam Altman, Elon Musk, ..."}
+    
+    meta = ib['meta']    # list of metadata items
+    # {"data_type": "string", "label": "article_title", "value": "OpenAI"}
+    # {"data_type": "string", "label": "template_name", "value": "infobox company"}
+
+# Extract infobox as flat dict:
+if isinstance(data['Infobox'], dict):
+    fields = {item['label']: item['value'] for item in data['Infobox']['content']}
+    # fields['Founded'] == 'December 08, 2015'
+    # fields['Products'] == 'ChatGPT, GPT-5...'
+```
+
+`Infobox` is `""` (empty string, not `None`, not `{}`) when absent. Always check with `isinstance(data['Infobox'], dict)`.
+
+---
+
+## Query parameters
+
+| Parameter | Values | Effect |
+|-----------|--------|--------|
+| `q` | URL-encoded query | The search query |
+| `format` | `json` | Required — omit for HTML response |
+| `no_redirect` | `1` | Returns redirect URL in `Redirect` field instead of HTTP 302; required for bang queries (`!g`, `!yt`) |
+| `no_html` | `1` | Strips `<b>` from `Answer`; strips bold markup from `Result` HTML; use in almost every call |
+| `skip_disambig` | `1` | Resolves ambiguous D-type queries to the primary result; upgrades D→A when unambiguous |
+| `t` | any string | Source identifier tag (e.g. `t=myapp`); has no effect on results |
+| `callback` | function name | Wraps response in JSONP: `mycallback({...})` |
+
+---
+
+## Type field values
+
+| Type | Meaning | AbstractText | RelatedTopics |
+|------|---------|--------------|---------------|
+| `A` | Article — specific Wikipedia entity | Full paragraph | Category links |
+| `D` | Disambiguation — ambiguous term | Empty `""` | List of possible meanings (may include sections) |
+| `C` | Categories | Varies | Category items |
+| `N` | Name | Varies | Name-related items |
+| `E` | Exclusive — instant answer widget | Empty `""` | Empty `[]` |
+| `""` | No result | Empty `""` | Empty `[]` |
+
+In practice, C and N types are rare. A, D, E, and empty cover nearly all queries.
+
+---
+
+## What returns useful results vs empty
+
+**Returns AbstractText (A type):**
+- Named companies: `apple inc`, `openai`, `google`
+- Specific technologies: `python programming language`, `javascript`, `linux kernel`
+- Well-known people with `skip_disambig=1`: `elon musk`, `ada lovelace`
+- Scientific concepts: `machine learning`, `photosynthesis`, `circumference`
+- Specific software: `vim`, `postgresql`, `nginx`
+
+**Returns RelatedTopics only (D type):**
+- Ambiguous single words: `python`, `linux`, `react`, `programming`
+- Ambiguous names: `apple` (returns empty — too ambiguous even for D), `new york`
+
+**Returns empty (Type = ""):**
+- How-to queries: `how to cook pasta`, `how to learn python`
+- Opinion/listicle: `best laptops 2024`, `top 10 programming languages`
+- Current events: `weather london`, `bitcoin price`
+- Site search operators: `site:example.com`
+- Multi-word specifics not in DDG's dataset: `numpy python library`, `javascript tutorial`
+
+**Returns instant answer (E type):**
+- Random: `random number`, `generate password`, `lorem ipsum`
+- Math: `pi`, `timer 5 minutes`
+- Network: `ip address`
+- Encoding: `base64 encode <text>`, `md5 hash <text>`
+- Color lookup: `color #RRGGBB` (must URL-encode the `#`)
+
+---
+
+## Gotchas
+
+**`Infobox` is `""` not `None` when absent.** Always check with `isinstance(data['Infobox'], dict)` — `if data['Infobox']` also works since `""` is falsy.
+
+**Image and Icon URLs are relative.** `data['Image']` is `/i/abc123.png`. Prepend `https://duckduckgo.com` to make it absolute. Same for Icon URLs in `RelatedTopics` and `Results`.
+
+**`Answer` can be a dict (widget), not a string.** Queries like `1 mile in km`, `100 USD in EUR`, `sqrt(144)`, and `stopwatch` return `Answer` as a dict with `{'from': 'calculator', 'result': '', ...}`. The `result` key is empty — the widget computes client-side. Only string `Answer` values are usable via the API.
+
+**`color #RRGGBB` requires URL encoding of `#`.** Using `q=color+#FF5733` returns an HTML page (HTTP redirect). Use `urllib.parse.quote("color #FF5733")` which encodes to `color+%23FF5733`.
+
+**Bang queries without `no_redirect=1` return HTML, not JSON.** `!g python` (without `no_redirect=1`) causes an HTTP 302 to `google.com/search?q=python`. The `http_get` helper follows the redirect and returns Google's HTML — `json.loads` fails. Always add `no_redirect=1` when the query might contain bangs.
+
+**`skip_disambig=1` can add latency for truly ambiguous terms.** For `apple` (no "inc"), DDG returns Type `""` even with `skip_disambig=1` — it's so ambiguous it gives nothing. For `elon musk`, `skip_disambig=1` switches from D to A and adds `RelatedTopics` (39 items vs 4), which means a larger response (~5x).
+
+**`AbstractText` is empty for D-type results.** When `Type == 'D'`, DDG only returns `RelatedTopics` (the disambiguation list). The abstract is only filled for `Type == 'A'`.
+
+**`RelatedTopics` for A-type are Wikipedia categories, not related searches.** For `openai`, the 4 `RelatedTopics` are `"American artificial intelligence companies"`, `"Companies in San Francisco"`, etc. — these are DDG category page links, not useful web search results.
+
+**`Definition` / `DefinitionSource` / `DefinitionURL` are always empty** in observed responses. These fields are part of the schema but not reliably populated by any current DDG plugin.
+
+**No rate limiting observed.** 15 rapid sequential requests completed in 3.11s (~208ms avg) with no throttling, no 429, and consistent response structure throughout. DDG does not publish rate limits; the API is designed for "reasonable" use with a `t=` source identifier.
+
+**`OfficialWebsite` is only set for a subset of A-type results.** `machine learning` (Type A) has no `OfficialWebsite`. `openai`, `python programming language`, and `linux kernel` all have one. Always check with `data.get('OfficialWebsite', '')`.
+
+**No_html does not affect the `Result` HTML string.** `Results[0]['Result']` still contains `<a href="...">` tags with `no_html=1`. The `no_html` flag only removes `<b>` bold tags. Use `Results[0]['Text']` for the plain-text version, or `Results[0]['FirstURL']` for just the URL.
+
+---
+
+## Complete working example
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+def ddg_entity(query: str) -> dict | None:
+    """
+    Fetch a DuckDuckGo Instant Answer for a named entity.
+    Returns structured data or None if no result.
+    """
+    q = urllib.parse.quote(query)
+    raw = http_get(
+        f"https://api.duckduckgo.com/?q={q}&format=json&no_html=1&skip_disambig=1"
+    )
+    data = json.loads(raw)
+    if not data.get('AbstractText') and not data.get('Answer'):
+        return None
+
+    result = {
+        'type': data['Type'],
+        'heading': data['Heading'],
+        'abstract': data['AbstractText'],
+        'abstract_url': data['AbstractURL'],
+        'entity': data['Entity'],
+        'official_website': data['OfficialWebsite'],
+        'image': f"https://duckduckgo.com{data['Image']}" if data['Image'] else None,
+        'answer': data['Answer'] if isinstance(data['Answer'], str) else None,
+        'answer_type': data['AnswerType'],
+    }
+
+    # Extract infobox as flat dict
+    if isinstance(data['Infobox'], dict):
+        result['infobox'] = {
+            item['label']: item['value']
+            for item in data['Infobox']['content']
+        }
+
+    # Official site URL (from Results)
+    if data['Results']:
+        result['official_site_url'] = data['Results'][0]['FirstURL']
+
+    return result
+
+# Example outputs (validated 2026-04-18):
+r = ddg_entity("openai")
+# r['type']            == 'A'
+# r['heading']         == 'OpenAI'
+# r['abstract'][:50]   == 'OpenAI is an American artificial intelligence res'
+# r['entity']          == 'company'
+# r['official_website']== 'https://openai.com/'
+# r['image']           == 'https://duckduckgo.com/i/fb410946942ab334.png'
+# r['infobox']['Founded'] == 'December 08, 2015'
+# r['infobox']['Products'] == 'ChatGPT, GPT-5...'
+
+r = ddg_entity("python programming language")
+# r['type']            == 'A'
+# r['entity']          == 'programming language'
+# r['official_website']== 'https://www.python.org/'
+# r['infobox']['Paradigm'] == 'Multi-paradigm: object-oriented,...'
+```

--- a/domain-skills/goodreads/scraping.md
+++ b/domain-skills/goodreads/scraping.md
@@ -1,0 +1,461 @@
+# Goodreads — Book Data Extraction
+
+Field-tested against goodreads.com on 2026-04-18 via `http_get` (no browser required).
+All five URL types return full HTML with no bot-wall, CAPTCHA, or login gate.
+
+## Access Summary
+
+| Page type          | `http_get` works? | Data format              |
+|--------------------|-------------------|--------------------------|
+| Book show page     | Yes               | `__NEXT_DATA__` + JSON-LD |
+| Search results     | Yes               | Server-rendered HTML (schema.org microdata) |
+| Author show page   | Yes               | Server-rendered HTML + OG meta |
+| Listopia list page | Yes               | Server-rendered HTML (schema.org microdata) |
+
+Goodreads shut down its public API in 2020. All extraction is HTML-based.
+Open Library is a reliable supplement with a free JSON API (see [Open Library fallback](#open-library-api-fallback)).
+
+---
+
+## Book Page — Full Data (`__NEXT_DATA__`)
+
+URL pattern: `https://www.goodreads.com/book/show/{book_id}` or `/{book_id}.{Slug}`
+
+The slug is optional — numeric ID alone works and redirects cleanly.
+
+```python
+import re, json
+from helpers import http_get
+
+def parse_book(book_id):
+    html = http_get(f"https://www.goodreads.com/book/show/{book_id}")
+
+    # Parse Apollo state from Next.js page
+    nd = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    ap = json.loads(nd.group(1))['props']['pageProps']['apolloState']
+
+    # The primary Book entity matches the URL's legacy ID
+    book = next(v for v in ap.values()
+                if v.get('__typename') == 'Book' and v.get('legacyId') == int(book_id))
+    work = next((v for v in ap.values() if v.get('__typename') == 'Work'), {})
+    author_ref = book['primaryContributorEdge']['node']['__ref']
+    author = ap.get(author_ref, {})
+
+    stats = work.get('stats', {})
+    work_details = work.get('details', {})
+    book_details = book.get('details', {})
+
+    return {
+        'title':            book['title'],
+        'title_complete':   book['titleComplete'],
+        'book_id':          book['legacyId'],
+        'url':              book['webUrl'],
+        'cover_url':        book['imageUrl'],
+        # Strip HTML tags from description
+        'description':      re.sub(r'<[^>]+>', '', book.get('description({"stripped":true})',
+                                   book.get('description', ''))).strip(),
+        'genres':           [g['genre']['name'] for g in book.get('bookGenres', [])],
+        'series':           [{'name': s['series']['title'], 'position': s.get('userPosition')}
+                             for s in book.get('bookSeries', [])],
+        # Author
+        'author_name':      author.get('name'),
+        'author_url':       author.get('webUrl'),
+        # Edition details
+        'format':           book_details.get('format'),
+        'num_pages':        book_details.get('numPages'),
+        'publisher':        book_details.get('publisher'),
+        'language':         (book_details.get('language') or {}).get('name'),
+        'isbn':             book_details.get('isbn'),
+        'isbn13':           book_details.get('isbn13'),
+        'pub_timestamp_ms': book_details.get('publicationTime'),
+        # Ratings (from Work, not Book)
+        'avg_rating':       stats.get('averageRating'),
+        'ratings_count':    stats.get('ratingsCount'),
+        'text_reviews':     stats.get('textReviewsCount'),
+        # ratings_dist is list of counts for [1-star, 2-star, 3-star, 4-star, 5-star]
+        'ratings_dist':     stats.get('ratingsCountDist'),
+        # Awards
+        'awards':           [a['name'] + (' — ' + a['category'] if a.get('category') else '')
+                             for a in work_details.get('awardsWon', [])],
+    }
+
+# Example
+book = parse_book(149267)  # The Stand by Stephen King
+# book['title']        => "The Stand"
+# book['avg_rating']   => 4.35
+# book['ratings_count']=> 845591
+# book['genres']       => ["Horror", "Fiction", "Fantasy", ...]
+# book['awards']       => ["Locus Award — Best SF Novel", ...]
+```
+
+**Field notes:**
+- `book['legacyId']` is the integer in the URL (e.g. `149267`). Use it to match the correct entity — the `apolloState` often contains 2-3 Book entries for different editions.
+- Ratings and awards live in the `Work` entity, not `Book`. The `Work` is always `__typename == 'Work'`.
+- `description` comes in two forms: `description` (HTML) and `description({"stripped":true})` (plain text). Prefer the stripped version.
+- `pub_timestamp_ms` is a Unix timestamp in **milliseconds**. Convert: `datetime.fromtimestamp(ts/1000)`.
+- `isbn` / `isbn13` are often `null` on older editions — the JSON-LD path (below) is no more reliable.
+
+---
+
+## Book Page — Fast Path (JSON-LD)
+
+Use when you only need title, author, rating, page count, and awards. ~3× less parsing code.
+
+```python
+import re, json
+from helpers import http_get
+
+def parse_book_fast(book_id):
+    html = http_get(f"https://www.goodreads.com/book/show/{book_id}")
+    blocks = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    if not blocks:
+        return None
+    ld = json.loads(blocks[0])
+    return {
+        'title':        ld.get('name'),
+        'author':       ld['author'][0]['name'] if ld.get('author') else None,
+        'avg_rating':   ld.get('aggregateRating', {}).get('ratingValue'),
+        'ratings_count':ld.get('aggregateRating', {}).get('ratingCount'),
+        'review_count': ld.get('aggregateRating', {}).get('reviewCount'),
+        'num_pages':    ld.get('numberOfPages'),
+        'isbn':         ld.get('isbn'),
+        'cover_url':    ld.get('image'),
+        'awards':       ld.get('awards'),   # single string, comma-separated
+        'format':       ld.get('bookFormat'),
+    }
+
+book = parse_book_fast(149267)
+# book['avg_rating']   => 4.35
+# book['ratings_count']=> 845591
+```
+
+**JSON-LD does NOT include:** description, genres, series membership, per-star rating distribution, publisher, language.
+Use `parse_book()` (the `__NEXT_DATA__` path) when you need any of those.
+
+---
+
+## Search Results
+
+URL: `https://www.goodreads.com/search?q={query}&search_type=books&page={n}`
+
+Search uses server-rendered HTML with schema.org microdata `<tr>` rows. No `__NEXT_DATA__`.
+
+```python
+import re, json
+from helpers import http_get
+
+def search_books(query, page=1):
+    from urllib.parse import quote_plus
+    url = f"https://www.goodreads.com/search?q={quote_plus(query)}&search_type=books&page={page}"
+    html = http_get(url)
+
+    rows = re.findall(
+        r'<tr itemscope itemtype="http://schema.org/Book">(.*?)</tr>',
+        html, re.DOTALL
+    )
+
+    results = []
+    for row in rows:
+        bid    = re.search(r'<div id="(\d+)" class="u-anchorTarget">', row)
+        title  = re.search(r"itemprop='name'[^>]*>([^<]+)</span>", row)
+        author = re.search(r'class="authorName"[^>]*><span[^>]*>([^<]+)</span>', row)
+        avg    = re.search(r'(\d+\.\d+)\s*avg rating', row)
+        cnt    = re.search(r'(\d[\d,]*)\s*rating', row)
+        cover  = re.search(r'img alt="[^"]*" class="bookCover"[^>]*src="([^"]+)"', row)
+        if not (bid and title):
+            continue
+        results.append({
+            'book_id':      bid.group(1),
+            'title':        title.group(1).strip(),
+            'author':       author.group(1).strip() if author else None,
+            'avg_rating':   float(avg.group(1)) if avg else None,
+            'ratings_count':cnt.group(1).replace(',', '') if cnt else None,
+            'cover_url':    cover.group(1) if cover else None,
+            'url':          f"https://www.goodreads.com/book/show/{bid.group(1)}",
+        })
+
+    total_m = re.search(r'([\d,]+)\s+results', html)
+    total   = int(total_m.group(1).replace(',', '')) if total_m else None
+
+    return {'total': total, 'page': page, 'results': results}
+
+# Example
+r = search_books("dune")
+# r['total']   => 101026
+# r['results'] => [{'book_id':'44767458', 'title':'Dune (Dune, #1)', 'avg_rating':4.29, ...}, ...]
+```
+
+**Field notes:**
+- Returns exactly 20 results per page.
+- `total` is the result count shown in `"N results for…"` header.
+- The `avg rating` regex uses `&mdash;` (HTML entity) in the raw HTML — the pattern above matches the decoded text.
+- `ratings_count` regex hits the first occurrence of `\d+ rating` in the row, which is always the book's count (not a user review count).
+- `cover_url` is a 75px thumbnail (`._SY75_.jpg`). Swap `_SY75_` → `_SX315_` for a larger image.
+
+---
+
+## Author Page
+
+URL: `https://www.goodreads.com/author/show/{author_id}.{Slug}`
+
+Author pages are **not** Next.js — they use classic server-rendered HTML with OG meta tags and microdata.
+The author ID and slug can be obtained from a book's `author_url` field.
+
+```python
+import re, json
+from helpers import http_get
+
+def parse_author(author_id_and_slug):
+    # author_id_and_slug e.g. "58.Frank_Patrick_Herbert"
+    html = http_get(f"https://www.goodreads.com/author/show/{author_id_and_slug}")
+
+    # Name and basic info from OG/meta tags
+    name    = re.search(r"<meta content='([^']+)' property='og:title'>", html)
+    img     = re.search(r"<meta content='([^']+)' property='og:image'>", html)
+    website = re.search(r"Website\s*</div>\s*<div[^>]*>\s*<a[^>]*href=\"([^\"]+)\"", html)
+
+    # Full biography from hidden span (shown/hidden by "...more" toggle in browser)
+    bio_span = re.search(
+        r'<span id="freeText(?:author|long)\d+"[^>]*>(.*?)</span>',
+        html, re.DOTALL
+    )
+    bio = re.sub(r'<[^>]+>', '', bio_span.group(1)).strip() if bio_span else None
+
+    # Top books listed on the page (10 rows, same microdata format as search)
+    rows = re.findall(
+        r'<tr itemscope itemtype="http://schema.org/Book">(.*?)</tr>',
+        html, re.DOTALL
+    )
+    books = []
+    for row in rows:
+        bid   = re.search(r'<div id="(\d+)" class="u-anchorTarget">', row)
+        title = re.search(r"itemprop='name'[^>]*>([^<]+)</span>", row)
+        avg   = re.search(r'(\d+\.\d+)\s*avg rating', row)
+        cnt   = re.search(r'(\d[\d,]*)\s*rating', row)
+        if bid and title:
+            books.append({
+                'book_id':      bid.group(1),
+                'title':        title.group(1).strip(),
+                'avg_rating':   float(avg.group(1)) if avg else None,
+                'ratings_count':cnt.group(1).replace(',', '') if cnt else None,
+                'url':          f"https://www.goodreads.com/book/show/{bid.group(1)}",
+            })
+
+    return {
+        'name':         name.group(1) if name else None,
+        'profile_image':img.group(1) if img else None,
+        'bio':          bio,
+        'website':      website.group(1) if website else None,
+        'top_books':    books,
+    }
+
+# Example
+author = parse_author("58.Frank_Patrick_Herbert")
+# author['name']    => "Frank Patrick Herbert"
+# author['bio']     => "Franklin Patrick Herbert Jr. was an American science fiction..."
+# len(author['top_books']) => 10
+```
+
+**Field notes:**
+- Author IDs can be found in a book's `author_url` (from `__NEXT_DATA__` or JSON-LD).
+- The slug is optional in the URL — numeric ID alone redirects correctly.
+- `profile_image` from OG tag is a large portrait (p8 suffix = 800px). Swap to `p5` for 500px.
+- The bio is server-rendered in a `<span id="freeTextauthor{ID}">` or `<span id="freeTextlong{ID}">` — which variant appears depends on length.
+- Follower count is **not** present in the static HTML — it requires JS execution to appear.
+- Page lists exactly 10 books. To get all books, paginate `/author/list/{author_id}?page=N`.
+
+---
+
+## Listopia List Page
+
+URL: `https://www.goodreads.com/list/show/{list_id}.{Slug}?page={n}`
+
+Returns 100 books per page with rank numbers.
+
+```python
+import re, json
+from helpers import http_get
+
+def parse_list(list_id_and_slug, page=1):
+    url = f"https://www.goodreads.com/list/show/{list_id_and_slug}?page={page}"
+    html = http_get(url)
+
+    rows = re.findall(
+        r'<tr itemscope itemtype="http://schema.org/Book">(.*?)</tr>',
+        html, re.DOTALL
+    )
+
+    results = []
+    for row in rows:
+        rank   = re.search(r'<td[^>]*class="number"[^>]*>(\d+)</td>', row)
+        bid    = re.search(r'<div id="(\d+)" class="u-anchorTarget">', row)
+        title  = re.search(r"itemprop='name'[^>]*>([^<]+)</span>", row)
+        author = re.search(r'class="authorName"[^>]*><span[^>]*>([^<]+)</span>', row)
+        avg    = re.search(r'(\d+\.\d+)\s*avg rating', row)
+        cnt    = re.search(r'(\d[\d,]*)\s*rating', row)
+        if not (bid and title):
+            continue
+        results.append({
+            'rank':         int(rank.group(1)) if rank else None,
+            'book_id':      bid.group(1),
+            'title':        title.group(1).strip(),
+            'author':       author.group(1).strip() if author else None,
+            'avg_rating':   float(avg.group(1)) if avg else None,
+            'ratings_count':cnt.group(1).replace(',', '') if cnt else None,
+            'url':          f"https://www.goodreads.com/book/show/{bid.group(1)}",
+        })
+
+    return {'page': page, 'results': results}
+
+# Example
+lst = parse_list("1.Best_Books_Ever")
+# lst['results'][0] => {'rank': 1, 'book_id': '2767052',
+#                       'title': 'The Hunger Games (The Hunger Games, #1)',
+#                       'author': 'Suzanne Collins', 'avg_rating': 4.35, ...}
+```
+
+**Field notes:**
+- 100 rows per page. Ranks are sequential across pages (page 2 starts at rank 101).
+- Paginate with `?page=2`, `?page=3` etc.
+- List pages do not use `__NEXT_DATA__` — same classic HTML format as author pages.
+
+---
+
+## Open Library API Fallback
+
+Use Open Library when you need structured JSON without HTML parsing, or when you want supplementary data (birth/death dates, ISBNs across editions, subjects).
+
+Open Library's ratings are from its own user base (~400 ratings vs. Goodreads' 800k+ for Dune) — use Goodreads ratings when accuracy matters.
+
+### Search
+
+```python
+import json
+from urllib.parse import quote_plus
+from helpers import http_get
+
+def ol_search(query, limit=10):
+    url = f"https://openlibrary.org/search.json?q={quote_plus(query)}&limit={limit}"
+    data = json.loads(http_get(url))
+    results = []
+    for doc in data.get('docs', []):
+        cover_id = doc.get('cover_i')
+        results.append({
+            'ol_key':           doc['key'],           # e.g. "/works/OL893415W"
+            'title':            doc.get('title'),
+            'author':           (doc.get('author_name') or [''])[0],
+            'author_key':       (doc.get('author_key') or [''])[0],
+            'first_pub_year':   doc.get('first_publish_year'),
+            'edition_count':    doc.get('edition_count'),
+            'series':           doc.get('series_name'),
+            'cover_url':        f"https://covers.openlibrary.org/b/id/{cover_id}-M.jpg" if cover_id else None,
+        })
+    return {'total': data.get('numFound'), 'results': results}
+
+r = ol_search("dune frank herbert", limit=5)
+# r['results'][0]['ol_key']  => "/works/OL893415W"
+# r['results'][0]['title']   => "Dune"
+```
+
+### Work (book details)
+
+```python
+def ol_work(ol_key):
+    # ol_key like "/works/OL893415W" or just "OL893415W"
+    key = ol_key if ol_key.startswith('/') else f'/works/{ol_key}'
+    data = json.loads(http_get(f"https://openlibrary.org{key}.json"))
+    desc = data.get('description', '')
+    if isinstance(desc, dict):
+        desc = desc.get('value', '')
+    return {
+        'title':    data.get('title'),
+        'subjects': data.get('subjects', []),
+        'series':   data.get('series', []),
+        'description': desc,
+        'covers':   data.get('covers', []),
+        'links':    data.get('links', []),
+    }
+
+work = ol_work("OL893415W")
+# work['title']    => "Dune"
+# work['subjects'] => ["Dune (Imaginary place)", "Fiction", ...]
+```
+
+### Ratings for a work
+
+```python
+def ol_ratings(ol_key):
+    key = ol_key if ol_key.startswith('/') else f'/works/{ol_key}'
+    data = json.loads(http_get(f"https://openlibrary.org{key}/ratings.json"))
+    return data.get('summary', {})
+
+# {'average': 4.30, 'count': 414, 'sortable': 4.21}
+```
+
+### Author
+
+```python
+def ol_author(author_key):
+    # author_key like "OL79034A"
+    data = json.loads(http_get(f"https://openlibrary.org/authors/{author_key}.json"))
+    bio = data.get('bio', '')
+    if isinstance(bio, dict):
+        bio = bio.get('value', '')
+    return {
+        'name':        data.get('name'),
+        'birth_date':  data.get('birth_date'),
+        'death_date':  data.get('death_date'),
+        'bio':         bio,
+        'ol_key':      data.get('key'),
+    }
+
+author = ol_author("OL79034A")
+# author['name']       => "Frank Herbert"
+# author['birth_date'] => "8 October 1920"
+# author['death_date'] => "11 February 1986"
+```
+
+---
+
+## Combining Goodreads + Open Library
+
+```python
+# Get full book data: Goodreads for ratings/genres/description, OL for ISBNs/edition details
+def get_book_full(goodreads_book_id, ol_work_key=None):
+    gr = parse_book(goodreads_book_id)
+    result = dict(gr)
+    if ol_work_key:
+        ol = ol_work(ol_work_key)
+        result['ol_subjects']    = ol['subjects']
+        result['ol_description'] = ol['description']
+        result['ol_covers']      = ol['covers']
+    return result
+```
+
+---
+
+## Gotchas
+
+- **Goodreads API is gone**: The official API was shut down in December 2020. All data must come from HTML scraping or the unofficial paths documented here.
+
+- **Book ID 5107 redirects**: The URL `goodreads.com/book/show/5107.The_Stand` actually resolves to *The Catcher in the Rye* (ID 5107). The Stand is ID `149267`. Always verify `book['legacyId']` matches the URL ID.
+
+- **Author page ID mismatch**: Author ID `10538` in the URL resolves to Carl Sagan, not Frank Herbert (ID `58`). Always obtain author IDs from the `author_url` field inside a book's data rather than guessing.
+
+- **Two Book entities in `apolloState`**: The `apolloState` contains multiple `Book:` entries — one is a stub (only has `legacyId` and `webUrl`), and one is full. Filter by `legacyId == int(book_id)` AND check that the entry has more than 3 fields.
+
+- **Ratings are on `Work`, not `Book`**: `avg_rating`, `ratingsCount`, and `ratingsCountDist` are in the `Work` entity's `stats` key. The `Book` entity has no rating fields.
+
+- **Author pages are old-style HTML**: Author pages (`/author/show/`) do not use Next.js or `__NEXT_DATA__`. Use OG meta tags and regex for extraction. The follower count only loads via JS — it will be missing from `http_get` responses.
+
+- **Search has no `__NEXT_DATA__`**: Search result pages (`/search`) are classic server-rendered HTML. JSON-LD is absent. Use the `<tr itemscope itemtype="http://schema.org/Book">` microdata rows.
+
+- **`ratings_count` regex order matters**: The pattern `r'(\d[\d,]*)\s*rating'` always matches the book's aggregate rating count first in each search row — this is reliable. Do not use `minirating` span text as it contains nested HTML.
+
+- **Open Library cover URLs return binary JPEG**: `http_get()` will raise a `UnicodeDecodeError` on cover image URLs. Use `urllib.request.urlopen()` directly and read bytes, or just store the URL string without fetching.
+
+- **Open Library ratings are sparse**: OL has ~400 community ratings for Dune vs. Goodreads' 1.6M. Use OL ratings only as a last resort.
+
+- **Search page `&mdash;` entity**: The raw HTML uses `&mdash;` (not `—`) between rating value and count in search and author pages. The regex patterns above match the decoded text because Python's `re` operates on the decoded string after `http_get()` decodes UTF-8.
+
+- **Book slug is optional**: `goodreads.com/book/show/44767458` (no slug) works identically to `goodreads.com/book/show/44767458-dune`. Redirects are transparent.

--- a/domain-skills/sec-edgar/scraping.md
+++ b/domain-skills/sec-edgar/scraping.md
@@ -1,0 +1,361 @@
+# SEC EDGAR — Scraping & Data Extraction
+
+`https://www.sec.gov` / `https://data.sec.gov` / `https://efts.sec.gov` — all public data, no auth required. Every workflow here is pure `http_get` — no browser needed.
+
+## Do this first
+
+**SEC.gov requires a custom User-Agent on `www.sec.gov` and `data.sec.gov`. Always pass `headers=UA` or you get 403.**
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+# Format required: "CompanyName contact@email.com"
+# "Mozilla/5.0" (http_get default) works on efts.sec.gov and data.sec.gov
+# but FAILS on www.sec.gov (company_tickers.json, Archives/, etc.)
+```
+
+Start with `company_tickers.json` to resolve any ticker → CIK in one call, then branch to whichever endpoint you need.
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+tickers = json.loads(http_get("https://www.sec.gov/files/company_tickers.json", headers=UA))
+# 10,391 public companies, ~50KB, always fresh
+# Entry format: {"cik_str": 320193, "ticker": "AAPL", "title": "Apple Inc."}
+
+# Look up by ticker (exact, case-sensitive in the data)
+aapl = next(v for v in tickers.values() if v['ticker'] == 'AAPL')
+# {'cik_str': 320193, 'ticker': 'AAPL', 'title': 'Apple Inc.'}
+
+# CIK is an int here; pad to 10 digits for API URLs
+cik = str(aapl['cik_str']).zfill(10)  # "0000320193"
+```
+
+## Common workflows
+
+### Ticker / name → CIK lookup
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+tickers = json.loads(http_get("https://www.sec.gov/files/company_tickers.json", headers=UA))
+
+# By ticker
+tsla = next((v for v in tickers.values() if v['ticker'] == 'TSLA'), None)
+# {'cik_str': 1318605, 'ticker': 'TSLA', 'title': 'Tesla, Inc.'}
+
+# By partial name match
+apples = [v for v in tickers.values() if 'APPLE' in v['title'].upper()]
+# [{'cik_str': 320193, 'ticker': 'AAPL', 'title': 'Apple Inc.'}, ...]
+```
+
+### Company submissions (metadata + recent filings list)
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+cik = "0000320193"  # Apple - always zero-pad to 10 digits
+data = json.loads(http_get(f"https://data.sec.gov/submissions/CIK{cik}.json", headers=UA))
+
+print(data['name'])             # "Apple Inc."
+print(data['cik'])              # "0000320193"
+print(data['sic'])              # "3571"
+print(data['sicDescription'])   # "Electronic Computers"
+print(data['tickers'])          # ["AAPL"]
+print(data['exchanges'])        # ["Nasdaq"]
+
+# Most recent ~1,000 filings are in data['filings']['recent']
+recent = data['filings']['recent']
+# Fields per filing (parallel arrays, same index):
+# accessionNumber, filingDate, reportDate, form, primaryDocument,
+# primaryDocDescription, size, isXBRL, items, fileNumber
+
+# Filter for 10-K and 10-Q only
+filings_10k = [
+    (f, d, a, doc)
+    for f, d, a, doc in zip(
+        recent['form'], recent['filingDate'],
+        recent['accessionNumber'], recent['primaryDocument']
+    )
+    if f in ('10-K', '10-Q')
+]
+# Result: [('10-Q', '2026-01-30', '0000320193-26-000006', 'aapl-20251227.htm'), ...]
+```
+
+### Build direct filing document URL
+
+```python
+# Given accessionNumber and primaryDocument from submissions JSON:
+accn = "0000320193-25-000079"
+doc  = "aapl-20250927.htm"
+cik  = "320193"  # int part only (no leading zeros) for Archives path
+
+accn_nodash = accn.replace("-", "")
+url = f"https://www.sec.gov/Archives/edgar/data/{cik}/{accn_nodash}/{doc}"
+# https://www.sec.gov/Archives/edgar/data/320193/000032019325000079/aapl-20250927.htm
+
+# Full 10-K is 1.5MB of XBRL-tagged HTML — use http_get for text extraction
+content = http_get(url, headers=UA)  # UA required on www.sec.gov
+```
+
+### XBRL financial data — single company, one concept over time
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+cik_padded = "0000320193"
+
+# companyconcept: one metric, all reported values (quarterly + annual)
+data = json.loads(http_get(
+    f"https://data.sec.gov/api/xbrl/companyconcept/CIK{cik_padded}/us-gaap/Assets.json",
+    headers=UA
+))
+# data keys: cik, taxonomy, tag, label, description, entityName, units
+# data['units']['USD'] -> list of {end, val, accn, fy, fp, form, filed}
+
+entries = data['units']['USD']
+
+# Deduplicate: same period re-reported across multiple filings — keep latest
+def annual_series(entries):
+    seen = {}
+    for e in entries:
+        if e.get('form') == '10-K' and e.get('fp') == 'FY':
+            end = e['end']
+            if end not in seen or e['filed'] > seen[end]['filed']:
+                seen[end] = e
+    return [seen[k] for k in sorted(seen)]
+
+assets = annual_series(entries)
+for e in assets[-5:]:
+    print(f"{e['end']}  ${e['val']/1e9:.1f}B")
+# 2021-09-25  $351.0B
+# 2022-09-24  $352.8B
+# 2023-09-30  $352.6B
+# 2024-09-28  $365.0B
+# 2025-09-27  $359.2B
+```
+
+### XBRL financial data — all US-GAAP metrics for a company
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+
+# companyfacts: all reported XBRL concepts in one ~5MB call
+data = json.loads(http_get(
+    "https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json",
+    headers=UA
+))
+# data['entityName'] = "Apple Inc."
+# data['facts'] = {'us-gaap': {...503 concepts...}, 'dei': {...}}
+
+usgaap = data['facts']['us-gaap']
+print(len(usgaap))   # 503 concepts for Apple
+
+# Common concept names (companies vary — check what's available):
+# Revenue:     RevenueFromContractWithCustomerExcludingAssessedTax  (post-2018 standard)
+#              SalesRevenueNet                                       (older filings)
+#              Revenues                                              (some companies still use)
+# Net income:  NetIncomeLoss
+# Assets:      Assets
+# Cash:        CashAndCashEquivalentsAtCarryingValue
+# EPS:         EarningsPerShareBasic, EarningsPerShareDiluted
+
+# Find all revenue-related concepts this company reported:
+revenue_keys = [k for k in usgaap if 'Revenue' in k]
+
+# Extract annual revenue — handle company-specific concept name
+for concept in ['RevenueFromContractWithCustomerExcludingAssessedTax', 'SalesRevenueNet', 'Revenues']:
+    if concept in usgaap:
+        entries = usgaap[concept]['units'].get('USD', [])
+        annual = {}
+        for e in entries:
+            if e.get('form') == '10-K' and e.get('fp') == 'FY':
+                end = e['end']
+                if end not in annual or e['filed'] > annual[end]['filed']:
+                    annual[end] = e
+        if annual:
+            print(f"Using: {concept}")
+            for end in sorted(annual)[-3:]:
+                print(f"  {end}  ${annual[end]['val']/1e9:.1f}B")
+            break
+# Apple output:
+# Using: RevenueFromContractWithCustomerExcludingAssessedTax
+#   2023-09-30  $383.3B
+#   2024-09-28  $391.0B
+#   2025-09-27  $416.2B
+```
+
+### Cross-company financial comparison (XBRL frames)
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+
+# frames: one concept, one period, all companies that reported it
+# Period formats:
+#   CY2024           = calendar year 2024 (annual)
+#   CY2024Q4I        = Q4 2024 instantaneous (balance sheet items)
+#   CY2024Q4         = Q4 2024 duration (income statement items)
+
+# Top companies by annual revenue (2024)
+data = json.loads(http_get(
+    "https://data.sec.gov/api/xbrl/frames/us-gaap/RevenueFromContractWithCustomerExcludingAssessedTax/USD/CY2024.json",
+    headers=UA
+))
+companies = sorted(data['data'], key=lambda x: x['val'], reverse=True)
+# data['data'] entries: {accn, cik, entityName, loc, start, end, val}
+for c in companies[:5]:
+    print(f"{c['entityName']:<40}  ${c['val']/1e9:.0f}B")
+# Walmart Inc.                              $675B
+# AMAZON.COM, INC.                          $638B
+# Apple Inc.                                $391B
+# McKESSON CORPORATION                      $359B
+# Alphabet Inc.                             $350B
+
+# Total assets snapshot end of 2024 (balance sheet = instantaneous)
+data2 = json.loads(http_get(
+    "https://data.sec.gov/api/xbrl/frames/us-gaap/Assets/USD/CY2024Q4I.json",
+    headers=UA
+))
+# 6,229 companies for this frame
+```
+
+### Full-text search across all filings
+
+```python
+import json
+UA = {"User-Agent": "browser-harness research@example.com"}
+
+# Search for any phrase across filing documents
+# Params: q (quoted phrase), forms (comma-separated), dateRange=custom,
+#         startdt, enddt, size (max 100), from (offset for pagination)
+url = (
+    "https://efts.sec.gov/LATEST/search-index"
+    "?q=%22climate+risk%22"
+    "&forms=10-K"
+    "&dateRange=custom&startdt=2024-01-01"
+    "&size=10&from=0"
+)
+data = json.loads(http_get(url, headers=UA))
+# Note: default http_get UA (Mozilla/5.0) works fine on efts.sec.gov
+
+print(data['hits']['total']['value'])   # e.g. 1438 matching documents
+hits = data['hits']['hits']             # up to 100 per call
+
+for h in hits:
+    src = h['_source']
+    # Key fields: display_names, ciks, form, file_date, adsh (accession), period_ending
+    name = src['display_names'][0] if src.get('display_names') else '?'
+    cik  = src['ciks'][0] if src.get('ciks') else '?'
+    print(f"{name}  form={src['form']}  filed={src['file_date']}  accn={src['adsh']}")
+
+# Pagination: max 100 per page, use from= to walk through results
+# Page 2: from=100, Page 3: from=200, etc.
+for page in range(0, 300, 100):
+    page_url = url + f"&from={page}"
+    page_data = json.loads(http_get(page_url, headers=UA))
+    if not page_data['hits']['hits']:
+        break
+    # process...
+
+# Aggregations — group hits by entity, SIC, state
+aggs = data['aggregations']
+top_entities = aggs['entity_filter']['buckets']   # [{key: "Name (CIK...)", doc_count: N}, ...]
+top_sics     = aggs['sic_filter']['buckets']
+top_states   = aggs['biz_states_filter']['buckets']
+```
+
+### Find a company's CIK by name search (via search aggregations)
+
+```python
+import json, re
+UA = {"User-Agent": "browser-harness research@example.com"}
+
+# Best method: company_tickers.json (fastest, all tickers)
+tickers = json.loads(http_get("https://www.sec.gov/files/company_tickers.json", headers=UA))
+msft = next(v for v in tickers.values() if v['ticker'] == 'MSFT')
+# CIK = msft['cik_str']  → 789019
+
+# Alternative: full-text search aggregations (finds CIK from company name)
+data = json.loads(http_get(
+    "https://efts.sec.gov/LATEST/search-index?q=%22microsoft+corporation%22&forms=10-K",
+    headers=UA
+))
+buckets = data['aggregations']['entity_filter']['buckets']
+# [{'key': 'MICROSOFT CORP  (MSFT)  (CIK 0000789019)', 'doc_count': 11}, ...]
+for b in buckets[:3]:
+    m = re.search(r'\(CIK (\d+)\)', b['key'])
+    if m:
+        print(f"{b['key'][:50]}  →  CIK {m.group(1)}")
+```
+
+### Parallel fetching (multiple companies)
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+UA = {"User-Agent": "browser-harness research@example.com"}
+
+def get_company_meta(ticker_cik):
+    ticker, cik = ticker_cik
+    subs = json.loads(http_get(f"https://data.sec.gov/submissions/CIK{cik}.json", headers=UA))
+    return {"ticker": ticker, "name": subs['name'], "sic": subs['sic']}
+
+companies = [("AAPL", "0000320193"), ("TSLA", "0001318605"), ("MSFT", "0000789019")]
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(get_company_meta, companies))
+# Confirmed: 3 requests complete in ~0.28s
+# SEC rate limit: 10 req/sec — stay at max_workers ≤ 8 to be safe
+```
+
+## API reference
+
+| Endpoint | What it returns | UA required |
+|---|---|---|
+| `www.sec.gov/files/company_tickers.json` | All 10,391 tickers → CIK mapping | YES |
+| `data.sec.gov/submissions/CIK{10-digit}.json` | Company meta + ~1000 recent filings | YES |
+| `data.sec.gov/api/xbrl/companyfacts/CIK{10-digit}.json` | All XBRL facts (~5MB) | YES |
+| `data.sec.gov/api/xbrl/companyconcept/CIK{10-digit}/{taxonomy}/{concept}.json` | One concept, all values | YES |
+| `data.sec.gov/api/xbrl/frames/{taxonomy}/{concept}/{unit}/{period}.json` | All companies for one period | YES |
+| `efts.sec.gov/LATEST/search-index?q=...` | Full-text search across filings | NO (Mozilla/5.0 works) |
+| `www.sec.gov/Archives/edgar/data/{cik}/{accn-nodash}/{doc}` | Actual filing document | YES |
+
+`data.sec.gov` accepts `Mozilla/5.0` (the http_get default). `www.sec.gov` (Archives, company_tickers) requires the `"CompanyName email@example.com"` format.
+
+## Rate limits
+
+SEC documents a **10 requests/second** limit. In practice:
+- 12 rapid sequential calls to `data.sec.gov` completed in 2.4s (5 req/s) with no throttling.
+- 3 parallel calls completed in 0.28s without issue.
+- Stay at `max_workers ≤ 8` for ThreadPoolExecutor to respect the 10 req/s ceiling.
+- No per-day or per-hour cap documented; the 10/s limit is the only stated constraint.
+
+## Gotchas
+
+- **`www.sec.gov` returns 403 with `Mozilla/5.0` UA** — The http_get default (`"Mozilla/5.0"`) works on `data.sec.gov` and `efts.sec.gov` but is blocked on `www.sec.gov`. Always pass `headers=UA` where UA includes your company name and email. Confirmed: `"python-requests/2.28"` → 403.
+
+- **`data.sec.gov` is more permissive** — `Mozilla/5.0` works on `data.sec.gov` (submissions, xbrl). But always use the proper UA anyway — SEC's policy page explicitly requires it and they can add stricter checks at any time.
+
+- **XBRL contains duplicate entries per period** — The same fiscal year end date appears multiple times when a company restates or re-files. Each entry has a `filed` date and `accn` (accession). To get the canonical value, deduplicate by `end` keeping the entry with the latest `filed` date.
+
+- **Revenue concept name varies by company and era** — There is no single canonical "revenue" concept. Apple uses `RevenueFromContractWithCustomerExcludingAssessedTax`. Microsoft uses the same for recent years, but older filings used `SalesRevenueNet`. Always check which concepts are actually present: `[k for k in usgaap if 'Revenue' in k]`.
+
+- **`fp` field for annual filings is `'FY'`, but quarterly values also appear in 10-K** — A 10-K re-reports each quarter (fp=Q1, Q2, Q3) plus the full year (fp=FY). Filter on both `form == '10-K'` AND `fp == 'FY'` to get only annual totals.
+
+- **`companyfacts` is ~5MB per company** — For a single metric, use `companyconcept` instead (much smaller). Only use `companyfacts` when you need multiple concepts from the same company.
+
+- **`submissions` recent filings cap at ~1,000** — Very old filings don't appear. If you need historical data before that window, use the `filings.files` array in submissions JSON to find older filing JSON pages (`data.sec.gov/submissions/CIK{cik}-submissions-001.json`, etc.).
+
+- **`adsh` in search results is the accession number** — The search index returns `adsh` (no dashes). To build the document URL, insert dashes: `adsh[:10] + '-' + adsh[10:12] + '-' + adsh[12:]`, or use the `accessionNumber` field from submissions JSON (which already has dashes).
+
+- **`size` param is capped at 100** — Requesting `size=200` silently returns 100 hits. Walk results with `from=0`, `from=100`, etc. Maximum reachable index is 10,000 (Elasticsearch default).
+
+- **Search total `'gte'` relation means >10,000 hits** — When `total['relation'] == 'gte'`, there are more than 10,000 results (only first 10,000 accessible). Narrow with `dateRange` or `forms` filters.
+
+- **`company_tickers.json` covers only exchange-listed companies** — ~10,391 entries. Many SEC filers (private companies, bond issuers, FHLBs) have CIKs but no ticker. Find them via the full-text search aggregations or `submissions` lookup if you have the CIK.
+
+- **Filing document is XBRL-tagged HTML, 1–2MB** — Retrieving the actual 10-K HTML works but is large. For financial data extraction, always prefer the XBRL API endpoints over parsing the document.
+
+- **CIK format gotcha** — `company_tickers.json` returns `cik_str` as an int (`320193`). The submissions and xbrl APIs require a 10-digit zero-padded string in the filename (`CIK0000320193`). Always use `str(cik).zfill(10)` when building URLs.

--- a/domain-skills/trustpilot/scraping.md
+++ b/domain-skills/trustpilot/scraping.md
@@ -1,0 +1,375 @@
+# Trustpilot — Company Reviews Scraping
+
+Field-tested against trustpilot.com on 2026-04-18.
+`http_get` with a generic Mozilla/5.0 UA works — no JS challenge, no Cloudflare block.
+The Trustpilot Consumer API (`api.trustpilot.com`) returns 403 for all endpoints without an API key.
+
+---
+
+## Fastest Approach: `http_get` + `__NEXT_DATA__`
+
+Trustpilot is a Next.js SSR app. Every company review page embeds the full data payload in a
+`<script id="__NEXT_DATA__">` JSON block — no browser needed. This includes the business unit
+metadata, all 20 reviews for the current page, pagination info, and rating distribution.
+
+```python
+import re, json
+from helpers import http_get
+
+def get_trustpilot_page(domain, page=1, stars=None, languages='en', verified=False):
+    """
+    Fetch one page of reviews for a company domain.
+    Returns (business_unit, reviews, pagination, rating_distribution).
+    Returns (None, [], {}, {}) if page is beyond the cap or no data.
+    """
+    url = f"https://www.trustpilot.com/review/{domain}?languages={languages}&page={page}"
+    if stars:
+        url += f"&stars={stars}"
+    if verified:
+        url += "&verified=true"
+
+    html = http_get(url)
+    m = re.search(
+        r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>',
+        html, re.DOTALL
+    )
+    if not m:
+        return None, [], {}, {}
+
+    data = json.loads(m.group(1))
+    pp = data['props']['pageProps']
+    bu = pp['businessUnit']
+    filters = pp.get('filters') or {}
+    pagination = filters.get('pagination', {})
+    ratings = filters.get('reviewStatistics', {}).get('ratings', {})
+    reviews = pp.get('reviews', [])
+
+    return bu, reviews, pagination, ratings
+```
+
+---
+
+## Business Unit (Company) Metadata
+
+```python
+bu, reviews, pagination, ratings = get_trustpilot_page("amazon.com")
+
+# Confirmed fields (tested 2026-04-18):
+bu['id']               # '46ad346800006400050092d0'  — stable MongoDB ObjectId
+bu['displayName']      # 'Amazon'
+bu['identifyingName']  # 'www.amazon.com'
+bu['trustScore']       # 1.7  (float, 1.0–5.0)
+bu['stars']            # 1.5  (display stars: 1, 1.5, 2, 2.5 … 5)
+bu['numberOfReviews']  # 45228  — total across all languages
+bu['websiteUrl']       # 'https://www.amazon.com'
+bu['isClaimed']        # True/False
+bu['isClosed']         # True/False
+bu['isCollectingReviews']  # True/False
+
+# Rating distribution (from filters.reviewStatistics.ratings):
+ratings  # {'total': 45228, 'one': 29718, 'two': 2701, 'three': 1759, 'four': 2367, 'five': 8683}
+
+# Pagination (filtered count, default is English only):
+pagination  # {'currentPage': 1, 'perPage': 20, 'totalCount': 28039, 'totalPages': 1402}
+```
+
+---
+
+## Review Fields
+
+Each review in the `reviews` list has these confirmed fields:
+
+```python
+review = {
+    'id':      '69e3103e09f46d6b5910f3c1',  # hex ObjectId, unique
+    'rating':  1,                             # int 1–5
+    'title':   'UNDELIVERABLE',
+    'text':    'UNDELIVERABLE\nThis is the only explanation...',
+    'language': 'en',
+    'likes':   0,                             # upvote count
+    'source':  'Organic',                     # 'Organic' or 'Invitation'
+    'filtered': False,
+    'isPending': False,
+
+    'dates': {
+        'experiencedDate': '2026-03-29T00:00:00.000Z',  # when they used the service
+        'publishedDate':   '2026-04-18T07:01:50.000Z',  # when review was posted
+        'updatedDate':     None,
+        'submittedDate':   None,
+    },
+
+    'consumer': {
+        'id':              '5cafe2feb158a8533b443467',
+        'displayName':     'Baldy Bloke',
+        'imageUrl':        'https://user-images.trustpilot.com/...',
+        'numberOfReviews': 17,
+        'countryCode':     'GB',
+        'hasImage':        True,
+        'isVerified':      False,
+    },
+
+    'labels': {
+        'verification': {
+            'isVerified':        False,
+            'verificationLevel': 'not-verified',   # or 'verified'
+            'reviewSourceName':  'Organic',
+            'verificationSource': 'invitation',
+            'createdDateTime':   '2026-04-18T07:01:50.000Z',
+            'hasDachExclusion':  False,
+        },
+        'merged': None,
+    },
+
+    'reply': None,           # or {'message': '...', 'publishedDate': '...', 'updatedDate': None}
+    'location': None,        # populated for multi-location businesses
+    'productReviews': [],    # non-empty for product-level reviews
+}
+```
+
+---
+
+## Paginating — Collect Up to 200 Reviews
+
+**Hard cap: pages 1–10 work; page 11+ returns an empty `reviews` array (no error, just empty).**
+This cap applies per filter combination, so `stars=1` gives 200 reviews, `stars=2` gives another
+200, etc.
+
+```python
+import re, json, time
+from helpers import http_get
+
+def collect_reviews(domain, stars=None, languages='en', max_pages=10, delay=0.5):
+    """
+    Collect up to max_pages*20 = 200 reviews. Returns list of review dicts.
+    stars: 1-5 to filter by rating (None = all)
+    languages: 'en' (default), 'all', or ISO code like 'de'
+    delay: seconds between requests (0.5 is safe; tested 5 rapid reqs with no block)
+    """
+    base = f"https://www.trustpilot.com/review/{domain}"
+    params = f"?languages={languages}"
+    if stars:
+        params += f"&stars={stars}"
+
+    all_reviews = []
+    seen_ids = set()
+
+    for page in range(1, max_pages + 1):
+        url = f"{base}{params}&page={page}"
+        html = http_get(url)
+        m = re.search(
+            r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>',
+            html, re.DOTALL
+        )
+        if not m:
+            break
+        data = json.loads(m.group(1))
+        reviews = data['props']['pageProps'].get('reviews', [])
+        if not reviews:
+            break   # hit the page 10 cap or truly no more reviews
+
+        new = [r for r in reviews if r['id'] not in seen_ids]
+        seen_ids.update(r['id'] for r in reviews)
+        all_reviews.extend(new)
+
+        if page < max_pages:
+            time.sleep(delay)
+
+    return all_reviews
+
+
+# Usage — 200 reviews per call:
+reviews = collect_reviews("shopify.com")               # English only, all ratings
+reviews_1star = collect_reviews("amazon.com", stars=1) # 200 x 1-star reviews
+reviews_all = collect_reviews("stripe.com", languages='all')  # all languages
+```
+
+### Maximize unique reviews by sweeping all star ratings
+
+Since each star filter gives an independent 200-review window, you can collect up to 1,000
+reviews per company (pages are deduplicated across filters):
+
+```python
+all_reviews = {}
+for stars in range(1, 6):
+    for r in collect_reviews("amazon.com", stars=stars, delay=0.5):
+        all_reviews[r['id']] = r
+
+print(f"Total unique reviews: {len(all_reviews)}")
+```
+
+---
+
+## Filters Reference
+
+All filter params are appended to the base URL `https://www.trustpilot.com/review/{domain}`:
+
+| Param | Values | Notes |
+|---|---|---|
+| `page` | 1–10 | Page 11+ returns empty `reviews` (tested). 20 reviews per page. |
+| `languages` | `en`, `all`, `de`, `fr`, `it`, `nl`, `sv`, `da`… | Default is `en`. Use `all` for all languages. |
+| `stars` | `1`, `2`, `3`, `4`, `5` | Filter to that star rating only. Works correctly. |
+| `verified` | `true` | Returns only invitation-verified reviews. Amazon has only ~21 verified reviews total. |
+| `date` | `last30days`, `last6months`, `last12months` | Reflected in `filters.selected.date` but data volume unchanged vs no filter — server-side filtering may be best-effort. |
+| `sort` | `recency`, `highest_rated`, `lowest_rated`, `helpful` | The `sort` param is accepted but **ignored server-side** via SSR — `filters.selected.sort` always returns `recency`. Sort only works in browser JS navigation. |
+
+---
+
+## Pagination Object
+
+```python
+# From filters.pagination (present on pages 1–10 when data exists):
+pagination = {
+    'currentPage': 1,
+    'perPage':     20,
+    'totalCount':  28039,   # filtered count (e.g. English only)
+    'totalPages':  1402,    # math: ceil(totalCount / 20)
+}
+
+# NOTE: totalPages can be 1402 but you can only access pages 1–10 (200 reviews).
+# On page 11+ the reviews list is empty and pagination is absent.
+```
+
+---
+
+## Rate Limits and Anti-bot
+
+- **No Cloudflare, no DataDome** — plain HTTP with `Mozilla/5.0` UA works immediately (tested
+  5 rapid requests in <5 seconds without any block).
+- **No CAPTCHA** observed during any test run.
+- **No 429 / rate-limit headers** seen on rapid sequential requests.
+- Safe rate: 0.5s between requests is conservative. Tested 5 consecutive requests at natural
+  speed (0.2–1s each) with no issue.
+- **robots.txt** has `User-agent: * / Disallow: /` (all paths blocked for unnamed bots) and
+  explicitly blocks `anthropic-ai`, `ClaudeBot`, `Claude-User`, `Claude-SearchBot`, `GPTBot`,
+  `anthropic-ai`, `CCBot`, etc. Despite this, `http_get` with `Mozilla/5.0` UA is not blocked
+  server-side (robots.txt is advisory only). Respect the policy if operating at scale.
+
+---
+
+## Consumer API (`api.trustpilot.com`)
+
+All Consumer API endpoints require an API key (OAuth2 client credentials). Without a key:
+
+```
+GET https://api.trustpilot.com/v1/business-units/find?name=amazon.com  → 403 Forbidden
+GET https://api.trustpilot.com/v1/business-units/{id}/reviews          → 403 Forbidden
+```
+
+The Business Unit ID embedded in `__NEXT_DATA__` (`businessUnit.id`) is the same ID used in the
+Consumer API, so if you have an API key, you can use it directly without a separate lookup.
+
+---
+
+## Gotchas
+
+1. **Page cap is 10, not `totalPages`**: `filters.pagination.totalPages` may show 1402, but
+   requests for pages 11+ return `reviews: []` silently. The server-rendered SSR cap is
+   hard-coded at page 10 (200 reviews).
+
+2. **`totalCount` in pagination is language-filtered**: With `languages=en`, `totalCount` is the
+   English-only count (e.g. 28,039 for Amazon). `businessUnit.numberOfReviews` is the true total
+   across all languages (45,228). Use `languages=all` to see the full count in pagination.
+
+3. **Sort param ignored in SSR**: `?sort=highest_rated` is reflected in `filters.selected.sort`
+   in the JSON but the reviews returned are always `recency`-sorted. Sort only takes effect
+   via browser-side JS navigation.
+
+4. **Verified filter is narrow**: Amazon has 45,228 reviews but only 21 are `isVerified=True`
+   (verificationLevel = 'verified'). Most reviews are organic/not-verified. Page 1 of
+   `verified=true` shows a misleading `totalCount=28039` — page 2 corrects to `totalCount=21`.
+
+5. **`date` filter behavior**: The `date` param is reflected in `filters.selected.date` but the
+   total review counts and returned reviews do not visibly change vs no filter in testing. The
+   server may apply it only partially or it may affect ordering rather than filtering.
+
+6. **`languages=en` is the default** and the server returns it even without the param. Use
+   `languages=all` explicitly to get reviews in all languages.
+
+7. **No `__NEXT_DATA__` fallback**: Never observed an empty or missing `__NEXT_DATA__` on valid
+   company pages. If absent, the domain may not have a Trustpilot profile — check for a
+   redirect or 404 in the HTML title.
+
+8. **Stars `1.5` vs `2`**: `businessUnit.stars` uses half-star display values (1.5, 2.0, etc).
+   `businessUnit.trustScore` is the precise float (1.7). Use `trustScore` for numeric comparison.
+
+---
+
+## Complete One-Shot Example
+
+```python
+import re, json, time
+from helpers import http_get
+
+def scrape_trustpilot(domain, max_unique=200):
+    """
+    Scrape up to max_unique reviews. Returns (company_info, reviews_list).
+    With max_unique=1000, sweeps all 5 star ratings to maximize coverage.
+    """
+    def _fetch_page(domain, page, stars=None, languages='en'):
+        url = f"https://www.trustpilot.com/review/{domain}?languages={languages}&page={page}"
+        if stars:
+            url += f"&stars={stars}"
+        html = http_get(url)
+        m = re.search(
+            r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>',
+            html, re.DOTALL
+        )
+        if not m:
+            return None, []
+        d = json.loads(m.group(1))
+        pp = d['props']['pageProps']
+        return pp['businessUnit'], pp.get('reviews', [])
+
+    company_info = None
+    all_reviews = {}
+
+    # First page to get company info
+    bu, reviews = _fetch_page(domain, 1)
+    company_info = {
+        'id':           bu['id'],
+        'name':         bu['displayName'],
+        'domain':       bu['identifyingName'],
+        'trust_score':  bu['trustScore'],
+        'stars':        bu['stars'],
+        'total_reviews': bu['numberOfReviews'],
+        'is_claimed':   bu['isClaimed'],
+    }
+    for r in reviews:
+        all_reviews[r['id']] = r
+
+    if max_unique <= 20:
+        return company_info, list(all_reviews.values())
+
+    # Pages 2–10 (no star filter)
+    for page in range(2, 11):
+        if len(all_reviews) >= max_unique:
+            break
+        _, reviews = _fetch_page(domain, page)
+        if not reviews:
+            break
+        for r in reviews:
+            all_reviews[r['id']] = r
+        time.sleep(0.5)
+
+    # If we want more, sweep by star rating
+    if len(all_reviews) < max_unique and max_unique > 200:
+        for stars in range(1, 6):
+            for page in range(1, 11):
+                if len(all_reviews) >= max_unique:
+                    break
+                _, reviews = _fetch_page(domain, page, stars=stars)
+                if not reviews:
+                    break
+                for r in reviews:
+                    all_reviews[r['id']] = r
+                time.sleep(0.5)
+
+    return company_info, list(all_reviews.values())[:max_unique]
+
+
+# Run it:
+company, reviews = scrape_trustpilot("shopify.com", max_unique=200)
+print(f"{company['name']} — TrustScore {company['trust_score']} — {company['total_reviews']} total reviews")
+print(f"Collected: {len(reviews)} reviews")
+print(f"Sample: [{reviews[0]['rating']}★] {reviews[0]['title'][:60]}")
+```


### PR DESCRIPTION
## Summary
- **SEC EDGAR**: `www.sec.gov` requires `"CompanyName email@example.com"` UA (returns 403 otherwise); `data.sec.gov` XBRL endpoints return up to 5MB JSON; frames endpoint for cross-company comparisons; 10 req/s limit; deduplicate XBRL by `end` date keeping latest `filed`
- **Coursera**: Public `api.coursera.org` works without auth (20K+ courses, 422 partners); `q=search` is POST-only — returns 405 on GET; `paging.total` absent after page 1; `linked` resources always return empty `{}`
- **Goodreads**: `http_get` works on all page types; book pages use `__NEXT_DATA__` Apollo state; ratings live in `Work` entity not `Book` — must join manually; search returns schema.org microdata rows (20/page)
- **DuckDuckGo**: Instant Answer API free/no auth; `skip_disambig=1` essential for named entities; `Infobox` is `""` not `None` when absent; widget answers (`Answer` field) return empty `result` — computation is JS-only; no rate limiting observed
- **TrustPilot**: `http_get` works — Next.js SSR with `__NEXT_DATA__`; 20 reviews/page, max 10 pages per filter (200 reviews); sweep all 5 star ratings for up to 1,000 unique reviews; `sort` param is ignored server-side

## Test plan
- [ ] SEC EDGAR company tickers JSON returns 10K+ companies
- [ ] Coursera courses API returns paginated course list
- [ ] Goodreads book page __NEXT_DATA__ extracts Apollo state
- [ ] DuckDuckGo IA API returns article type with skip_disambig
- [ ] TrustPilot __NEXT_DATA__ contains reviews array

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five domain skills docs for SEC EDGAR, Coursera, Goodreads, DuckDuckGo, and Trustpilot, detailing reliable endpoints, parsing patterns, and limits for fast, no-auth data extraction.

- **New Features**
  - SEC EDGAR: Requires UA format "CompanyName email"; `company_tickers.json`; XBRL `companyfacts`/`companyconcept`/`frames`; dedupe by `end` keeping latest `filed`; ~10 req/s limit.
  - Coursera: Public `api.coursera.org` works; paginate via `start` (`paging.total` only on page 1); `q=search` is POST-only (GET 405); `linked` always empty.
  - Goodreads: `http_get` works; book pages expose `__NEXT_DATA__` (Apollo) + JSON-LD; ratings in `Work` entity; search/author/list pages use microdata HTML.
  - DuckDuckGo: Instant Answer API JSON; use `skip_disambig=1` and `no_html=1`; `Infobox` is `""` when missing; widget answers return dicts with empty `result`; no rate limit seen.
  - Trustpilot: SSR `__NEXT_DATA__` includes company + reviews; 20 reviews/page with a 10-page cap per filter (200); sweep stars 1–5 for up to ~1,000 unique; `sort` is ignored server-side.

<sup>Written for commit 40291337cef6d7eed4318b32b5f8c7a90b1338f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

