### PR TITLE
Add domain skills: Walmart, Spotify, Weather APIs, OpenStreetMap, Archive.org

### DIFF
--- a/domain-skills/archive-org/scraping.md
+++ b/domain-skills/archive-org/scraping.md
@@ -1,0 +1,341 @@
+# Internet Archive / Wayback Machine — Scraping & Data Extraction
+
+`https://archive.org` / `https://web.archive.org` — all public data, no auth required. Every workflow here is pure `http_get` — no browser needed.
+
+## Do this first
+
+**Use the CDX API for anything Wayback-related — it is the reliable workhorse. The Wayback Availability API (`/wayback/available`) is known to return empty `archived_snapshots` even for well-archived URLs and should not be used as a primary mechanism.**
+
+```python
+import json
+
+# Find snapshots of any URL — primary entry point for Wayback data
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json&limit=5"
+    "&fl=timestamp,original,statuscode,mimetype,length",
+    timeout=40.0
+)
+rows = json.loads(r)
+headers = rows[0]   # ['timestamp', 'original', 'statuscode', 'mimetype', 'length']
+for row in rows[1:]:
+    ts, orig, status, mime, length = row
+    snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+    print(f"{ts}  {status}  {snap_url}")
+```
+
+For item metadata (books, video, audio, software), go straight to:
+
+```python
+data = json.loads(http_get("https://archive.org/metadata/{identifier}", timeout=30.0))
+```
+
+## Common workflows
+
+### Find the nearest archived snapshot to a target date
+
+```python
+import json
+
+# CDX sort=closest returns the single snapshot nearest to the given timestamp
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json&limit=1"
+    "&fl=timestamp,original,statuscode"
+    "&closest=20230601120000&sort=closest",
+    timeout=60.0   # CDX can be slow — always use timeout >= 40s
+)
+rows = json.loads(r)
+# rows[0] = header, rows[1] = closest snapshot
+ts, orig, status = rows[1]
+snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+# Result: ts='20230601114925', orig='https://www.iana.org/', status='200'
+# snap_url: https://web.archive.org/web/20230601114925/https://www.iana.org/
+```
+
+Timestamp format is always 14-digit `YYYYMMDDHHMMSS`. Pass any prefix — `20230601` (day), `202306` (month), `2023` (year) — and CDX will match.
+
+### List all monthly snapshots for a URL (collapsed)
+
+```python
+import json
+
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json"
+    "&collapse=timestamp:6"   # :6 = dedupe by YYYYMM (one per month)
+    "&from=20230101&to=20231231"
+    "&fl=timestamp,original",
+    timeout=60.0
+)
+rows = json.loads(r)
+# rows[0] = header ['timestamp', 'original']
+# rows[1:] = one row per month:
+# ['20230101103807', 'https://www.iana.org/']
+# ['20230201144829', 'https://www.iana.org/']
+# ...12 rows for 2023
+
+for ts, orig in rows[1:]:
+    print(f"{ts[:4]}-{ts[4:6]}  https://web.archive.org/web/{ts}/{orig}")
+```
+
+`collapse=timestamp:N` deduplicates by the first N digits of the timestamp:
+- `:4` = one per year, `:6` = one per month, `:8` = one per day
+
+### List snapshots for an entire domain (all pages)
+
+```python
+import json
+
+# matchType=domain captures all URLs under that domain
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&matchType=domain&output=json"
+    "&limit=10&fl=timestamp,original,statuscode"
+    "&collapse=timestamp:8",  # one capture per URL per day
+    timeout=60.0
+)
+rows = json.loads(r)
+for row in rows[1:]:
+    print(row)
+# ['19971210061738', 'http://www.iana.org:80/', '200']
+# ['19980211065537', 'http://www.iana.org:80/', '200']
+# ...
+```
+
+`matchType` options: `exact` (default), `prefix` (URL + subpaths), `host` (all subdomains), `domain` (host + all subdomains).
+
+### Filter snapshots by prefix path
+
+```python
+import json
+
+# All archived pages under /domains/ path
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org/domains/&matchType=prefix&output=json"
+    "&limit=5&fl=timestamp,original,statuscode",
+    timeout=40.0
+)
+rows = json.loads(r)
+for row in rows[1:]:
+    print(row)
+# ['20080509121811', 'http://www.iana.org/domains/', '200']
+# ['20080704174537', 'http://iana.org/domains/', '200']
+```
+
+### Paginate CDX results with resumeKey
+
+```python
+import json
+from urllib.parse import quote
+
+def cdx_all_snapshots(url, fl="timestamp,original,statuscode", page_size=500):
+    """Iterate all CDX records for a URL, yielding rows (excluding header)."""
+    base = (
+        f"https://web.archive.org/cdx/search/cdx"
+        f"?url={quote(url, safe='')}&output=json"
+        f"&fl={fl}&limit={page_size}&showResumeKey=true"
+    )
+    resume_key = None
+    while True:
+        endpoint = base if resume_key is None else f"{base}&resumeKey={quote(resume_key)}"
+        rows = json.loads(http_get(endpoint, timeout=60.0))
+        # rows structure with showResumeKey=true:
+        # [header, row1, row2, ..., [], [resume_key_string]]
+        # The second-to-last row is [] (separator), last row is [resume_key]
+        has_resume = len(rows) >= 2 and rows[-1] != [] and rows[-2] == []
+        data_rows = rows[1:-2] if has_resume else rows[1:]
+        for row in data_rows:
+            yield row
+        if not has_resume:
+            break
+        resume_key = rows[-1][0]
+
+for row in cdx_all_snapshots("iana.org", fl="timestamp,original"):
+    ts, orig = row
+    # process...
+```
+
+### Retrieve the actual archived page
+
+```python
+# Direct snapshot URL: /web/{14-digit-timestamp}/{original-url}
+snap_url = "https://web.archive.org/web/19971210061738/http://www.iana.org:80/"
+content = http_get(snap_url, timeout=30.0)
+# Returns the archived HTML with Wayback toolbar injected at top
+# The toolbar is inside <!-- BEGIN WAYBACK TOOLBAR INSERT --> comments
+
+# The calendar view URL pattern (for browser navigation, not http_get):
+# https://web.archive.org/web/20230101000000*/python.org
+# The * tells Wayback to show the calendar — returns HTML, not raw page
+```
+
+### Item metadata (books, video, audio, software, collections)
+
+```python
+import json
+from urllib.parse import quote
+
+identifier = "HardWonWisdomTrailer"
+data = json.loads(http_get(f"https://archive.org/metadata/{identifier}", timeout=30.0))
+
+# Top-level keys:
+# alternate_locations, created, d1, d2, dir, files, files_count,
+# is_collection, item_last_updated, item_size, metadata, server, uniq, workable_servers
+
+meta = data['metadata']
+# Common metadata fields (not all present on every item):
+print(meta.get('identifier'))   # 'HardWonWisdomTrailer'
+print(meta.get('title'))        # 'Hard Won Wisdom Trailer'
+print(meta.get('mediatype'))    # 'movies' | 'texts' | 'audio' | 'software' | 'collection'
+print(meta.get('creator'))      # 'jakemauz'
+print(meta.get('date'))         # '2017-02-18'
+print(meta.get('description'))  # HTML string — strip tags if needed
+print(meta.get('subject'))      # str OR list of str depending on item
+print(meta.get('publicdate'))   # '2017-02-18 11:51:16'
+print(meta.get('collection'))   # parent collection identifier
+
+files = data['files']
+# Each file entry:
+# name, source ('original'|'derivative'|'metadata'), format, size (bytes as str),
+# md5, sha1, crc32, mtime
+# For video/audio: length (seconds as str), height, width
+# For derivative: original (name of source file)
+
+# Find the primary original file
+orig_files = [f for f in files if f.get('source') == 'original']
+# orig_files[0]: {'name': 'Hard-won wisdom trailer.mp4', 'source': 'original',
+#  'format': 'MPEG4', 'size': '7532153', 'length': '94.13',
+#  'height': '360', 'width': '640', 'md5': 'aaeebe0481...', ...}
+
+# Build download URL — two equivalent forms:
+server = data['server']      # 'ia601405.us.archive.org'
+dir_path = data['dir']       # '/2/items/HardWonWisdomTrailer'
+fname = orig_files[0]['name']
+from urllib.parse import quote as urlquote
+# Form 1: direct storage server (fastest)
+url1 = f"https://{server}{dir_path}/{urlquote(fname)}"
+# Form 2: standard redirect URL (always works, resolved by CDN)
+url2 = f"https://archive.org/download/{identifier}/{urlquote(fname)}"
+# Both confirmed status 200, Content-Type: video/mp4
+```
+
+### Search items (books, audio, video, software)
+
+```python
+import json
+
+# advancedsearch.php is the correct API — /search returns HTML
+r = http_get(
+    "https://archive.org/advancedsearch.php"
+    "?q=artificial+intelligence+AND+mediatype:texts"
+    "&fl[]=identifier&fl[]=title&fl[]=creator&fl[]=date&fl[]=downloads"
+    "&rows=5&sort[]=downloads+desc&output=json",
+    timeout=30.0
+)
+data = json.loads(r)
+# data['responseHeader']['status'] = 0 (success)
+# data['responseHeader']['QTime'] = query time ms
+# data['response']['numFound'] = 25911 (total matches)
+# data['response']['start'] = 0 (offset)
+# data['response']['docs'] = list of item dicts
+
+resp = data['response']
+print(f"Total: {resp['numFound']}, showing: {len(resp['docs'])}")
+for doc in resp['docs']:
+    print(f"  {doc['identifier']}  {doc.get('title', '')[:50]}")
+    # doc fields are only present if they have values — always use .get()
+```
+
+Pagination: use `start=` offset (not `page=`). Max `rows=` is not documented but 100 works reliably.
+
+### Search with all supported parameters
+
+```python
+import json
+
+r = http_get(
+    "https://archive.org/advancedsearch.php"
+    "?q=machine+learning+AND+mediatype:texts"  # Lucene query syntax
+    "&fl[]=identifier&fl[]=title&fl[]=date&fl[]=year"
+    "&fl[]=creator&fl[]=subject&fl[]=description&fl[]=downloads"
+    "&rows=3"
+    "&start=0"               # pagination offset
+    "&sort[]=date+desc"      # sort field + direction
+    "&output=json",
+    timeout=30.0
+)
+data = json.loads(r)
+# Confirmed fields in fl[]:
+# identifier, title, date, year, creator, subject, description,
+# downloads, mediatype, collection, language, avg_rating, num_reviews
+
+# mediatype values: texts, audio, movies, software, image, etree, data, collection, account
+# Sort fields: date, downloads, avg_rating, num_reviews, publicdate, addeddate
+```
+
+## API reference
+
+| Endpoint | What it returns | Auth |
+|---|---|---|
+| `web.archive.org/cdx/search/cdx?url=...&output=json` | Snapshot index: all captures of a URL | None |
+| `archive.org/wayback/available?url=...` | Nearest snapshot (DEGRADED — see gotchas) | None |
+| `archive.org/metadata/{identifier}` | Item metadata + files list | None |
+| `archive.org/advancedsearch.php?q=...&output=json` | Full-text + metadata search | None |
+| `archive.org/download/{identifier}/{filename}` | Direct file download | None |
+| `web.archive.org/web/{timestamp}/{url}` | Archived page HTML | None |
+
+## CDX field reference
+
+The CDX API returns a JSON array of arrays. The first row is always the header when `output=json`.
+
+| Field | Description | Example |
+|---|---|---|
+| `urlkey` | SURT-format URL (reversed domain, path in parens) | `org,iana)/` |
+| `timestamp` | Capture time, 14-digit `YYYYMMDDHHMMSS` | `19971210061738` |
+| `original` | Original crawled URL (exact, including port) | `http://www.iana.org:80/` |
+| `mimetype` | Content-Type of the archived response | `text/html` |
+| `statuscode` | HTTP status at crawl time | `200` |
+| `digest` | SHA-1 of response body, base32-encoded | `I4YBMQ6PHPWE2TD6TIXNWHZB6MXRNTSR` |
+| `length` | Content length in bytes (as string) | `1418` |
+
+Default `fl=` when omitted: `urlkey,timestamp,original,mimetype,statuscode,digest,length` (all 7 fields in that order).
+
+## Rate limits
+
+No auth, no API key. In practice:
+- CDX API: **intermittently slow** — individual queries time out at 20s and succeed at 40–60s. Always use `timeout=40.0` minimum. 3 rapid sequential CDX calls in ~10s completed; 10 rapid calls produced 3 timeouts.
+- Metadata API: Fast and reliable — 5 sequential calls completed in 3.0s with no errors.
+- Search API: Fast — typically responds in 30–65ms (`QTime` in response header).
+- No documented per-second or per-day limits. Archive.org's policy is to be respectful: add `time.sleep(1)` between CDX calls in loops.
+
+## Gotchas
+
+- **CDX times out — always set `timeout=40.0` or higher.** The default 20s is often too short for CDX. Metadata and search APIs are fine at 20–30s. CDX slowness is backend-side and unpredictable; add retry logic for production use.
+
+- **Wayback Availability API is unreliable.** `GET /wayback/available?url=iana.org` returns `{"url": "iana.org", "archived_snapshots": {}}` even for URLs confirmed archived via CDX. Tested 2026-04-18 across many URLs and timestamp combinations — consistently empty. Use `CDX ?sort=closest&limit=1` instead (confirmed working).
+
+- **CDX first row is always the header when `output=json`.** `rows[0]` is `['timestamp', 'original', ...]`, not a data row. Always slice `rows[1:]` for data. When `showResumeKey=true`, the last two rows are `[]` (separator) and `['<resume_key_string>']`.
+
+- **CDX `fl=` must match exactly what you iterate.** If you request `&fl=timestamp,original` you get 2-element rows; forgetting a field breaks destructuring. When in doubt, omit `fl=` entirely and get all 7 fields.
+
+- **`output=json` is required — there is no default JSON mode.** Omitting `output=json` returns space-separated text. `output=text` also works and is slightly faster for simple queries.
+
+- **`timestamp` is a string, not an integer.** Even in JSON, CDX returns all fields as strings: `'1418'` not `1418`, `'200'` not `200`. Cast explicitly: `int(row[4])`, `int(row[6])`.
+
+- **The `original` field preserves port numbers.** Old crawls captured `http://www.iana.org:80/` — the `:80` is part of the URL. When building a playback URL, use `original` verbatim: `f"https://web.archive.org/web/{ts}/{orig}"` works correctly with the port included.
+
+- **Metadata `{}` means the item doesn't exist or is private.** `http_get("https://archive.org/metadata/nonexistent")` returns `'{}'` (2-byte response) with HTTP 200. Always check `if not data` or `if not data.get('metadata')` before accessing fields.
+
+- **Metadata `subject` can be a string or a list.** When a single subject tag is set, the API returns `"subject": "short film"`. When multiple, it returns `"subject": ["short film", "spoken word"]`. Normalize with: `subjects = [meta['subject']] if isinstance(meta.get('subject'), str) else meta.get('subject', [])`.
+
+- **File `size` and `length` are strings, not numbers.** `files[0]['size']` is `'7532153'` (bytes). `files[0]['length']` is `'94.13'` (seconds for video/audio). Cast with `int()` and `float()` respectively.
+
+- **Use `archive.org/download/` not the raw storage server URL for reliability.** The raw URL (`ia601405.us.archive.org/2/items/...`) is faster but server-specific. `archive.org/download/{id}/{file}` redirects to the correct storage node and remains stable as items migrate.
+
+- **`/search?output=json` returns HTML, not JSON.** The `/search` endpoint is a React SPA — it ignores `output=json`. Always use `advancedsearch.php` for programmatic access.
+
+- **`collapse=timestamp:6` gives one row per month, but it keeps the FIRST capture of that month.** If you want the last, you'd need to reverse and re-collapse, or fetch all and filter client-side. The `collapse` parameter de-duplicates by truncating the timestamp to N digits and keeping the first matching row.
+
+- **CDX `from=` / `to=` accept partial timestamps.** `from=20230101` means `20230101000000`. `to=20231231` means `20231231000000` (exclusive). To include all of 2023, use `to=20240101`.

--- a/domain-skills/openstreetmap/scraping.md
+++ b/domain-skills/openstreetmap/scraping.md
@@ -1,0 +1,490 @@
+# OpenStreetMap — Nominatim Geocoding + Overpass API
+
+Two fully public, no-auth APIs. Everything is a direct HTTP call — never need a browser.
+
+- **Nominatim**: geocoding (place name → lat/lon and reverse). Rate limit: 1 req/s.
+- **Overpass API**: spatial query engine over the full OSM dataset. Rate limit: 2 concurrent slots per IP on the public instance.
+
+**Do not use `http_get` without overriding `User-Agent`** — its default `Mozilla/5.0` is blocked by both APIs with HTTP 403. Pass `headers={"User-Agent": "browser-harness/1.0"}` on every call.
+
+---
+
+## Fastest path: forward geocode a place
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+
+def geocode(query: str, limit: int = 3) -> list[dict]:
+    q = urllib.parse.quote(query)
+    raw = http_get(
+        f"https://nominatim.openstreetmap.org/search?q={q}&format=json&limit={limit}&addressdetails=1",
+        headers=UA
+    )
+    return json.loads(raw)  # [] when nothing found
+
+results = geocode("Eiffel Tower")
+# results[0]['display_name']  == 'Tour Eiffel, 5, Avenue Anatole France, ..., 75007, France'
+# results[0]['lat']            == '48.8582599'   ← STRING, not float
+# results[0]['lon']            == '2.2945006'    ← STRING, not float
+# results[0]['type']           == 'tower'
+# results[0]['class']          == 'man_made'
+# results[0]['importance']     == 0.6205937724353116
+# results[0]['osm_type']       == 'way'
+# results[0]['osm_id']         == 5013364
+# results[0]['boundingbox']    == ['48.8574753', '48.8590453', '2.2933119', '2.2956897']  ← all strings
+# results[0]['address']['city']     == 'Paris'
+# results[0]['address']['postcode'] == '75007'
+# results[0]['address']['country']  == 'France'
+# results[0]['address']['country_code'] == 'fr'
+```
+
+---
+
+## Nominatim: all three query modes
+
+### 1. Forward geocode (free-text)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+
+raw = http_get(
+    "https://nominatim.openstreetmap.org/search?q=Eiffel+Tower&format=json&limit=3&addressdetails=1",
+    headers=UA
+)
+results = json.loads(raw)
+# Returns [] when nothing found — no exception
+
+# Useful optional params:
+# &addressdetails=1   → adds 'address' dict to each result (city, postcode, road, etc.)
+# &extratags=1        → adds 'extratags' dict (website, wikidata, phone, etc.)
+# &namedetails=1      → adds 'namedetails' dict (name:en, name:fr, etc.)
+# &countrycodes=fr,de → restrict to countries (comma-separated ISO 3166-1 alpha-2)
+# &viewbox=2.2,48.8,2.4,48.9 &bounded=1  → restrict to bounding box (lon_min,lat_min,lon_max,lat_max)
+```
+
+### 2. Reverse geocode (lat/lon → address)
+
+```python
+raw = http_get(
+    "https://nominatim.openstreetmap.org/reverse?lat=48.8584&lon=2.2945&format=json",
+    headers=UA
+)
+result = json.loads(raw)
+# result['display_name']  == 'Avenue Gustave Eiffel, Quartier du Gros-Caillou, ..., France'
+# result['address']['road']         == 'Avenue Gustave Eiffel'
+# result['address']['city']         == 'Paris'
+# result['address']['postcode']     == '75007'
+# result['address']['country']      == 'France'
+# result['address']['country_code'] == 'fr'
+# result['address']['state']        == 'Île-de-France'
+# result['lat'], result['lon']  → strings (not floats)
+
+# Optional: &zoom=N (0-18) controls granularity of the returned address
+# zoom=3 → country, zoom=10 → city, zoom=18 → street/building (default)
+```
+
+### 3. Structured search (field-based)
+
+```python
+raw = http_get(
+    "https://nominatim.openstreetmap.org/search?city=Paris&country=France&format=json&limit=1",
+    headers=UA
+)
+result = json.loads(raw)[0]
+# result['name']          == 'Paris'
+# result['lat']           == '48.8534951'
+# result['lon']           == '2.3483915'
+# result['type']          == 'administrative'
+# result['place_rank']    == 12  (lower = broader: 4=country, 8=state, 12=city, 30=POI)
+# result['addresstype']   == 'city'
+# result['boundingbox']   == ['48.8155755', '48.9021560', '2.2241220', '2.4697602']
+
+# Supported structured params: street, city, county, state, country, postalcode
+```
+
+### 4. Lookup by OSM ID
+
+```python
+# Prefix: N=node, W=way, R=relation
+raw = http_get(
+    "https://nominatim.openstreetmap.org/lookup?osm_ids=W5013364&format=json",
+    headers=UA
+)
+result = json.loads(raw)
+# Returns list. Eiffel Tower way: result[0]['name'] == 'Tour Eiffel'
+# Supports up to 50 IDs: osm_ids=W5013364,N123456,R789
+```
+
+---
+
+## Nominatim response field reference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `place_id` | int | Internal Nominatim ID — do not cache long-term, can change |
+| `osm_type` | str | `"node"`, `"way"`, or `"relation"` |
+| `osm_id` | int | The OSM element ID |
+| `lat` | **str** | Latitude as string — convert with `float(r['lat'])` |
+| `lon` | **str** | Longitude as string — convert with `float(r['lon'])` |
+| `display_name` | str | Full human-readable address string |
+| `name` | str | Short name of the place |
+| `type` | str | OSM type tag value: `"tower"`, `"administrative"`, `"restaurant"`, etc. |
+| `class` | str | OSM key: `"man_made"`, `"boundary"`, `"amenity"`, `"highway"`, etc. |
+| `addresstype` | str | Semantic category: `"city"`, `"road"`, `"man_made"`, etc. |
+| `place_rank` | int | Hierarchy rank: 4=country, 8=state, 12=city, 16=suburb, 30=POI |
+| `importance` | float | 0–1 relevance score (higher = more notable) |
+| `boundingbox` | list[str] | `[south_lat, north_lat, west_lon, east_lon]` — all strings, note unusual order |
+| `licence` | str | ODbL attribution string — include in user-facing output |
+| `address` | dict | Only present with `&addressdetails=1` or in reverse results |
+
+`address` dict common keys: `road`, `house_number`, `quarter`, `suburb`, `city_district`, `city`, `state`, `postcode`, `country`, `country_code`, `ISO3166-2-lvl4/6`.
+
+---
+
+## Overpass API: query OSM data by tags
+
+Overpass is a read-only query engine over the full OSM planet. It supports finding POIs by tag, radius, bounding box, and combinations.
+
+**Endpoint**: `https://overpass-api.de/api/interpreter`
+**Backup instances** (use when main is overloaded, which happens often):
+- `https://overpass.openstreetmap.fr/api/interpreter` — requires non-Mozilla User-Agent
+
+**http_get works for GET requests** — pass `headers={"User-Agent": "browser-harness/1.0"}`. For POST, use `urllib` directly (see example below).
+
+### GET query (simplest for http_get)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_get(query: str) -> dict:
+    url = f"{OVERPASS}?data={urllib.parse.quote(query)}"
+    raw = http_get(url, headers=UA)
+    if not raw.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML returned): {raw[:200]}")
+    return json.loads(raw)
+
+# Find cafes in central Paris (bbox: south_lat, west_lon, north_lat, east_lon)
+r = overpass_get('[out:json][timeout:25];node["amenity"="cafe"](48.855,2.295,48.862,2.308);out 10;')
+# r['version']    == 0.6
+# r['generator']  == 'Overpass API 0.7.62.7 375dc00a'
+# r['elements']   → list of matching OSM elements
+
+for cafe in r['elements']:
+    print(cafe['tags'].get('name'), cafe['lat'], cafe['lon'])
+# 'Café de l\'Alma' 48.8609068 2.3015143
+# 'Le Campanella'   48.8585847 2.3032822
+# 'Kozy Bosquet'    48.855445  2.3054013
+
+# Find restaurants within 500m radius of a point (around filter)
+r = overpass_get(
+    '[out:json][timeout:25];node["amenity"="restaurant"](around:500,37.7749,-122.4194);out 10;'
+)
+for rest in r['elements']:
+    print(rest['tags'].get('name'), rest['tags'].get('cuisine',''))
+# 'Nepalese Indian Cusine' 'indian;nepali'
+# 'Local Diner' 'coffee_shop;italian;burger;seafood'
+# 'Moya Cafe' ''
+```
+
+### POST query (for complex QL, avoids URL length limits)
+
+```python
+import json, urllib.parse, urllib.request, gzip
+from helpers import http_get  # http_get is GET-only; use urllib for POST
+
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_post(query: str) -> dict:
+    """POST to Overpass — no URL length limits, preferred for multi-statement QL."""
+    data = urllib.parse.urlencode({"data": query}).encode()
+    req = urllib.request.Request(
+        OVERPASS, data=data, method="POST",
+        headers={
+            "User-Agent": "browser-harness/1.0",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept-Encoding": "gzip",
+        }
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        body = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+    body = body.decode()
+    if not body.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML): {body[:300]}")
+    return json.loads(body)
+
+# Example: cafes in Paris bbox
+r = overpass_post('[out:json][timeout:25];node["amenity"="cafe"](48.855,2.295,48.862,2.308);out 5;')
+print(len(r['elements']))  # 5 (or up to 5)
+```
+
+### Overpass element structure
+
+Every element in `r['elements']` is a dict with at minimum:
+
+```python
+{
+    "type": "node",          # "node", "way", or "relation"
+    "id": 308684349,         # int — OSM element ID (stable, use for dedup)
+    "lat": 48.8609068,       # float — ONLY present for node type
+    "lon": 2.3015143,        # float — ONLY present for node type
+    "tags": {                # dict — all OSM tags on this element
+        "amenity": "cafe",
+        "name": "Café de l'Alma",
+        "name:fr": "Café de l'Alma",
+        "outdoor_seating": "yes",
+        "payment:credit_cards": "yes",
+        "phone": "+33 1 45 51 56 74",
+        "opening_hours": "Mo-Sa 08:00-23:00; Su 09:00-19:00",  # optional
+        "website": "https://...",                               # optional
+        "wheelchair": "yes"                                     # optional
+    }
+}
+```
+
+For `way` elements, use `out center;` to get a `center` dict with lat/lon instead of a node list:
+
+```python
+# way element with out center:
+{
+    "type": "way",
+    "id": 338411946,
+    "center": {"lat": 48.8660087, "lon": 2.3153233},  # centroid of the polygon
+    "nodes": [3454913623, 3454913707, ...],            # node IDs forming the boundary
+    "tags": {"amenity": "cafe", "name": "Café 1902", ...}
+}
+
+# Query to get both nodes and ways with lat/lon:
+query = '[out:json][timeout:25];(node["amenity"="cafe"](48.85,2.29,48.87,2.32);way["amenity"="cafe"](48.85,2.29,48.87,2.32););out center 20;'
+r = overpass_get(query)
+for el in r['elements']:
+    if el['type'] == 'node':
+        lat, lon = el['lat'], el['lon']
+    else:  # way
+        lat, lon = el['center']['lat'], el['center']['lon']
+    print(el['tags'].get('name'), lat, lon)
+```
+
+### Overpass QL quick reference
+
+```
+[out:json][timeout:25]      # Required header: JSON output, 25s timeout
+[maxsize:52428800]          # Optional: 50MB max result size (default is server limit)
+
+node["amenity"="cafe"](south,west,north,east);out N;
+#  ↑ bbox order: south_lat, west_lon, north_lat, east_lon
+#  Note: DIFFERENT from Nominatim's boundingbox field which is [south,north,west,east]
+
+node["amenity"="cafe"](around:RADIUS_METERS,LAT,LON);out N;
+
+node["amenity"~"cafe|restaurant"](bbox);out N;    # regex match on tag value
+node[!"name"](bbox);out N;                        # elements WITHOUT the 'name' tag
+node["name"~"Star",i](bbox);out N;               # case-insensitive regex
+
+# Union of types:
+(node["amenity"="cafe"](bbox); way["amenity"="cafe"](bbox););out center N;
+
+# Multiple tags (AND logic):
+node["amenity"="cafe"]["outdoor_seating"="yes"](bbox);out N;
+```
+
+---
+
+## OSM tile server (reference only, no scraping)
+
+```
+https://{a,b,c}.tile.openstreetmap.org/{z}/{x}/{y}.png
+```
+
+- Subdomains `a`, `b`, `c` for load balancing
+- `z` = zoom level 0–19, `x`/`y` = tile coordinates
+- Returns 256×256 PNG tiles
+- Policy: max 2 req/s per IP, non-commercial use, must display OSM attribution
+- Tile coordinate calculator: `https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames`
+- Bulk tile downloading is prohibited — use Overpass or data extracts instead
+
+```python
+# Convert lat/lon to tile coordinates
+import math
+
+def lat_lon_to_tile(lat, lon, zoom):
+    n = 2 ** zoom
+    x = int((lon + 180) / 360 * n)
+    y = int((1 - math.log(math.tan(math.radians(lat)) + 1 / math.cos(math.radians(lat))) / math.pi) / 2 * n)
+    return x, y
+
+x, y = lat_lon_to_tile(48.8582, 2.2945, 14)
+url = f"https://a.tile.openstreetmap.org/14/{x}/{y}.png"
+# url == 'https://a.tile.openstreetmap.org/14/8281/5646.png'
+```
+
+---
+
+## Rate limits
+
+| API | Limit | Enforcement | 429 behavior |
+|-----|-------|-------------|--------------|
+| Nominatim | 1 req/s | Soft — rapid requests work but you get delayed/dropped | Returns HTTP 403 if your IP is banned (not 429) |
+| Overpass (main) | 2 concurrent slots per IP | Hard — 3rd concurrent req returns HTML error immediately | HTML error page with `rate_limited` in body |
+| Overpass (main) | Also: query complexity quota | Resets over time (~per hour) | HTML error page with `rate_limited` |
+| Tile server | 2 req/s per IP | Soft/hard | IP block |
+
+**Check your Overpass quota**:
+```python
+raw = http_get("https://overpass-api.de/api/status", headers={"User-Agent": "browser-harness/1.0"})
+print(raw)
+# Connected as: 1728118854
+# Rate limit: 2
+# 2 slots available now.
+# Slot available after: 2026-04-18T11:00:00Z, in 30 seconds.
+```
+
+**Handle rate limiting in production**:
+```python
+import time
+
+def overpass_get_with_retry(query: str, max_retries: int = 3) -> dict:
+    for attempt in range(max_retries):
+        url = f"https://overpass.openstreetmap.fr/api/interpreter?data={urllib.parse.quote(query)}"
+        raw = http_get(url, headers={"User-Agent": "browser-harness/1.0"})
+        if raw.startswith("{"):
+            return json.loads(raw)
+        if "rate_limited" in raw or "too busy" in raw:
+            wait = 2 ** attempt * 10  # 10s, 20s, 40s
+            time.sleep(wait)
+            continue
+        raise RuntimeError(f"Overpass error: {raw[:200]}")
+    raise RuntimeError("Overpass: too many retries")
+```
+
+---
+
+## Complete working example
+
+```python
+import json, time, urllib.parse, urllib.request, gzip
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+NOMINATIM = "https://nominatim.openstreetmap.org"
+OVERPASS   = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def geocode(query: str, limit: int = 1) -> list[dict]:
+    """Forward geocode — returns [] if nothing found."""
+    q = urllib.parse.quote(query)
+    raw = http_get(f"{NOMINATIM}/search?q={q}&format=json&limit={limit}&addressdetails=1", headers=UA)
+    return json.loads(raw)
+
+def reverse_geocode(lat: float, lon: float) -> dict:
+    """Reverse geocode — always returns a result (nearest road/place)."""
+    raw = http_get(f"{NOMINATIM}/reverse?lat={lat}&lon={lon}&format=json", headers=UA)
+    return json.loads(raw)
+
+def overpass_get(query: str) -> list[dict]:
+    """Run an Overpass QL query, return elements list."""
+    url = f"{OVERPASS}?data={urllib.parse.quote(query)}"
+    raw = http_get(url, headers=UA)
+    if not raw.startswith("{"):
+        raise RuntimeError(f"Overpass error: {raw[:200]}")
+    return json.loads(raw)["elements"]
+
+def overpass_post(query: str) -> list[dict]:
+    """POST variant — avoids URL length limits for complex queries."""
+    data = urllib.parse.urlencode({"data": query}).encode()
+    req = urllib.request.Request(
+        OVERPASS, data=data, method="POST",
+        headers={"User-Agent": "browser-harness/1.0",
+                 "Content-Type": "application/x-www-form-urlencoded",
+                 "Accept-Encoding": "gzip"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        body = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+    body = body.decode()
+    if not body.startswith("{"):
+        raise RuntimeError(f"Overpass error: {body[:300]}")
+    return json.loads(body)["elements"]
+
+# --- Usage examples (validated 2026-04-18) ---
+
+# 1. Geocode a landmark
+places = geocode("Eiffel Tower", limit=3)
+# places[0]['lat']  == '48.8582599'  (string)
+# places[0]['lon']  == '2.2945006'   (string)
+# places[0]['display_name'] == 'Tour Eiffel, 5, Avenue Anatole France, ..., 75007, France'
+# places[0]['address']['city'] == 'Paris'
+lat = float(places[0]['lat'])
+lon = float(places[0]['lon'])
+
+# 2. Reverse geocode the coordinates
+addr = reverse_geocode(lat, lon)
+# addr['address']['road']    == 'Avenue Gustave Eiffel'
+# addr['address']['city']    == 'Paris'
+# addr['address']['postcode']== '75007'
+# addr['address']['country'] == 'France'
+
+# 3. Find nearby cafes (wait 1s between nominatim and overpass if same script)
+time.sleep(1)
+cafes = overpass_get(
+    f"[out:json][timeout:25];node[\"amenity\"=\"cafe\"](around:500,{lat},{lon});out 10;"
+)
+for cafe in cafes:
+    print(f"{cafe['tags'].get('name','?'):30s}  {cafe['lat']:.4f}, {cafe['lon']:.4f}")
+# Café de l'Alma                  48.8609, 2.3015
+# Le Campanella                   48.8586, 2.3033
+
+# 4. Structured city lookup + find restaurants in bounding box
+time.sleep(1)
+paris = geocode("Paris, France")[0]
+bb = paris['boundingbox']  # [south_lat, north_lat, west_lon, east_lon] ← Nominatim order!
+# For Overpass: need (south_lat, west_lon, north_lat, east_lon) ← DIFFERENT order
+south, north, west, east = bb[0], bb[1], bb[2], bb[3]
+# Restrict to center slice to avoid massive result set
+center_bbox = f"48.855,2.295,48.865,2.315"
+rests = overpass_post(
+    f"[out:json][timeout:25];node[\"amenity\"=\"restaurant\"]({center_bbox});out 5;"
+)
+print(f"Found {len(rests)} restaurants near Paris center")
+```
+
+---
+
+## Gotchas
+
+**`http_get` default UA (`Mozilla/5.0`) is blocked by both APIs.** Always pass `headers={"User-Agent": "browser-harness/1.0"}`. The `headers` kwarg in `http_get` does a `.update()` so it properly overrides the default. Confirmed: Mozilla/5.0 → 403 on Nominatim; `browser-harness/1.0` → 200.
+
+**Blocked User-Agent patterns on Nominatim**: `Mozilla/5.0`, `python-requests/*`, `Wget/*`. Accepted: any non-generic app-style UA like `browser-harness/1.0`, `MyApp/2.0`, `curl/7.x`. Nominatim policy requires a descriptive UA with contact info, but in practice any non-library string passes.
+
+**Nominatim lat/lon are strings, Overpass lat/lon are floats.** Always convert Nominatim coordinates: `float(result['lat'])`. Overpass element `lat`/`lon` are native Python floats — no conversion needed.
+
+**Nominatim `boundingbox` field order is `[south_lat, north_lat, west_lon, east_lon]` — NOT `[south, west, north, east]`.** Overpass bbox uses `(south_lat, west_lon, north_lat, east_lon)`. When feeding a Nominatim bounding box into Overpass, you must reorder: `f"({bb[0]},{bb[2]},{bb[1]},{bb[3]})"`.
+
+**`overpass-api.de` main instance is frequently overloaded.** Returns HTTP 504 (timeout) or an HTML error page with `rate_limited` when busy. The FR mirror (`overpass.openstreetmap.fr`) is usually more responsive but also blocks `Mozilla/5.0`. Always detect non-JSON responses: `if not raw.startswith("{")`.
+
+**Overpass error responses are HTML, not JSON.** The API returns HTTP 200 with an HTML error page when rate-limited or when the server is too busy. Always check `raw.startswith("{")` before parsing.
+
+**Overpass rate limit: 2 concurrent slots, NOT 2 requests/s.** You can run 2 queries simultaneously. A 3rd concurrent query immediately returns an error. Sequential queries with no sleep between them work fine as long as each completes before the next starts.
+
+**`out N;` limits results to N elements — use it.** Without a limit, large bounding boxes can return thousands of elements and hit the 512MB memory limit, returning a `maxsize` error. Default safe limit: `out 50;` for exploration, `out 500;` for bulk collection.
+
+**Overpass QL bbox order is `(south, west, north, east)` — latitude FIRST.** This is the opposite of the standard GeoJSON convention `[west, south, east, north]`. The `around:` filter uses `(around:METERS,LAT,LON)` — note lat before lon.
+
+**`name` tag in Overpass is the local-language name.** For Paris cafes this is French. English names may appear under `name:en` but are often absent. Never assume `name` is in English.
+
+**Nominatim `/reverse` always returns the nearest result** — it never returns an empty response (unlike `/search`). If the coordinates are in the ocean, it still returns the nearest coastline or country.
+
+**`place_id` is internal and ephemeral** — do not store it for long-term use. Use `osm_type` + `osm_id` for stable references (e.g., `way/5013364` for the Eiffel Tower).
+
+**Overpass `http_get` POST workaround**: `http_get` only supports GET. For POST requests (needed to avoid URL length limits for complex multi-statement QL), use `urllib.request.Request` directly as shown in the `overpass_post()` example above.

--- a/domain-skills/spotify/scraping.md
+++ b/domain-skills/spotify/scraping.md
@@ -1,0 +1,339 @@
+# Spotify — Data Extraction
+
+Field-tested against open.spotify.com on 2026-04-18.
+No authentication required for any approach documented here.
+
+---
+
+## Approach 1 (Fastest): oEmbed API — No Auth, No Browser
+
+`https://open.spotify.com/oembed?url=<resource_url>`
+
+Returns JSON in ~0.25s. Works for tracks, albums, playlists, and artists. Does **not** work for episodes/shows.
+
+```python
+from helpers import http_get
+import json
+
+def spotify_oembed(resource_type, resource_id):
+    """Fetch oEmbed metadata for a Spotify resource.
+
+    resource_type: 'track', 'album', 'playlist', or 'artist'
+    resource_id:   Spotify ID (22-char alphanumeric)
+    """
+    resource_url = f"https://open.spotify.com/{resource_type}/{resource_id}"
+    url = f"https://open.spotify.com/oembed?url={resource_url}"
+    data = json.loads(http_get(url))
+    return data
+
+# Example: track
+track = spotify_oembed("track", "4PTG3Z6ehGkBFwjybzWkR8")
+# {
+#   "title":           "Never Gonna Give You Up",
+#   "thumbnail_url":   "https://image-cdn-ak.spotifycdn.com/image/ab67616100005174...",
+#   "thumbnail_width": 320,
+#   "thumbnail_height": 320,
+#   "type":            "rich",
+#   "html":            "<iframe ...src=\"https://open.spotify.com/embed/track/4PTG3Z6...\"...>",
+#   "iframe_url":      "https://open.spotify.com/embed/track/4PTG3Z6ehGkBFwjybzWkR8?utm_source=oembed",
+#   "width":           456,
+#   "height":          152,
+#   "version":         "1.0",
+#   "provider_name":   "Spotify",
+#   "provider_url":    "https://spotify.com"
+# }
+
+# Artist (height is 352 — taller widget)
+artist = spotify_oembed("artist", "0gxyHStUsqpMadRV0Di1Qt")
+# title="Rick Astley", thumbnail_url=<artist photo URL>
+
+# Album
+album = spotify_oembed("album", "4LH4d3cOWNNsVw41Gqt2kv")
+# title="The Dark Side of the Moon", thumbnail_url=<album art URL>
+
+# Playlist
+pl = spotify_oembed("playlist", "37i9dQZF1DXcBWIGoYBM5M")
+# title="Today's Top Hits", thumbnail_url=<playlist cover URL>
+```
+
+### Bulk fetching (ThreadPoolExecutor)
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import json
+from helpers import http_get
+
+track_ids = [
+    "4PTG3Z6ehGkBFwjybzWkR8",
+    "7qiZfU4dY1lWllzX7mPBI3",
+    "0VjIjW4GlUZAMYd2vXMi3b",
+]
+
+def fetch_oembed(tid):
+    url = f"https://open.spotify.com/oembed?url=https://open.spotify.com/track/{tid}"
+    try:
+        return json.loads(http_get(url))
+    except Exception as e:
+        return {"error": str(e), "id": tid}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_oembed, track_ids))
+# 5 tracks: ~1.3s total, ~0.26s per track
+```
+
+---
+
+## Approach 2: Static HTML — Rich Metadata via http_get
+
+Every open.spotify.com page (track, album, playlist, artist) serves full HTML with no JS requirement. The HTML contains JSON-LD and Open Graph tags that provide structured data.
+
+### Track page — all extractable fields
+
+```python
+from helpers import http_get
+import json, re
+
+def scrape_track(track_id):
+    url = f"https://open.spotify.com/track/{track_id}"
+    html = http_get(url)
+
+    # ---- JSON-LD (most structured) ----
+    ld_raw = re.search(r'<script type="application/ld\+json"[^>]*>(.*?)</script>', html, re.DOTALL)
+    ld = json.loads(ld_raw.group(1)) if ld_raw else {}
+
+    # ---- Open Graph / music: meta tags ----
+    metas = {}
+    for m in re.finditer(r'<meta\s+(?:property|name)="([^"]+)"\s+content="([^"]*)"', html):
+        key, val = m.group(1), m.group(2)
+        if key not in metas:
+            metas[key] = val
+
+    musician_urls = re.findall(r'<meta\s+(?:property|name)="music:musician"\s+content="([^"]*)"', html)
+    allowed_countries = re.findall(r'<meta\s+property="og:restrictions:country:allowed"\s+content="([^"]*)"', html)
+
+    return {
+        "title":          metas.get("og:title"),
+        "artist":         metas.get("music:musician_description"),
+        "artist_urls":    musician_urls,               # spotify artist page URLs
+        "album_url":      metas.get("music:album"),    # spotify album page URL
+        "track_number":   metas.get("music:album:track"),
+        "duration_s":     int(metas.get("music:duration", 0)),
+        "release_date":   metas.get("music:release_date"),  # YYYY-MM-DD
+        "cover_art":      metas.get("og:image"),       # 640px JPG
+        "audio_preview":  metas.get("og:audio"),       # 30s MP3 (may be None)
+        "spotify_url":    metas.get("og:url"),
+        "description":    metas.get("og:description"),
+        "eligible_regions": allowed_countries,
+        "ld_name":        ld.get("name"),
+        "ld_date":        ld.get("datePublished"),
+    }
+
+# Tested on track/4PTG3Z6ehGkBFwjybzWkR8 (Never Gonna Give You Up):
+# {
+#   "title":         "Never Gonna Give You Up",
+#   "artist":        "Rick Astley",
+#   "artist_urls":   ["https://open.spotify.com/artist/0gxyHStUsqpMadRV0Di1Qt"],
+#   "album_url":     "https://open.spotify.com/album/6eUW0wxWtzkFdaEFsTJto6",
+#   "track_number":  "1",
+#   "duration_s":    214,
+#   "release_date":  "1987-11-12",
+#   "cover_art":     "https://i.scdn.co/image/ab67616d0000b27315ebbedaacef61af244262a8",
+#   "audio_preview": "https://p.scdn.co/mp3-preview/b4c682084c3fd05538726d0a126b7e14b6e92c83",
+#   "spotify_url":   "https://open.spotify.com/track/4PTG3Z6ehGkBFwjybzWkR8",
+#   "eligible_regions": [185 country codes],
+# }
+```
+
+### Artist page — fields available
+
+```python
+def scrape_artist(artist_id):
+    url = f"https://open.spotify.com/artist/{artist_id}"
+    html = http_get(url)
+
+    ld_raw = re.search(r'<script type="application/ld\+json"[^>]*>(.*?)</script>', html, re.DOTALL)
+    ld = json.loads(ld_raw.group(1)) if ld_raw else {}
+
+    metas = {}
+    for m in re.finditer(r'<meta\s+(?:property|name)="([^"]+)"\s+content="([^"]*)"', html):
+        if m.group(1) not in metas:
+            metas[m.group(1)] = m.group(2)
+
+    return {
+        "name":              metas.get("og:title"),
+        "monthly_listeners": metas.get("og:description"),  # "Artist · 6.7M monthly listeners."
+        "image":             metas.get("og:image"),         # full-size artist photo
+        "spotify_url":       metas.get("og:url"),
+        "description":       ld.get("description"),
+    }
+
+# Tested on Rick Astley (artist/0gxyHStUsqpMadRV0Di1Qt):
+# {
+#   "name":              "Rick Astley",
+#   "monthly_listeners": "Artist · 6.7M monthly listeners.",
+#   "image":             "https://i.scdn.co/image/ab6761610000e5ebe834a63a0cfa3c0f57a9a434",
+# }
+```
+
+---
+
+## Approach 3: Embed Page — Structured JSON with Track Lists
+
+`https://open.spotify.com/embed/{type}/{id}` returns a small Next.js SSR page. Its `__NEXT_DATA__` script tag contains a fully-parsed entity object. This is the only no-auth route that returns track listings for albums, playlists, and artists.
+
+```python
+from helpers import http_get
+import json, re
+
+def scrape_embed(resource_type, resource_id):
+    """
+    resource_type: 'track', 'album', 'playlist', or 'artist'
+    Returns the entity dict from __NEXT_DATA__.
+    """
+    url = f"https://open.spotify.com/embed/{resource_type}/{resource_id}"
+    html = http_get(url)
+    m = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    data = json.loads(m.group(1))
+    return data['props']['pageProps']['state']['data']['entity']
+
+# ---- TRACK ----
+entity = scrape_embed("track", "4PTG3Z6ehGkBFwjybzWkR8")
+# entity keys: type, name, uri, id, title, artists, releaseDate, duration,
+#              isPlayable, isExplicit, audioPreview, hasVideo, visualIdentity
+# {
+#   "name":     "Never Gonna Give You Up",
+#   "uri":      "spotify:track:4PTG3Z6ehGkBFwjybzWkR8",
+#   "artists":  [{"name": "Rick Astley", "uri": "spotify:artist:0gxyHStUsqpMadRV0Di1Qt"}],
+#   "duration": 213573,   # milliseconds
+#   "releaseDate": {"isoString": "1987-11-12T00:00:00Z"},
+#   "isPlayable": True,
+#   "isExplicit": False,
+#   "audioPreview": {"url": "https://p.scdn.co/mp3-preview/b4c682..."},
+#   "visualIdentity": {
+#     "image": [
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d00001e02...", "maxWidth": 300, "maxHeight": 300},
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d000048...", "maxWidth": 64,  "maxHeight": 64},
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d0000b27...", "maxWidth": 640, "maxHeight": 640},
+#     ]
+#   }
+# }
+
+# ---- ALBUM (includes full track list) ----
+entity = scrape_embed("album", "6fu8fvc7O4p8Gb8KMTBTUW")
+# entity.trackList — list of all album tracks, e.g. 12 items:
+# [{
+#   "uri":          "spotify:track:4e1zdmsDwNBNe9rk7HHC0i",
+#   "title":        "Prelude for Piano No. 1 in E-Flat Major",
+#   "subtitle":     "Eduard Abramyan,\u00a0Sona Shaboyan",
+#   "duration":     107426,
+#   "isPlayable":   True,
+#   "audioPreview": {"url": "https://p.scdn.co/mp3-preview/d03c37..."},
+#   "entityType":   "track"
+# }, ...]
+
+# ---- PLAYLIST (includes up to 50 tracks) ----
+entity = scrape_embed("playlist", "37i9dQZF1DXcBWIGoYBM5M")
+# entity.trackList — 50 items
+# entity.subtitle  — "Spotify"
+# entity.authors   — [{"name": "Spotify"}]
+
+# ---- ARTIST (includes top 10 tracks) ----
+entity = scrape_embed("artist", "0gxyHStUsqpMadRV0Di1Qt")
+# entity.trackList — 10 top tracks, same shape as album trackList
+# entity.subtitle  — "Top tracks"
+```
+
+### Bonus: Anonymous access token (embedded in every embed page)
+
+The embed page SSR data includes a short-lived anonymous Spotify Web Player access token. The token is valid (~1 hour) but **anonymous tokens are severely rate-limited for api.spotify.com/v1 calls** (observed `Retry-After: 79561` seconds on the tracks endpoint after a few requests).
+
+```python
+def get_embed_token(resource_type="track", resource_id="4PTG3Z6ehGkBFwjybzWkR8"):
+    """Extract the anonymous access token from an embed page."""
+    url = f"https://open.spotify.com/embed/{resource_type}/{resource_id}"
+    html = http_get(url)
+    m = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    data = json.loads(m.group(1))
+    session = data['props']['pageProps']['state']['settings']['session']
+    return {
+        "access_token":  session['accessToken'],
+        "expires_ms":    session['accessTokenExpirationTimestampMs'],
+        "is_anonymous":  session['isAnonymous'],          # always True
+        "client_id":     data['props']['pageProps']['config']['clientId'],
+    }
+
+# Returned fields (verified 2026-04-18):
+# access_token: "BQBfxv..." (a standard Spotify Bearer token, ~160 chars)
+# expires_ms:   1776512455031 (~1 hour TTL)
+# is_anonymous: True
+# client_id:    "ab9ad0d96a624805a7d51e8868df1f97"
+
+# WARNING: Do NOT use this token to hammer api.spotify.com/v1 — anonymous tokens
+# share a global rate-limit bucket. One call can trigger a 22-hour ban window.
+# Use the embed page __NEXT_DATA__ directly instead (Approach 3 above).
+```
+
+---
+
+## What Requires a Browser
+
+The following are **not accessible** via http_get and require the CDP browser:
+
+- Lyrics (login-gated; JSON-LD confirms: `isAccessibleForFree: false`)
+- Search (`/search?q=...`) — loads client-side only, no meaningful HTML on first response
+- User library / listening history — requires OAuth
+- Full audio playback — requires OAuth + Widevine DRM
+- Podcast episodes — oEmbed returns 404; embed page `__NEXT_DATA__` lacks `state.data.entity`
+- Track recommendations beyond the top-10 artist view
+- Artist discography / full album list
+
+If browser access is needed for search:
+
+```python
+goto("https://open.spotify.com/search")
+wait_for_load()
+wait(2)
+# Type into the search box
+js("document.querySelector('input[data-testid=\"search-input\"]').focus()")
+type_text("never gonna give you up")
+wait(1)
+# Results appear in [data-testid="top-results-card"] or similar dynamic selectors
+```
+
+---
+
+## URL Patterns
+
+| Resource  | URL pattern                                    | ID format         |
+|-----------|------------------------------------------------|-------------------|
+| Track     | `https://open.spotify.com/track/{id}`          | 22-char alphanum  |
+| Album     | `https://open.spotify.com/album/{id}`          | 22-char alphanum  |
+| Artist    | `https://open.spotify.com/artist/{id}`         | 22-char alphanum  |
+| Playlist  | `https://open.spotify.com/playlist/{id}`       | 22-char alphanum  |
+| oEmbed    | `https://open.spotify.com/oembed?url={resource_url}` | any of above |
+| Embed     | `https://open.spotify.com/embed/{type}/{id}`   | same ID           |
+
+Extract Spotify ID from any URL:
+
+```python
+import re
+def spotify_id(url):
+    m = re.search(r'spotify\.com/(?:embed/)?(?:track|album|artist|playlist)/([A-Za-z0-9]{22})', url)
+    return m.group(1) if m else None
+```
+
+---
+
+## Gotchas
+
+- **oEmbed 404 for valid IDs**: A 404 from oEmbed can mean the resource is region-locked or not available for embedding, not necessarily that the ID is wrong. Verified: track `3n3Ppam7vgaVa1iaRUIOKE` returns 404 on oEmbed despite existing on Spotify.
+- **oEmbed 404 for artists**: Only works with valid, existing artist IDs. The artist ID `4gzpq5DumSF1a1LpGLBBl5` returns 404 — verify IDs from canonical Spotify URLs before using.
+- **oEmbed does not support episodes**: `open.spotify.com/episode/{id}` always returns 404 from the oEmbed endpoint.
+- **Embed page for episodes**: The embed page SSR for episodes does not include `state.data.entity` in the expected structure — parse defensively.
+- **Anonymous token rate limiting**: The access token from embed pages is valid but severely rate-limited for `api.spotify.com/v1`. Observed `Retry-After: 79561` (~22 hours) after 2-3 rapid API calls. Use embed `__NEXT_DATA__` data instead of the API.
+- **`get_access_token` endpoint blocked**: `https://open.spotify.com/get_access_token?reason=transport&productType=web_player` returns HTTP 403 from plain http_get regardless of headers. Token must be sourced from the embed page HTML.
+- **`music:musician` meta tag dedup**: `re.findall` on `music:musician` returns all artist URLs. `dict(re.finditer(...))` would only keep the last one — always use `findall` for multi-value tags.
+- **Cover art CDN differences**: oEmbed thumbnail uses `image-cdn-ak.spotifycdn.com`; track page `og:image` uses `i.scdn.co`. Both are publicly accessible. The embed `visualIdentity.image` array provides three sizes (64, 300, 640).
+- **No `__NEXT_DATA__` on main open.spotify.com pages**: The SSR `__NEXT_DATA__` pattern only works on `open.spotify.com/embed/*`, not on main track/album/artist pages. Those pages use JSON-LD and Open Graph tags instead.
+- **Track duration units differ**: `music:duration` meta tag is in **seconds** (integer). Embed `__NEXT_DATA__` `entity.duration` is in **milliseconds**.
+- **Rate limits for http_get pages**: No rate limit observed on oEmbed or static HTML pages in testing (10 concurrent requests succeeded; ~0.25s avg per oEmbed call).

--- a/domain-skills/walmart/scraping.md
+++ b/domain-skills/walmart/scraping.md
@@ -1,0 +1,444 @@
+# Walmart — Product Search & Data Extraction
+
+Field-tested against walmart.com on 2026-04-18 using `http_get` (no browser required).
+All code blocks were run and outputs verified against live responses.
+
+---
+
+## Fastest Approach: `http_get` with `__NEXT_DATA__`
+
+Walmart's Next.js SSR embeds the full search or product payload as JSON in a
+`<script id="__NEXT_DATA__">` tag. **No browser needed for search or product detail pages.**
+~2–3 s per page fetch; no CAPTCHA or session cookies required.
+
+### Critical UA rule
+
+| User-Agent | Result |
+|---|---|
+| `Mozilla/5.0` (bare) | Full HTML + `__NEXT_DATA__` — **use this** |
+| `Mozilla/5.0 ... Chrome/120 ...` (full) | PerimeterX "Robot or human?" challenge (200, 15 KB) |
+| `Safari/17` full UA | Works (full HTML, ~1.15 MB) |
+| `curl/7.x` | PerimeterX challenge |
+| `python-requests/2.31` | PerimeterX challenge |
+
+The bare `Mozilla/5.0` string bypasses PerimeterX. Any UA that looks like a headless
+client or includes a recognizable browser fingerprint triggers the JS challenge page.
+
+### Base fetch helper
+
+```python
+import json, re, gzip, urllib.request
+
+def fetch_walmart(url):
+    """
+    Fetch any walmart.com page.
+    Returns decoded HTML string.
+    Raises RuntimeError if PerimeterX bot challenge is returned.
+    """
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"},
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        html = data.decode()
+    if "Robot or human" in html:
+        raise RuntimeError(f"PerimeterX challenge triggered: {url}")
+    return html
+
+def parse_next_data(html):
+    m = re.search(r'id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    if not m:
+        raise ValueError("__NEXT_DATA__ not found — page structure may have changed")
+    return json.loads(m.group(1))
+```
+
+---
+
+## Search Results
+
+### URL patterns
+
+```python
+# Keyword search
+"https://www.walmart.com/search?q=laptop"
+
+# Pagination — append &page=N
+"https://www.walmart.com/search?q=laptop&page=2"
+
+# Sort options (confirmed working)
+"https://www.walmart.com/search?q=laptop&sort=best_match"    # default
+"https://www.walmart.com/search?q=laptop&sort=best_seller"
+"https://www.walmart.com/search?q=laptop&sort=price_low"
+"https://www.walmart.com/search?q=laptop&sort=customer_rating"
+
+# Price filter
+"https://www.walmart.com/search?q=laptop&min_price=200&max_price=500"
+
+# Browse by category (department ID path)
+"https://www.walmart.com/browse/electronics/laptops/3944_1089430_3951"
+```
+
+### `__NEXT_DATA__` path to items
+
+```
+data
+  .props.pageProps.initialData.searchResult
+    .aggregatedCount        — int: total matching products (e.g. 18818)
+    .paginationV2.maxPage   — int: last page number
+    .itemStacks[]           — array of stacks (usually 2: sponsored + organic)
+      .items[]              — array of product objects
+```
+
+### Full extractor (field-tested)
+
+```python
+def extract_search_results(html):
+    """
+    Returns (items, total_count, max_page).
+    items is a list of dicts with confirmed fields.
+    """
+    data = parse_next_data(html)
+    sr = data["props"]["pageProps"]["initialData"]["searchResult"]
+
+    items = []
+    for stack in sr.get("itemStacks", []):
+        for item in stack.get("items", []):
+            pi = item.get("priceInfo") or {}
+            img = item.get("imageInfo") or {}
+            rating = item.get("rating") or {}
+            avail = item.get("availabilityStatusV2") or {}
+            items.append({
+                "usItemId":        item.get("usItemId"),           # str, Walmart item ID
+                "name":            item.get("name"),               # str
+                "brand":           item.get("brand"),              # str or None
+                "price":           item.get("price"),              # int, current price in USD
+                "linePrice":       pi.get("linePrice"),            # str "$429.00"
+                "wasPrice":        pi.get("wasPrice") or None,     # str "$699.00" or None
+                "savings":         pi.get("savings") or None,      # str "SAVE $270.00" or None
+                "averageRating":   rating.get("averageRating"),    # float e.g. 4.3
+                "numberOfReviews": rating.get("numberOfReviews"),  # int
+                "availability":    avail.get("value"),             # "IN_STOCK" / "OUT_OF_STOCK"
+                "isSponsored":     bool(item.get("isSponsoredFlag")),
+                "url":             "https://www.walmart.com" + (item.get("canonicalUrl") or "").split("?")[0],
+                "thumbnailUrl":    img.get("thumbnailUrl"),
+            })
+
+    total = sr.get("aggregatedCount")
+    max_page = (sr.get("paginationV2") or {}).get("maxPage")
+    return items, total, max_page
+
+
+# Usage
+html = fetch_walmart("https://www.walmart.com/search?q=laptop")
+items, total, max_page = extract_search_results(html)
+# items: 66 items on page 1, total=18818, max_page=11
+
+# Filter out sponsored
+organic = [i for i in items if not i["isSponsored"]]
+```
+
+### Field notes (confirmed)
+
+- **`usItemId`**: string, matches the numeric ID at the end of `/ip/.../ITEMID` URLs.
+  Some non-product rows (ad widgets) have `usItemId=None` — filter with `if item.get("usItemId")`.
+- **`price`**: integer cents-less price (e.g. `429` for "$429.00"). Use `priceInfo.linePrice` for
+  the formatted string including the dollar sign.
+- **`wasPrice` / `savings`**: only present when item is on sale. Always `None` for full-price items.
+- **`isSponsoredFlag`**: the first batch of results across both itemStacks are frequently sponsored.
+  On a laptop search, ~56 of 66 SSR items carry `isSponsoredFlag: true`.
+- **`rating`**: present on ~91% of items (60/66 in test). `averageRating` is a float; `numberOfReviews` is int.
+- **`canonicalUrl`**: always includes `?classType=...&athbdg=...` query params — strip with `.split("?")[0]`
+  to get a clean URL.
+- **Two itemStacks**: Walmart returns two stacks (`itemStacks[0]` and `itemStacks[1]`). Merge them.
+  `itemStacks[0]` is the primary grid; `itemStacks[1]` is a secondary sponsored/related block.
+
+### Pagination
+
+```python
+for page in range(1, max_page + 1):
+    html = fetch_walmart(f"https://www.walmart.com/search?q=laptop&page={page}")
+    items, _, _ = extract_search_results(html)
+    # process items...
+```
+
+Page responses average ~2.5 s each. No rate-limiting was observed across 3 sequential requests.
+For bulk scraping, add a 1–2 s delay between requests to be safe.
+
+---
+
+## Product Detail Page
+
+### URL pattern
+
+```
+https://www.walmart.com/ip/{slug}/{usItemId}
+```
+
+The slug is ignored in routing — only the numeric `usItemId` matters.
+These work identically:
+```
+https://www.walmart.com/ip/anything/19717318352
+https://www.walmart.com/ip/Apple-MacBook-Neo/19717318352
+```
+
+### `__NEXT_DATA__` path on a product page
+
+```
+data.props.pageProps.initialData.data
+  .product        — core product object
+  .idml           — long description, specs, highlights, warranty
+  .reviews        — rating breakdown + first 10 customer reviews (SSR)
+```
+
+### Full extractor (field-tested)
+
+```python
+def extract_product_detail(html):
+    """
+    Returns a dict with all confirmed product fields.
+    idml.specifications returns all spec rows as a flat dict.
+    reviews returns the SSR-rendered first 10 customer reviews.
+    """
+    data = parse_next_data(html)
+    d = data["props"]["pageProps"]["initialData"]["data"]
+    product = d["product"]
+    idml    = d.get("idml") or {}
+    reviews = d.get("reviews") or {}
+
+    pi = product.get("priceInfo") or {}
+    cp = pi.get("currentPrice") or {}
+    img = product.get("imageInfo") or {}
+    avail = product.get("availabilityStatusV2") or {}
+
+    specs = {
+        spec.get("name"): spec.get("value")
+        for spec in (idml.get("specifications") or [])
+    }
+
+    all_images = [
+        img_item.get("url")
+        for img_item in (img.get("allImages") or [])
+        if img_item.get("url")
+    ]
+
+    customer_reviews = [
+        {
+            "title":    r.get("reviewTitle"),
+            "rating":   r.get("rating"),           # int 1-5 (field is "rating", NOT "overallRating")
+            "text":     r.get("reviewText"),
+            "author":   r.get("userNickname"),
+            "date":     r.get("reviewSubmissionTime"),
+        }
+        for r in (reviews.get("customerReviews") or [])
+    ]
+
+    return {
+        # identity
+        "usItemId":            product.get("usItemId"),
+        "name":                product.get("name"),
+        "brand":               product.get("brand"),
+        "model":               product.get("model"),
+        "upc":                 product.get("upc"),
+        # price
+        "price":               cp.get("price"),            # float, e.g. 599
+        "priceString":         cp.get("priceString"),      # "$599.00"
+        "wasPrice":            (pi.get("wasPrice") or {}).get("priceString"),
+        "savings":             (pi.get("savings") or {}).get("savingsString"),
+        # availability
+        "availability":        avail.get("value"),         # "IN_STOCK" / "OUT_OF_STOCK"
+        "availabilityDisplay": avail.get("display"),       # "In stock"
+        # ratings
+        "averageRating":       product.get("averageRating"),
+        "numberOfReviews":     product.get("numberOfReviews"),
+        # text
+        "shortDescription":    product.get("shortDescription"),
+        "longDescription":     idml.get("longDescription"),  # HTML string
+        # media
+        "thumbnailUrl":        img.get("thumbnailUrl"),
+        "allImages":           all_images,          # up to 10 image URLs
+        # specs
+        "specifications":      specs,               # {"Brand": "Apple", "Processor": "A18 Pro", ...}
+        "highlights":          [                    # top highlighted specs with icons
+            {"name": h.get("name"), "value": h.get("value")}
+            for h in (idml.get("productHighlights") or [])
+        ],
+        # URL
+        "canonicalUrl":        "https://www.walmart.com" + (product.get("canonicalUrl") or ""),
+        # fulfillment
+        "fulfillmentOptions":  product.get("fulfillmentOptions") or [],
+        # reviews (SSR-rendered, first 10)
+        "reviewSummary": {
+            "averageOverallRating":    reviews.get("averageOverallRating"),
+            "totalReviewCount":        reviews.get("totalReviewCount"),
+            "reviewsWithTextCount":    reviews.get("reviewsWithTextCount"),
+            "recommendedPercentage":   reviews.get("recommendedPercentage"),
+        },
+        "customerReviews":     customer_reviews,
+    }
+
+
+# Usage
+url = "https://www.walmart.com/ip/Apple-MacBook-Neo/19717318352"
+html = fetch_walmart(url)
+product = extract_product_detail(html)
+
+# Example output (confirmed live):
+# product["name"]         → "Apple MacBook Neo 13-inch Apple A18 Pro chip..."
+# product["price"]        → 599
+# product["priceString"]  → "$599.00"
+# product["availability"] → "IN_STOCK"
+# product["model"]        → "MHFD4LL/A"
+# product["upc"]          → "195950852745"
+# len(product["specifications"])  → 29 spec rows
+# len(product["allImages"])       → 10
+# product["specifications"]["Processor"] → "A18 Pro"
+```
+
+### Field notes (confirmed)
+
+- **`averageRating` / `numberOfReviews`** on the product node: present for items with reviews.
+  New/few-review items may return `None` for both.
+- **`reviewSummary.averageOverallRating`** in the reviews node often differs slightly from
+  `product.averageRating` — the reviews node is more precise (e.g. `4.75` vs `4.8`).
+- **`customerReviews`** (SSR): always the first 10 reviews. The per-review rating field is `"rating"`
+  (int 1–5), **not** `"overallRating"` (which is always `None`).
+- **`longDescription`**: raw HTML string including `<ul>/<li>` tags. Strip tags before display.
+- **`specifications`**: flat dict — confirmed 29–31 rows for electronics. Key names use display labels
+  (e.g. `"RAM memory"`, `"Screen size"`, `"HD capacity"`).
+- **`wasPrice` / `savings`** on detail page: same as search — `None` when item is not discounted.
+- **No JSON-LD**: Walmart product pages do **not** include `<script type="application/ld+json">`.
+  All structured data lives in `__NEXT_DATA__`.
+
+---
+
+## Anti-Bot: PerimeterX
+
+Walmart uses **PerimeterX** (app ID `PXu6b0qd2S`, confirmed in `runtimeConfig.perimeterX`).
+
+| Signal | Detail |
+|---|---|
+| Bot detector | PerimeterX |
+| Challenge page | "Robot or human?" — 200 OK, 15 KB HTML |
+| Triggered by | Full browser UA strings (Chrome, curl, python-requests) |
+| Bypassed by | `User-Agent: Mozilla/5.0` (bare prefix only) |
+| No JS execution | SSR response is complete — no JS challenge to solve |
+
+Detection in code:
+```python
+if "Robot or human" in html:
+    raise RuntimeError("PerimeterX challenge — switch to browser harness")
+```
+
+If `http_get` starts returning the challenge after a run of successful fetches, switch to the
+browser harness (see below).
+
+---
+
+## Browser Harness Fallback
+
+Use the browser harness when:
+- PerimeterX starts blocking `http_get` on your IP
+- You need to interact with the page (add to cart, filter UI, infinite scroll)
+- You need variant switching (color/size selectors)
+
+```python
+# Browser-based search extraction
+new_tab("https://www.walmart.com/search?q=laptop")
+wait_for_load()
+wait(2)  # JS renders product cards after readyState=complete
+
+# Extract via __NEXT_DATA__ in-browser (identical structure to http_get)
+import json
+nd = js("document.getElementById('__NEXT_DATA__')?.textContent")
+data = json.loads(nd)
+sr = data["props"]["pageProps"]["initialData"]["searchResult"]
+items = []
+for stack in sr.get("itemStacks", []):
+    items.extend(stack.get("items", []))
+```
+
+### Browser selectors (confirmed working for DOM-based extraction)
+
+```python
+# Product cards on search results page
+results = js("""
+  Array.from(document.querySelectorAll('[data-item-id]')).map(el => ({
+    itemId:    el.getAttribute('data-item-id'),
+    name:      el.querySelector('[itemprop="name"]')?.innerText?.trim(),
+    price:     el.querySelector('[itemprop="price"]')?.getAttribute('content'),
+    url:       el.querySelector('a[link-identifier]')?.href,
+  })).filter(r => r.itemId)
+""")
+
+# If [data-item-id] misses items, use the Next.js data attribute alternative:
+results_alt = js("""
+  Array.from(document.querySelectorAll('[data-testid="list-view"]'))
+    .map(el => el.innerText.trim())
+""")
+```
+
+> **Prefer `__NEXT_DATA__` over DOM selectors** even in-browser — the JSON is complete and
+> stable. DOM class names at Walmart are obfuscated and change between deployments.
+
+### Session gotcha
+
+Always open Walmart with `new_tab()` on first visit:
+```python
+new_tab("https://www.walmart.com/search?q=laptop")
+wait_for_load()
+wait(2)
+```
+After that, `goto()` works normally within the same session.
+
+---
+
+## Public API
+
+Walmart's affiliate/partner API (`developer.api.walmart.com`) requires a registered API key
+and returns HTTP 403 without one. No unauthenticated public product API is available.
+The `__NEXT_DATA__` SSR approach replaces any need for the official API for read-only data.
+
+---
+
+## Gotchas
+
+- **UA must be `Mozilla/5.0` bare**: Any fuller string (Chrome, Safari, curl, requests) hits
+  PerimeterX. This is counterintuitive — the *shorter*, less realistic UA is the one that works.
+
+- **Regex must use `id=` attribute match**: The regex
+  `r'<script id="__NEXT_DATA__" type="application/json">...'` fails because the actual tag is
+  `<script id="__NEXT_DATA__">` without `type`. Use:
+  ```python
+  re.search(r'id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+  ```
+
+- **`usItemId` can be `None`**: ~5/66 items on a page are non-product ad widgets with no `usItemId`.
+  Always filter: `[i for i in items if i.get("usItemId")]`.
+
+- **Two `itemStacks`**: Walmart returns two stacks. Iterate over all stacks or you'll miss
+  ~10 items from the second stack.
+
+- **`canonicalUrl` includes tracking params**: Always strip with `.split("?")[0]`.
+
+- **Review field is `"rating"` not `"overallRating"`**: Each `customerReviews` entry has a `"rating"`
+  int field (1–5). The `"overallRating"` field is always `None`. Don't confuse with
+  `product.averageRating` (the aggregate float).
+
+- **No JSON-LD on product pages**: Zero `<script type="application/ld+json">` tags were found.
+  All structured data is in `__NEXT_DATA__`.
+
+- **`longDescription` is HTML**: Strip tags before text use. May contain promotional/financing copy
+  mixed with real product description.
+
+- **Page sizes vary**: Page 1 returned 66 items across 2 stacks; page 2 returned 55.
+  Do not assume a fixed items-per-page count.
+
+- **`http_get` default already sends `Mozilla/5.0`**: `helpers.http_get()` uses
+  `"User-Agent": "Mozilla/5.0"` by default — no override needed when calling it directly.
+  Only pass a custom `headers=` if you need to change something else.
+
+- **`developer.api.walmart.com`** returns HTTP 403 without an API key. Not usable for
+  unauthenticated scraping.

--- a/domain-skills/weather/scraping.md
+++ b/domain-skills/weather/scraping.md
@@ -1,0 +1,398 @@
+# Weather APIs — Data Extraction
+
+Three free, no-auth weather APIs tested: **wttr.in** (simplest), **Open-Meteo** (most complete), **weather.gov / NWS** (US only, official).
+
+All work with `http_get` — no browser needed.
+
+## Do this first: pick your API
+
+| Goal | Best API | Latency | Notes |
+|------|----------|---------|-------|
+| Quick current + 3-day forecast, any city name | wttr.in `?format=j1` | ~800ms | US + international |
+| Rich hourly/daily/historical, any coordinates | Open-Meteo | ~700ms | 10K req/day free |
+| City name → coordinates | Open-Meteo geocoding | ~700ms | Use with Open-Meteo forecast |
+| Official US forecasts with PoP and text | weather.gov NWS | ~90ms /points + ~70ms /forecast | US only, 2-call flow |
+
+**Never use a browser for any of these APIs.** All return JSON over plain HTTP.
+
+---
+
+## Fastest approach: wttr.in one-call current + 3-day forecast
+
+```python
+import json
+data = json.loads(http_get("https://wttr.in/San+Francisco?format=j1"))
+
+# Current conditions
+cc = data['current_condition'][0]
+print(cc['temp_F'], '°F /', cc['temp_C'], '°C')      # '47', '8'
+print(cc['FeelsLikeF'], '°F feels like')              # '46'
+print(cc['humidity'], '%')                            # '80'
+print(cc['windspeedMiles'], 'mph', cc['winddir16Point'])  # '3', 'SW'
+print(cc['weatherDesc'][0]['value'])                  # 'Partly cloudy'
+print(cc['precipMM'], 'mm precip')                   # '0.0'
+print(cc['visibility'], 'km', cc['visibilityMiles'], 'mi')
+print(cc['pressure'], 'hPa', cc['pressureInches'], 'inHg')
+print(cc['uvIndex'])                                  # '0'
+print(cc['cloudcover'], '%')                          # '50'
+print(cc['observation_time'])                         # '10:48 AM' (UTC)
+print(cc['localObsDateTime'])                         # '2026-04-18 03:34 AM' (local)
+
+# 3-day forecast (today + 2 more)
+for day in data['weather']:
+    print(day['date'], day['maxtempF'], '/', day['mintempF'], '°F')
+    # also: maxtempC, mintempC, avgtempF, avgtempC, sunHour, uvIndex, totalSnow_cm
+    astro = day['astronomy'][0]
+    print('  sunrise:', astro['sunrise'], 'sunset:', astro['sunset'])
+    print('  moon:', astro['moon_phase'], astro['moon_illumination'], '%')
+    # Hourly breakdown (8 entries per day, every 3 hours: time 0,300,600,...,2100)
+    for h in day['hourly']:
+        print(h['time'], h['tempF'], '°F', h['weatherDesc'][0]['value'])
+        # time is '0','300','600',...,'2100' (not HH:MM)
+        # also: chanceofrain, chanceofsnow, chanceofthunder, chanceoffog, humidity, etc.
+
+# Location info
+na = data['nearest_area'][0]
+print(na['areaName'][0]['value'])    # 'San Francisco'
+print(na['country'][0]['value'])     # 'United States of America'
+print(na['latitude'], na['longitude'])  # '37.775', '-122.418' (strings)
+print(na['region'][0]['value'])      # 'California'
+```
+
+**Works with city names, coordinates, airport codes (`~SFO`), and zip codes.**
+
+---
+
+## Open-Meteo: most complete free weather API
+
+### Step 1: city name → coordinates (geocoding)
+
+```python
+import json
+geo = json.loads(http_get("https://geocoding-api.open-meteo.com/v1/search?name=Chicago&count=1"))
+city = geo['results'][0]
+lat  = city['latitude']   # 41.85003
+lon  = city['longitude']  # -87.65005
+tz   = city['timezone']   # 'America/Chicago'
+# Also available: city['elevation'], city['country'], city['country_code'],
+#                 city['admin1'] (state/province), city['population']
+```
+
+Always use `count=1` and take `results[0]` for unambiguous city names. For "San Francisco" `results[0]` is always the California city (pop 864K).
+
+### Current conditions (extended — preferred over current_weather)
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+    f"precipitation,weathercode,windspeed_10m,winddirection_10m,"
+    f"uv_index,surface_pressure"
+    f"&timezone={tz}"
+))
+
+cur   = data['current']
+units = data['current_units']
+# cur keys and units (all confirmed):
+# temperature_2m        °C   (or °F with &temperature_unit=fahrenheit)
+# relative_humidity_2m  %
+# apparent_temperature  °C
+# precipitation         mm
+# weathercode           WMO code int (see table below)
+# windspeed_10m         km/h (or mph with &windspeed_unit=mph)
+# winddirection_10m     °
+# uv_index              (unitless float)
+# surface_pressure      hPa
+# time                  ISO8601 local time (e.g. '2026-04-18T10:45')
+# interval              900 (seconds — 15-min update cadence)
+
+print(cur['temperature_2m'], units['temperature_2m'])   # 8.7 °C
+print(cur['apparent_temperature'])                      # 6.6
+print(cur['relative_humidity_2m'])                      # 80
+print(cur['windspeed_10m'], cur['winddirection_10m'])   # 6.1  242
+print(cur['weathercode'])                               # 0 = clear sky
+```
+
+The older `&current_weather=true` param works too — returns `data['current_weather']` with only temperature, windspeed, winddirection, weathercode, time, is_day, interval.
+
+### Hourly forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&hourly=temperature_2m,dewpoint_2m,apparent_temperature,"
+    f"precipitation_probability,precipitation,rain,showers,snowfall,snow_depth,"
+    f"weathercode,cloudcover,visibility,windspeed_10m,winddirection_10m,"
+    f"windgusts_10m,uv_index"
+    f"&forecast_days=3&timezone={tz}"
+))
+
+hourly = data['hourly']
+units  = data['hourly_units']
+# hourly is a dict of parallel arrays, all same length
+# time entries: ISO8601 strings, one per hour ('2026-04-18T00:00', etc.)
+# 3 forecast days → 72 entries
+
+for i, t in enumerate(hourly['time'][:5]):
+    print(t,
+          hourly['temperature_2m'][i], units['temperature_2m'],
+          hourly['precipitation_probability'][i], units['precipitation_probability'],
+          hourly['windspeed_10m'][i], units['windspeed_10m'])
+
+# Confirmed units (all from live response):
+# temperature_2m              °C      dewpoint_2m          °C
+# apparent_temperature        °C      precipitation_probability  %
+# precipitation               mm      rain                 mm
+# showers                     mm      snowfall             cm
+# snow_depth                  m       weathercode          wmo code
+# cloudcover                  %       visibility           m (not km!)
+# windspeed_10m               km/h    winddirection_10m    °
+# windgusts_10m               km/h    uv_index             (unitless)
+```
+
+`forecast_days` defaults to 7, max is 16.
+
+### Daily forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,"
+    f"apparent_temperature_min,precipitation_sum,rain_sum,snowfall_sum,"
+    f"precipitation_hours,precipitation_probability_max,"
+    f"windspeed_10m_max,windgusts_10m_max,winddirection_10m_dominant,"
+    f"shortwave_radiation_sum,uv_index_max,sunrise,sunset"
+    f"&timezone={tz}&forecast_days=7"
+))
+
+daily = data['daily']
+units = data['daily_units']
+for i, date in enumerate(daily['time']):
+    print(date,
+          daily['temperature_2m_max'][i], '/', daily['temperature_2m_min'][i], units['temperature_2m_max'],
+          f"precip={daily['precipitation_sum'][i]}{units['precipitation_sum']}",
+          f"pop={daily['precipitation_probability_max'][i]}%",
+          f"UV={daily['uv_index_max'][i]}",
+          f"sunrise={daily['sunrise'][i]}",
+          f"sunset={daily['sunset'][i]}")
+# sunrise/sunset are ISO8601 local datetimes ('2026-04-18T06:29')
+# shortwave_radiation_sum in MJ/m²
+```
+
+### Historical data (archive API)
+
+Different subdomain — `archive-api.open-meteo.com`:
+
+```python
+data = json.loads(http_get(
+    "https://archive-api.open-meteo.com/v1/archive"
+    "?latitude=37.7749&longitude=-122.4194"
+    "&start_date=2024-01-01&end_date=2024-01-07"
+    "&daily=temperature_2m_max,precipitation_sum"
+    "&timezone=America/Los_Angeles"
+))
+# Returns same structure as forecast — daily dict of parallel arrays
+# Hourly also works: &hourly=temperature_2m,precipitation,weathercode
+# Data goes back to 1940 for most locations
+```
+
+### Unit overrides
+
+All unit conversions are server-side — just add params:
+
+```
+&temperature_unit=fahrenheit    # default: celsius
+&windspeed_unit=mph             # default: kmh (also: ms, kn)
+&precipitation_unit=inch        # default: mm
+```
+
+---
+
+## weather.gov NWS (US only — 2-call flow)
+
+Required for official NWS text forecasts with probability-of-precipitation text and storm warnings.
+
+```python
+import json, urllib.request, gzip
+
+def nws_get(url):
+    """NWS requires a descriptive User-Agent or returns 403."""
+    h = {
+        "User-Agent": "(myapp.example.com, contact@example.com)",
+        "Accept": "application/geo+json",
+    }
+    req = urllib.request.Request(url, headers=h)
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+# Call 1: resolve lat/lon to forecast office + grid cell (~90ms)
+pts  = json.loads(nws_get("https://api.weather.gov/points/37.7749,-122.4194"))
+prop = pts['properties']
+office = prop['gridId']    # 'MTR'
+gx     = prop['gridX']    # 85
+gy     = prop['gridY']    # 105
+forecast_url = prop['forecast']          # 7-day
+hourly_url   = prop['forecastHourly']    # hourly
+
+# Also available from /points: prop['timeZone'], prop['observationStations'],
+# prop['relativeLocation']['properties']['city'] and ['state']
+
+# Call 2: 7-day forecast (14 half-day periods) (~70ms)
+fc  = json.loads(nws_get(forecast_url))
+for p in fc['properties']['periods']:
+    print(p['name'],            # 'Saturday', 'Saturday Night', 'Sunday', ...
+          p['temperature'], p['temperatureUnit'],     # 74 F
+          p['windSpeed'], p['windDirection'],          # '6 to 14 mph' 'SW'
+          p['shortForecast'],                          # 'Mostly Sunny'
+          p['probabilityOfPrecipitation']['value'],    # 0  (integer percent)
+          p['isDaytime'])                              # True/False
+    # p['detailedForecast'] — plain English paragraph, e.g.
+    # 'Sunny, with a high near 74. Southwest wind 6 to 14 mph.'
+
+# Hourly (156 hours out — ~6.5 days)
+fch = json.loads(nws_get(hourly_url))
+for p in fch['properties']['periods'][:5]:
+    print(p['startTime'],           # '2026-04-18T03:00:00-07:00'
+          p['temperature'], '°F',
+          p['shortForecast'],
+          p['windSpeed'],
+          f"humidity={p['relativeHumidity']['value']}%",
+          f"dewpoint={p['dewpoint']['value']:.1f}°C")
+```
+
+`/points` response is cached `max-age=20500` (~5.7 hours) at the CDN — safe to call once per session and reuse grid coordinates.
+
+---
+
+## WMO weather code table (Open-Meteo `weathercode`)
+
+```python
+WMO_CODES = {
+    0: "Clear sky",
+    1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+    45: "Fog", 48: "Icy fog",
+    51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+    61: "Slight rain", 63: "Moderate rain", 65: "Heavy rain",
+    71: "Slight snow", 73: "Moderate snow", 75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight rain showers", 81: "Moderate rain showers", 82: "Violent rain showers",
+    85: "Slight snow showers", 86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with slight hail", 99: "Thunderstorm with heavy hail",
+}
+
+def wmo_desc(code):
+    return WMO_CODES.get(code, f"Unknown code {code}")
+```
+
+---
+
+## Complete end-to-end pattern: city name → rich forecast
+
+```python
+import json
+
+def get_weather(city: str) -> dict:
+    """City name → current + 7-day daily forecast via Open-Meteo."""
+    # 1. Geocode
+    geo  = json.loads(http_get(
+        f"https://geocoding-api.open-meteo.com/v1/search?name={city.replace(' ', '+')}&count=1"
+    ))
+    if not geo.get('results'):
+        raise ValueError(f"City not found: {city}")
+    loc  = geo['results'][0]
+    lat, lon, tz = loc['latitude'], loc['longitude'], loc['timezone']
+
+    # 2. Forecast (single call: current + daily)
+    data = json.loads(http_get(
+        f"https://api.open-meteo.com/v1/forecast"
+        f"?latitude={lat}&longitude={lon}"
+        f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+        f"precipitation,weathercode,windspeed_10m,winddirection_10m,uv_index"
+        f"&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,"
+        f"precipitation_probability_max,weathercode,sunrise,sunset"
+        f"&timezone={tz}&forecast_days=7"
+    ))
+    return {"location": loc, "current": data['current'],
+            "daily": data['daily'], "units": {
+                "current": data['current_units'],
+                "daily": data['daily_units'],
+            }}
+
+result = get_weather("Tokyo")
+cur = result['current']
+print(f"{result['location']['name']}: {cur['temperature_2m']}°C feels like {cur['apparent_temperature']}°C")
+print(f"Humidity {cur['relative_humidity_2m']}%, wind {cur['windspeed_10m']} km/h")
+```
+
+Total: 2 API calls, ~1400ms combined.
+
+---
+
+## Gotchas
+
+**wttr.in returns HTML (or ANSI art) instead of JSON if you forget `?format=j1`.**
+The `?format=j1` suffix is mandatory for JSON. Without it:
+- Browser `User-Agent` → full HTML page (~21KB)
+- `curl`/`Wget` User-Agent → ANSI escape-code ASCII art (~500B)
+Neither is parseable as JSON.
+
+**wttr.in text formats require a non-browser User-Agent.**
+`http_get()` sends `Mozilla/5.0` — wttr.in responds with an HTML page for `?format=%t`, `?format=3`, `?format=4`.
+Use `Wget/1.21` (or any non-browser UA) for text format endpoints:
+```python
+import urllib.request, gzip
+
+def http_get_wttr(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "Wget/1.21", "Accept": "*/*"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+# Text format tokens (URL-encode %): %25l=location, %25C=condition desc,
+# %25t=temp, %25f=feels-like, %25h=humidity, %25w=wind
+print(http_get_wttr("https://wttr.in/London?format=%25t"))           # '+55°F'
+print(http_get_wttr("https://wttr.in/Tokyo?format=3"))               # 'tokyo: ☀️   +69°F'
+print(http_get_wttr("https://wttr.in/Berlin?format=%25l:+%25C+%25t+(feels+%25f)+%25h+%25w"))
+# 'berlin: Sunny +65°F (feels +65°F) 42% ↖5mph'
+```
+
+**wttr.in `format=j1` returns only 3 days** (today + 2). Use Open-Meteo for longer forecasts (up to 16 days).
+
+**wttr.in `nearest_area.areaName` is often wrong.** The returned area name is a reverse-geocoded neighborhood, not the city you queried (`"Mccormickville"` for Chicago, `"Lomita Park"` for SFO airport). Use `request[0].query` for what was actually resolved.
+
+**wttr.in `hourly[].time` is `'0'`, `'300'`, `'600'`...`'2100'`** — not HH:MM strings. Parse as `int(time) // 100` for hours.
+
+**wttr.in `weatherDesc` is a list**: `cc['weatherDesc'][0]['value']`, not a string. Same for `areaName`, `country`, `region`, `weatherIconUrl`.
+
+**wttr.in unknown city returns HTTP 500**, not 404 or a JSON error.
+
+**Open-Meteo default timezone is GMT.** Always pass `&timezone={tz}` or daily `sunrise`/`sunset` values will be in UTC, and daily buckets will be wrong.
+
+**Open-Meteo `visibility` is in metres** (not km). Divide by 1000 to get km.
+
+**Open-Meteo returns HTTP 400 with JSON error body on bad params:**
+```json
+{"reason": "Latitude must be in range of -90 to 90°. Given: 999.0.", "error": true}
+```
+`http_get()` raises an exception on 4xx — catch `urllib.error.HTTPError` and read `e.read()` (may be gzip-compressed) for the reason.
+
+**weather.gov requires a descriptive `User-Agent`.** The NWS API blocks generic `python-urllib` or `Mozilla/5.0` agents sporadically. Always set `User-Agent: (yourapp.com, your@email.com)` or use your actual app name.
+
+**weather.gov is US-only.** `/points/{lat},{lon}` returns HTTP 404 for coordinates outside the US (including territories like Puerto Rico for some grid edges). Fall back to Open-Meteo for non-US locations.
+
+**weather.gov `windSpeed` is a string like `"6 to 14 mph"`**, not a number. Parse with regex if you need a numeric value.
+
+**weather.gov `probabilityOfPrecipitation` is a dict**: `p['probabilityOfPrecipitation']['value']`, with `p['probabilityOfPrecipitation']['unitCode']` = `'wmoUnit:percent'`.
+
+**Open-Meteo rate limit: 10,000 requests/day on the free tier.** The geocoding API and forecast API count separately. No rate limit headers are returned — track usage yourself.
+
+**weather.gov /points response is heavily cached** (`Cache-Control: public, max-age=20500`). Store the office/gridX/gridY and reuse — only call `/points` once per location.


### PR DESCRIPTION
## Summary
- Walmart: http_get works with bare Mozilla/5.0 UA (full Chrome UA triggers PerimeterX); __NEXT_DATA__ via id= regex; 60+ items per search; no JSON-LD on product pages
- Spotify: oEmbed no-auth for track/album/playlist/artist; embed __NEXT_DATA__ has full trackList + preview URLs; anonymous token triggers 22h Retry-After
- Weather: wttr.in format=j1 (text UA required); Open-Meteo free API (always pass timezone=); NWS two-call flow; NWS 404 for non-US coords
- OpenStreetMap: Nominatim lat/lon are strings; Overpass bbox order differs from Nominatim; overpass-api.de overloaded, use overpass.openstreetmap.fr; POST required for Overpass
- Archive.org: Wayback availability API degraded; use CDX sort=closest; advancedsearch.php for programmatic search (not /search?output=json)

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five domain‑skill guides with copy‑paste HTTP recipes for Walmart, Spotify, Weather APIs, OpenStreetMap, and Archive.org. Enables reliable, browser‑free data extraction with tested endpoints and key gotchas.

- **New Features**
  - Walmart: Fetch with `Mozilla/5.0` UA and parse `__NEXT_DATA__` for search/product pages; merge both `itemStacks`; extract price/reviews/specs; detect PerimeterX and strip tracking from URLs.
  - Spotify: Use oEmbed (no auth) for basic metadata; parse embed `__NEXT_DATA__` for track lists and previews (album/playlist/artist); avoid anonymous token due to long `Retry-After`; JSON-LD/OG fallbacks.
  - Weather: `wttr.in?format=j1` for quick current + 3‑day; Open‑Meteo geocoding + current/hourly/daily + archive with timezone and units; NWS `/points` → `/forecast` flow (US‑only) with descriptive `User-Agent`.
  - OpenStreetMap: Nominatim with custom `User-Agent` (lat/lon as strings); Overpass GET/POST with bbox order, mirrors, rate limits, and `out center`; error handling for HTML responses.
  - Archive.org: Prefer CDX API (incl. `sort=closest`, `resumeKey`) over degraded Wayback Availability; item `metadata/{id}`, `advancedsearch.php`, and download URLs; timeouts and field type notes.

<sup>Written for commit f897a29d17436a8cf193e0d0831a67e88687b518. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

