### PR TITLE
Add domain skills: Glassdoor, Medium, SoundCloud, Genius, Dev.to

### DIFF
--- a/domain-skills/archive-org/scraping.md
+++ b/domain-skills/archive-org/scraping.md
@@ -1,0 +1,341 @@
+# Internet Archive / Wayback Machine — Scraping & Data Extraction
+
+`https://archive.org` / `https://web.archive.org` — all public data, no auth required. Every workflow here is pure `http_get` — no browser needed.
+
+## Do this first
+
+**Use the CDX API for anything Wayback-related — it is the reliable workhorse. The Wayback Availability API (`/wayback/available`) is known to return empty `archived_snapshots` even for well-archived URLs and should not be used as a primary mechanism.**
+
+```python
+import json
+
+# Find snapshots of any URL — primary entry point for Wayback data
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json&limit=5"
+    "&fl=timestamp,original,statuscode,mimetype,length",
+    timeout=40.0
+)
+rows = json.loads(r)
+headers = rows[0]   # ['timestamp', 'original', 'statuscode', 'mimetype', 'length']
+for row in rows[1:]:
+    ts, orig, status, mime, length = row
+    snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+    print(f"{ts}  {status}  {snap_url}")
+```
+
+For item metadata (books, video, audio, software), go straight to:
+
+```python
+data = json.loads(http_get("https://archive.org/metadata/{identifier}", timeout=30.0))
+```
+
+## Common workflows
+
+### Find the nearest archived snapshot to a target date
+
+```python
+import json
+
+# CDX sort=closest returns the single snapshot nearest to the given timestamp
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json&limit=1"
+    "&fl=timestamp,original,statuscode"
+    "&closest=20230601120000&sort=closest",
+    timeout=60.0   # CDX can be slow — always use timeout >= 40s
+)
+rows = json.loads(r)
+# rows[0] = header, rows[1] = closest snapshot
+ts, orig, status = rows[1]
+snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+# Result: ts='20230601114925', orig='https://www.iana.org/', status='200'
+# snap_url: https://web.archive.org/web/20230601114925/https://www.iana.org/
+```
+
+Timestamp format is always 14-digit `YYYYMMDDHHMMSS`. Pass any prefix — `20230601` (day), `202306` (month), `2023` (year) — and CDX will match.
+
+### List all monthly snapshots for a URL (collapsed)
+
+```python
+import json
+
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json"
+    "&collapse=timestamp:6"   # :6 = dedupe by YYYYMM (one per month)
+    "&from=20230101&to=20231231"
+    "&fl=timestamp,original",
+    timeout=60.0
+)
+rows = json.loads(r)
+# rows[0] = header ['timestamp', 'original']
+# rows[1:] = one row per month:
+# ['20230101103807', 'https://www.iana.org/']
+# ['20230201144829', 'https://www.iana.org/']
+# ...12 rows for 2023
+
+for ts, orig in rows[1:]:
+    print(f"{ts[:4]}-{ts[4:6]}  https://web.archive.org/web/{ts}/{orig}")
+```
+
+`collapse=timestamp:N` deduplicates by the first N digits of the timestamp:
+- `:4` = one per year, `:6` = one per month, `:8` = one per day
+
+### List snapshots for an entire domain (all pages)
+
+```python
+import json
+
+# matchType=domain captures all URLs under that domain
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&matchType=domain&output=json"
+    "&limit=10&fl=timestamp,original,statuscode"
+    "&collapse=timestamp:8",  # one capture per URL per day
+    timeout=60.0
+)
+rows = json.loads(r)
+for row in rows[1:]:
+    print(row)
+# ['19971210061738', 'http://www.iana.org:80/', '200']
+# ['19980211065537', 'http://www.iana.org:80/', '200']
+# ...
+```
+
+`matchType` options: `exact` (default), `prefix` (URL + subpaths), `host` (all subdomains), `domain` (host + all subdomains).
+
+### Filter snapshots by prefix path
+
+```python
+import json
+
+# All archived pages under /domains/ path
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org/domains/&matchType=prefix&output=json"
+    "&limit=5&fl=timestamp,original,statuscode",
+    timeout=40.0
+)
+rows = json.loads(r)
+for row in rows[1:]:
+    print(row)
+# ['20080509121811', 'http://www.iana.org/domains/', '200']
+# ['20080704174537', 'http://iana.org/domains/', '200']
+```
+
+### Paginate CDX results with resumeKey
+
+```python
+import json
+from urllib.parse import quote
+
+def cdx_all_snapshots(url, fl="timestamp,original,statuscode", page_size=500):
+    """Iterate all CDX records for a URL, yielding rows (excluding header)."""
+    base = (
+        f"https://web.archive.org/cdx/search/cdx"
+        f"?url={quote(url, safe='')}&output=json"
+        f"&fl={fl}&limit={page_size}&showResumeKey=true"
+    )
+    resume_key = None
+    while True:
+        endpoint = base if resume_key is None else f"{base}&resumeKey={quote(resume_key)}"
+        rows = json.loads(http_get(endpoint, timeout=60.0))
+        # rows structure with showResumeKey=true:
+        # [header, row1, row2, ..., [], [resume_key_string]]
+        # The second-to-last row is [] (separator), last row is [resume_key]
+        has_resume = len(rows) >= 2 and rows[-1] != [] and rows[-2] == []
+        data_rows = rows[1:-2] if has_resume else rows[1:]
+        for row in data_rows:
+            yield row
+        if not has_resume:
+            break
+        resume_key = rows[-1][0]
+
+for row in cdx_all_snapshots("iana.org", fl="timestamp,original"):
+    ts, orig = row
+    # process...
+```
+
+### Retrieve the actual archived page
+
+```python
+# Direct snapshot URL: /web/{14-digit-timestamp}/{original-url}
+snap_url = "https://web.archive.org/web/19971210061738/http://www.iana.org:80/"
+content = http_get(snap_url, timeout=30.0)
+# Returns the archived HTML with Wayback toolbar injected at top
+# The toolbar is inside <!-- BEGIN WAYBACK TOOLBAR INSERT --> comments
+
+# The calendar view URL pattern (for browser navigation, not http_get):
+# https://web.archive.org/web/20230101000000*/python.org
+# The * tells Wayback to show the calendar — returns HTML, not raw page
+```
+
+### Item metadata (books, video, audio, software, collections)
+
+```python
+import json
+from urllib.parse import quote
+
+identifier = "HardWonWisdomTrailer"
+data = json.loads(http_get(f"https://archive.org/metadata/{identifier}", timeout=30.0))
+
+# Top-level keys:
+# alternate_locations, created, d1, d2, dir, files, files_count,
+# is_collection, item_last_updated, item_size, metadata, server, uniq, workable_servers
+
+meta = data['metadata']
+# Common metadata fields (not all present on every item):
+print(meta.get('identifier'))   # 'HardWonWisdomTrailer'
+print(meta.get('title'))        # 'Hard Won Wisdom Trailer'
+print(meta.get('mediatype'))    # 'movies' | 'texts' | 'audio' | 'software' | 'collection'
+print(meta.get('creator'))      # 'jakemauz'
+print(meta.get('date'))         # '2017-02-18'
+print(meta.get('description'))  # HTML string — strip tags if needed
+print(meta.get('subject'))      # str OR list of str depending on item
+print(meta.get('publicdate'))   # '2017-02-18 11:51:16'
+print(meta.get('collection'))   # parent collection identifier
+
+files = data['files']
+# Each file entry:
+# name, source ('original'|'derivative'|'metadata'), format, size (bytes as str),
+# md5, sha1, crc32, mtime
+# For video/audio: length (seconds as str), height, width
+# For derivative: original (name of source file)
+
+# Find the primary original file
+orig_files = [f for f in files if f.get('source') == 'original']
+# orig_files[0]: {'name': 'Hard-won wisdom trailer.mp4', 'source': 'original',
+#  'format': 'MPEG4', 'size': '7532153', 'length': '94.13',
+#  'height': '360', 'width': '640', 'md5': 'aaeebe0481...', ...}
+
+# Build download URL — two equivalent forms:
+server = data['server']      # 'ia601405.us.archive.org'
+dir_path = data['dir']       # '/2/items/HardWonWisdomTrailer'
+fname = orig_files[0]['name']
+from urllib.parse import quote as urlquote
+# Form 1: direct storage server (fastest)
+url1 = f"https://{server}{dir_path}/{urlquote(fname)}"
+# Form 2: standard redirect URL (always works, resolved by CDN)
+url2 = f"https://archive.org/download/{identifier}/{urlquote(fname)}"
+# Both confirmed status 200, Content-Type: video/mp4
+```
+
+### Search items (books, audio, video, software)
+
+```python
+import json
+
+# advancedsearch.php is the correct API — /search returns HTML
+r = http_get(
+    "https://archive.org/advancedsearch.php"
+    "?q=artificial+intelligence+AND+mediatype:texts"
+    "&fl[]=identifier&fl[]=title&fl[]=creator&fl[]=date&fl[]=downloads"
+    "&rows=5&sort[]=downloads+desc&output=json",
+    timeout=30.0
+)
+data = json.loads(r)
+# data['responseHeader']['status'] = 0 (success)
+# data['responseHeader']['QTime'] = query time ms
+# data['response']['numFound'] = 25911 (total matches)
+# data['response']['start'] = 0 (offset)
+# data['response']['docs'] = list of item dicts
+
+resp = data['response']
+print(f"Total: {resp['numFound']}, showing: {len(resp['docs'])}")
+for doc in resp['docs']:
+    print(f"  {doc['identifier']}  {doc.get('title', '')[:50]}")
+    # doc fields are only present if they have values — always use .get()
+```
+
+Pagination: use `start=` offset (not `page=`). Max `rows=` is not documented but 100 works reliably.
+
+### Search with all supported parameters
+
+```python
+import json
+
+r = http_get(
+    "https://archive.org/advancedsearch.php"
+    "?q=machine+learning+AND+mediatype:texts"  # Lucene query syntax
+    "&fl[]=identifier&fl[]=title&fl[]=date&fl[]=year"
+    "&fl[]=creator&fl[]=subject&fl[]=description&fl[]=downloads"
+    "&rows=3"
+    "&start=0"               # pagination offset
+    "&sort[]=date+desc"      # sort field + direction
+    "&output=json",
+    timeout=30.0
+)
+data = json.loads(r)
+# Confirmed fields in fl[]:
+# identifier, title, date, year, creator, subject, description,
+# downloads, mediatype, collection, language, avg_rating, num_reviews
+
+# mediatype values: texts, audio, movies, software, image, etree, data, collection, account
+# Sort fields: date, downloads, avg_rating, num_reviews, publicdate, addeddate
+```
+
+## API reference
+
+| Endpoint | What it returns | Auth |
+|---|---|---|
+| `web.archive.org/cdx/search/cdx?url=...&output=json` | Snapshot index: all captures of a URL | None |
+| `archive.org/wayback/available?url=...` | Nearest snapshot (DEGRADED — see gotchas) | None |
+| `archive.org/metadata/{identifier}` | Item metadata + files list | None |
+| `archive.org/advancedsearch.php?q=...&output=json` | Full-text + metadata search | None |
+| `archive.org/download/{identifier}/{filename}` | Direct file download | None |
+| `web.archive.org/web/{timestamp}/{url}` | Archived page HTML | None |
+
+## CDX field reference
+
+The CDX API returns a JSON array of arrays. The first row is always the header when `output=json`.
+
+| Field | Description | Example |
+|---|---|---|
+| `urlkey` | SURT-format URL (reversed domain, path in parens) | `org,iana)/` |
+| `timestamp` | Capture time, 14-digit `YYYYMMDDHHMMSS` | `19971210061738` |
+| `original` | Original crawled URL (exact, including port) | `http://www.iana.org:80/` |
+| `mimetype` | Content-Type of the archived response | `text/html` |
+| `statuscode` | HTTP status at crawl time | `200` |
+| `digest` | SHA-1 of response body, base32-encoded | `I4YBMQ6PHPWE2TD6TIXNWHZB6MXRNTSR` |
+| `length` | Content length in bytes (as string) | `1418` |
+
+Default `fl=` when omitted: `urlkey,timestamp,original,mimetype,statuscode,digest,length` (all 7 fields in that order).
+
+## Rate limits
+
+No auth, no API key. In practice:
+- CDX API: **intermittently slow** — individual queries time out at 20s and succeed at 40–60s. Always use `timeout=40.0` minimum. 3 rapid sequential CDX calls in ~10s completed; 10 rapid calls produced 3 timeouts.
+- Metadata API: Fast and reliable — 5 sequential calls completed in 3.0s with no errors.
+- Search API: Fast — typically responds in 30–65ms (`QTime` in response header).
+- No documented per-second or per-day limits. Archive.org's policy is to be respectful: add `time.sleep(1)` between CDX calls in loops.
+
+## Gotchas
+
+- **CDX times out — always set `timeout=40.0` or higher.** The default 20s is often too short for CDX. Metadata and search APIs are fine at 20–30s. CDX slowness is backend-side and unpredictable; add retry logic for production use.
+
+- **Wayback Availability API is unreliable.** `GET /wayback/available?url=iana.org` returns `{"url": "iana.org", "archived_snapshots": {}}` even for URLs confirmed archived via CDX. Tested 2026-04-18 across many URLs and timestamp combinations — consistently empty. Use `CDX ?sort=closest&limit=1` instead (confirmed working).
+
+- **CDX first row is always the header when `output=json`.** `rows[0]` is `['timestamp', 'original', ...]`, not a data row. Always slice `rows[1:]` for data. When `showResumeKey=true`, the last two rows are `[]` (separator) and `['<resume_key_string>']`.
+
+- **CDX `fl=` must match exactly what you iterate.** If you request `&fl=timestamp,original` you get 2-element rows; forgetting a field breaks destructuring. When in doubt, omit `fl=` entirely and get all 7 fields.
+
+- **`output=json` is required — there is no default JSON mode.** Omitting `output=json` returns space-separated text. `output=text` also works and is slightly faster for simple queries.
+
+- **`timestamp` is a string, not an integer.** Even in JSON, CDX returns all fields as strings: `'1418'` not `1418`, `'200'` not `200`. Cast explicitly: `int(row[4])`, `int(row[6])`.
+
+- **The `original` field preserves port numbers.** Old crawls captured `http://www.iana.org:80/` — the `:80` is part of the URL. When building a playback URL, use `original` verbatim: `f"https://web.archive.org/web/{ts}/{orig}"` works correctly with the port included.
+
+- **Metadata `{}` means the item doesn't exist or is private.** `http_get("https://archive.org/metadata/nonexistent")` returns `'{}'` (2-byte response) with HTTP 200. Always check `if not data` or `if not data.get('metadata')` before accessing fields.
+
+- **Metadata `subject` can be a string or a list.** When a single subject tag is set, the API returns `"subject": "short film"`. When multiple, it returns `"subject": ["short film", "spoken word"]`. Normalize with: `subjects = [meta['subject']] if isinstance(meta.get('subject'), str) else meta.get('subject', [])`.
+
+- **File `size` and `length` are strings, not numbers.** `files[0]['size']` is `'7532153'` (bytes). `files[0]['length']` is `'94.13'` (seconds for video/audio). Cast with `int()` and `float()` respectively.
+
+- **Use `archive.org/download/` not the raw storage server URL for reliability.** The raw URL (`ia601405.us.archive.org/2/items/...`) is faster but server-specific. `archive.org/download/{id}/{file}` redirects to the correct storage node and remains stable as items migrate.
+
+- **`/search?output=json` returns HTML, not JSON.** The `/search` endpoint is a React SPA — it ignores `output=json`. Always use `advancedsearch.php` for programmatic access.
+
+- **`collapse=timestamp:6` gives one row per month, but it keeps the FIRST capture of that month.** If you want the last, you'd need to reverse and re-collapse, or fetch all and filter client-side. The `collapse` parameter de-duplicates by truncating the timestamp to N digits and keeping the first matching row.
+
+- **CDX `from=` / `to=` accept partial timestamps.** `from=20230101` means `20230101000000`. `to=20231231` means `20231231000000` (exclusive). To include all of 2023, use `to=20240101`.

--- a/domain-skills/dev-to/scraping.md
+++ b/domain-skills/dev-to/scraping.md
@@ -1,0 +1,323 @@
+# DEV Community (dev.to) — Data Extraction
+
+`https://dev.to` — developer blogging platform. Everything useful is available via a public REST API with no auth required. No browser needed for any read task.
+
+## Do this first
+
+**Use the REST API — it returns clean JSON in ~150–250ms with no browser, no login, no JS rendering.**
+
+```python
+import json
+articles = json.loads(http_get("https://dev.to/api/articles?per_page=10&tag=python"))
+# Each article: id, title, description, url, cover_image, tag_list, tags,
+#               published_at, published_timestamp, readable_publish_date,
+#               reading_time_minutes, positive_reactions_count,
+#               public_reactions_count, comments_count, user, organization,
+#               flare_tag, collection_id, slug, path, canonical_url,
+#               social_image, language, subforem_id
+```
+
+The API serves **V0 (beta) by default** and emits a `Warning: 299` header on every response. Suppress it silently with the V1 `Accept` header (same data, no deprecated warning):
+
+```python
+import json
+import urllib.request, gzip
+
+def dev_get(url):
+    h = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept-Encoding": "gzip",
+        "Accept": "application/vnd.forem.api-v1+json",
+    }
+    with urllib.request.urlopen(urllib.request.Request(url, headers=h), timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+articles = json.loads(dev_get("https://dev.to/api/articles?per_page=10&tag=python"))
+```
+
+Or just use `http_get` directly if you don't care about the warning header noise.
+
+---
+
+## Common workflows
+
+### Articles by tag
+
+```python
+import json
+articles = json.loads(http_get("https://dev.to/api/articles?per_page=10&tag=python"))
+# Paginate with &page=2, &page=3 etc. (1-indexed)
+for a in articles:
+    print(a['id'], a['positive_reactions_count'], a['title'][:60])
+```
+
+Confirmed working tags: `python`, `javascript`, `typescript`, `rust`, `go`, `webdev`, `tutorial`, `react`, `devops`, `ai`, `beginners`.
+
+### Top articles by time window
+
+```python
+import json
+# top=N means "top articles from the last N days"
+top_day   = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=1"))
+top_week  = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=7"))
+top_month = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=30"))
+top_year  = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=365"))
+```
+
+### Articles by username
+
+```python
+import json
+articles = json.loads(http_get("https://dev.to/api/articles?per_page=10&username=ben"))
+# Paginates cleanly: page=1, page=2 etc. Return distinct IDs, no overlap.
+```
+
+### New and rising articles
+
+```python
+import json
+fresh  = json.loads(http_get("https://dev.to/api/articles?per_page=10&state=fresh"))   # very new
+rising = json.loads(http_get("https://dev.to/api/articles?per_page=10&state=rising"))  # gaining traction
+# state=all returns 0 results (requires auth, not useful unauthenticated)
+```
+
+### Single article by ID (adds body_html and body_markdown)
+
+```python
+import json
+article = json.loads(http_get("https://dev.to/api/articles/3442047"))
+# Full article adds two fields not in list response:
+#   body_html     — rendered HTML (safe to display directly)
+#   body_markdown — raw Markdown source
+print(len(article['body_html']), len(article['body_markdown']))
+```
+
+### Single article by username/slug
+
+```python
+import json
+# path field from list response is "/username/slug"
+article = json.loads(http_get("https://dev.to/api/articles/ben/some-article-slug"))
+```
+
+### Tags — popular list with colors
+
+```python
+import json
+tags = json.loads(http_get("https://dev.to/api/tags?per_page=10"))
+# Fields: id, name, bg_color_hex, text_color_hex, short_summary
+# Sorted by popularity. Paginate with &page=2 etc.
+for t in tags:
+    print(t['name'], t['bg_color_hex'], t['text_color_hex'])
+# e.g. webdev  #562765  #ffffff
+#      javascript  #f7df1e  #000000
+#      ai  #17fd1a  #ffffff
+```
+
+### User profile
+
+```python
+import json
+user = json.loads(http_get("https://dev.to/api/users/by_username?url=ben"))
+# Fields: type_of, id, username, name, twitter_username, github_username,
+#         summary, location, website_url, joined_at, profile_image
+print(user['id'], user['username'], user['summary'])
+# e.g. 1  ben  "A Canadian software developer who thinks he's funny."
+```
+
+`joined_at` is a human string like `"Dec 27, 2015"` — not ISO 8601. Parse with `datetime.strptime(user['joined_at'], "%b %d, %Y")`.
+
+### Comments on an article
+
+```python
+import json
+comments = json.loads(http_get("https://dev.to/api/comments?a_id=3442047"))
+# Returns top-level comments only (replies nested under children key)
+# Fields per comment: id_code (string, not int!), type_of, body_html,
+#                     created_at, user (dict), children (list of same shape)
+for c in comments:
+    print(c['id_code'], c['user']['username'], c['created_at'])
+    for reply in c.get('children', []):
+        print("  reply:", reply['id_code'], reply['user']['username'])
+```
+
+### Single comment by id_code
+
+```python
+import json
+comment = json.loads(http_get("https://dev.to/api/comments/36lnc"))
+# Same fields as above: id_code, body_html, created_at, user, children
+```
+
+### Bulk tag fetch (parallel)
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+tags = ['python', 'javascript', 'typescript', 'rust', 'go',
+        'devops', 'webdev', 'tutorial', 'productivity', 'react']
+
+def fetch_tag(tag):
+    data = json.loads(http_get(f"https://dev.to/api/articles?per_page=5&tag={tag}"))
+    return tag, data
+
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = dict(ex.map(lambda t: fetch_tag(t), tags))
+# 10 tags × 5 articles each: ~0.67s total with max_workers=3
+```
+
+---
+
+## Endpoint reference
+
+| Endpoint | Auth | Key params | Latency |
+|----------|------|-----------|---------|
+| `GET /api/articles` | None | `tag`, `username`, `top`, `state`, `page`, `per_page` | ~200ms |
+| `GET /api/articles/{id}` | None | — | ~80ms |
+| `GET /api/articles/{username}/{slug}` | None | — | ~200ms |
+| `GET /api/tags` | None | `page`, `per_page` | ~190ms |
+| `GET /api/users/by_username?url={username}` | None | — | ~190ms |
+| `GET /api/comments?a_id={article_id}` | None | — | ~160ms |
+| `GET /api/comments/{id_code}` | None | — | ~150ms |
+| `GET /api/listings` | None | `category`, `page`, `per_page` | ~260ms (returns 0) |
+
+**Listings endpoint returns 0 results.** The `/api/listings` endpoint is documented but returns an empty array for all categories (`jobs`, `forsale`, `education`, `cfp`) without auth. Skip it.
+
+---
+
+## Pagination
+
+All list endpoints paginate with `page=` (1-indexed) and `per_page=`:
+
+```python
+import json
+
+def get_all_articles_by_tag(tag, max_pages=5):
+    results = []
+    for page in range(1, max_pages + 1):
+        batch = json.loads(http_get(
+            f"https://dev.to/api/articles?per_page=30&tag={tag}&page={page}"
+        ))
+        if not batch:
+            break
+        results.extend(batch)
+    return results
+```
+
+- `per_page` supports up to **1000** (confirmed). No documented max, but 1000 works in testing.
+- No `total_count` field in list responses — you paginate until an empty array.
+- Page ordering is consistent — confirmed no ID overlap between page 1 and page 2.
+
+---
+
+## Article field reference
+
+All fields returned in list responses (single article adds `body_html` and `body_markdown`):
+
+```
+id                      int    — article ID, stable, use for single-article fetch
+title                   str
+description             str    — auto-excerpt, never null
+slug                    str    — URL slug component
+path                    str    — "/username/slug"
+url                     str    — full canonical URL
+canonical_url           str    — same as url for native posts; author's site URL for cross-posts
+cover_image             str|null — CDN URL or null (~30% of articles have no cover image)
+social_image            str    — always present (generated if no cover_image)
+tag_list                list   — e.g. ['python', 'ai', 'tutorial']  ← use this for code
+tags                    str    — same tags as comma-separated string "python, ai, tutorial"
+published_at            str    — ISO 8601 UTC e.g. "2026-04-18T03:49:36Z"
+published_timestamp     str    — identical to published_at
+readable_publish_date   str    — human string e.g. "Apr 18"
+reading_time_minutes    int
+positive_reactions_count int   — hearts/likes count
+public_reactions_count  int    — total reactions (usually same as positive_reactions_count)
+comments_count          int
+user                    dict   — name, username, twitter_username, github_username,
+                                 user_id, website_url, profile_image, profile_image_90
+organization            dict|null — present when posted under an org: name, username, slug,
+                                     profile_image, profile_image_90
+flare_tag               dict|null — {name, bg_color_hex, text_color_hex} — discussion/challenge badge
+collection_id           int|null  — series/collection ID if part of a series
+language                str    — e.g. "en"
+subforem_id             int|null
+crossposted_at          str|null — ISO datetime if cross-posted
+edited_at               str|null
+last_comment_at         str|null
+created_at              str    — ISO 8601
+type_of                 str    — always "article"
+```
+
+---
+
+## Rate limits
+
+- **Burst limit: ~6 rapid sequential requests**, then HTTP 429.
+- **Recovery: `Retry-After: 1` second** — wait 1s after a 429 and you're good again.
+- No `X-RateLimit-*` headers in 200 responses — you only see `Retry-After` on the 429 itself.
+- With `ThreadPoolExecutor(max_workers=3)`, 10 concurrent requests succeed without hitting the limit.
+- No difference in limits between V0 (default) and V1 (`Accept` header) — same underlying rate limit.
+- **No auth token tested** — all endpoints above work without `api_key`. Authenticated requests likely have higher limits.
+
+Safe pattern for bulk fetching:
+
+```python
+import json, time
+from concurrent.futures import ThreadPoolExecutor
+
+def safe_fetch(url):
+    for attempt in range(3):
+        try:
+            return json.loads(http_get(url))
+        except Exception as e:
+            if '429' in str(e):
+                time.sleep(1)   # Retry-After is 1s
+                continue
+            raise
+    return []
+
+urls = [
+    f"https://dev.to/api/articles?per_page=10&tag={tag}"
+    for tag in ['python', 'javascript', 'typescript', 'rust']
+]
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(safe_fetch, urls))
+```
+
+---
+
+## Gotchas
+
+- **`tag_list` (list) vs `tags` (string)** — both fields always present. `tag_list` is a Python list; `tags` is the same data as a comma-separated string. Use `tag_list` in code.
+
+- **Comments have `id_code`, not `id`** — comment identifiers are alphanumeric strings like `"36lnc"`, not integers. The integer `id` field is absent from comment objects. Use `id_code` to fetch a specific comment via `GET /api/comments/{id_code}`.
+
+- **Comments endpoint returns top-level only** — replies are nested under `children` recursively, not returned as a flat list. A thread with 100 total comments may only show 60 top-level objects; walk `children` recursively to count all.
+
+- **`cover_image` can be null** — ~30% of articles have no cover image. Always guard: `a.get('cover_image') or a['social_image']` for a guaranteed image URL.
+
+- **`flare_tag` is null for most articles** — only discussion/challenge posts carry it. It's a dict `{name, bg_color_hex, text_color_hex}` when present.
+
+- **`published_at` == `published_timestamp`** — both fields contain identical ISO 8601 UTC strings. `readable_publish_date` is human-only (`"Apr 18"`, no year).
+
+- **`joined_at` on user profile is not ISO** — it's `"Dec 27, 2015"`. Parse: `datetime.strptime(u['joined_at'], "%b %d, %Y")`.
+
+- **`state=all` returns 0 results unauthenticated** — it's for the authenticated user's own feed. `state=fresh` and `state=rising` work without auth.
+
+- **`top=N` means last N days** — `top=1` is last 24h, `top=7` is last week, `top=30` is last month, `top=365` is last year. Results differ from the `state=` param.
+
+- **V0 warning header on every response** — `Warning: 299 - This endpoint is part of the V0 (beta) API…` appears on all responses without the `Accept` header. It's harmless but noisy. Suppress with `"Accept": "application/vnd.forem.api-v1+json"`.
+
+- **No `total_count` in list responses** — paginate until an empty array. There is no way to know upfront how many total results exist.
+
+- **Listings endpoint returns empty** — `GET /api/listings` and all category variants return `[]` without auth. Documented but non-functional publicly.
+
+- **`/api/articles/{id}/comments` returns 404** — comments must be fetched via `GET /api/comments?a_id={id}`, not as a sub-resource of articles.
+
+- **`canonical_url` may point off-site** — for cross-posted articles, `canonical_url` is the author's original blog URL, not dev.to. Use `url` for the dev.to link.
+
+- **`organization` field is null for personal posts** — only present when the article was posted under an org account. Check before accessing sub-fields.

--- a/domain-skills/genius/scraping.md
+++ b/domain-skills/genius/scraping.md
@@ -1,0 +1,511 @@
+# Genius — Data Extraction
+
+Field-tested against genius.com on 2026-04-18.
+No authentication required for any approach documented here.
+
+---
+
+## Anti-Bot: http_get Fails, Custom UA Required
+
+`http_get` uses `User-Agent: Mozilla/5.0` (bare string). Genius returns HTTP 403 for that UA on both HTML pages and internal API endpoints. Adding any OS token (e.g. `(Macintosh; Intel Mac OS X 10_15_7)`) immediately lifts the block — no cookies, no session, no JavaScript required.
+
+```python
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    """Drop-in replacement for http_get on genius.com endpoints."""
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+```
+
+Use `genius_get` everywhere in this document instead of bare `http_get`.
+
+---
+
+## Approach 1 (Fastest): Internal JSON API — No Auth, No Browser
+
+Genius's own website calls `genius.com/api/*` (not `api.genius.com`) from
+its server-side rendering layer. These endpoints are public and require only
+a browser-like User-Agent. They return rich structured JSON in ~0.13s.
+
+### Song metadata
+
+```python
+import json
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+
+def genius_song(song_id):
+    """Fetch full song metadata by Genius song ID."""
+    data = json.loads(genius_get(f"https://genius.com/api/songs/{song_id}"))
+    return data["response"]["song"]
+
+song = genius_song(1063)
+# All fields available in one call (no auth):
+# song["title"]                          → "Bohemian Rhapsody"
+# song["full_title"]                     → "Bohemian Rhapsody by Queen"
+# song["artist_names"]                   → "Queen"
+# song["primary_artist"]["name"]         → "Queen"
+# song["primary_artist"]["id"]           → 563
+# song["primary_artist"]["url"]          → "https://genius.com/artists/Queen"
+# song["release_date"]                   → "1975-10-31"
+# song["release_date_for_display"]       → "October 31, 1975"
+# song["release_date_components"]        → {"year": 1975, "month": 10, "day": 31}
+# song["stats"]["pageviews"]             → 11067562
+# song["stats"]["contributors"]          → 516
+# song["stats"]["accepted_annotations"]  → 20
+# song["pyongs_count"]                   → 703
+# song["annotation_count"]              → 33
+# song["comment_count"]                 → 253
+# song["album"]["name"]                 → "Studio Collection"   (varies by region)
+# song["albums"][0]["name"]             → "A Night at the Opera"  (first = original)
+# song["url"]                           → "https://genius.com/Queen-bohemian-rhapsody-lyrics"
+# song["path"]                          → "/Queen-bohemian-rhapsody-lyrics"
+# song["song_art_image_url"]            → "https://images.genius.com/718de9d..."
+# song["explicit"]                      → False
+# song["language"]                      → "en"
+# song["lyrics_state"]                  → "complete"
+# song["lyrics_verified"]              → False
+# song["spotify_uuid"]                  → "7tFiyTwD0nx5a1eklYtX2J"
+# song["youtube_url"]                   → "https://www.youtube.com/watch?v=fJ9rUzIMcZQ"
+# song["writer_artists"]                → [{"name": "Freddie Mercury", ...}]
+# song["producer_artists"]              → [{"name": "Roy Thomas Baker"}, {"name": "Queen"}]
+# song["featured_artists"]             → []
+
+# Primary album (first in list = original release):
+primary_album = song["albums"][0]["name"]   # "A Night at the Opera"
+```
+
+### Search
+
+```python
+def genius_search(query, per_page=5):
+    """Search Genius. Returns sections: top_hit, song, lyric, artist, album, video, article, user."""
+    url = f"https://genius.com/api/search/multi?per_page={per_page}&q={urllib.parse.quote(query)}"
+    data = json.loads(genius_get(url))
+    return data["response"]["sections"]
+
+import urllib.parse
+sections = genius_search("Bohemian Rhapsody Queen", per_page=5)
+# sections is a list of dicts with keys: "type", "hits"
+# Each hit has: "type", "result"
+# For type="song", result has: id, full_title, url, primary_artist, stats, ...
+
+for section in sections:
+    if section["type"] == "song":
+        for hit in section["hits"]:
+            r = hit["result"]
+            print(r["full_title"], r["url"], r["id"])
+        # Bohemian Rhapsody by Queen  https://genius.com/Queen-bohemian-rhapsody-lyrics  1063
+        break
+
+# Simpler search (song section only):
+def genius_search_songs(query, per_page=5):
+    sections = genius_search(query, per_page)
+    for s in sections:
+        if s["type"] == "song":
+            return [h["result"] for h in s["hits"]]
+    return []
+```
+
+### Artist songs (paginated)
+
+```python
+def genius_artist_songs(artist_id, per_page=20, sort="popularity"):
+    """Fetch paginated list of songs for an artist. sort: 'popularity' or 'title'."""
+    page = 1
+    while True:
+        url = (f"https://genius.com/api/artists/{artist_id}/songs"
+               f"?per_page={per_page}&page={page}&sort={sort}")
+        data = json.loads(genius_get(url))["response"]
+        songs = data["songs"]
+        if not songs:
+            break
+        yield from songs
+        if data["next_page"] is None:
+            break
+        page = data["next_page"]
+
+# Example: get top 5 Queen songs by popularity
+for song in list(genius_artist_songs(563, per_page=5))[:5]:
+    print(f"{song['full_title']} — {song['stats']['pageviews']:,} views")
+# Bohemian Rhapsody by Queen — 11,067,663 views
+# Don't Stop Me Now by Queen — 2,453,240 views
+# Under Pressure by Queen & David Bowie — 1,972,606 views
+# Somebody to Love by Queen — 1,241,740 views
+# Killer Queen by Queen — 1,146,813 views
+```
+
+---
+
+## Approach 2: Lyrics from HTML — Regex on data-lyrics-container
+
+The lyrics live in `<div data-lyrics-container="true">` elements on the song's
+lyrics page. There are usually 3–5 such divs (the song is split across sections).
+Each div can contain nested child divs for annotation highlights — including a
+`data-exclude-from-selection="true"` header div that must be stripped first.
+
+```python
+import re, json
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+
+def _remove_excluded_divs(html):
+    """Strip all <div data-exclude-from-selection="true"> subtrees (contributor headers)."""
+    while True:
+        idx = html.find('data-exclude-from-selection="true"')
+        if idx == -1:
+            break
+        tag_start = html.rfind("<div", 0, idx)
+        depth, pos = 0, tag_start
+        while pos < len(html):
+            if html[pos:pos+4] == "<div":
+                depth += 1; pos += 4
+            elif html[pos:pos+6] == "</div>":
+                depth -= 1; pos += 6
+                if depth == 0:
+                    html = html[:tag_start] + html[pos:]
+                    break
+            else:
+                pos += 1
+        else:
+            break
+    return html
+
+def _extract_div_content(html, marker):
+    """Extract all <div> subtrees that contain the given attribute marker."""
+    parts = []
+    start = 0
+    while True:
+        idx = html.find(marker, start)
+        if idx == -1:
+            break
+        tag_start = html.rfind("<div", 0, idx)
+        depth, pos = 0, tag_start
+        while pos < len(html):
+            if html[pos:pos+4] == "<div":
+                depth += 1; pos += 4
+            elif html[pos:pos+6] == "</div>":
+                depth -= 1; pos += 6
+                if depth == 0:
+                    parts.append(html[tag_start:pos])
+                    break
+            else:
+                pos += 1
+        start = idx + 1
+    return parts
+
+def _html_to_text(html_str):
+    """Convert lyrics HTML to plain text, preserving line breaks."""
+    text = re.sub(r"<br\s*/?>", "\n", html_str)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = (text
+            .replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+            .replace("&#39;", "'").replace("&quot;", '"').replace("&#x27;", "'")
+            .replace("&#x2F;", "/").replace("&nbsp;", " "))
+    # Collapse multiple blank lines to one
+    lines = [l.strip() for l in text.split("\n")]
+    result, prev_blank = [], False
+    for line in lines:
+        if not line:
+            if not prev_blank:
+                result.append("")
+            prev_blank = True
+        else:
+            result.append(line)
+            prev_blank = False
+    return "\n".join(result).strip()
+
+def genius_lyrics(url):
+    """
+    Scrape lyrics from a Genius song URL.
+
+    url: the canonical lyrics URL, e.g. 'https://genius.com/Queen-bohemian-rhapsody-lyrics'
+    Returns: plain-text lyrics string with section headers like [Verse 1], [Chorus].
+    """
+    html = genius_get(url)
+    cleaned = _remove_excluded_divs(html)
+    containers = _extract_div_content(cleaned, 'data-lyrics-container="true"')
+    parts = []
+    for c in containers:
+        text = _html_to_text(c).strip()
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
+
+lyrics = genius_lyrics("https://genius.com/Queen-bohemian-rhapsody-lyrics")
+# Returns 2076 chars, 62 lines, structured as:
+# [Intro]
+# Is this the real life? Is this just fantasy?
+# Caught in a landslide, no escape from reality
+# ...
+# [Verse 1]
+# Mama, just killed a man
+# ...
+# [Outro]
+# Nothing really matters to me
+# Any way the wind blows
+```
+
+**Performance:** Lyrics page is ~1.2 MB. One `genius_get` call takes ~0.18s.
+No rate limiting observed across 10 rapid sequential requests.
+
+---
+
+## Approach 3: Combined Workflow — Metadata + Lyrics
+
+The fastest complete extraction pattern: one API call for all metadata,
+one HTML call for lyrics. Song ID can be derived several ways.
+
+```python
+import json, re, urllib.parse
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+
+def genius_song_id_from_url(lyrics_url):
+    """
+    Extract Genius song ID from a lyrics page URL without fetching it.
+    Returns None if not determinable — fall back to fetching the page.
+    """
+    # Not possible from the slug alone; must fetch the page or use search.
+    # From the HTML: <meta content="genius://songs/{id}" name="twitter:app:url:iphone">
+    html = genius_get(lyrics_url)
+    m = re.search(r'content="genius://songs/(\d+)"', html)
+    return int(m.group(1)) if m else None
+
+def genius_full(query):
+    """
+    Search for a song, return metadata + lyrics in two HTTP calls.
+    """
+    # Call 1: search for song
+    sections = json.loads(
+        genius_get(f"https://genius.com/api/search/multi?per_page=3&q={urllib.parse.quote(query)}")
+    )["response"]["sections"]
+    song_result = None
+    for s in sections:
+        if s["type"] == "song" and s["hits"]:
+            song_result = s["hits"][0]["result"]
+            break
+    if not song_result:
+        return None
+
+    song_id = song_result["id"]
+    lyrics_url = song_result["url"]
+
+    # Call 2: full metadata from internal API
+    meta = json.loads(genius_get(f"https://genius.com/api/songs/{song_id}"))["response"]["song"]
+
+    # Call 3: lyrics from HTML
+    lyrics = genius_lyrics(lyrics_url)   # uses the function from Approach 2
+
+    return {
+        "id":           meta["id"],
+        "title":        meta["title"],
+        "artist":       meta["primary_artist"]["name"],
+        "artist_id":    meta["primary_artist"]["id"],
+        "album":        meta["albums"][0]["name"] if meta.get("albums") else None,
+        "release_date": meta["release_date"],           # "1975-10-31"
+        "pageviews":    meta["stats"]["pageviews"],      # 11067562
+        "contributors": meta["stats"]["contributors"],   # 516
+        "writers":      [a["name"] for a in meta["writer_artists"]],
+        "producers":    [a["name"] for a in meta["producer_artists"]],
+        "spotify_uuid": meta["spotify_uuid"],
+        "youtube_url":  meta["youtube_url"],
+        "song_art_url": meta["song_art_image_url"],
+        "lyrics_url":   meta["url"],
+        "lyrics":       lyrics,
+    }
+
+result = genius_full("Queen Bohemian Rhapsody")
+# {
+#   "id":           1063,
+#   "title":        "Bohemian Rhapsody",
+#   "artist":       "Queen",
+#   "artist_id":    563,
+#   "album":        "A Night at the Opera",
+#   "release_date": "1975-10-31",
+#   "pageviews":    11067562,
+#   "contributors": 516,
+#   "writers":      ["Freddie Mercury"],
+#   "producers":    ["Roy Thomas Baker", "Queen"],
+#   "spotify_uuid": "7tFiyTwD0nx5a1eklYtX2J",
+#   "youtube_url":  "https://www.youtube.com/watch?v=fJ9rUzIMcZQ",
+#   "song_art_url": "https://images.genius.com/718de9d1fbcaae9f3c9b1bf483bfa8f1.1000x1000x1.png",
+#   "lyrics_url":   "https://genius.com/Queen-bohemian-rhapsody-lyrics",
+#   "lyrics":       "[Intro]\nIs this the real life?..."
+# }
+```
+
+---
+
+## URL and ID Patterns
+
+| Resource    | URL pattern                                   | Notes                            |
+|-------------|-----------------------------------------------|----------------------------------|
+| Song page   | `genius.com/{Artist}-{song-slug}-lyrics`      | Slug is lowercased, hyphenated   |
+| Artist page | `genius.com/artists/{Artist}`                 | Title-cased artist name          |
+| Album page  | `genius.com/albums/{Artist}/{album-slug}`     |                                  |
+| Song API    | `genius.com/api/songs/{id}`                   | Internal; no auth required       |
+| Artist API  | `genius.com/api/artists/{id}`                 | Internal; no auth required       |
+| Artist songs| `genius.com/api/artists/{id}/songs?...`       | per_page, page, sort params      |
+| Search API  | `genius.com/api/search/multi?per_page=N&q=...`| Internal; multi-section results  |
+
+**Extracting song ID from a known lyrics URL:**
+
+```python
+# The slug alone cannot be decoded to an ID. Must fetch HTML or search.
+# From lyrics page HTML (fastest — one line):
+song_id = re.search(r'content="genius://songs/(\d+)"', html).group(1)
+
+# Or from __PRELOADED_STATE__ (same page, equally reliable):
+song_id = re.search(r'\\"song\\":\s*(\d+)', html).group(1)
+
+# Or from search API (no HTML required):
+sections = json.loads(genius_get(f"https://genius.com/api/search/multi?per_page=1&q={query}"))
+# then walk sections for type="song"
+```
+
+---
+
+## What Requires a Browser
+
+The following are **not available** via `genius_get` / HTTP:
+
+- **Search results page** (`/search?q=...`): renders client-side only. The
+  returned HTML contains no song results matching the query. Use the internal
+  search API (`/api/search/multi`) instead — it works without a browser.
+
+- **Public API** (`api.genius.com`): returns HTTP 401 without a Bearer token
+  even with a browser-like User-Agent. Must register at genius.com/developers
+  to obtain a client access token. The internal site API (`genius.com/api/*`)
+  is the no-auth alternative and returns equivalent data.
+
+- **Annotations content**: annotation HTML is embedded in `__PRELOADED_STATE__`
+  but the JSON is multi-escaped (six levels of backslash nesting) and cannot
+  be reliably parsed with plain string operations. Annotation IDs are
+  available but their body text is not easily extractable.
+
+- **Login-gated features**: user library, personalization, editor tools.
+
+---
+
+## Public API (api.genius.com) — Requires Bearer Token
+
+If you have a token (free registration at genius.com/developers):
+
+```python
+def genius_api(path, token):
+    """Call the official public API. path example: '/songs/1063'"""
+    import json
+    from helpers import http_get
+    url = f"https://api.genius.com{path}"
+    return json.loads(http_get(url, headers={"Authorization": f"Bearer {token}"}))
+
+# Returns same structure as the internal /api/* endpoints.
+# Endpoints: /songs/{id}, /artists/{id}, /artists/{id}/songs, /search?q=...
+# Without a token: HTTP 401 with body:
+# {"meta": {"status": 401, "message": "This call requires an access_token..."}}
+```
+
+---
+
+## Gotchas
+
+- **`http_get` returns 403**: The default `User-Agent: Mozilla/5.0` (bare) is
+  blocked. Add any OS string — `(Macintosh; Intel Mac OS X 10_15_7)` is
+  sufficient. Use the `genius_get` wrapper from this document.
+
+- **`data-lyrics-container` split across 3–5 divs**: Don't look for a single
+  lyrics block. Use `_extract_div_content` on all occurrences, then join.
+  Empty containers (`<div ...></div>`, 87 bytes) appear between sections —
+  the `if text:` guard skips them cleanly.
+
+- **`data-exclude-from-selection` header in first container**: The first
+  lyrics container includes a contributor credit header div. It must be
+  stripped before text extraction or the output will begin with
+  `"516 ContributorsTranslations..."` instead of `"[Intro]"`.
+
+- **`album` field vs `albums[0]`**: `song["album"]` is the "primary" album
+  used by Genius's album link (often a compilation or reissue). `song["albums"][0]`
+  is the first album in the full list and is typically the original release.
+  Verified: for Bohemian Rhapsody, `album.name` = "Studio Collection" but
+  `albums[0].name` = "A Night at the Opera".
+
+- **`__PRELOADED_STATE__` is not parseable**: The state is embedded as
+  `JSON.parse('...')` where the inner JSON is escaped six levels deep
+  (`\\\\\"` for a literal quote inside HTML content). Standard string
+  replacement fails due to `\\'` and `\$` sequences. Don't try to parse it —
+  use the `/api/songs/{id}` endpoint instead.
+
+- **No `__NEXT_DATA__`**: Genius does not use Next.js. There is no
+  `<script id="__NEXT_DATA__">` on any page.
+
+- **No JSON-LD**: Genius does not emit `<script type="application/ld+json">`.
+  Open Graph tags are present but minimal (only `og:title`, `og:image`,
+  `og:description`, `og:url`, `og:type`). Use the API for structured data.
+
+- **Search page is client-side only**: `GET /search?q=...` returns an HTML
+  shell with ~5 unrelated song links (trending, not query-matched). The actual
+  search results are fetched client-side by JavaScript. Use `/api/search/multi`
+  instead — it works without a browser and returns properly filtered results.
+
+- **Rate limiting**: No rate limiting observed across 10 rapid sequential
+  requests to `/api/songs/{id}` (avg 0.13s/request). Song lyrics pages
+  average 0.18s. No Retry-After headers observed.
+
+- **Cloudflare**: Present (confirmed by `<meta itemprop="cf-country">` and
+  `cf-cache-status` tags), but in pass-through mode — no JS challenge, no
+  CAPTCHA. A browser-like User-Agent is all that's needed.

--- a/domain-skills/glassdoor/scraping.md
+++ b/domain-skills/glassdoor/scraping.md
@@ -1,0 +1,543 @@
+# Glassdoor — Company Data, Reviews, Jobs & Salaries
+
+Field-tested against glassdoor.com on 2026-04-18.
+
+## Anti-bot verdict: browser required, no http_get workaround exists
+
+**`http_get` returns HTTP 403 on every Glassdoor URL without exception.**
+
+Tested endpoints (all 403):
+- `/Reviews/Google-Reviews-E9079.htm`
+- `/Overview/Working-at-Google-EI_IE9079.htm`
+- `/Job/jobs.htm?sc.keyword=software+engineer`
+- `/Salaries/software-engineer-salary-SRCH_KO0,17.htm`
+- `/graph` (GraphQL)
+- `sitemap.xml`
+
+UAs tested (all blocked): `Mozilla/5.0`, full Chrome 124, Googlebot, `curl/7.88.1`.
+
+**Stack:** Cloudflare Bot Management (`Server: cloudflare`, `Cf-Mitigated: challenge`).
+Challenge type: `managed` (JS-executed browser fingerprint check, no CAPTCHA widget, no user click
+required in a real browser). Cookie-only bypass also fails — the `__cf_bm` cookie returned in the
+403 response is bound to the browser TLS fingerprint and does not grant access when replayed.
+
+`api.glassdoor.com` (the old public partner API) returned `410 Gone` — permanently shut down.
+
+**Use `goto()` + `wait()` exclusively. Never use `http_get` for Glassdoor.**
+
+---
+
+## Do this first: open in a new tab, wait for CF to resolve
+
+```python
+new_tab("https://www.glassdoor.com/Reviews/Google-Reviews-E9079.htm")
+wait_for_load()
+wait(5)  # CF managed challenge runs for ~2-4s after readyState=complete
+```
+
+`wait(5)` is mandatory. CF's managed challenge executes JS fingerprinting probes after the DOM
+is ready. Extracting before this resolves returns an empty or partial page.
+
+Verify you are past the challenge before extracting:
+
+```python
+title = js("document.title")
+url = page_info()["url"]
+if "Security" in title or "__cf_chl_tk" in url:
+    # CF challenge did not resolve yet — wait longer
+    wait(5)
+    title = js("document.title")
+    assert "Security" not in title, "Still on CF block page"
+```
+
+---
+
+## URL patterns
+
+| Goal | URL |
+|---|---|
+| Company reviews | `/Reviews/{Company-slug}-Reviews-E{employer_id}.htm` |
+| Company overview | `/Overview/Working-at-{Company-slug}-EI_IE{employer_id}.htm` |
+| Company jobs | `/Jobs/{Company-slug}-Jobs-E{employer_id}.htm` |
+| Keyword job search | `/Job/jobs.htm?sc.keyword={keyword}` |
+| Keyword + location | `/Job/jobs.htm?sc.keyword={keyword}&locT=C&locKeyword={city}` |
+| Remote jobs | `/Job/jobs.htm?sc.keyword={keyword}&remoteWorkType=1` |
+| Job search page 2+ | append `&p=2`, `&p=3` |
+| Salary page | `/Salaries/{role-slug}-salary-SRCH_KO0,{len}.htm` |
+
+Employer IDs and company slugs are stable. Example: Google = `EI_IE9079`, slug = `Google`.
+
+Find the employer ID from a search result URL or the company's Glassdoor page URL.
+
+---
+
+## Workflow 1: Job search — extract result cards
+
+Glassdoor renders job cards client-side. Wait 5 seconds after load before extracting.
+
+```python
+import json
+from urllib.parse import quote_plus
+
+query = "software engineer"
+new_tab(f"https://www.glassdoor.com/Job/jobs.htm?sc.keyword={quote_plus(query)}")
+wait_for_load()
+wait(5)   # CF challenge + JS render
+
+# Dismiss cookie banner if present (GDPR regions)
+dismiss_cookie_banner()
+
+jobs = js("""
+(function() {
+  // Primary selector as of 2026-04
+  var cards = document.querySelectorAll('li[data-jobid]');
+  if (!cards.length) {
+    // Fallback: class-based (Next.js CSS modules use hashed suffixes — match prefix)
+    cards = document.querySelectorAll('[class*="JobsList_jobListItem"]');
+  }
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+    var jobId  = c.getAttribute('data-jobid') || '';
+    var titleEl = c.querySelector('[data-test="job-title"], a[class*="JobCard_jobTitle"]');
+    var compEl  = c.querySelector('[data-test="employer-name"], [class*="JobCard_employer"]');
+    var locEl   = c.querySelector('[data-test="emp-location"], [class*="JobCard_location"]');
+    var salEl   = c.querySelector('[data-test="detailSalary"], [class*="salary"], .salaryEstimate');
+    var ratingEl = c.querySelector('[data-test="rating"], [class*="ratingNumber"]');
+    var linkEl  = c.querySelector('a[href*="/job-listing/"], a[href*="glassdoor.com/job"]');
+    out.push({
+      jobId,
+      title:   titleEl  ? titleEl.innerText.trim()  : '',
+      company: compEl   ? compEl.innerText.trim()   : '',
+      location: locEl   ? locEl.innerText.trim()    : '',
+      salary:  salEl    ? salEl.innerText.trim()    : '',
+      rating:  ratingEl ? ratingEl.innerText.trim() : '',
+      url:     linkEl   ? linkEl.href               : '',
+    });
+  }
+  return JSON.stringify(out.filter(j => j.title));
+})()
+""")
+
+results = json.loads(jobs)
+for r in results:
+    print(r["title"], "|", r["company"], "|", r["location"])
+```
+
+**If `results` is empty:** take a screenshot and check which page you are on. Glassdoor often
+serves a different layout under A/B tests. The screenshot will reveal the actual card selector.
+
+```python
+screenshot("/tmp/glassdoor_jobs.png")
+# Inspect the image, then adjust the querySelectorAll selector above
+```
+
+---
+
+## Workflow 2: Job search pagination
+
+Glassdoor paginates via `&p=N` on the job search URL.
+
+```python
+import json
+from urllib.parse import quote_plus
+
+query = "data scientist"
+all_jobs = []
+
+for page in range(1, 4):   # pages 1-3, ~10 cards each
+    url = f"https://www.glassdoor.com/Job/jobs.htm?sc.keyword={quote_plus(query)}&p={page}"
+    goto(url)
+    wait_for_load()
+    wait(5 if page == 1 else 3)  # first page needs CF wait; subsequent pages are faster
+
+    if page == 1:
+        dismiss_cookie_banner()
+
+    batch_json = js("""
+    (function() {
+      var cards = document.querySelectorAll('li[data-jobid], [class*="JobsList_jobListItem"]');
+      var out = [];
+      for (var i = 0; i < cards.length; i++) {
+        var c = cards[i];
+        var jobId   = c.getAttribute('data-jobid') || '';
+        var titleEl = c.querySelector('[data-test="job-title"], a[class*="JobCard_jobTitle"]');
+        var compEl  = c.querySelector('[data-test="employer-name"]');
+        var locEl   = c.querySelector('[data-test="emp-location"]');
+        var salEl   = c.querySelector('[data-test="detailSalary"], [class*="salary"]');
+        var linkEl  = c.querySelector('a[href*="/job-listing/"]');
+        out.push({
+          jobId,
+          title:    titleEl ? titleEl.innerText.trim() : '',
+          company:  compEl  ? compEl.innerText.trim()  : '',
+          location: locEl   ? locEl.innerText.trim()   : '',
+          salary:   salEl   ? salEl.innerText.trim()   : '',
+          url:      linkEl  ? linkEl.href               : '',
+        });
+      }
+      return JSON.stringify(out.filter(j => j.title));
+    })()
+    """)
+
+    batch = json.loads(batch_json)
+    if not batch:
+        break   # no more results
+    all_jobs.extend(batch)
+
+print(f"Collected {len(all_jobs)} jobs across {page} pages")
+```
+
+---
+
+## Workflow 3: Company overview — rating and review count
+
+Navigate to the company Overview or Reviews page. These pages require login for full content but the
+summary header (overall rating, review count, recommend %) is visible without login.
+
+```python
+import json, re
+
+# Example: Google (employer_id=9079)
+employer_id = 9079
+company_slug = "Google"
+
+goto(f"https://www.glassdoor.com/Overview/Working-at-{company_slug}-EI_IE{employer_id}.htm")
+wait_for_load()
+wait(5)   # CF challenge
+
+# Try __NEXT_DATA__ first — fastest and most complete
+next_data_raw = js("document.getElementById('__NEXT_DATA__') ? document.getElementById('__NEXT_DATA__').textContent : null")
+
+if next_data_raw:
+    nd = json.loads(next_data_raw)
+    # Company data lives under props.pageProps — path varies by page type
+    # Try employer overview path
+    props = nd.get("props", {}).get("pageProps", {})
+    employer = props.get("employer") or props.get("employerOverview")
+    if employer:
+        print("Rating:", employer.get("overallRating"))
+        print("Reviews:", employer.get("reviewCount") or employer.get("numberOfReviews"))
+        print("Name:", employer.get("name") or employer.get("shortName"))
+else:
+    # Fall back to DOM selectors
+    summary = js("""
+    (function() {
+      var ratingEl  = document.querySelector('[data-test="rating"], .ratingNumber, [class*="ratingNum"]');
+      var countEl   = document.querySelector('[data-test="reviewCount"], .reviewCount, [class*="reviewCount"]');
+      var nameEl    = document.querySelector('h1[data-test="employer-name"], [class*="EmployerProfile_name"]');
+      var recEl     = document.querySelector('[data-test="recommend"], [class*="recommend"]');
+      return JSON.stringify({
+        rating:  ratingEl ? ratingEl.innerText.trim() : '',
+        reviews: countEl  ? countEl.innerText.trim()  : '',
+        name:    nameEl   ? nameEl.innerText.trim()   : '',
+        recommend: recEl  ? recEl.innerText.trim()    : '',
+      });
+    })()
+    """)
+    print(json.loads(summary))
+```
+
+---
+
+## Workflow 4: Company reviews page — extract individual reviews
+
+Reviews pages show up to ~10 reviews per page without login. A login modal appears after scrolling.
+Extract before scrolling.
+
+```python
+import json
+
+employer_id = 9079
+company_slug = "Google"
+
+goto(f"https://www.glassdoor.com/Reviews/{company_slug}-Reviews-E{employer_id}.htm")
+wait_for_load()
+wait(5)
+
+dismiss_cookie_banner()
+
+reviews = js("""
+(function() {
+  // Review cards — confirmed selector pattern
+  var cards = document.querySelectorAll('[id^="empReview_"], [data-test="review-card"], [class*="ReviewCard"]');
+  if (!cards.length) {
+    cards = document.querySelectorAll('article[class*="review"]');
+  }
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+
+    // Overall star rating (1-5)
+    var starsEl = c.querySelector('[data-test="review-rating"], [class*="starRating"], span[class*="ratingNumber"]');
+    var stars = starsEl ? starsEl.innerText.trim() : '';
+
+    // Pros / Cons text
+    var prosEl = c.querySelector('[data-test="pros"], [class*="pros"], p[class*="pros"]');
+    var consEl = c.querySelector('[data-test="cons"], [class*="cons"], p[class*="cons"]');
+    var pros = prosEl ? prosEl.innerText.trim() : '';
+    var cons = consEl ? consEl.innerText.trim() : '';
+
+    // Review title
+    var titleEl = c.querySelector('[data-test="review-title"], h2[class*="reviewTitle"], [class*="title"] a');
+    var title = titleEl ? titleEl.innerText.trim() : '';
+
+    // Job title of reviewer
+    var jobTitleEl = c.querySelector('[data-test="reviewer-job-title"], [class*="reviewerInfo"], [class*="authorJobTitle"]');
+    var jobTitle = jobTitleEl ? jobTitleEl.innerText.trim() : '';
+
+    // Date
+    var dateEl = c.querySelector('time, [data-test="review-date"], [class*="reviewDate"]');
+    var date = dateEl ? (dateEl.getAttribute('datetime') || dateEl.innerText.trim()) : '';
+
+    if (pros || cons || title) {
+      out.push({stars, title, jobTitle, pros, cons, date});
+    }
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+results = json.loads(reviews)
+for r in results:
+    print(f"{r['stars']}★ | {r['title']} | {r['jobTitle']}")
+    print(f"  + {r['pros'][:100]}")
+    print(f"  - {r['cons'][:100]}")
+```
+
+---
+
+## Workflow 5: Salary page — extract reported salary data
+
+```python
+import json
+from urllib.parse import quote_plus
+
+# Salary pages use slug + character-count in the URL (n = len(role_slug))
+role = "software-engineer"
+n = len(role)  # 17 for "software-engineer"
+
+goto(f"https://www.glassdoor.com/Salaries/{role}-salary-SRCH_KO0,{n}.htm")
+wait_for_load()
+wait(5)
+
+# Try __NEXT_DATA__ for structured salary data
+next_data_raw = js("document.getElementById('__NEXT_DATA__') ? document.getElementById('__NEXT_DATA__').textContent : null")
+
+if next_data_raw:
+    nd = json.loads(next_data_raw)
+    # Salary data is typically under props.pageProps.salaryData or .salaryEstimate
+    props = nd.get("props", {}).get("pageProps", {})
+    salary_data = props.get("salaryData") or props.get("payData")
+    if salary_data:
+        print(json.dumps(salary_data, indent=2))
+
+# DOM fallback
+salary_summary = js("""
+(function() {
+  var medianEl = document.querySelector('[data-test="salary-estimate"], [class*="salaryEstimate"], [class*="median"]');
+  var rangeEl  = document.querySelector('[data-test="salary-range"],  [class*="salaryRange"]');
+  var countEl  = document.querySelector('[data-test="salary-count"],  [class*="salaryCount"]');
+  return JSON.stringify({
+    median:  medianEl ? medianEl.innerText.trim() : '',
+    range:   rangeEl  ? rangeEl.innerText.trim()  : '',
+    count:   countEl  ? countEl.innerText.trim()  : '',
+  });
+})()
+""")
+print(json.loads(salary_summary))
+```
+
+---
+
+## Handling the login modal
+
+Glassdoor shows a sign-in modal:
+- On Reviews/Salary pages: after viewing ~3-5 items (scroll-triggered)
+- On job detail pages: often immediately
+
+Dismiss it before extracting anything that requires scrolling:
+
+```python
+def dismiss_glassdoor_login_modal():
+    """Close the Glassdoor sign-in modal. Safe to call if no modal is present."""
+    closed = js("""
+    (function() {
+      var selectors = [
+        '[alt="Close"]',
+        'button[class*="modal_closeIcon"]',
+        '[data-test="close-modal"]',
+        '[aria-label="Close"]',
+        'button[data-test="CloseButton"]',
+        '[class*="CloseButton"]',
+      ];
+      for (var i = 0; i < selectors.length; i++) {
+        var btn = document.querySelector(selectors[i]);
+        if (btn && btn.offsetParent !== null) {
+          btn.click();
+          return selectors[i];
+        }
+      }
+      return null;
+    })()
+    """)
+    if closed:
+        wait(1)
+    return closed
+
+def dismiss_cookie_banner():
+    """Dismiss GDPR consent overlay. Safe to call even if no banner is present."""
+    dismissed = js("""
+    (function() {
+      var selectors = [
+        'button[data-test="accept-cookies"]',
+        '#onetrust-accept-btn-handler',
+        'button[id*="accept-all"]',
+        'button[class*="accept"]',
+        'button[class*="consent"]',
+      ];
+      for (var i = 0; i < selectors.length; i++) {
+        var btn = document.querySelector(selectors[i]);
+        if (btn && btn.offsetParent !== null) {
+          btn.click();
+          return selectors[i];
+        }
+      }
+      return null;
+    })()
+    """)
+    if dismissed:
+        wait(1)
+    return dismissed
+```
+
+For Reviews/Salary pages: call `dismiss_glassdoor_login_modal()` immediately after the initial
+wait, before any scrolling. Once you scroll down, the modal blocks the page and the X button
+may itself be outside the viewport.
+
+---
+
+## Detecting whether you are past the CF challenge
+
+After `goto()` + `wait(5)`, confirm you are on the real page:
+
+```python
+def glassdoor_is_cf_blocked() -> bool:
+    """True if the CF managed challenge is still running."""
+    title = js("document.title") or ""
+    url   = page_info()["url"]
+    return "Security" in title or "__cf_chl_tk" in url
+
+# Usage
+goto("https://www.glassdoor.com/Reviews/Google-Reviews-E9079.htm")
+wait_for_load()
+wait(5)
+
+if glassdoor_is_cf_blocked():
+    wait(10)   # give CF extra time
+    if glassdoor_is_cf_blocked():
+        screenshot("/tmp/glassdoor_cf_block.png")
+        raise RuntimeError("CF challenge did not resolve — check screenshot")
+```
+
+---
+
+## Glassdoor company ID lookup
+
+Glassdoor uses numeric employer IDs (e.g., Google = 9079, Apple = 1138, Meta = 40772).
+To find the ID for any company:
+
+```python
+from urllib.parse import quote_plus
+
+company_name = "OpenAI"
+goto(f"https://www.glassdoor.com/Search/results.htm?keyword={quote_plus(company_name)}&locT=N")
+wait_for_load()
+wait(5)
+
+# Extract company cards from search results
+companies = js("""
+(function() {
+  var cards = document.querySelectorAll('[data-test="employer-card"], [class*="EmployerCard"], [class*="employer-card"]');
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+    var link = c.querySelector('a[href*="Overview"], a[href*="Reviews"]');
+    if (!link) continue;
+    var href = link.href;
+    // Extract employer ID: EI_IE{id} or E{id}
+    var m = href.match(/E(?:I_IE)?(\d+)/);
+    var empId = m ? m[1] : '';
+    var nameEl = c.querySelector('[class*="EmployerCard_name"], h2, [class*="name"]');
+    out.push({
+      empId,
+      name: nameEl ? nameEl.innerText.trim() : '',
+      href,
+    });
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+import json
+for c in json.loads(companies):
+    print(c["empId"], c["name"], c["href"][:60])
+```
+
+---
+
+## Gotchas
+
+- **`http_get` is permanently blocked.** Cloudflare Bot Management blocks every IP-level request
+  with a JS managed challenge. No User-Agent, cookie, or header combination bypasses it. The
+  `__cf_bm` cookie returned in the 403 response is TLS-fingerprint-bound and cannot be replayed.
+  `api.glassdoor.com` is 410 Gone (shut down). Only real Chrome via CDP works.
+
+- **`wait(5)` minimum after `wait_for_load()`.** CF's managed challenge runs for 2-4 seconds after
+  `readyState = complete`. Extracting too early returns the challenge page HTML, not Glassdoor
+  content. If you get empty results or the title is "Security | Glassdoor", wait longer.
+
+- **Login modal triggers on scroll, not on load.** Extract all visible content immediately on page
+  load before any scrolling. Call `dismiss_glassdoor_login_modal()` right after the initial wait —
+  before issuing any `scroll()` calls.
+
+- **Glassdoor shows ~10 cards without login.** Reviews and salary pages are severely limited
+  without an account. Job search cards are more accessible (~10-15 per page). If you need 30+
+  reviews, a logged-in session is required.
+
+- **CSS class names use Next.js hashed suffixes.** Selectors like `[class*="JobCard_jobTitle"]`
+  match despite the hash suffix (e.g., `JobCard_jobTitle__abc12`). Never hardcode the full hashed
+  class name — it changes with deployments. Always use `[class*="prefix"]`.
+
+- **`__NEXT_DATA__` is the fast path.** When accessible, Glassdoor's Next.js pages embed all page
+  data in `<script id="__NEXT_DATA__" type="application/json">`. Parse it before falling back to
+  DOM queries. Data path varies by page type: look under `props.pageProps.employer`,
+  `props.pageProps.salaryData`, `props.pageProps.jobListings`, etc.
+
+- **Company URL slugs and IDs are stable.** The employer ID (e.g., `9079` for Google) never
+  changes. Slugs occasionally change when a company rebrands — always verify by following the
+  canonical redirect from a search result.
+
+- **Rate limiting.** Glassdoor rate-limits by IP after ~5 company-page loads per minute.
+  Use `wait(5)` between consecutive company page navigations. Salary and reviews pages are heavier
+  — use `wait(8)` between those.
+
+- **Salary URL requires character-count parameter.** The `SRCH_KO0,{n}` fragment encodes
+  `0` (start of role name) and `n` (end, i.e., `len(role_slug)`). For `"software-engineer"` (17
+  chars): `SRCH_KO0,17`. Wrong count returns a 404.
+
+- **`locKeyword` vs `locId` for location filter.** `locKeyword=San+Francisco` works without
+  knowing Glassdoor's internal city ID. `locT=C` means city-type location. For metro areas,
+  also try `locT=M`. Omit `locId` unless you have the exact numeric ID from a Glassdoor URL.
+
+- **PerimeterX is also active as a secondary layer.** After passing CF, Glassdoor runs behavioral
+  fingerprinting. Rapid automated scrolling, mouse movement, or navigation patterns may trigger a
+  secondary block. Mitigate with `wait(2)` between actions and avoid scripted mouse movement.
+
+- **Review and salary data require login on some accounts.** Anonymous sessions get a subset of
+  data. If a field returns empty consistently, the page may require authentication before surfacing
+  that data in the DOM or `__NEXT_DATA__`.
+
+- **`goto()` vs `new_tab()` for first navigation.** Use `new_tab()` for the very first Glassdoor
+  page in a session. If the harness is attached to a non-Glassdoor tab, `goto()` can silently
+  fail to pass the CF challenge because the existing tab may not have a clean origin context.
+  After the first successful load, `goto()` works fine for subsequent Glassdoor navigations.

--- a/domain-skills/medium/scraping.md
+++ b/domain-skills/medium/scraping.md
@@ -1,0 +1,414 @@
+# Medium — Data Extraction
+
+`https://medium.com` — blogging platform. Three access paths tested and validated: the undocumented `?format=json` endpoint (fastest for article + publication data), the undocumented GraphQL API (best for targeted metric lookups), and RSS feeds (best for recent posts lists without auth). No browser needed for any read-only task.
+
+## Do this first: pick your access path
+
+| Goal | Best approach | Latency |
+|------|--------------|---------|
+| Article metadata + full body | `?format=json` on article URL | ~400ms |
+| Article metrics only (claps, visibility) | GraphQL `post(id:)` | ~275ms |
+| Author profile + follower count | GraphQL `user(username:)` | ~220ms |
+| Recent posts for a user (up to 10) | `?format=json` on profile URL | ~240ms |
+| Recent posts for a publication | `?format=json` on publication URL | ~300ms |
+| Paginated post list (feed) | RSS feed | ~260ms |
+| Full article body as HTML | RSS `content:encoded` field | ~260ms |
+| Publication subscriber count | `?format=json` on publication URL | ~300ms |
+
+**Never use a browser for read-only Medium tasks.** All article content, metadata, and metrics are available over HTTP. Browser is only needed for authenticated actions (clapping, posting, account management).
+
+---
+
+## The XSSI prefix
+
+Every `?format=json` response starts with the anti-hijacking prefix `])}while(1);</x>` before the JSON. **Strip it before parsing.** The helper below handles this.
+
+```python
+import urllib.request, gzip, json, re
+
+def medium_json(url):
+    """Fetch any Medium URL with ?format=json and return parsed dict.
+    Strips the XSSI prefix ])}while(1);</x> automatically.
+    Works on: article URLs, user profile URLs, publication URLs.
+    Does NOT work on: search pages, /latest, profile stream API.
+    """
+    sep = '&' if '?' in url else '?'
+    req = urllib.request.Request(
+        url + sep + 'format=json',
+        headers={
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            "Accept": "application/json, */*",
+            "Accept-Encoding": "gzip",
+        }
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        raw = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            raw = gzip.decompress(raw)
+        text = raw.decode()
+    # Strip everything before the first {
+    return json.loads(re.sub(r'^[^\{]+', '', text))
+```
+
+---
+
+## Path 1: `?format=json` — article metadata + body (fastest for articles)
+
+Append `?format=json` to any article URL. Returns full metadata, virtuals (metrics), and the complete article body in a structured `bodyModel`. No auth required for public and subscriber-locked articles alike — the metadata and full body are always returned, but paywalled body content in a browser would be truncated.
+
+```python
+data = medium_json("https://medium.com/@karpathy/software-2-0-a64152b37c35")
+payload = data['payload']
+val     = payload['value']        # article fields
+refs    = payload['references']   # User, Social, SocialStats dicts keyed by ID
+
+# --- Article fields ---
+title       = val['title']                              # "Software 2.0"
+article_id  = val['id']                                 # "a64152b37c35"
+creator_id  = val['creatorId']                          # "ac9d9a35533e"
+slug        = val['uniqueSlug']                         # "software-2-0-a64152b37c35"
+url         = val['canonicalUrl']                       # "https://medium.com/@karpathy/..."
+first_pub   = val['firstPublishedAt']                   # unix ms: 1510438733751
+last_pub    = val['latestPublishedAt']                  # unix ms: 1615659523264
+visibility  = val['visibility']                         # 0=public, 2=subscriber-locked
+is_locked   = val['isSubscriptionLocked']               # True if paywalled
+locked_src  = val['lockedPostSource']                   # 0=free, 1=Medium Partner Program
+
+# --- Metrics (in val['virtuals']) ---
+virtuals    = val['virtuals']
+clap_count  = virtuals['totalClapCount']                # 60865 (all claps, including multi-clap)
+recommends  = virtuals['recommends']                    # 8846 (unique clappers)
+read_time   = virtuals['readingTime']                   # 8.79811320754717 (minutes, float)
+word_count  = virtuals['wordCount']                     # 2146
+
+# --- Tags ---
+tags = [t['slug'] for t in virtuals['tags']]
+# ['machine-learning', 'artificial-intelligence', 'programming', 'software-development', 'future']
+
+# --- Author (from references) ---
+user = refs['User'][creator_id]
+author_name = user['name']          # "Andrej Karpathy"
+author_handle = user['username']    # "karpathy"
+author_bio  = user['bio']           # "I like to train deep neural nets on large datasets."
+author_twitter = user['twitterScreenName']  # "karpathy"
+
+# --- Follower count (from SocialStats) ---
+ss = refs['SocialStats'][creator_id]
+follower_count  = ss['usersFollowedByCount']   # 60027
+following_count = ss['usersFollowedCount']     # 183
+```
+
+### Detect paywall
+
+```python
+# Paywalled (Medium Partner Program): isSubscriptionLocked=True, visibility=2, lockedPostSource=1
+# Free: isSubscriptionLocked=False, visibility=0, lockedPostSource=0
+is_paywalled = val['isSubscriptionLocked']   # True / False
+```
+
+Confirmed on real TDS articles: paywalled articles return `isSubscriptionLocked=True`, `visibility=2`, `lockedPostSource=1`. Free articles: all three are `False`/`0`.
+
+### Article body
+
+The full body is in `val['content']['bodyModel']['paragraphs']` — a list of dicts:
+
+```python
+paragraphs = val['content']['bodyModel']['paragraphs']
+
+# Paragraph types (confirmed for this article):
+# type=1  -> body text (P)
+# type=3  -> heading (H1/H2)
+# type=4  -> image (text is empty; metadata has image ID)
+
+# Reconstruct plain text:
+text_paras = [p['text'] for p in paragraphs if p.get('text')]
+full_text   = '\n\n'.join(text_paras)
+```
+
+---
+
+## Path 2: GraphQL API — targeted metric lookups
+
+`POST https://medium.com/_/graphql` with a JSON body. No auth, no CSRF token required.
+Returns HTTP 200 with JSON even for unauthenticated queries. Invalid fields return HTTP 400 — do not assume a field exists without testing first.
+
+```python
+import json, urllib.request, gzip
+
+def gql(query):
+    body = json.dumps({"query": query}).encode()
+    req  = urllib.request.Request(
+        "https://medium.com/_/graphql",
+        data=body,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        raw = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            raw = gzip.decompress(raw)
+        return json.loads(raw.decode())
+```
+
+### Fetch article metrics (fastest)
+
+```python
+result = gql("""
+{
+  post(id: "a64152b37c35") {
+    title
+    id
+    firstPublishedAt
+    latestPublishedAt
+    visibility
+    uniqueSlug
+    canonicalUrl
+    mediumUrl
+    isLocked
+    clapCount
+    readingTime
+    wordCount
+  }
+}
+""")
+post = result['data']['post']
+# post['visibility']  -> "PUBLIC" | "LOCKED"  (string, not numeric)
+# post['isLocked']    -> False | True
+# post['clapCount']   -> 60865  (same as totalClapCount in format=json)
+# post['readingTime'] -> 8.79811320754717  (minutes)
+# post['wordCount']   -> 2146
+```
+
+**Confirmed working `post()` fields:** `title`, `id`, `createdAt`, `updatedAt`, `firstPublishedAt`, `latestPublishedAt`, `visibility`, `uniqueSlug`, `canonicalUrl`, `mediumUrl`, `isLocked`, `clapCount`, `readingTime`, `wordCount`
+
+**Nested object that works:** `topics { name slug }`, `creator { name username }`, `collection { name id slug description domain creator { name username } }`
+
+**Fields that return HTTP 400 (not available):** `tags`, `author`, `recommends`, `content`, `publication`, `responses`, `sequence`
+
+### Fetch author profile
+
+```python
+result = gql("""
+{
+  user(username: "karpathy") {
+    name
+    username
+    id
+    bio
+    imageId
+    twitterScreenName
+    mediumMemberAt
+    socialStats {
+      followerCount
+      followingCount
+    }
+  }
+}
+""")
+user = result['data']['user']
+# user['name']                       -> "Andrej Karpathy"
+# user['id']                         -> "ac9d9a35533e"
+# user['bio']                        -> "I like to train deep neural nets on large datasets."
+# user['twitterScreenName']          -> "karpathy"
+# user['socialStats']['followerCount'] -> 60028
+# user['mediumMemberAt']             -> 0 (not a member); nonzero = unix ms join date
+```
+
+**Confirmed working `user()` fields:** `name`, `username`, `id`, `bio`, `imageId`, `twitterScreenName`, `mediumMemberAt`, `socialStats { followerCount followingCount }`
+
+**Fields that return HTTP 400:** `followerCount` (top-level), `followingCount` (top-level), `postCount`
+
+### Fetch collection (publication) by ID
+
+The GraphQL `collection()` query only accepts `id`, not `slug`. Get the ID from `?format=json` on the publication page.
+
+```python
+# TDS Archive id: 7f60cf5620c9  (from medium.com/towards-data-science?format=json)
+result = gql("""
+{
+  collection(id: "7f60cf5620c9") {
+    name
+    id
+    slug
+    description
+    domain
+    creator { name username }
+  }
+}
+""")
+coll = result['data']['collection']
+# coll['name'] -> "TDS Archive"
+# coll['slug'] -> "data-science"
+```
+
+---
+
+## Path 3: RSS feeds (best for recent posts list + article bodies)
+
+Works with plain `http_get`. Returns up to 10 most recent posts. Full article HTML is in `content:encoded`. No clap count or visibility info in RSS.
+
+```python
+import re
+from helpers import http_get
+
+def parse_rss_items(rss_xml):
+    """Extract items from Medium RSS feed. Returns list of dicts."""
+    def cdata(tag, text):
+        m = re.search(rf'<{tag}[^>]*><!\[CDATA\[(.*?)\]\]></{tag}>', text, re.DOTALL)
+        return m.group(1).strip() if m else None
+
+    items = []
+    for raw in re.findall(r'<item>(.*?)</item>', rss_xml, re.DOTALL):
+        # link is plain text (not CDATA)
+        link_m = re.search(r'<link>(.*?)</link>', raw, re.DOTALL)
+        items.append({
+            'title':    cdata('title', raw),
+            'link':     link_m.group(1).strip() if link_m else None,
+            'pubDate':  cdata('pubDate', raw),
+            'creator':  cdata('dc:creator', raw),
+            'tags':     re.findall(r'<category><!\[CDATA\[(.*?)\]\]></category>', raw),
+            'body_html': cdata('content:encoded', raw),   # full article HTML
+        })
+    return items
+
+# User feed (up to 10 latest posts)
+rss = http_get("https://medium.com/feed/@karpathy")
+posts = parse_rss_items(rss)
+# posts[0]['title']    -> "Software 2.0"
+# posts[0]['pubDate']  -> "Sat, 11 Nov 2017 22:18:53 GMT"
+# posts[0]['creator']  -> "Andrej Karpathy"
+# posts[0]['tags']     -> ['programming', 'software-development', 'artificial-intelligence', 'future', 'machine-learning']
+# posts[0]['link']     -> "https://karpathy.medium.com/software-2-0-a64152b37c35?source=rss-..."
+# posts[0]['body_html'] -> full article body as HTML string (~15KB for this article)
+
+# Publication feed (up to 10 latest posts)
+rss_pub = http_get("https://medium.com/feed/towards-data-science")
+pub_posts = parse_rss_items(rss_pub)
+```
+
+**RSS limitations:**
+- RSS does not include clap count, view count, or paywall status.
+- `body_html` contains the full article body as HTML, including `<p>`, `<strong>`, `<a>`, `<img>` tags.
+- Pagination is not supported — RSS always returns the 10 most recent posts.
+
+---
+
+## Path 4: `?format=json` on user profile — recent posts with metrics
+
+Better than RSS when you need clap counts alongside post list. Returns up to `limit` posts (default 10) plus full author metadata.
+
+```python
+data = medium_json("https://medium.com/@karpathy?limit=10")
+payload = data['payload']
+
+user = payload['user']
+# user['name']     -> "Andrej Karpathy"
+# user['username'] -> "karpathy"
+# user['bio']      -> "I like to train deep neural nets on large datasets."
+
+refs = payload['references']
+ss   = refs['SocialStats'][user['userId']]
+# ss['usersFollowedByCount'] -> 60028 (followers)
+# ss['usersFollowedCount']   -> 183   (following)
+
+posts = refs.get('Post', {})  # dict keyed by post ID
+for pid, p in posts.items():
+    v = p['virtuals']
+    print(p['title'], v['totalClapCount'], round(v['readingTime'], 1))
+
+# Paginate: use paging['next'] from payload
+paging = payload['paging']
+next_params = paging['next']
+# next_params = {'limit': 10, 'to': '1495652975362', 'source': 'overview', 'page': 2, 'ignoredIds': []}
+# Append as query params to the same profile URL to get next page
+next_url = (
+    f"https://medium.com/@{user['username']}"
+    f"?limit={next_params['limit']}&to={next_params['to']}"
+    f"&source={next_params['source']}&page={next_params['page']}"
+)
+data2 = medium_json(next_url)
+# Note: karpathy has only 8 total posts — pagination returns same refs on page 2
+```
+
+---
+
+## Path 5: `?format=json` on publication page
+
+Returns publication metadata and recent posts with metrics.
+
+```python
+data = medium_json("https://medium.com/towards-data-science")
+payload = data['payload']
+
+coll = payload['collection']
+# coll['name']            -> "TDS Archive"
+# coll['slug']            -> "data-science"
+# coll['description']     -> full description string
+# coll['subscriberCount'] -> 828527
+# coll['metadata']['followerCount'] -> 828527
+# coll['tags']            -> ['DATA SCIENCE', 'MACHINE LEARNING', ...]
+
+posts = payload['references'].get('Post', {})
+for pid, p in posts.items():
+    v = p['virtuals']
+    print(p['title'], v['totalClapCount'], p['isSubscriptionLocked'])
+# Also includes: p['visibility'] (0=free, 2=paywalled)
+
+# Paginate (same pattern as user profile)
+paging = payload['paging']
+# paging['next'] = {'to': '1738573325936', 'page': 3}
+```
+
+---
+
+## Retrieving the article ID from a URL
+
+The `id` is the last 12 hex chars of a Medium article URL slug:
+
+```python
+import re
+
+url = "https://medium.com/@karpathy/software-2-0-a64152b37c35"
+article_id = re.search(r'-([a-f0-9]{12})$', url.rstrip('/').split('?')[0])
+if article_id:
+    article_id = article_id.group(1)   # "a64152b37c35"
+```
+
+This ID is the same across all URL forms (`medium.com/@user/slug`, `user.medium.com/slug`, `medium.com/publication/slug`).
+
+---
+
+## Gotchas
+
+- **HTTP 403 on plain `http_get`** — The default `http_get` helper sends `User-Agent: Mozilla/5.0` which Medium accepts for most endpoints, but article HTML pages (without `?format=json`) return 403. Always use `?format=json` for article and profile pages.
+
+- **`?format=json` works; profile stream API does not** — `https://medium.com/_/api/users/{id}/profile/stream` returns HTTP 403 for unauthenticated requests. Use `?format=json` on the profile URL instead.
+
+- **`?format=json` on search pages returns 403 or broken JSON** — `medium.com/search?q=...&format=json` and `medium.com/search/posts?q=...&format=json` both fail. Search is not available without auth.
+
+- **GraphQL `collection()` requires ID, not slug** — `collection(slug: "towards-data-science")` returns HTTP 400. You must use the numeric ID (e.g. `"7f60cf5620c9"`). Get it from `?format=json` on the publication page: `payload['collection']['id']`.
+
+- **GraphQL `tags` field on `post()` returns HTTP 400** — Use `topics { name slug }` instead. Topics are a subset of tags but work without auth.
+
+- **GraphQL visibility is a string, not a number** — `post().visibility` returns `"PUBLIC"` or `"LOCKED"` (string). The `?format=json` `value.visibility` field uses integers: `0`=public, `2`=locked. Both agree on the lock status.
+
+- **`totalClapCount` vs `recommends`** — `totalClapCount` (60865) counts all claps (Medium allows up to 50 claps per reader). `recommends` (8846) counts unique clappers. The GraphQL `clapCount` field equals `totalClapCount`, not `recommends`.
+
+- **RSS returns at most 10 items, no clap counts** — RSS is best for getting recent article links + full HTML body. Use `?format=json` profile if you need metrics.
+
+- **RSS link contains tracking params** — `posts[0]['link']` includes `?source=rss-{userId}------2`. Strip with `.split('?')[0]` if you need a clean URL.
+
+- **`content:encoded` in RSS is full HTML, not plaintext** — Strip HTML tags if you want plaintext: `re.sub(r'<[^>]+>', '', body_html)`.
+
+- **Medium subdomains** — Some users have custom subdomains (`karpathy.medium.com`). Both `medium.com/@karpathy/...` and `karpathy.medium.com/...` resolve to the same article; `?format=json` works on both.
+
+- **towardsdatascience.com is no longer Medium** — TDS moved to its own WordPress site. `towardsdatascience.com/article-slug?format=json` returns full WordPress HTML, not Medium JSON. Use `medium.com/towards-data-science` for the archived Medium publication.
+
+- **No public search API** — Medium has no Algolia equivalent. Finding articles by keyword requires either a browser, or fetching a user/publication feed and filtering locally.
+
+- **Timestamps are unix milliseconds** — `firstPublishedAt`, `createdAt`, `latestPublishedAt` are all in milliseconds. Convert: `datetime.fromtimestamp(val['firstPublishedAt'] / 1000, tz=timezone.utc)`.

--- a/domain-skills/openstreetmap/scraping.md
+++ b/domain-skills/openstreetmap/scraping.md
@@ -1,0 +1,490 @@
+# OpenStreetMap — Nominatim Geocoding + Overpass API
+
+Two fully public, no-auth APIs. Everything is a direct HTTP call — never need a browser.
+
+- **Nominatim**: geocoding (place name → lat/lon and reverse). Rate limit: 1 req/s.
+- **Overpass API**: spatial query engine over the full OSM dataset. Rate limit: 2 concurrent slots per IP on the public instance.
+
+**Do not use `http_get` without overriding `User-Agent`** — its default `Mozilla/5.0` is blocked by both APIs with HTTP 403. Pass `headers={"User-Agent": "browser-harness/1.0"}` on every call.
+
+---
+
+## Fastest path: forward geocode a place
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+
+def geocode(query: str, limit: int = 3) -> list[dict]:
+    q = urllib.parse.quote(query)
+    raw = http_get(
+        f"https://nominatim.openstreetmap.org/search?q={q}&format=json&limit={limit}&addressdetails=1",
+        headers=UA
+    )
+    return json.loads(raw)  # [] when nothing found
+
+results = geocode("Eiffel Tower")
+# results[0]['display_name']  == 'Tour Eiffel, 5, Avenue Anatole France, ..., 75007, France'
+# results[0]['lat']            == '48.8582599'   ← STRING, not float
+# results[0]['lon']            == '2.2945006'    ← STRING, not float
+# results[0]['type']           == 'tower'
+# results[0]['class']          == 'man_made'
+# results[0]['importance']     == 0.6205937724353116
+# results[0]['osm_type']       == 'way'
+# results[0]['osm_id']         == 5013364
+# results[0]['boundingbox']    == ['48.8574753', '48.8590453', '2.2933119', '2.2956897']  ← all strings
+# results[0]['address']['city']     == 'Paris'
+# results[0]['address']['postcode'] == '75007'
+# results[0]['address']['country']  == 'France'
+# results[0]['address']['country_code'] == 'fr'
+```
+
+---
+
+## Nominatim: all three query modes
+
+### 1. Forward geocode (free-text)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+
+raw = http_get(
+    "https://nominatim.openstreetmap.org/search?q=Eiffel+Tower&format=json&limit=3&addressdetails=1",
+    headers=UA
+)
+results = json.loads(raw)
+# Returns [] when nothing found — no exception
+
+# Useful optional params:
+# &addressdetails=1   → adds 'address' dict to each result (city, postcode, road, etc.)
+# &extratags=1        → adds 'extratags' dict (website, wikidata, phone, etc.)
+# &namedetails=1      → adds 'namedetails' dict (name:en, name:fr, etc.)
+# &countrycodes=fr,de → restrict to countries (comma-separated ISO 3166-1 alpha-2)
+# &viewbox=2.2,48.8,2.4,48.9 &bounded=1  → restrict to bounding box (lon_min,lat_min,lon_max,lat_max)
+```
+
+### 2. Reverse geocode (lat/lon → address)
+
+```python
+raw = http_get(
+    "https://nominatim.openstreetmap.org/reverse?lat=48.8584&lon=2.2945&format=json",
+    headers=UA
+)
+result = json.loads(raw)
+# result['display_name']  == 'Avenue Gustave Eiffel, Quartier du Gros-Caillou, ..., France'
+# result['address']['road']         == 'Avenue Gustave Eiffel'
+# result['address']['city']         == 'Paris'
+# result['address']['postcode']     == '75007'
+# result['address']['country']      == 'France'
+# result['address']['country_code'] == 'fr'
+# result['address']['state']        == 'Île-de-France'
+# result['lat'], result['lon']  → strings (not floats)
+
+# Optional: &zoom=N (0-18) controls granularity of the returned address
+# zoom=3 → country, zoom=10 → city, zoom=18 → street/building (default)
+```
+
+### 3. Structured search (field-based)
+
+```python
+raw = http_get(
+    "https://nominatim.openstreetmap.org/search?city=Paris&country=France&format=json&limit=1",
+    headers=UA
+)
+result = json.loads(raw)[0]
+# result['name']          == 'Paris'
+# result['lat']           == '48.8534951'
+# result['lon']           == '2.3483915'
+# result['type']          == 'administrative'
+# result['place_rank']    == 12  (lower = broader: 4=country, 8=state, 12=city, 30=POI)
+# result['addresstype']   == 'city'
+# result['boundingbox']   == ['48.8155755', '48.9021560', '2.2241220', '2.4697602']
+
+# Supported structured params: street, city, county, state, country, postalcode
+```
+
+### 4. Lookup by OSM ID
+
+```python
+# Prefix: N=node, W=way, R=relation
+raw = http_get(
+    "https://nominatim.openstreetmap.org/lookup?osm_ids=W5013364&format=json",
+    headers=UA
+)
+result = json.loads(raw)
+# Returns list. Eiffel Tower way: result[0]['name'] == 'Tour Eiffel'
+# Supports up to 50 IDs: osm_ids=W5013364,N123456,R789
+```
+
+---
+
+## Nominatim response field reference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `place_id` | int | Internal Nominatim ID — do not cache long-term, can change |
+| `osm_type` | str | `"node"`, `"way"`, or `"relation"` |
+| `osm_id` | int | The OSM element ID |
+| `lat` | **str** | Latitude as string — convert with `float(r['lat'])` |
+| `lon` | **str** | Longitude as string — convert with `float(r['lon'])` |
+| `display_name` | str | Full human-readable address string |
+| `name` | str | Short name of the place |
+| `type` | str | OSM type tag value: `"tower"`, `"administrative"`, `"restaurant"`, etc. |
+| `class` | str | OSM key: `"man_made"`, `"boundary"`, `"amenity"`, `"highway"`, etc. |
+| `addresstype` | str | Semantic category: `"city"`, `"road"`, `"man_made"`, etc. |
+| `place_rank` | int | Hierarchy rank: 4=country, 8=state, 12=city, 16=suburb, 30=POI |
+| `importance` | float | 0–1 relevance score (higher = more notable) |
+| `boundingbox` | list[str] | `[south_lat, north_lat, west_lon, east_lon]` — all strings, note unusual order |
+| `licence` | str | ODbL attribution string — include in user-facing output |
+| `address` | dict | Only present with `&addressdetails=1` or in reverse results |
+
+`address` dict common keys: `road`, `house_number`, `quarter`, `suburb`, `city_district`, `city`, `state`, `postcode`, `country`, `country_code`, `ISO3166-2-lvl4/6`.
+
+---
+
+## Overpass API: query OSM data by tags
+
+Overpass is a read-only query engine over the full OSM planet. It supports finding POIs by tag, radius, bounding box, and combinations.
+
+**Endpoint**: `https://overpass-api.de/api/interpreter`
+**Backup instances** (use when main is overloaded, which happens often):
+- `https://overpass.openstreetmap.fr/api/interpreter` — requires non-Mozilla User-Agent
+
+**http_get works for GET requests** — pass `headers={"User-Agent": "browser-harness/1.0"}`. For POST, use `urllib` directly (see example below).
+
+### GET query (simplest for http_get)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_get(query: str) -> dict:
+    url = f"{OVERPASS}?data={urllib.parse.quote(query)}"
+    raw = http_get(url, headers=UA)
+    if not raw.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML returned): {raw[:200]}")
+    return json.loads(raw)
+
+# Find cafes in central Paris (bbox: south_lat, west_lon, north_lat, east_lon)
+r = overpass_get('[out:json][timeout:25];node["amenity"="cafe"](48.855,2.295,48.862,2.308);out 10;')
+# r['version']    == 0.6
+# r['generator']  == 'Overpass API 0.7.62.7 375dc00a'
+# r['elements']   → list of matching OSM elements
+
+for cafe in r['elements']:
+    print(cafe['tags'].get('name'), cafe['lat'], cafe['lon'])
+# 'Café de l\'Alma' 48.8609068 2.3015143
+# 'Le Campanella'   48.8585847 2.3032822
+# 'Kozy Bosquet'    48.855445  2.3054013
+
+# Find restaurants within 500m radius of a point (around filter)
+r = overpass_get(
+    '[out:json][timeout:25];node["amenity"="restaurant"](around:500,37.7749,-122.4194);out 10;'
+)
+for rest in r['elements']:
+    print(rest['tags'].get('name'), rest['tags'].get('cuisine',''))
+# 'Nepalese Indian Cusine' 'indian;nepali'
+# 'Local Diner' 'coffee_shop;italian;burger;seafood'
+# 'Moya Cafe' ''
+```
+
+### POST query (for complex QL, avoids URL length limits)
+
+```python
+import json, urllib.parse, urllib.request, gzip
+from helpers import http_get  # http_get is GET-only; use urllib for POST
+
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_post(query: str) -> dict:
+    """POST to Overpass — no URL length limits, preferred for multi-statement QL."""
+    data = urllib.parse.urlencode({"data": query}).encode()
+    req = urllib.request.Request(
+        OVERPASS, data=data, method="POST",
+        headers={
+            "User-Agent": "browser-harness/1.0",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept-Encoding": "gzip",
+        }
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        body = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+    body = body.decode()
+    if not body.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML): {body[:300]}")
+    return json.loads(body)
+
+# Example: cafes in Paris bbox
+r = overpass_post('[out:json][timeout:25];node["amenity"="cafe"](48.855,2.295,48.862,2.308);out 5;')
+print(len(r['elements']))  # 5 (or up to 5)
+```
+
+### Overpass element structure
+
+Every element in `r['elements']` is a dict with at minimum:
+
+```python
+{
+    "type": "node",          # "node", "way", or "relation"
+    "id": 308684349,         # int — OSM element ID (stable, use for dedup)
+    "lat": 48.8609068,       # float — ONLY present for node type
+    "lon": 2.3015143,        # float — ONLY present for node type
+    "tags": {                # dict — all OSM tags on this element
+        "amenity": "cafe",
+        "name": "Café de l'Alma",
+        "name:fr": "Café de l'Alma",
+        "outdoor_seating": "yes",
+        "payment:credit_cards": "yes",
+        "phone": "+33 1 45 51 56 74",
+        "opening_hours": "Mo-Sa 08:00-23:00; Su 09:00-19:00",  # optional
+        "website": "https://...",                               # optional
+        "wheelchair": "yes"                                     # optional
+    }
+}
+```
+
+For `way` elements, use `out center;` to get a `center` dict with lat/lon instead of a node list:
+
+```python
+# way element with out center:
+{
+    "type": "way",
+    "id": 338411946,
+    "center": {"lat": 48.8660087, "lon": 2.3153233},  # centroid of the polygon
+    "nodes": [3454913623, 3454913707, ...],            # node IDs forming the boundary
+    "tags": {"amenity": "cafe", "name": "Café 1902", ...}
+}
+
+# Query to get both nodes and ways with lat/lon:
+query = '[out:json][timeout:25];(node["amenity"="cafe"](48.85,2.29,48.87,2.32);way["amenity"="cafe"](48.85,2.29,48.87,2.32););out center 20;'
+r = overpass_get(query)
+for el in r['elements']:
+    if el['type'] == 'node':
+        lat, lon = el['lat'], el['lon']
+    else:  # way
+        lat, lon = el['center']['lat'], el['center']['lon']
+    print(el['tags'].get('name'), lat, lon)
+```
+
+### Overpass QL quick reference
+
+```
+[out:json][timeout:25]      # Required header: JSON output, 25s timeout
+[maxsize:52428800]          # Optional: 50MB max result size (default is server limit)
+
+node["amenity"="cafe"](south,west,north,east);out N;
+#  ↑ bbox order: south_lat, west_lon, north_lat, east_lon
+#  Note: DIFFERENT from Nominatim's boundingbox field which is [south,north,west,east]
+
+node["amenity"="cafe"](around:RADIUS_METERS,LAT,LON);out N;
+
+node["amenity"~"cafe|restaurant"](bbox);out N;    # regex match on tag value
+node[!"name"](bbox);out N;                        # elements WITHOUT the 'name' tag
+node["name"~"Star",i](bbox);out N;               # case-insensitive regex
+
+# Union of types:
+(node["amenity"="cafe"](bbox); way["amenity"="cafe"](bbox););out center N;
+
+# Multiple tags (AND logic):
+node["amenity"="cafe"]["outdoor_seating"="yes"](bbox);out N;
+```
+
+---
+
+## OSM tile server (reference only, no scraping)
+
+```
+https://{a,b,c}.tile.openstreetmap.org/{z}/{x}/{y}.png
+```
+
+- Subdomains `a`, `b`, `c` for load balancing
+- `z` = zoom level 0–19, `x`/`y` = tile coordinates
+- Returns 256×256 PNG tiles
+- Policy: max 2 req/s per IP, non-commercial use, must display OSM attribution
+- Tile coordinate calculator: `https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames`
+- Bulk tile downloading is prohibited — use Overpass or data extracts instead
+
+```python
+# Convert lat/lon to tile coordinates
+import math
+
+def lat_lon_to_tile(lat, lon, zoom):
+    n = 2 ** zoom
+    x = int((lon + 180) / 360 * n)
+    y = int((1 - math.log(math.tan(math.radians(lat)) + 1 / math.cos(math.radians(lat))) / math.pi) / 2 * n)
+    return x, y
+
+x, y = lat_lon_to_tile(48.8582, 2.2945, 14)
+url = f"https://a.tile.openstreetmap.org/14/{x}/{y}.png"
+# url == 'https://a.tile.openstreetmap.org/14/8281/5646.png'
+```
+
+---
+
+## Rate limits
+
+| API | Limit | Enforcement | 429 behavior |
+|-----|-------|-------------|--------------|
+| Nominatim | 1 req/s | Soft — rapid requests work but you get delayed/dropped | Returns HTTP 403 if your IP is banned (not 429) |
+| Overpass (main) | 2 concurrent slots per IP | Hard — 3rd concurrent req returns HTML error immediately | HTML error page with `rate_limited` in body |
+| Overpass (main) | Also: query complexity quota | Resets over time (~per hour) | HTML error page with `rate_limited` |
+| Tile server | 2 req/s per IP | Soft/hard | IP block |
+
+**Check your Overpass quota**:
+```python
+raw = http_get("https://overpass-api.de/api/status", headers={"User-Agent": "browser-harness/1.0"})
+print(raw)
+# Connected as: 1728118854
+# Rate limit: 2
+# 2 slots available now.
+# Slot available after: 2026-04-18T11:00:00Z, in 30 seconds.
+```
+
+**Handle rate limiting in production**:
+```python
+import time
+
+def overpass_get_with_retry(query: str, max_retries: int = 3) -> dict:
+    for attempt in range(max_retries):
+        url = f"https://overpass.openstreetmap.fr/api/interpreter?data={urllib.parse.quote(query)}"
+        raw = http_get(url, headers={"User-Agent": "browser-harness/1.0"})
+        if raw.startswith("{"):
+            return json.loads(raw)
+        if "rate_limited" in raw or "too busy" in raw:
+            wait = 2 ** attempt * 10  # 10s, 20s, 40s
+            time.sleep(wait)
+            continue
+        raise RuntimeError(f"Overpass error: {raw[:200]}")
+    raise RuntimeError("Overpass: too many retries")
+```
+
+---
+
+## Complete working example
+
+```python
+import json, time, urllib.parse, urllib.request, gzip
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+NOMINATIM = "https://nominatim.openstreetmap.org"
+OVERPASS   = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def geocode(query: str, limit: int = 1) -> list[dict]:
+    """Forward geocode — returns [] if nothing found."""
+    q = urllib.parse.quote(query)
+    raw = http_get(f"{NOMINATIM}/search?q={q}&format=json&limit={limit}&addressdetails=1", headers=UA)
+    return json.loads(raw)
+
+def reverse_geocode(lat: float, lon: float) -> dict:
+    """Reverse geocode — always returns a result (nearest road/place)."""
+    raw = http_get(f"{NOMINATIM}/reverse?lat={lat}&lon={lon}&format=json", headers=UA)
+    return json.loads(raw)
+
+def overpass_get(query: str) -> list[dict]:
+    """Run an Overpass QL query, return elements list."""
+    url = f"{OVERPASS}?data={urllib.parse.quote(query)}"
+    raw = http_get(url, headers=UA)
+    if not raw.startswith("{"):
+        raise RuntimeError(f"Overpass error: {raw[:200]}")
+    return json.loads(raw)["elements"]
+
+def overpass_post(query: str) -> list[dict]:
+    """POST variant — avoids URL length limits for complex queries."""
+    data = urllib.parse.urlencode({"data": query}).encode()
+    req = urllib.request.Request(
+        OVERPASS, data=data, method="POST",
+        headers={"User-Agent": "browser-harness/1.0",
+                 "Content-Type": "application/x-www-form-urlencoded",
+                 "Accept-Encoding": "gzip"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        body = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+    body = body.decode()
+    if not body.startswith("{"):
+        raise RuntimeError(f"Overpass error: {body[:300]}")
+    return json.loads(body)["elements"]
+
+# --- Usage examples (validated 2026-04-18) ---
+
+# 1. Geocode a landmark
+places = geocode("Eiffel Tower", limit=3)
+# places[0]['lat']  == '48.8582599'  (string)
+# places[0]['lon']  == '2.2945006'   (string)
+# places[0]['display_name'] == 'Tour Eiffel, 5, Avenue Anatole France, ..., 75007, France'
+# places[0]['address']['city'] == 'Paris'
+lat = float(places[0]['lat'])
+lon = float(places[0]['lon'])
+
+# 2. Reverse geocode the coordinates
+addr = reverse_geocode(lat, lon)
+# addr['address']['road']    == 'Avenue Gustave Eiffel'
+# addr['address']['city']    == 'Paris'
+# addr['address']['postcode']== '75007'
+# addr['address']['country'] == 'France'
+
+# 3. Find nearby cafes (wait 1s between nominatim and overpass if same script)
+time.sleep(1)
+cafes = overpass_get(
+    f"[out:json][timeout:25];node[\"amenity\"=\"cafe\"](around:500,{lat},{lon});out 10;"
+)
+for cafe in cafes:
+    print(f"{cafe['tags'].get('name','?'):30s}  {cafe['lat']:.4f}, {cafe['lon']:.4f}")
+# Café de l'Alma                  48.8609, 2.3015
+# Le Campanella                   48.8586, 2.3033
+
+# 4. Structured city lookup + find restaurants in bounding box
+time.sleep(1)
+paris = geocode("Paris, France")[0]
+bb = paris['boundingbox']  # [south_lat, north_lat, west_lon, east_lon] ← Nominatim order!
+# For Overpass: need (south_lat, west_lon, north_lat, east_lon) ← DIFFERENT order
+south, north, west, east = bb[0], bb[1], bb[2], bb[3]
+# Restrict to center slice to avoid massive result set
+center_bbox = f"48.855,2.295,48.865,2.315"
+rests = overpass_post(
+    f"[out:json][timeout:25];node[\"amenity\"=\"restaurant\"]({center_bbox});out 5;"
+)
+print(f"Found {len(rests)} restaurants near Paris center")
+```
+
+---
+
+## Gotchas
+
+**`http_get` default UA (`Mozilla/5.0`) is blocked by both APIs.** Always pass `headers={"User-Agent": "browser-harness/1.0"}`. The `headers` kwarg in `http_get` does a `.update()` so it properly overrides the default. Confirmed: Mozilla/5.0 → 403 on Nominatim; `browser-harness/1.0` → 200.
+
+**Blocked User-Agent patterns on Nominatim**: `Mozilla/5.0`, `python-requests/*`, `Wget/*`. Accepted: any non-generic app-style UA like `browser-harness/1.0`, `MyApp/2.0`, `curl/7.x`. Nominatim policy requires a descriptive UA with contact info, but in practice any non-library string passes.
+
+**Nominatim lat/lon are strings, Overpass lat/lon are floats.** Always convert Nominatim coordinates: `float(result['lat'])`. Overpass element `lat`/`lon` are native Python floats — no conversion needed.
+
+**Nominatim `boundingbox` field order is `[south_lat, north_lat, west_lon, east_lon]` — NOT `[south, west, north, east]`.** Overpass bbox uses `(south_lat, west_lon, north_lat, east_lon)`. When feeding a Nominatim bounding box into Overpass, you must reorder: `f"({bb[0]},{bb[2]},{bb[1]},{bb[3]})"`.
+
+**`overpass-api.de` main instance is frequently overloaded.** Returns HTTP 504 (timeout) or an HTML error page with `rate_limited` when busy. The FR mirror (`overpass.openstreetmap.fr`) is usually more responsive but also blocks `Mozilla/5.0`. Always detect non-JSON responses: `if not raw.startswith("{")`.
+
+**Overpass error responses are HTML, not JSON.** The API returns HTTP 200 with an HTML error page when rate-limited or when the server is too busy. Always check `raw.startswith("{")` before parsing.
+
+**Overpass rate limit: 2 concurrent slots, NOT 2 requests/s.** You can run 2 queries simultaneously. A 3rd concurrent query immediately returns an error. Sequential queries with no sleep between them work fine as long as each completes before the next starts.
+
+**`out N;` limits results to N elements — use it.** Without a limit, large bounding boxes can return thousands of elements and hit the 512MB memory limit, returning a `maxsize` error. Default safe limit: `out 50;` for exploration, `out 500;` for bulk collection.
+
+**Overpass QL bbox order is `(south, west, north, east)` — latitude FIRST.** This is the opposite of the standard GeoJSON convention `[west, south, east, north]`. The `around:` filter uses `(around:METERS,LAT,LON)` — note lat before lon.
+
+**`name` tag in Overpass is the local-language name.** For Paris cafes this is French. English names may appear under `name:en` but are often absent. Never assume `name` is in English.
+
+**Nominatim `/reverse` always returns the nearest result** — it never returns an empty response (unlike `/search`). If the coordinates are in the ocean, it still returns the nearest coastline or country.
+
+**`place_id` is internal and ephemeral** — do not store it for long-term use. Use `osm_type` + `osm_id` for stable references (e.g., `way/5013364` for the Eiffel Tower).
+
+**Overpass `http_get` POST workaround**: `http_get` only supports GET. For POST requests (needed to avoid URL length limits for complex multi-statement QL), use `urllib.request.Request` directly as shown in the `overpass_post()` example above.

--- a/domain-skills/soundcloud/scraping.md
+++ b/domain-skills/soundcloud/scraping.md
@@ -1,0 +1,362 @@
+# SoundCloud — Data Extraction
+
+Field-tested against soundcloud.com on 2026-04-18.
+No authentication required for any approach documented here. All code uses `http_get` (pure HTTP, no browser).
+
+---
+
+## Approach 1 (Fastest): oEmbed API — No Auth, No Client ID
+
+`https://soundcloud.com/oembed?url=<resource_url>&format=json`
+
+Returns JSON in ~0.3s. Works for **tracks, playlists/sets, and user profiles**. No key required.
+
+```python
+from helpers import http_get
+import json
+
+def soundcloud_oembed(resource_url):
+    """Fetch oEmbed metadata for any public SoundCloud URL.
+
+    Works for:
+      - https://soundcloud.com/{user}/{track-slug}
+      - https://soundcloud.com/{user}/sets/{playlist-slug}
+      - https://soundcloud.com/{user}
+    """
+    url = f"https://soundcloud.com/oembed?url={resource_url}&format=json"
+    return json.loads(http_get(url))
+
+# Track
+track = soundcloud_oembed("https://soundcloud.com/forss/flickermood")
+# {
+#   "version": 1.0,
+#   "type": "rich",
+#   "provider_name": "SoundCloud",
+#   "provider_url": "https://soundcloud.com",
+#   "height": 400,
+#   "width": "100%",
+#   "title": "Flickermood by Forss",
+#   "description": "From the Soulhack album...",
+#   "thumbnail_url": "https://i1.sndcdn.com/artworks-000067273316-smsiqx-t500x500.jpg",
+#   "html": "<iframe width=\"100%\" height=\"400\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=...\">",
+#   "author_name": "Forss",
+#   "author_url": "https://soundcloud.com/forss"
+# }
+
+# Playlist/set
+pl = soundcloud_oembed("https://soundcloud.com/forss/sets/soulhack")
+# title="Soulhack by Forss", description="My 2003 debut album...", height=450
+
+# User profile
+user = soundcloud_oembed("https://soundcloud.com/forss")
+# title="Forss", description="Artist & Founder SoundCloud", height=450
+```
+
+### oEmbed fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `title` | str | "{Track Title} by {Artist}" for tracks, "{Name}" for users |
+| `author_name` | str | Artist/user display name |
+| `author_url` | str | Profile URL |
+| `thumbnail_url` | str | Artwork at 500×500px (t500x500) |
+| `description` | str | Track/profile description (may contain HTML entities) |
+| `html` | str | Embed iframe for the SoundCloud player widget |
+| `height` | int | 400 for tracks, 450 for playlists and users |
+| `width` | str | Always `"100%"` |
+
+---
+
+## Approach 2: Page Hydration (`__sc_hydration`) — Rich Metadata, No Client ID
+
+Every SoundCloud page embeds a JSON array in a `<script>` tag as `window.__sc_hydration`. This contains full API-grade metadata with no key required.
+
+```python
+from helpers import http_get
+import json, re
+
+def extract_hydration(page_url):
+    """Extract __sc_hydration JSON from any SoundCloud page."""
+    html = http_get(page_url)
+    match = re.search(r'window\.__sc_hydration\s*=\s*(\[.*?\]);\s*<', html, re.DOTALL)
+    if not match:
+        return []
+    return json.loads(match.group(1))
+
+def get_hydration_by_type(page_url, hydratable):
+    """Get the 'data' dict for a specific hydratable type."""
+    for obj in extract_hydration(page_url):
+        if obj.get('hydratable') == hydratable:
+            return obj.get('data')
+    return None
+
+# Track page — hydration key is 'sound'
+track = get_hydration_by_type("https://soundcloud.com/forss/flickermood", "sound")
+# track['id']             = 293
+# track['title']          = "Flickermood"
+# track['playback_count'] = 962685
+# track['likes_count']    = 2592
+# track['duration']       = 213886  (milliseconds)
+# track['genre']          = "Electronic"
+# track['created_at']     = "2007-09-22T14:45:46Z"
+# track['artwork_url']    = "https://i1.sndcdn.com/artworks-000067273316-smsiqx-large.jpg"
+# track['waveform_url']   = "https://wave.sndcdn.com/cWHNerOLlkUq_m.json"
+# track['streamable']     = True
+# track['downloadable']   = True
+# track['license']        = "all-rights-reserved"
+# track['tag_list']       = "downtempo"
+# track['urn']            = "soundcloud:tracks:293"
+# track['media']          = {'transcodings': [...]}  (HLS/progressive stream URLs — need auth)
+# track['user']           = {full user object nested}
+
+# User page — hydration key is 'user'
+user = get_hydration_by_type("https://soundcloud.com/forss", "user")
+# user['id']               = 183
+# user['username']         = "Forss"
+# user['full_name']        = "Eric Quidenus-Wahlforss"
+# user['followers_count']  = 132203
+# user['track_count']      = 26
+# user['verified']         = True
+# user['city']             = "Berlin"
+# user['country_code']     = "DE"
+# user['description']      = "Artist & Founder SoundCloud"
+# user['creator_subscription'] = {'product': {'id': 'creator-pro-unlimited'}}
+# user['badges']           = {'pro_unlimited': True, 'verified': True}
+
+# Playlist/set page — hydration key is 'playlist'
+playlist = get_hydration_by_type("https://soundcloud.com/forss/sets/soulhack", "playlist")
+# playlist['id']           = 18
+# playlist['title']        = "Soulhack"
+# playlist['track_count']  = 11
+# playlist['tracks']       = [full track objects list]
+# playlist['is_album']     = True/False
+# playlist['genre']        = "Electronic"
+```
+
+### All hydration keys on a typical page
+
+| `hydratable` | Content |
+|---|---|
+| `sound` | Full track object (on track pages) |
+| `playlist` | Full playlist + all tracks (on set pages) |
+| `user` | Full user object (on any page with a profile) |
+| `apiClient` | `{'id': '<client_id>', 'isExpiring': False}` — the client_id |
+| `geoip` | Viewer country/city/coordinates |
+| `features` | Feature flags dict |
+| `anonymousId` | Session tracking ID (not useful) |
+
+---
+
+## Approach 3: API v2 — Full Query Power (Requires Client ID)
+
+The `client_id` lives in every page's `__sc_hydration` under the `apiClient` key. It is **stable across all pages and sessions** — extract once and reuse.
+
+```python
+from helpers import http_get
+import json, re
+
+def get_client_id(page_url="https://soundcloud.com"):
+    """Extract client_id from any SoundCloud page's __sc_hydration."""
+    html = http_get(page_url)
+    match = re.search(r'window\.__sc_hydration\s*=\s*(\[.*?\]);\s*<', html, re.DOTALL)
+    if not match:
+        raise ValueError("No hydration found")
+    for obj in json.loads(match.group(1)):
+        if obj.get('hydratable') == 'apiClient':
+            return obj['data']['id']
+    raise ValueError("apiClient not found in hydration")
+
+CLIENT_ID = get_client_id()  # "efg2kjLJnAJpInbN6P3hsHzispI1SKQH" (example — extract fresh)
+
+def sc_api(path, **params):
+    """Call api-v2.soundcloud.com. Returns parsed JSON."""
+    params['client_id'] = CLIENT_ID
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    return json.loads(http_get(f"https://api-v2.soundcloud.com/{path}?{qs}"))
+```
+
+### Resolve any URL to a resource
+
+```python
+# Resolve a permalink URL to get its resource with full metadata
+track = sc_api("resolve", url="https://soundcloud.com/forss/flickermood")
+# Returns: {'kind': 'track', 'id': 293, 'title': 'Flickermood', ...}
+
+user = sc_api("resolve", url="https://soundcloud.com/forss")
+# Returns: {'kind': 'user', 'id': 183, 'username': 'Forss', ...}
+```
+
+### Track lookup
+
+```python
+# Single track by numeric ID
+track = sc_api("tracks/293")
+
+# Bulk track lookup (comma-separated IDs — returns list)
+tracks = sc_api("tracks", ids="293,290,48031525")
+# Returns a JSON array directly (not wrapped in 'collection')
+for t in tracks:
+    print(t['id'], t['title'], t['playback_count'])
+```
+
+### Search
+
+```python
+# Tracks
+results = sc_api("search/tracks", q="jazz", limit=20)
+# results['collection']    = list of track objects
+# results['total_results'] = 5293248
+# results['next_href']     = pagination URL (see below)
+
+# Users
+results = sc_api("search/users", q="jazz", limit=10)
+
+# Playlists/sets
+results = sc_api("search/playlists", q="jazz", limit=10)
+
+# Paginate with next_href
+def paginate(first_response):
+    """Yield all pages of a collection response."""
+    yield from first_response.get('collection', [])
+    next_href = first_response.get('next_href')
+    while next_href:
+        page = json.loads(http_get(f"{next_href}&client_id={CLIENT_ID}"))
+        yield from page.get('collection', [])
+        next_href = page.get('next_href')
+```
+
+### Trending charts
+
+```python
+# Trending tracks across all genres
+trending = sc_api("charts", kind="trending",
+                  genre="soundcloud:genres:all-music", limit=20)
+for item in trending['collection']:
+    t = item['track']
+    print(f"{t['title']} — score={item['score']:.4f}")
+
+# Genre options: soundcloud:genres:all-music, soundcloud:genres:electronic,
+#                soundcloud:genres:hiphoprap, soundcloud:genres:ambient, etc.
+```
+
+### User resources
+
+```python
+user_id = 183  # numeric ID from resolve or hydration
+
+# User's tracks
+tracks = sc_api(f"users/{user_id}/tracks", limit=20)
+# tracks['collection'] = list of track objects
+
+# User's playlists
+playlists = sc_api(f"users/{user_id}/playlists", limit=10)
+
+# User's likes
+likes = sc_api(f"users/{user_id}/likes", limit=10)
+
+# Related tracks for a track
+related = sc_api("tracks/293/related", limit=10)
+# related['collection'] = list of track objects
+```
+
+### Waveform data
+
+```python
+# Waveform URL comes from track['waveform_url']
+waveform_url = "https://wave.sndcdn.com/cWHNerOLlkUq_m.json"
+waveform = json.loads(http_get(waveform_url))
+# {
+#   'width': 1800,   # number of sample points
+#   'height': 140,   # max amplitude value
+#   'samples': [11, 86, 91, 80, ...]  # 1800 amplitude values
+# }
+```
+
+---
+
+## Full track fields from `__sc_hydration` / API v2
+
+```
+id               int     Numeric track ID (e.g. 293)
+urn              str     "soundcloud:tracks:293"
+title            str     Track title
+description      str     May contain HTML entities/tags
+genre            str     Genre string
+tag_list         str     Space-separated tags
+created_at       str     ISO 8601 UTC
+last_modified    str     ISO 8601 UTC
+release_date     str     ISO 8601 UTC (original release)
+display_date     str     ISO 8601 UTC (shown to users)
+duration         int     Milliseconds
+full_duration    int     Milliseconds (untruncated)
+playback_count   int
+likes_count      int
+reposts_count    int
+comment_count    int
+download_count   int
+artwork_url      str     e.g. .../artworks-...-large.jpg (replace 'large' with 't500x500' for 500px)
+waveform_url     str     https://wave.sndcdn.com/....json
+permalink        str     Slug (e.g. "flickermood")
+permalink_url    str     Full canonical URL
+streamable       bool
+downloadable     bool
+license          str     e.g. "all-rights-reserved", "cc-by"
+sharing          str     "public" or "private"
+state            str     "finished" | "processing" | "failed"
+monetization_model str   "AD_SUPPORTED" | "SUB_HIGH_TIER" | "NOT_APPLICABLE"
+embeddable_by    str     "all" | "me" | "none"
+user             dict    Nested user object (id, username, avatar_url, verified, ...)
+user_id          int     Owner numeric ID
+publisher_metadata dict  {artist, publisher, isrc, contains_music, ...}
+media            dict    {'transcodings': [...]}  — stream URLs (require OAuth, not usable without login)
+label_name       str     Record label
+purchase_url     str     External buy link
+station_urn      str     "soundcloud:system-playlists:track-stations:{id}"
+```
+
+---
+
+## Gotchas
+
+**client_id is required for api-v2.soundcloud.com** — requests without it return HTTP 401. Always extract from `__sc_hydration['apiClient']['id']`.
+
+**client_id source: hydration, not JS bundles** — the JS bundles on `a-v2.sndcdn.com` do NOT contain the `client_id` pattern. The only reliable source is the `apiClient` object in the page hydration. It is stable across all pages (same value from homepage, track pages, user pages) and does not appear to rotate on short timescales.
+
+**Artwork URL sizes** — hydration/API returns `...-large.jpg` (100×100). Replace the size suffix to get larger images:
+- `-large.jpg` → 100×100
+- `-t300x300.jpg` → 300×300
+- `-t500x500.jpg` → 500×500 (oEmbed returns this size)
+
+**Regex must use `re.DOTALL`** — the `__sc_hydration` JSON spans multiple lines. Without `re.DOTALL`, the `.` in the regex won't match newlines.
+
+**Stream URLs (media.transcodings) are gated** — the HLS/progressive audio stream URLs in `track['media']['transcodings']` require an OAuth token even to fetch a stream manifest. They cannot be played without a logged-in session.
+
+**Bulk track lookup returns a list, not collection** — `GET /tracks?ids=...` returns a JSON array directly. Do NOT look for `.get('collection')`.
+
+**Search `total_results` can be huge** — results like 5M+ are normal for broad queries. Use `next_href` for pagination; do not calculate offsets manually.
+
+**oEmbed description contains HTML** — SoundCloud descriptions may include `&nbsp;` and anchor tags. Decode with `html.unescape()` if you need plain text.
+
+**HTTP 400 on some endpoints** — `/tracks/{id}/comments` returns 400 without OAuth headers. Timed comments are not accessible without login.
+
+**No browser required** — all documented approaches work with plain `http_get`. SoundCloud does not require JavaScript rendering for metadata extraction.
+
+**Rate limits** — 20 rapid sequential API v2 requests completed without errors in testing. SoundCloud does not publish official rate limits; stay under ~50 req/s for sustained scraping. oEmbed is more lenient than api-v2.
+
+---
+
+## Quick Reference
+
+| Goal | Approach | Auth |
+|------|----------|------|
+| Track title/author/thumbnail from URL | oEmbed | None |
+| Full track metadata + play counts | `__sc_hydration` `sound` key | None |
+| Full user profile + stats | `__sc_hydration` `user` key | None |
+| Full playlist with all tracks | `__sc_hydration` `playlist` key | None |
+| Search tracks/users/playlists | API v2 `/search/*` | client_id |
+| Trending charts | API v2 `/charts` | client_id |
+| Bulk track lookup by IDs | API v2 `/tracks?ids=` | client_id |
+| User's track list | API v2 `/users/{id}/tracks` | client_id |
+| Resolve permalink to resource | API v2 `/resolve?url=` | client_id |
+| Waveform amplitude data | Direct fetch of `waveform_url` | None |
+| Audio stream playback | OAuth login required | Login |

--- a/domain-skills/spotify/scraping.md
+++ b/domain-skills/spotify/scraping.md
@@ -1,0 +1,339 @@
+# Spotify — Data Extraction
+
+Field-tested against open.spotify.com on 2026-04-18.
+No authentication required for any approach documented here.
+
+---
+
+## Approach 1 (Fastest): oEmbed API — No Auth, No Browser
+
+`https://open.spotify.com/oembed?url=<resource_url>`
+
+Returns JSON in ~0.25s. Works for tracks, albums, playlists, and artists. Does **not** work for episodes/shows.
+
+```python
+from helpers import http_get
+import json
+
+def spotify_oembed(resource_type, resource_id):
+    """Fetch oEmbed metadata for a Spotify resource.
+
+    resource_type: 'track', 'album', 'playlist', or 'artist'
+    resource_id:   Spotify ID (22-char alphanumeric)
+    """
+    resource_url = f"https://open.spotify.com/{resource_type}/{resource_id}"
+    url = f"https://open.spotify.com/oembed?url={resource_url}"
+    data = json.loads(http_get(url))
+    return data
+
+# Example: track
+track = spotify_oembed("track", "4PTG3Z6ehGkBFwjybzWkR8")
+# {
+#   "title":           "Never Gonna Give You Up",
+#   "thumbnail_url":   "https://image-cdn-ak.spotifycdn.com/image/ab67616100005174...",
+#   "thumbnail_width": 320,
+#   "thumbnail_height": 320,
+#   "type":            "rich",
+#   "html":            "<iframe ...src=\"https://open.spotify.com/embed/track/4PTG3Z6...\"...>",
+#   "iframe_url":      "https://open.spotify.com/embed/track/4PTG3Z6ehGkBFwjybzWkR8?utm_source=oembed",
+#   "width":           456,
+#   "height":          152,
+#   "version":         "1.0",
+#   "provider_name":   "Spotify",
+#   "provider_url":    "https://spotify.com"
+# }
+
+# Artist (height is 352 — taller widget)
+artist = spotify_oembed("artist", "0gxyHStUsqpMadRV0Di1Qt")
+# title="Rick Astley", thumbnail_url=<artist photo URL>
+
+# Album
+album = spotify_oembed("album", "4LH4d3cOWNNsVw41Gqt2kv")
+# title="The Dark Side of the Moon", thumbnail_url=<album art URL>
+
+# Playlist
+pl = spotify_oembed("playlist", "37i9dQZF1DXcBWIGoYBM5M")
+# title="Today's Top Hits", thumbnail_url=<playlist cover URL>
+```
+
+### Bulk fetching (ThreadPoolExecutor)
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import json
+from helpers import http_get
+
+track_ids = [
+    "4PTG3Z6ehGkBFwjybzWkR8",
+    "7qiZfU4dY1lWllzX7mPBI3",
+    "0VjIjW4GlUZAMYd2vXMi3b",
+]
+
+def fetch_oembed(tid):
+    url = f"https://open.spotify.com/oembed?url=https://open.spotify.com/track/{tid}"
+    try:
+        return json.loads(http_get(url))
+    except Exception as e:
+        return {"error": str(e), "id": tid}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_oembed, track_ids))
+# 5 tracks: ~1.3s total, ~0.26s per track
+```
+
+---
+
+## Approach 2: Static HTML — Rich Metadata via http_get
+
+Every open.spotify.com page (track, album, playlist, artist) serves full HTML with no JS requirement. The HTML contains JSON-LD and Open Graph tags that provide structured data.
+
+### Track page — all extractable fields
+
+```python
+from helpers import http_get
+import json, re
+
+def scrape_track(track_id):
+    url = f"https://open.spotify.com/track/{track_id}"
+    html = http_get(url)
+
+    # ---- JSON-LD (most structured) ----
+    ld_raw = re.search(r'<script type="application/ld\+json"[^>]*>(.*?)</script>', html, re.DOTALL)
+    ld = json.loads(ld_raw.group(1)) if ld_raw else {}
+
+    # ---- Open Graph / music: meta tags ----
+    metas = {}
+    for m in re.finditer(r'<meta\s+(?:property|name)="([^"]+)"\s+content="([^"]*)"', html):
+        key, val = m.group(1), m.group(2)
+        if key not in metas:
+            metas[key] = val
+
+    musician_urls = re.findall(r'<meta\s+(?:property|name)="music:musician"\s+content="([^"]*)"', html)
+    allowed_countries = re.findall(r'<meta\s+property="og:restrictions:country:allowed"\s+content="([^"]*)"', html)
+
+    return {
+        "title":          metas.get("og:title"),
+        "artist":         metas.get("music:musician_description"),
+        "artist_urls":    musician_urls,               # spotify artist page URLs
+        "album_url":      metas.get("music:album"),    # spotify album page URL
+        "track_number":   metas.get("music:album:track"),
+        "duration_s":     int(metas.get("music:duration", 0)),
+        "release_date":   metas.get("music:release_date"),  # YYYY-MM-DD
+        "cover_art":      metas.get("og:image"),       # 640px JPG
+        "audio_preview":  metas.get("og:audio"),       # 30s MP3 (may be None)
+        "spotify_url":    metas.get("og:url"),
+        "description":    metas.get("og:description"),
+        "eligible_regions": allowed_countries,
+        "ld_name":        ld.get("name"),
+        "ld_date":        ld.get("datePublished"),
+    }
+
+# Tested on track/4PTG3Z6ehGkBFwjybzWkR8 (Never Gonna Give You Up):
+# {
+#   "title":         "Never Gonna Give You Up",
+#   "artist":        "Rick Astley",
+#   "artist_urls":   ["https://open.spotify.com/artist/0gxyHStUsqpMadRV0Di1Qt"],
+#   "album_url":     "https://open.spotify.com/album/6eUW0wxWtzkFdaEFsTJto6",
+#   "track_number":  "1",
+#   "duration_s":    214,
+#   "release_date":  "1987-11-12",
+#   "cover_art":     "https://i.scdn.co/image/ab67616d0000b27315ebbedaacef61af244262a8",
+#   "audio_preview": "https://p.scdn.co/mp3-preview/b4c682084c3fd05538726d0a126b7e14b6e92c83",
+#   "spotify_url":   "https://open.spotify.com/track/4PTG3Z6ehGkBFwjybzWkR8",
+#   "eligible_regions": [185 country codes],
+# }
+```
+
+### Artist page — fields available
+
+```python
+def scrape_artist(artist_id):
+    url = f"https://open.spotify.com/artist/{artist_id}"
+    html = http_get(url)
+
+    ld_raw = re.search(r'<script type="application/ld\+json"[^>]*>(.*?)</script>', html, re.DOTALL)
+    ld = json.loads(ld_raw.group(1)) if ld_raw else {}
+
+    metas = {}
+    for m in re.finditer(r'<meta\s+(?:property|name)="([^"]+)"\s+content="([^"]*)"', html):
+        if m.group(1) not in metas:
+            metas[m.group(1)] = m.group(2)
+
+    return {
+        "name":              metas.get("og:title"),
+        "monthly_listeners": metas.get("og:description"),  # "Artist · 6.7M monthly listeners."
+        "image":             metas.get("og:image"),         # full-size artist photo
+        "spotify_url":       metas.get("og:url"),
+        "description":       ld.get("description"),
+    }
+
+# Tested on Rick Astley (artist/0gxyHStUsqpMadRV0Di1Qt):
+# {
+#   "name":              "Rick Astley",
+#   "monthly_listeners": "Artist · 6.7M monthly listeners.",
+#   "image":             "https://i.scdn.co/image/ab6761610000e5ebe834a63a0cfa3c0f57a9a434",
+# }
+```
+
+---
+
+## Approach 3: Embed Page — Structured JSON with Track Lists
+
+`https://open.spotify.com/embed/{type}/{id}` returns a small Next.js SSR page. Its `__NEXT_DATA__` script tag contains a fully-parsed entity object. This is the only no-auth route that returns track listings for albums, playlists, and artists.
+
+```python
+from helpers import http_get
+import json, re
+
+def scrape_embed(resource_type, resource_id):
+    """
+    resource_type: 'track', 'album', 'playlist', or 'artist'
+    Returns the entity dict from __NEXT_DATA__.
+    """
+    url = f"https://open.spotify.com/embed/{resource_type}/{resource_id}"
+    html = http_get(url)
+    m = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    data = json.loads(m.group(1))
+    return data['props']['pageProps']['state']['data']['entity']
+
+# ---- TRACK ----
+entity = scrape_embed("track", "4PTG3Z6ehGkBFwjybzWkR8")
+# entity keys: type, name, uri, id, title, artists, releaseDate, duration,
+#              isPlayable, isExplicit, audioPreview, hasVideo, visualIdentity
+# {
+#   "name":     "Never Gonna Give You Up",
+#   "uri":      "spotify:track:4PTG3Z6ehGkBFwjybzWkR8",
+#   "artists":  [{"name": "Rick Astley", "uri": "spotify:artist:0gxyHStUsqpMadRV0Di1Qt"}],
+#   "duration": 213573,   # milliseconds
+#   "releaseDate": {"isoString": "1987-11-12T00:00:00Z"},
+#   "isPlayable": True,
+#   "isExplicit": False,
+#   "audioPreview": {"url": "https://p.scdn.co/mp3-preview/b4c682..."},
+#   "visualIdentity": {
+#     "image": [
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d00001e02...", "maxWidth": 300, "maxHeight": 300},
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d000048...", "maxWidth": 64,  "maxHeight": 64},
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d0000b27...", "maxWidth": 640, "maxHeight": 640},
+#     ]
+#   }
+# }
+
+# ---- ALBUM (includes full track list) ----
+entity = scrape_embed("album", "6fu8fvc7O4p8Gb8KMTBTUW")
+# entity.trackList — list of all album tracks, e.g. 12 items:
+# [{
+#   "uri":          "spotify:track:4e1zdmsDwNBNe9rk7HHC0i",
+#   "title":        "Prelude for Piano No. 1 in E-Flat Major",
+#   "subtitle":     "Eduard Abramyan,\u00a0Sona Shaboyan",
+#   "duration":     107426,
+#   "isPlayable":   True,
+#   "audioPreview": {"url": "https://p.scdn.co/mp3-preview/d03c37..."},
+#   "entityType":   "track"
+# }, ...]
+
+# ---- PLAYLIST (includes up to 50 tracks) ----
+entity = scrape_embed("playlist", "37i9dQZF1DXcBWIGoYBM5M")
+# entity.trackList — 50 items
+# entity.subtitle  — "Spotify"
+# entity.authors   — [{"name": "Spotify"}]
+
+# ---- ARTIST (includes top 10 tracks) ----
+entity = scrape_embed("artist", "0gxyHStUsqpMadRV0Di1Qt")
+# entity.trackList — 10 top tracks, same shape as album trackList
+# entity.subtitle  — "Top tracks"
+```
+
+### Bonus: Anonymous access token (embedded in every embed page)
+
+The embed page SSR data includes a short-lived anonymous Spotify Web Player access token. The token is valid (~1 hour) but **anonymous tokens are severely rate-limited for api.spotify.com/v1 calls** (observed `Retry-After: 79561` seconds on the tracks endpoint after a few requests).
+
+```python
+def get_embed_token(resource_type="track", resource_id="4PTG3Z6ehGkBFwjybzWkR8"):
+    """Extract the anonymous access token from an embed page."""
+    url = f"https://open.spotify.com/embed/{resource_type}/{resource_id}"
+    html = http_get(url)
+    m = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    data = json.loads(m.group(1))
+    session = data['props']['pageProps']['state']['settings']['session']
+    return {
+        "access_token":  session['accessToken'],
+        "expires_ms":    session['accessTokenExpirationTimestampMs'],
+        "is_anonymous":  session['isAnonymous'],          # always True
+        "client_id":     data['props']['pageProps']['config']['clientId'],
+    }
+
+# Returned fields (verified 2026-04-18):
+# access_token: "BQBfxv..." (a standard Spotify Bearer token, ~160 chars)
+# expires_ms:   1776512455031 (~1 hour TTL)
+# is_anonymous: True
+# client_id:    "ab9ad0d96a624805a7d51e8868df1f97"
+
+# WARNING: Do NOT use this token to hammer api.spotify.com/v1 — anonymous tokens
+# share a global rate-limit bucket. One call can trigger a 22-hour ban window.
+# Use the embed page __NEXT_DATA__ directly instead (Approach 3 above).
+```
+
+---
+
+## What Requires a Browser
+
+The following are **not accessible** via http_get and require the CDP browser:
+
+- Lyrics (login-gated; JSON-LD confirms: `isAccessibleForFree: false`)
+- Search (`/search?q=...`) — loads client-side only, no meaningful HTML on first response
+- User library / listening history — requires OAuth
+- Full audio playback — requires OAuth + Widevine DRM
+- Podcast episodes — oEmbed returns 404; embed page `__NEXT_DATA__` lacks `state.data.entity`
+- Track recommendations beyond the top-10 artist view
+- Artist discography / full album list
+
+If browser access is needed for search:
+
+```python
+goto("https://open.spotify.com/search")
+wait_for_load()
+wait(2)
+# Type into the search box
+js("document.querySelector('input[data-testid=\"search-input\"]').focus()")
+type_text("never gonna give you up")
+wait(1)
+# Results appear in [data-testid="top-results-card"] or similar dynamic selectors
+```
+
+---
+
+## URL Patterns
+
+| Resource  | URL pattern                                    | ID format         |
+|-----------|------------------------------------------------|-------------------|
+| Track     | `https://open.spotify.com/track/{id}`          | 22-char alphanum  |
+| Album     | `https://open.spotify.com/album/{id}`          | 22-char alphanum  |
+| Artist    | `https://open.spotify.com/artist/{id}`         | 22-char alphanum  |
+| Playlist  | `https://open.spotify.com/playlist/{id}`       | 22-char alphanum  |
+| oEmbed    | `https://open.spotify.com/oembed?url={resource_url}` | any of above |
+| Embed     | `https://open.spotify.com/embed/{type}/{id}`   | same ID           |
+
+Extract Spotify ID from any URL:
+
+```python
+import re
+def spotify_id(url):
+    m = re.search(r'spotify\.com/(?:embed/)?(?:track|album|artist|playlist)/([A-Za-z0-9]{22})', url)
+    return m.group(1) if m else None
+```
+
+---
+
+## Gotchas
+
+- **oEmbed 404 for valid IDs**: A 404 from oEmbed can mean the resource is region-locked or not available for embedding, not necessarily that the ID is wrong. Verified: track `3n3Ppam7vgaVa1iaRUIOKE` returns 404 on oEmbed despite existing on Spotify.
+- **oEmbed 404 for artists**: Only works with valid, existing artist IDs. The artist ID `4gzpq5DumSF1a1LpGLBBl5` returns 404 — verify IDs from canonical Spotify URLs before using.
+- **oEmbed does not support episodes**: `open.spotify.com/episode/{id}` always returns 404 from the oEmbed endpoint.
+- **Embed page for episodes**: The embed page SSR for episodes does not include `state.data.entity` in the expected structure — parse defensively.
+- **Anonymous token rate limiting**: The access token from embed pages is valid but severely rate-limited for `api.spotify.com/v1`. Observed `Retry-After: 79561` (~22 hours) after 2-3 rapid API calls. Use embed `__NEXT_DATA__` data instead of the API.
+- **`get_access_token` endpoint blocked**: `https://open.spotify.com/get_access_token?reason=transport&productType=web_player` returns HTTP 403 from plain http_get regardless of headers. Token must be sourced from the embed page HTML.
+- **`music:musician` meta tag dedup**: `re.findall` on `music:musician` returns all artist URLs. `dict(re.finditer(...))` would only keep the last one — always use `findall` for multi-value tags.
+- **Cover art CDN differences**: oEmbed thumbnail uses `image-cdn-ak.spotifycdn.com`; track page `og:image` uses `i.scdn.co`. Both are publicly accessible. The embed `visualIdentity.image` array provides three sizes (64, 300, 640).
+- **No `__NEXT_DATA__` on main open.spotify.com pages**: The SSR `__NEXT_DATA__` pattern only works on `open.spotify.com/embed/*`, not on main track/album/artist pages. Those pages use JSON-LD and Open Graph tags instead.
+- **Track duration units differ**: `music:duration` meta tag is in **seconds** (integer). Embed `__NEXT_DATA__` `entity.duration` is in **milliseconds**.
+- **Rate limits for http_get pages**: No rate limit observed on oEmbed or static HTML pages in testing (10 concurrent requests succeeded; ~0.25s avg per oEmbed call).

--- a/domain-skills/walmart/scraping.md
+++ b/domain-skills/walmart/scraping.md
@@ -1,0 +1,444 @@
+# Walmart — Product Search & Data Extraction
+
+Field-tested against walmart.com on 2026-04-18 using `http_get` (no browser required).
+All code blocks were run and outputs verified against live responses.
+
+---
+
+## Fastest Approach: `http_get` with `__NEXT_DATA__`
+
+Walmart's Next.js SSR embeds the full search or product payload as JSON in a
+`<script id="__NEXT_DATA__">` tag. **No browser needed for search or product detail pages.**
+~2–3 s per page fetch; no CAPTCHA or session cookies required.
+
+### Critical UA rule
+
+| User-Agent | Result |
+|---|---|
+| `Mozilla/5.0` (bare) | Full HTML + `__NEXT_DATA__` — **use this** |
+| `Mozilla/5.0 ... Chrome/120 ...` (full) | PerimeterX "Robot or human?" challenge (200, 15 KB) |
+| `Safari/17` full UA | Works (full HTML, ~1.15 MB) |
+| `curl/7.x` | PerimeterX challenge |
+| `python-requests/2.31` | PerimeterX challenge |
+
+The bare `Mozilla/5.0` string bypasses PerimeterX. Any UA that looks like a headless
+client or includes a recognizable browser fingerprint triggers the JS challenge page.
+
+### Base fetch helper
+
+```python
+import json, re, gzip, urllib.request
+
+def fetch_walmart(url):
+    """
+    Fetch any walmart.com page.
+    Returns decoded HTML string.
+    Raises RuntimeError if PerimeterX bot challenge is returned.
+    """
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"},
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        html = data.decode()
+    if "Robot or human" in html:
+        raise RuntimeError(f"PerimeterX challenge triggered: {url}")
+    return html
+
+def parse_next_data(html):
+    m = re.search(r'id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    if not m:
+        raise ValueError("__NEXT_DATA__ not found — page structure may have changed")
+    return json.loads(m.group(1))
+```
+
+---
+
+## Search Results
+
+### URL patterns
+
+```python
+# Keyword search
+"https://www.walmart.com/search?q=laptop"
+
+# Pagination — append &page=N
+"https://www.walmart.com/search?q=laptop&page=2"
+
+# Sort options (confirmed working)
+"https://www.walmart.com/search?q=laptop&sort=best_match"    # default
+"https://www.walmart.com/search?q=laptop&sort=best_seller"
+"https://www.walmart.com/search?q=laptop&sort=price_low"
+"https://www.walmart.com/search?q=laptop&sort=customer_rating"
+
+# Price filter
+"https://www.walmart.com/search?q=laptop&min_price=200&max_price=500"
+
+# Browse by category (department ID path)
+"https://www.walmart.com/browse/electronics/laptops/3944_1089430_3951"
+```
+
+### `__NEXT_DATA__` path to items
+
+```
+data
+  .props.pageProps.initialData.searchResult
+    .aggregatedCount        — int: total matching products (e.g. 18818)
+    .paginationV2.maxPage   — int: last page number
+    .itemStacks[]           — array of stacks (usually 2: sponsored + organic)
+      .items[]              — array of product objects
+```
+
+### Full extractor (field-tested)
+
+```python
+def extract_search_results(html):
+    """
+    Returns (items, total_count, max_page).
+    items is a list of dicts with confirmed fields.
+    """
+    data = parse_next_data(html)
+    sr = data["props"]["pageProps"]["initialData"]["searchResult"]
+
+    items = []
+    for stack in sr.get("itemStacks", []):
+        for item in stack.get("items", []):
+            pi = item.get("priceInfo") or {}
+            img = item.get("imageInfo") or {}
+            rating = item.get("rating") or {}
+            avail = item.get("availabilityStatusV2") or {}
+            items.append({
+                "usItemId":        item.get("usItemId"),           # str, Walmart item ID
+                "name":            item.get("name"),               # str
+                "brand":           item.get("brand"),              # str or None
+                "price":           item.get("price"),              # int, current price in USD
+                "linePrice":       pi.get("linePrice"),            # str "$429.00"
+                "wasPrice":        pi.get("wasPrice") or None,     # str "$699.00" or None
+                "savings":         pi.get("savings") or None,      # str "SAVE $270.00" or None
+                "averageRating":   rating.get("averageRating"),    # float e.g. 4.3
+                "numberOfReviews": rating.get("numberOfReviews"),  # int
+                "availability":    avail.get("value"),             # "IN_STOCK" / "OUT_OF_STOCK"
+                "isSponsored":     bool(item.get("isSponsoredFlag")),
+                "url":             "https://www.walmart.com" + (item.get("canonicalUrl") or "").split("?")[0],
+                "thumbnailUrl":    img.get("thumbnailUrl"),
+            })
+
+    total = sr.get("aggregatedCount")
+    max_page = (sr.get("paginationV2") or {}).get("maxPage")
+    return items, total, max_page
+
+
+# Usage
+html = fetch_walmart("https://www.walmart.com/search?q=laptop")
+items, total, max_page = extract_search_results(html)
+# items: 66 items on page 1, total=18818, max_page=11
+
+# Filter out sponsored
+organic = [i for i in items if not i["isSponsored"]]
+```
+
+### Field notes (confirmed)
+
+- **`usItemId`**: string, matches the numeric ID at the end of `/ip/.../ITEMID` URLs.
+  Some non-product rows (ad widgets) have `usItemId=None` — filter with `if item.get("usItemId")`.
+- **`price`**: integer cents-less price (e.g. `429` for "$429.00"). Use `priceInfo.linePrice` for
+  the formatted string including the dollar sign.
+- **`wasPrice` / `savings`**: only present when item is on sale. Always `None` for full-price items.
+- **`isSponsoredFlag`**: the first batch of results across both itemStacks are frequently sponsored.
+  On a laptop search, ~56 of 66 SSR items carry `isSponsoredFlag: true`.
+- **`rating`**: present on ~91% of items (60/66 in test). `averageRating` is a float; `numberOfReviews` is int.
+- **`canonicalUrl`**: always includes `?classType=...&athbdg=...` query params — strip with `.split("?")[0]`
+  to get a clean URL.
+- **Two itemStacks**: Walmart returns two stacks (`itemStacks[0]` and `itemStacks[1]`). Merge them.
+  `itemStacks[0]` is the primary grid; `itemStacks[1]` is a secondary sponsored/related block.
+
+### Pagination
+
+```python
+for page in range(1, max_page + 1):
+    html = fetch_walmart(f"https://www.walmart.com/search?q=laptop&page={page}")
+    items, _, _ = extract_search_results(html)
+    # process items...
+```
+
+Page responses average ~2.5 s each. No rate-limiting was observed across 3 sequential requests.
+For bulk scraping, add a 1–2 s delay between requests to be safe.
+
+---
+
+## Product Detail Page
+
+### URL pattern
+
+```
+https://www.walmart.com/ip/{slug}/{usItemId}
+```
+
+The slug is ignored in routing — only the numeric `usItemId` matters.
+These work identically:
+```
+https://www.walmart.com/ip/anything/19717318352
+https://www.walmart.com/ip/Apple-MacBook-Neo/19717318352
+```
+
+### `__NEXT_DATA__` path on a product page
+
+```
+data.props.pageProps.initialData.data
+  .product        — core product object
+  .idml           — long description, specs, highlights, warranty
+  .reviews        — rating breakdown + first 10 customer reviews (SSR)
+```
+
+### Full extractor (field-tested)
+
+```python
+def extract_product_detail(html):
+    """
+    Returns a dict with all confirmed product fields.
+    idml.specifications returns all spec rows as a flat dict.
+    reviews returns the SSR-rendered first 10 customer reviews.
+    """
+    data = parse_next_data(html)
+    d = data["props"]["pageProps"]["initialData"]["data"]
+    product = d["product"]
+    idml    = d.get("idml") or {}
+    reviews = d.get("reviews") or {}
+
+    pi = product.get("priceInfo") or {}
+    cp = pi.get("currentPrice") or {}
+    img = product.get("imageInfo") or {}
+    avail = product.get("availabilityStatusV2") or {}
+
+    specs = {
+        spec.get("name"): spec.get("value")
+        for spec in (idml.get("specifications") or [])
+    }
+
+    all_images = [
+        img_item.get("url")
+        for img_item in (img.get("allImages") or [])
+        if img_item.get("url")
+    ]
+
+    customer_reviews = [
+        {
+            "title":    r.get("reviewTitle"),
+            "rating":   r.get("rating"),           # int 1-5 (field is "rating", NOT "overallRating")
+            "text":     r.get("reviewText"),
+            "author":   r.get("userNickname"),
+            "date":     r.get("reviewSubmissionTime"),
+        }
+        for r in (reviews.get("customerReviews") or [])
+    ]
+
+    return {
+        # identity
+        "usItemId":            product.get("usItemId"),
+        "name":                product.get("name"),
+        "brand":               product.get("brand"),
+        "model":               product.get("model"),
+        "upc":                 product.get("upc"),
+        # price
+        "price":               cp.get("price"),            # float, e.g. 599
+        "priceString":         cp.get("priceString"),      # "$599.00"
+        "wasPrice":            (pi.get("wasPrice") or {}).get("priceString"),
+        "savings":             (pi.get("savings") or {}).get("savingsString"),
+        # availability
+        "availability":        avail.get("value"),         # "IN_STOCK" / "OUT_OF_STOCK"
+        "availabilityDisplay": avail.get("display"),       # "In stock"
+        # ratings
+        "averageRating":       product.get("averageRating"),
+        "numberOfReviews":     product.get("numberOfReviews"),
+        # text
+        "shortDescription":    product.get("shortDescription"),
+        "longDescription":     idml.get("longDescription"),  # HTML string
+        # media
+        "thumbnailUrl":        img.get("thumbnailUrl"),
+        "allImages":           all_images,          # up to 10 image URLs
+        # specs
+        "specifications":      specs,               # {"Brand": "Apple", "Processor": "A18 Pro", ...}
+        "highlights":          [                    # top highlighted specs with icons
+            {"name": h.get("name"), "value": h.get("value")}
+            for h in (idml.get("productHighlights") or [])
+        ],
+        # URL
+        "canonicalUrl":        "https://www.walmart.com" + (product.get("canonicalUrl") or ""),
+        # fulfillment
+        "fulfillmentOptions":  product.get("fulfillmentOptions") or [],
+        # reviews (SSR-rendered, first 10)
+        "reviewSummary": {
+            "averageOverallRating":    reviews.get("averageOverallRating"),
+            "totalReviewCount":        reviews.get("totalReviewCount"),
+            "reviewsWithTextCount":    reviews.get("reviewsWithTextCount"),
+            "recommendedPercentage":   reviews.get("recommendedPercentage"),
+        },
+        "customerReviews":     customer_reviews,
+    }
+
+
+# Usage
+url = "https://www.walmart.com/ip/Apple-MacBook-Neo/19717318352"
+html = fetch_walmart(url)
+product = extract_product_detail(html)
+
+# Example output (confirmed live):
+# product["name"]         → "Apple MacBook Neo 13-inch Apple A18 Pro chip..."
+# product["price"]        → 599
+# product["priceString"]  → "$599.00"
+# product["availability"] → "IN_STOCK"
+# product["model"]        → "MHFD4LL/A"
+# product["upc"]          → "195950852745"
+# len(product["specifications"])  → 29 spec rows
+# len(product["allImages"])       → 10
+# product["specifications"]["Processor"] → "A18 Pro"
+```
+
+### Field notes (confirmed)
+
+- **`averageRating` / `numberOfReviews`** on the product node: present for items with reviews.
+  New/few-review items may return `None` for both.
+- **`reviewSummary.averageOverallRating`** in the reviews node often differs slightly from
+  `product.averageRating` — the reviews node is more precise (e.g. `4.75` vs `4.8`).
+- **`customerReviews`** (SSR): always the first 10 reviews. The per-review rating field is `"rating"`
+  (int 1–5), **not** `"overallRating"` (which is always `None`).
+- **`longDescription`**: raw HTML string including `<ul>/<li>` tags. Strip tags before display.
+- **`specifications`**: flat dict — confirmed 29–31 rows for electronics. Key names use display labels
+  (e.g. `"RAM memory"`, `"Screen size"`, `"HD capacity"`).
+- **`wasPrice` / `savings`** on detail page: same as search — `None` when item is not discounted.
+- **No JSON-LD**: Walmart product pages do **not** include `<script type="application/ld+json">`.
+  All structured data lives in `__NEXT_DATA__`.
+
+---
+
+## Anti-Bot: PerimeterX
+
+Walmart uses **PerimeterX** (app ID `PXu6b0qd2S`, confirmed in `runtimeConfig.perimeterX`).
+
+| Signal | Detail |
+|---|---|
+| Bot detector | PerimeterX |
+| Challenge page | "Robot or human?" — 200 OK, 15 KB HTML |
+| Triggered by | Full browser UA strings (Chrome, curl, python-requests) |
+| Bypassed by | `User-Agent: Mozilla/5.0` (bare prefix only) |
+| No JS execution | SSR response is complete — no JS challenge to solve |
+
+Detection in code:
+```python
+if "Robot or human" in html:
+    raise RuntimeError("PerimeterX challenge — switch to browser harness")
+```
+
+If `http_get` starts returning the challenge after a run of successful fetches, switch to the
+browser harness (see below).
+
+---
+
+## Browser Harness Fallback
+
+Use the browser harness when:
+- PerimeterX starts blocking `http_get` on your IP
+- You need to interact with the page (add to cart, filter UI, infinite scroll)
+- You need variant switching (color/size selectors)
+
+```python
+# Browser-based search extraction
+new_tab("https://www.walmart.com/search?q=laptop")
+wait_for_load()
+wait(2)  # JS renders product cards after readyState=complete
+
+# Extract via __NEXT_DATA__ in-browser (identical structure to http_get)
+import json
+nd = js("document.getElementById('__NEXT_DATA__')?.textContent")
+data = json.loads(nd)
+sr = data["props"]["pageProps"]["initialData"]["searchResult"]
+items = []
+for stack in sr.get("itemStacks", []):
+    items.extend(stack.get("items", []))
+```
+
+### Browser selectors (confirmed working for DOM-based extraction)
+
+```python
+# Product cards on search results page
+results = js("""
+  Array.from(document.querySelectorAll('[data-item-id]')).map(el => ({
+    itemId:    el.getAttribute('data-item-id'),
+    name:      el.querySelector('[itemprop="name"]')?.innerText?.trim(),
+    price:     el.querySelector('[itemprop="price"]')?.getAttribute('content'),
+    url:       el.querySelector('a[link-identifier]')?.href,
+  })).filter(r => r.itemId)
+""")
+
+# If [data-item-id] misses items, use the Next.js data attribute alternative:
+results_alt = js("""
+  Array.from(document.querySelectorAll('[data-testid="list-view"]'))
+    .map(el => el.innerText.trim())
+""")
+```
+
+> **Prefer `__NEXT_DATA__` over DOM selectors** even in-browser — the JSON is complete and
+> stable. DOM class names at Walmart are obfuscated and change between deployments.
+
+### Session gotcha
+
+Always open Walmart with `new_tab()` on first visit:
+```python
+new_tab("https://www.walmart.com/search?q=laptop")
+wait_for_load()
+wait(2)
+```
+After that, `goto()` works normally within the same session.
+
+---
+
+## Public API
+
+Walmart's affiliate/partner API (`developer.api.walmart.com`) requires a registered API key
+and returns HTTP 403 without one. No unauthenticated public product API is available.
+The `__NEXT_DATA__` SSR approach replaces any need for the official API for read-only data.
+
+---
+
+## Gotchas
+
+- **UA must be `Mozilla/5.0` bare**: Any fuller string (Chrome, Safari, curl, requests) hits
+  PerimeterX. This is counterintuitive — the *shorter*, less realistic UA is the one that works.
+
+- **Regex must use `id=` attribute match**: The regex
+  `r'<script id="__NEXT_DATA__" type="application/json">...'` fails because the actual tag is
+  `<script id="__NEXT_DATA__">` without `type`. Use:
+  ```python
+  re.search(r'id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+  ```
+
+- **`usItemId` can be `None`**: ~5/66 items on a page are non-product ad widgets with no `usItemId`.
+  Always filter: `[i for i in items if i.get("usItemId")]`.
+
+- **Two `itemStacks`**: Walmart returns two stacks. Iterate over all stacks or you'll miss
+  ~10 items from the second stack.
+
+- **`canonicalUrl` includes tracking params**: Always strip with `.split("?")[0]`.
+
+- **Review field is `"rating"` not `"overallRating"`**: Each `customerReviews` entry has a `"rating"`
+  int field (1–5). The `"overallRating"` field is always `None`. Don't confuse with
+  `product.averageRating` (the aggregate float).
+
+- **No JSON-LD on product pages**: Zero `<script type="application/ld+json">` tags were found.
+  All structured data is in `__NEXT_DATA__`.
+
+- **`longDescription` is HTML**: Strip tags before text use. May contain promotional/financing copy
+  mixed with real product description.
+
+- **Page sizes vary**: Page 1 returned 66 items across 2 stacks; page 2 returned 55.
+  Do not assume a fixed items-per-page count.
+
+- **`http_get` default already sends `Mozilla/5.0`**: `helpers.http_get()` uses
+  `"User-Agent": "Mozilla/5.0"` by default — no override needed when calling it directly.
+  Only pass a custom `headers=` if you need to change something else.
+
+- **`developer.api.walmart.com`** returns HTTP 403 without an API key. Not usable for
+  unauthenticated scraping.

--- a/domain-skills/weather/scraping.md
+++ b/domain-skills/weather/scraping.md
@@ -1,0 +1,398 @@
+# Weather APIs — Data Extraction
+
+Three free, no-auth weather APIs tested: **wttr.in** (simplest), **Open-Meteo** (most complete), **weather.gov / NWS** (US only, official).
+
+All work with `http_get` — no browser needed.
+
+## Do this first: pick your API
+
+| Goal | Best API | Latency | Notes |
+|------|----------|---------|-------|
+| Quick current + 3-day forecast, any city name | wttr.in `?format=j1` | ~800ms | US + international |
+| Rich hourly/daily/historical, any coordinates | Open-Meteo | ~700ms | 10K req/day free |
+| City name → coordinates | Open-Meteo geocoding | ~700ms | Use with Open-Meteo forecast |
+| Official US forecasts with PoP and text | weather.gov NWS | ~90ms /points + ~70ms /forecast | US only, 2-call flow |
+
+**Never use a browser for any of these APIs.** All return JSON over plain HTTP.
+
+---
+
+## Fastest approach: wttr.in one-call current + 3-day forecast
+
+```python
+import json
+data = json.loads(http_get("https://wttr.in/San+Francisco?format=j1"))
+
+# Current conditions
+cc = data['current_condition'][0]
+print(cc['temp_F'], '°F /', cc['temp_C'], '°C')      # '47', '8'
+print(cc['FeelsLikeF'], '°F feels like')              # '46'
+print(cc['humidity'], '%')                            # '80'
+print(cc['windspeedMiles'], 'mph', cc['winddir16Point'])  # '3', 'SW'
+print(cc['weatherDesc'][0]['value'])                  # 'Partly cloudy'
+print(cc['precipMM'], 'mm precip')                   # '0.0'
+print(cc['visibility'], 'km', cc['visibilityMiles'], 'mi')
+print(cc['pressure'], 'hPa', cc['pressureInches'], 'inHg')
+print(cc['uvIndex'])                                  # '0'
+print(cc['cloudcover'], '%')                          # '50'
+print(cc['observation_time'])                         # '10:48 AM' (UTC)
+print(cc['localObsDateTime'])                         # '2026-04-18 03:34 AM' (local)
+
+# 3-day forecast (today + 2 more)
+for day in data['weather']:
+    print(day['date'], day['maxtempF'], '/', day['mintempF'], '°F')
+    # also: maxtempC, mintempC, avgtempF, avgtempC, sunHour, uvIndex, totalSnow_cm
+    astro = day['astronomy'][0]
+    print('  sunrise:', astro['sunrise'], 'sunset:', astro['sunset'])
+    print('  moon:', astro['moon_phase'], astro['moon_illumination'], '%')
+    # Hourly breakdown (8 entries per day, every 3 hours: time 0,300,600,...,2100)
+    for h in day['hourly']:
+        print(h['time'], h['tempF'], '°F', h['weatherDesc'][0]['value'])
+        # time is '0','300','600',...,'2100' (not HH:MM)
+        # also: chanceofrain, chanceofsnow, chanceofthunder, chanceoffog, humidity, etc.
+
+# Location info
+na = data['nearest_area'][0]
+print(na['areaName'][0]['value'])    # 'San Francisco'
+print(na['country'][0]['value'])     # 'United States of America'
+print(na['latitude'], na['longitude'])  # '37.775', '-122.418' (strings)
+print(na['region'][0]['value'])      # 'California'
+```
+
+**Works with city names, coordinates, airport codes (`~SFO`), and zip codes.**
+
+---
+
+## Open-Meteo: most complete free weather API
+
+### Step 1: city name → coordinates (geocoding)
+
+```python
+import json
+geo = json.loads(http_get("https://geocoding-api.open-meteo.com/v1/search?name=Chicago&count=1"))
+city = geo['results'][0]
+lat  = city['latitude']   # 41.85003
+lon  = city['longitude']  # -87.65005
+tz   = city['timezone']   # 'America/Chicago'
+# Also available: city['elevation'], city['country'], city['country_code'],
+#                 city['admin1'] (state/province), city['population']
+```
+
+Always use `count=1` and take `results[0]` for unambiguous city names. For "San Francisco" `results[0]` is always the California city (pop 864K).
+
+### Current conditions (extended — preferred over current_weather)
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+    f"precipitation,weathercode,windspeed_10m,winddirection_10m,"
+    f"uv_index,surface_pressure"
+    f"&timezone={tz}"
+))
+
+cur   = data['current']
+units = data['current_units']
+# cur keys and units (all confirmed):
+# temperature_2m        °C   (or °F with &temperature_unit=fahrenheit)
+# relative_humidity_2m  %
+# apparent_temperature  °C
+# precipitation         mm
+# weathercode           WMO code int (see table below)
+# windspeed_10m         km/h (or mph with &windspeed_unit=mph)
+# winddirection_10m     °
+# uv_index              (unitless float)
+# surface_pressure      hPa
+# time                  ISO8601 local time (e.g. '2026-04-18T10:45')
+# interval              900 (seconds — 15-min update cadence)
+
+print(cur['temperature_2m'], units['temperature_2m'])   # 8.7 °C
+print(cur['apparent_temperature'])                      # 6.6
+print(cur['relative_humidity_2m'])                      # 80
+print(cur['windspeed_10m'], cur['winddirection_10m'])   # 6.1  242
+print(cur['weathercode'])                               # 0 = clear sky
+```
+
+The older `&current_weather=true` param works too — returns `data['current_weather']` with only temperature, windspeed, winddirection, weathercode, time, is_day, interval.
+
+### Hourly forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&hourly=temperature_2m,dewpoint_2m,apparent_temperature,"
+    f"precipitation_probability,precipitation,rain,showers,snowfall,snow_depth,"
+    f"weathercode,cloudcover,visibility,windspeed_10m,winddirection_10m,"
+    f"windgusts_10m,uv_index"
+    f"&forecast_days=3&timezone={tz}"
+))
+
+hourly = data['hourly']
+units  = data['hourly_units']
+# hourly is a dict of parallel arrays, all same length
+# time entries: ISO8601 strings, one per hour ('2026-04-18T00:00', etc.)
+# 3 forecast days → 72 entries
+
+for i, t in enumerate(hourly['time'][:5]):
+    print(t,
+          hourly['temperature_2m'][i], units['temperature_2m'],
+          hourly['precipitation_probability'][i], units['precipitation_probability'],
+          hourly['windspeed_10m'][i], units['windspeed_10m'])
+
+# Confirmed units (all from live response):
+# temperature_2m              °C      dewpoint_2m          °C
+# apparent_temperature        °C      precipitation_probability  %
+# precipitation               mm      rain                 mm
+# showers                     mm      snowfall             cm
+# snow_depth                  m       weathercode          wmo code
+# cloudcover                  %       visibility           m (not km!)
+# windspeed_10m               km/h    winddirection_10m    °
+# windgusts_10m               km/h    uv_index             (unitless)
+```
+
+`forecast_days` defaults to 7, max is 16.
+
+### Daily forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,"
+    f"apparent_temperature_min,precipitation_sum,rain_sum,snowfall_sum,"
+    f"precipitation_hours,precipitation_probability_max,"
+    f"windspeed_10m_max,windgusts_10m_max,winddirection_10m_dominant,"
+    f"shortwave_radiation_sum,uv_index_max,sunrise,sunset"
+    f"&timezone={tz}&forecast_days=7"
+))
+
+daily = data['daily']
+units = data['daily_units']
+for i, date in enumerate(daily['time']):
+    print(date,
+          daily['temperature_2m_max'][i], '/', daily['temperature_2m_min'][i], units['temperature_2m_max'],
+          f"precip={daily['precipitation_sum'][i]}{units['precipitation_sum']}",
+          f"pop={daily['precipitation_probability_max'][i]}%",
+          f"UV={daily['uv_index_max'][i]}",
+          f"sunrise={daily['sunrise'][i]}",
+          f"sunset={daily['sunset'][i]}")
+# sunrise/sunset are ISO8601 local datetimes ('2026-04-18T06:29')
+# shortwave_radiation_sum in MJ/m²
+```
+
+### Historical data (archive API)
+
+Different subdomain — `archive-api.open-meteo.com`:
+
+```python
+data = json.loads(http_get(
+    "https://archive-api.open-meteo.com/v1/archive"
+    "?latitude=37.7749&longitude=-122.4194"
+    "&start_date=2024-01-01&end_date=2024-01-07"
+    "&daily=temperature_2m_max,precipitation_sum"
+    "&timezone=America/Los_Angeles"
+))
+# Returns same structure as forecast — daily dict of parallel arrays
+# Hourly also works: &hourly=temperature_2m,precipitation,weathercode
+# Data goes back to 1940 for most locations
+```
+
+### Unit overrides
+
+All unit conversions are server-side — just add params:
+
+```
+&temperature_unit=fahrenheit    # default: celsius
+&windspeed_unit=mph             # default: kmh (also: ms, kn)
+&precipitation_unit=inch        # default: mm
+```
+
+---
+
+## weather.gov NWS (US only — 2-call flow)
+
+Required for official NWS text forecasts with probability-of-precipitation text and storm warnings.
+
+```python
+import json, urllib.request, gzip
+
+def nws_get(url):
+    """NWS requires a descriptive User-Agent or returns 403."""
+    h = {
+        "User-Agent": "(myapp.example.com, contact@example.com)",
+        "Accept": "application/geo+json",
+    }
+    req = urllib.request.Request(url, headers=h)
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+# Call 1: resolve lat/lon to forecast office + grid cell (~90ms)
+pts  = json.loads(nws_get("https://api.weather.gov/points/37.7749,-122.4194"))
+prop = pts['properties']
+office = prop['gridId']    # 'MTR'
+gx     = prop['gridX']    # 85
+gy     = prop['gridY']    # 105
+forecast_url = prop['forecast']          # 7-day
+hourly_url   = prop['forecastHourly']    # hourly
+
+# Also available from /points: prop['timeZone'], prop['observationStations'],
+# prop['relativeLocation']['properties']['city'] and ['state']
+
+# Call 2: 7-day forecast (14 half-day periods) (~70ms)
+fc  = json.loads(nws_get(forecast_url))
+for p in fc['properties']['periods']:
+    print(p['name'],            # 'Saturday', 'Saturday Night', 'Sunday', ...
+          p['temperature'], p['temperatureUnit'],     # 74 F
+          p['windSpeed'], p['windDirection'],          # '6 to 14 mph' 'SW'
+          p['shortForecast'],                          # 'Mostly Sunny'
+          p['probabilityOfPrecipitation']['value'],    # 0  (integer percent)
+          p['isDaytime'])                              # True/False
+    # p['detailedForecast'] — plain English paragraph, e.g.
+    # 'Sunny, with a high near 74. Southwest wind 6 to 14 mph.'
+
+# Hourly (156 hours out — ~6.5 days)
+fch = json.loads(nws_get(hourly_url))
+for p in fch['properties']['periods'][:5]:
+    print(p['startTime'],           # '2026-04-18T03:00:00-07:00'
+          p['temperature'], '°F',
+          p['shortForecast'],
+          p['windSpeed'],
+          f"humidity={p['relativeHumidity']['value']}%",
+          f"dewpoint={p['dewpoint']['value']:.1f}°C")
+```
+
+`/points` response is cached `max-age=20500` (~5.7 hours) at the CDN — safe to call once per session and reuse grid coordinates.
+
+---
+
+## WMO weather code table (Open-Meteo `weathercode`)
+
+```python
+WMO_CODES = {
+    0: "Clear sky",
+    1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+    45: "Fog", 48: "Icy fog",
+    51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+    61: "Slight rain", 63: "Moderate rain", 65: "Heavy rain",
+    71: "Slight snow", 73: "Moderate snow", 75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight rain showers", 81: "Moderate rain showers", 82: "Violent rain showers",
+    85: "Slight snow showers", 86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with slight hail", 99: "Thunderstorm with heavy hail",
+}
+
+def wmo_desc(code):
+    return WMO_CODES.get(code, f"Unknown code {code}")
+```
+
+---
+
+## Complete end-to-end pattern: city name → rich forecast
+
+```python
+import json
+
+def get_weather(city: str) -> dict:
+    """City name → current + 7-day daily forecast via Open-Meteo."""
+    # 1. Geocode
+    geo  = json.loads(http_get(
+        f"https://geocoding-api.open-meteo.com/v1/search?name={city.replace(' ', '+')}&count=1"
+    ))
+    if not geo.get('results'):
+        raise ValueError(f"City not found: {city}")
+    loc  = geo['results'][0]
+    lat, lon, tz = loc['latitude'], loc['longitude'], loc['timezone']
+
+    # 2. Forecast (single call: current + daily)
+    data = json.loads(http_get(
+        f"https://api.open-meteo.com/v1/forecast"
+        f"?latitude={lat}&longitude={lon}"
+        f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+        f"precipitation,weathercode,windspeed_10m,winddirection_10m,uv_index"
+        f"&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,"
+        f"precipitation_probability_max,weathercode,sunrise,sunset"
+        f"&timezone={tz}&forecast_days=7"
+    ))
+    return {"location": loc, "current": data['current'],
+            "daily": data['daily'], "units": {
+                "current": data['current_units'],
+                "daily": data['daily_units'],
+            }}
+
+result = get_weather("Tokyo")
+cur = result['current']
+print(f"{result['location']['name']}: {cur['temperature_2m']}°C feels like {cur['apparent_temperature']}°C")
+print(f"Humidity {cur['relative_humidity_2m']}%, wind {cur['windspeed_10m']} km/h")
+```
+
+Total: 2 API calls, ~1400ms combined.
+
+---
+
+## Gotchas
+
+**wttr.in returns HTML (or ANSI art) instead of JSON if you forget `?format=j1`.**
+The `?format=j1` suffix is mandatory for JSON. Without it:
+- Browser `User-Agent` → full HTML page (~21KB)
+- `curl`/`Wget` User-Agent → ANSI escape-code ASCII art (~500B)
+Neither is parseable as JSON.
+
+**wttr.in text formats require a non-browser User-Agent.**
+`http_get()` sends `Mozilla/5.0` — wttr.in responds with an HTML page for `?format=%t`, `?format=3`, `?format=4`.
+Use `Wget/1.21` (or any non-browser UA) for text format endpoints:
+```python
+import urllib.request, gzip
+
+def http_get_wttr(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "Wget/1.21", "Accept": "*/*"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+# Text format tokens (URL-encode %): %25l=location, %25C=condition desc,
+# %25t=temp, %25f=feels-like, %25h=humidity, %25w=wind
+print(http_get_wttr("https://wttr.in/London?format=%25t"))           # '+55°F'
+print(http_get_wttr("https://wttr.in/Tokyo?format=3"))               # 'tokyo: ☀️   +69°F'
+print(http_get_wttr("https://wttr.in/Berlin?format=%25l:+%25C+%25t+(feels+%25f)+%25h+%25w"))
+# 'berlin: Sunny +65°F (feels +65°F) 42% ↖5mph'
+```
+
+**wttr.in `format=j1` returns only 3 days** (today + 2). Use Open-Meteo for longer forecasts (up to 16 days).
+
+**wttr.in `nearest_area.areaName` is often wrong.** The returned area name is a reverse-geocoded neighborhood, not the city you queried (`"Mccormickville"` for Chicago, `"Lomita Park"` for SFO airport). Use `request[0].query` for what was actually resolved.
+
+**wttr.in `hourly[].time` is `'0'`, `'300'`, `'600'`...`'2100'`** — not HH:MM strings. Parse as `int(time) // 100` for hours.
+
+**wttr.in `weatherDesc` is a list**: `cc['weatherDesc'][0]['value']`, not a string. Same for `areaName`, `country`, `region`, `weatherIconUrl`.
+
+**wttr.in unknown city returns HTTP 500**, not 404 or a JSON error.
+
+**Open-Meteo default timezone is GMT.** Always pass `&timezone={tz}` or daily `sunrise`/`sunset` values will be in UTC, and daily buckets will be wrong.
+
+**Open-Meteo `visibility` is in metres** (not km). Divide by 1000 to get km.
+
+**Open-Meteo returns HTTP 400 with JSON error body on bad params:**
+```json
+{"reason": "Latitude must be in range of -90 to 90°. Given: 999.0.", "error": true}
+```
+`http_get()` raises an exception on 4xx — catch `urllib.error.HTTPError` and read `e.read()` (may be gzip-compressed) for the reason.
+
+**weather.gov requires a descriptive `User-Agent`.** The NWS API blocks generic `python-urllib` or `Mozilla/5.0` agents sporadically. Always set `User-Agent: (yourapp.com, your@email.com)` or use your actual app name.
+
+**weather.gov is US-only.** `/points/{lat},{lon}` returns HTTP 404 for coordinates outside the US (including territories like Puerto Rico for some grid edges). Fall back to Open-Meteo for non-US locations.
+
+**weather.gov `windSpeed` is a string like `"6 to 14 mph"`**, not a number. Parse with regex if you need a numeric value.
+
+**weather.gov `probabilityOfPrecipitation` is a dict**: `p['probabilityOfPrecipitation']['value']`, with `p['probabilityOfPrecipitation']['unitCode']` = `'wmoUnit:percent'`.
+
+**Open-Meteo rate limit: 10,000 requests/day on the free tier.** The geocoding API and forecast API count separately. No rate limit headers are returned — track usage yourself.
+
+**weather.gov /points response is heavily cached** (`Cache-Control: public, max-age=20500`). Store the office/gridX/gridY and reuse — only call `/points` once per location.


### PR DESCRIPTION
## Summary
- Glassdoor: Cloudflare managed challenge blocks all http_get; browser-only via CDP; goto()+wait(5); __NEXT_DATA__ fast path with DOM fallbacks for ratings/reviews/jobs/salaries
- Medium: ?format=json endpoint works (strip XSSI prefix ])}while(1);</x>); GraphQL /_/graphql no auth needed; paywall detection via isSubscriptionLocked; RSS feeds for 10 latest posts
- SoundCloud: oEmbed for quick metadata; __sc_hydration apiClient.id is the client_id (not in JS bundles); API v2 /search /charts /resolve all work with client_id; bulk /tracks?ids= returns bare list not collection
- Genius: Add any OS token to UA (Macintosh; Intel Mac OS X) to bypass 403; internal /api/songs/{id} no auth; strip data-exclude-from-selection div before extracting lyrics; /search page is client-side only, use /api/search/multi
- Dev.to: Full public REST API no auth; burst 6 req then 429/Retry-After:1; listings empty without auth; joined_at is human string not ISO; use Accept: application/vnd.forem.api-v1+json to silence Warning:299

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds domain-skill docs for Glassdoor, Medium, SoundCloud, Genius, and Dev.to. Each guide shows the fastest reliable paths (API vs. browser), key headers, and common pitfalls.

- New Features
  - Glassdoor: Browser-only via CDP; Cloudflare blocks `http_get`. Parse `__NEXT_DATA__` with DOM fallbacks for reviews, jobs, and salaries.
  - Medium: Use `?format=json` (strip XSSI); GraphQL `/_/graphql` for metrics; RSS for recents; detect paywall via `isSubscriptionLocked`.
  - SoundCloud: oEmbed for quick metadata; get `client_id` from `__sc_hydration`; API v2 (`/search`, `/charts`, `/resolve`) works; bulk `/tracks?ids=` returns a raw list.
  - Genius: Add an OS token to `User-Agent` to avoid 403; use `/api/songs/{id}` and `/api/search/multi`; strip `data-exclude-from-selection` before extracting lyrics.
  - Dev.to: Public REST API (no auth); burst limit 6 req → 429 with `Retry-After: 1`; `listings` need auth; `joined_at` is human text; send `Accept: application/vnd.forem.api-v1+json`.

<sup>Written for commit c2167e544efb871d28769a1a8e5aa2f520bd21ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

