### PR TITLE
Add domain skills: CoinMarketCap, Quora, Itch.io, Steam, HowLongToBeat

### DIFF
--- a/domain-skills/archive-org/scraping.md
+++ b/domain-skills/archive-org/scraping.md
@@ -1,0 +1,341 @@
+# Internet Archive / Wayback Machine — Scraping & Data Extraction
+
+`https://archive.org` / `https://web.archive.org` — all public data, no auth required. Every workflow here is pure `http_get` — no browser needed.
+
+## Do this first
+
+**Use the CDX API for anything Wayback-related — it is the reliable workhorse. The Wayback Availability API (`/wayback/available`) is known to return empty `archived_snapshots` even for well-archived URLs and should not be used as a primary mechanism.**
+
+```python
+import json
+
+# Find snapshots of any URL — primary entry point for Wayback data
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json&limit=5"
+    "&fl=timestamp,original,statuscode,mimetype,length",
+    timeout=40.0
+)
+rows = json.loads(r)
+headers = rows[0]   # ['timestamp', 'original', 'statuscode', 'mimetype', 'length']
+for row in rows[1:]:
+    ts, orig, status, mime, length = row
+    snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+    print(f"{ts}  {status}  {snap_url}")
+```
+
+For item metadata (books, video, audio, software), go straight to:
+
+```python
+data = json.loads(http_get("https://archive.org/metadata/{identifier}", timeout=30.0))
+```
+
+## Common workflows
+
+### Find the nearest archived snapshot to a target date
+
+```python
+import json
+
+# CDX sort=closest returns the single snapshot nearest to the given timestamp
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json&limit=1"
+    "&fl=timestamp,original,statuscode"
+    "&closest=20230601120000&sort=closest",
+    timeout=60.0   # CDX can be slow — always use timeout >= 40s
+)
+rows = json.loads(r)
+# rows[0] = header, rows[1] = closest snapshot
+ts, orig, status = rows[1]
+snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+# Result: ts='20230601114925', orig='https://www.iana.org/', status='200'
+# snap_url: https://web.archive.org/web/20230601114925/https://www.iana.org/
+```
+
+Timestamp format is always 14-digit `YYYYMMDDHHMMSS`. Pass any prefix — `20230601` (day), `202306` (month), `2023` (year) — and CDX will match.
+
+### List all monthly snapshots for a URL (collapsed)
+
+```python
+import json
+
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&output=json"
+    "&collapse=timestamp:6"   # :6 = dedupe by YYYYMM (one per month)
+    "&from=20230101&to=20231231"
+    "&fl=timestamp,original",
+    timeout=60.0
+)
+rows = json.loads(r)
+# rows[0] = header ['timestamp', 'original']
+# rows[1:] = one row per month:
+# ['20230101103807', 'https://www.iana.org/']
+# ['20230201144829', 'https://www.iana.org/']
+# ...12 rows for 2023
+
+for ts, orig in rows[1:]:
+    print(f"{ts[:4]}-{ts[4:6]}  https://web.archive.org/web/{ts}/{orig}")
+```
+
+`collapse=timestamp:N` deduplicates by the first N digits of the timestamp:
+- `:4` = one per year, `:6` = one per month, `:8` = one per day
+
+### List snapshots for an entire domain (all pages)
+
+```python
+import json
+
+# matchType=domain captures all URLs under that domain
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org&matchType=domain&output=json"
+    "&limit=10&fl=timestamp,original,statuscode"
+    "&collapse=timestamp:8",  # one capture per URL per day
+    timeout=60.0
+)
+rows = json.loads(r)
+for row in rows[1:]:
+    print(row)
+# ['19971210061738', 'http://www.iana.org:80/', '200']
+# ['19980211065537', 'http://www.iana.org:80/', '200']
+# ...
+```
+
+`matchType` options: `exact` (default), `prefix` (URL + subpaths), `host` (all subdomains), `domain` (host + all subdomains).
+
+### Filter snapshots by prefix path
+
+```python
+import json
+
+# All archived pages under /domains/ path
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=iana.org/domains/&matchType=prefix&output=json"
+    "&limit=5&fl=timestamp,original,statuscode",
+    timeout=40.0
+)
+rows = json.loads(r)
+for row in rows[1:]:
+    print(row)
+# ['20080509121811', 'http://www.iana.org/domains/', '200']
+# ['20080704174537', 'http://iana.org/domains/', '200']
+```
+
+### Paginate CDX results with resumeKey
+
+```python
+import json
+from urllib.parse import quote
+
+def cdx_all_snapshots(url, fl="timestamp,original,statuscode", page_size=500):
+    """Iterate all CDX records for a URL, yielding rows (excluding header)."""
+    base = (
+        f"https://web.archive.org/cdx/search/cdx"
+        f"?url={quote(url, safe='')}&output=json"
+        f"&fl={fl}&limit={page_size}&showResumeKey=true"
+    )
+    resume_key = None
+    while True:
+        endpoint = base if resume_key is None else f"{base}&resumeKey={quote(resume_key)}"
+        rows = json.loads(http_get(endpoint, timeout=60.0))
+        # rows structure with showResumeKey=true:
+        # [header, row1, row2, ..., [], [resume_key_string]]
+        # The second-to-last row is [] (separator), last row is [resume_key]
+        has_resume = len(rows) >= 2 and rows[-1] != [] and rows[-2] == []
+        data_rows = rows[1:-2] if has_resume else rows[1:]
+        for row in data_rows:
+            yield row
+        if not has_resume:
+            break
+        resume_key = rows[-1][0]
+
+for row in cdx_all_snapshots("iana.org", fl="timestamp,original"):
+    ts, orig = row
+    # process...
+```
+
+### Retrieve the actual archived page
+
+```python
+# Direct snapshot URL: /web/{14-digit-timestamp}/{original-url}
+snap_url = "https://web.archive.org/web/19971210061738/http://www.iana.org:80/"
+content = http_get(snap_url, timeout=30.0)
+# Returns the archived HTML with Wayback toolbar injected at top
+# The toolbar is inside <!-- BEGIN WAYBACK TOOLBAR INSERT --> comments
+
+# The calendar view URL pattern (for browser navigation, not http_get):
+# https://web.archive.org/web/20230101000000*/python.org
+# The * tells Wayback to show the calendar — returns HTML, not raw page
+```
+
+### Item metadata (books, video, audio, software, collections)
+
+```python
+import json
+from urllib.parse import quote
+
+identifier = "HardWonWisdomTrailer"
+data = json.loads(http_get(f"https://archive.org/metadata/{identifier}", timeout=30.0))
+
+# Top-level keys:
+# alternate_locations, created, d1, d2, dir, files, files_count,
+# is_collection, item_last_updated, item_size, metadata, server, uniq, workable_servers
+
+meta = data['metadata']
+# Common metadata fields (not all present on every item):
+print(meta.get('identifier'))   # 'HardWonWisdomTrailer'
+print(meta.get('title'))        # 'Hard Won Wisdom Trailer'
+print(meta.get('mediatype'))    # 'movies' | 'texts' | 'audio' | 'software' | 'collection'
+print(meta.get('creator'))      # 'jakemauz'
+print(meta.get('date'))         # '2017-02-18'
+print(meta.get('description'))  # HTML string — strip tags if needed
+print(meta.get('subject'))      # str OR list of str depending on item
+print(meta.get('publicdate'))   # '2017-02-18 11:51:16'
+print(meta.get('collection'))   # parent collection identifier
+
+files = data['files']
+# Each file entry:
+# name, source ('original'|'derivative'|'metadata'), format, size (bytes as str),
+# md5, sha1, crc32, mtime
+# For video/audio: length (seconds as str), height, width
+# For derivative: original (name of source file)
+
+# Find the primary original file
+orig_files = [f for f in files if f.get('source') == 'original']
+# orig_files[0]: {'name': 'Hard-won wisdom trailer.mp4', 'source': 'original',
+#  'format': 'MPEG4', 'size': '7532153', 'length': '94.13',
+#  'height': '360', 'width': '640', 'md5': 'aaeebe0481...', ...}
+
+# Build download URL — two equivalent forms:
+server = data['server']      # 'ia601405.us.archive.org'
+dir_path = data['dir']       # '/2/items/HardWonWisdomTrailer'
+fname = orig_files[0]['name']
+from urllib.parse import quote as urlquote
+# Form 1: direct storage server (fastest)
+url1 = f"https://{server}{dir_path}/{urlquote(fname)}"
+# Form 2: standard redirect URL (always works, resolved by CDN)
+url2 = f"https://archive.org/download/{identifier}/{urlquote(fname)}"
+# Both confirmed status 200, Content-Type: video/mp4
+```
+
+### Search items (books, audio, video, software)
+
+```python
+import json
+
+# advancedsearch.php is the correct API — /search returns HTML
+r = http_get(
+    "https://archive.org/advancedsearch.php"
+    "?q=artificial+intelligence+AND+mediatype:texts"
+    "&fl[]=identifier&fl[]=title&fl[]=creator&fl[]=date&fl[]=downloads"
+    "&rows=5&sort[]=downloads+desc&output=json",
+    timeout=30.0
+)
+data = json.loads(r)
+# data['responseHeader']['status'] = 0 (success)
+# data['responseHeader']['QTime'] = query time ms
+# data['response']['numFound'] = 25911 (total matches)
+# data['response']['start'] = 0 (offset)
+# data['response']['docs'] = list of item dicts
+
+resp = data['response']
+print(f"Total: {resp['numFound']}, showing: {len(resp['docs'])}")
+for doc in resp['docs']:
+    print(f"  {doc['identifier']}  {doc.get('title', '')[:50]}")
+    # doc fields are only present if they have values — always use .get()
+```
+
+Pagination: use `start=` offset (not `page=`). Max `rows=` is not documented but 100 works reliably.
+
+### Search with all supported parameters
+
+```python
+import json
+
+r = http_get(
+    "https://archive.org/advancedsearch.php"
+    "?q=machine+learning+AND+mediatype:texts"  # Lucene query syntax
+    "&fl[]=identifier&fl[]=title&fl[]=date&fl[]=year"
+    "&fl[]=creator&fl[]=subject&fl[]=description&fl[]=downloads"
+    "&rows=3"
+    "&start=0"               # pagination offset
+    "&sort[]=date+desc"      # sort field + direction
+    "&output=json",
+    timeout=30.0
+)
+data = json.loads(r)
+# Confirmed fields in fl[]:
+# identifier, title, date, year, creator, subject, description,
+# downloads, mediatype, collection, language, avg_rating, num_reviews
+
+# mediatype values: texts, audio, movies, software, image, etree, data, collection, account
+# Sort fields: date, downloads, avg_rating, num_reviews, publicdate, addeddate
+```
+
+## API reference
+
+| Endpoint | What it returns | Auth |
+|---|---|---|
+| `web.archive.org/cdx/search/cdx?url=...&output=json` | Snapshot index: all captures of a URL | None |
+| `archive.org/wayback/available?url=...` | Nearest snapshot (DEGRADED — see gotchas) | None |
+| `archive.org/metadata/{identifier}` | Item metadata + files list | None |
+| `archive.org/advancedsearch.php?q=...&output=json` | Full-text + metadata search | None |
+| `archive.org/download/{identifier}/{filename}` | Direct file download | None |
+| `web.archive.org/web/{timestamp}/{url}` | Archived page HTML | None |
+
+## CDX field reference
+
+The CDX API returns a JSON array of arrays. The first row is always the header when `output=json`.
+
+| Field | Description | Example |
+|---|---|---|
+| `urlkey` | SURT-format URL (reversed domain, path in parens) | `org,iana)/` |
+| `timestamp` | Capture time, 14-digit `YYYYMMDDHHMMSS` | `19971210061738` |
+| `original` | Original crawled URL (exact, including port) | `http://www.iana.org:80/` |
+| `mimetype` | Content-Type of the archived response | `text/html` |
+| `statuscode` | HTTP status at crawl time | `200` |
+| `digest` | SHA-1 of response body, base32-encoded | `I4YBMQ6PHPWE2TD6TIXNWHZB6MXRNTSR` |
+| `length` | Content length in bytes (as string) | `1418` |
+
+Default `fl=` when omitted: `urlkey,timestamp,original,mimetype,statuscode,digest,length` (all 7 fields in that order).
+
+## Rate limits
+
+No auth, no API key. In practice:
+- CDX API: **intermittently slow** — individual queries time out at 20s and succeed at 40–60s. Always use `timeout=40.0` minimum. 3 rapid sequential CDX calls in ~10s completed; 10 rapid calls produced 3 timeouts.
+- Metadata API: Fast and reliable — 5 sequential calls completed in 3.0s with no errors.
+- Search API: Fast — typically responds in 30–65ms (`QTime` in response header).
+- No documented per-second or per-day limits. Archive.org's policy is to be respectful: add `time.sleep(1)` between CDX calls in loops.
+
+## Gotchas
+
+- **CDX times out — always set `timeout=40.0` or higher.** The default 20s is often too short for CDX. Metadata and search APIs are fine at 20–30s. CDX slowness is backend-side and unpredictable; add retry logic for production use.
+
+- **Wayback Availability API is unreliable.** `GET /wayback/available?url=iana.org` returns `{"url": "iana.org", "archived_snapshots": {}}` even for URLs confirmed archived via CDX. Tested 2026-04-18 across many URLs and timestamp combinations — consistently empty. Use `CDX ?sort=closest&limit=1` instead (confirmed working).
+
+- **CDX first row is always the header when `output=json`.** `rows[0]` is `['timestamp', 'original', ...]`, not a data row. Always slice `rows[1:]` for data. When `showResumeKey=true`, the last two rows are `[]` (separator) and `['<resume_key_string>']`.
+
+- **CDX `fl=` must match exactly what you iterate.** If you request `&fl=timestamp,original` you get 2-element rows; forgetting a field breaks destructuring. When in doubt, omit `fl=` entirely and get all 7 fields.
+
+- **`output=json` is required — there is no default JSON mode.** Omitting `output=json` returns space-separated text. `output=text` also works and is slightly faster for simple queries.
+
+- **`timestamp` is a string, not an integer.** Even in JSON, CDX returns all fields as strings: `'1418'` not `1418`, `'200'` not `200`. Cast explicitly: `int(row[4])`, `int(row[6])`.
+
+- **The `original` field preserves port numbers.** Old crawls captured `http://www.iana.org:80/` — the `:80` is part of the URL. When building a playback URL, use `original` verbatim: `f"https://web.archive.org/web/{ts}/{orig}"` works correctly with the port included.
+
+- **Metadata `{}` means the item doesn't exist or is private.** `http_get("https://archive.org/metadata/nonexistent")` returns `'{}'` (2-byte response) with HTTP 200. Always check `if not data` or `if not data.get('metadata')` before accessing fields.
+
+- **Metadata `subject` can be a string or a list.** When a single subject tag is set, the API returns `"subject": "short film"`. When multiple, it returns `"subject": ["short film", "spoken word"]`. Normalize with: `subjects = [meta['subject']] if isinstance(meta.get('subject'), str) else meta.get('subject', [])`.
+
+- **File `size` and `length` are strings, not numbers.** `files[0]['size']` is `'7532153'` (bytes). `files[0]['length']` is `'94.13'` (seconds for video/audio). Cast with `int()` and `float()` respectively.
+
+- **Use `archive.org/download/` not the raw storage server URL for reliability.** The raw URL (`ia601405.us.archive.org/2/items/...`) is faster but server-specific. `archive.org/download/{id}/{file}` redirects to the correct storage node and remains stable as items migrate.
+
+- **`/search?output=json` returns HTML, not JSON.** The `/search` endpoint is a React SPA — it ignores `output=json`. Always use `advancedsearch.php` for programmatic access.
+
+- **`collapse=timestamp:6` gives one row per month, but it keeps the FIRST capture of that month.** If you want the last, you'd need to reverse and re-collapse, or fetch all and filter client-side. The `collapse` parameter de-duplicates by truncating the timestamp to N digits and keeping the first matching row.
+
+- **CDX `from=` / `to=` accept partial timestamps.** `from=20230101` means `20230101000000`. `to=20231231` means `20231231000000` (exclusive). To include all of 2023, use `to=20240101`.

--- a/domain-skills/coinmarketcap/scraping.md
+++ b/domain-skills/coinmarketcap/scraping.md
@@ -1,0 +1,463 @@
+# CoinMarketCap — Data Extraction
+
+`https://coinmarketcap.com` — crypto market data. Three access paths tested: internal JSON API (fastest, no auth required), `__NEXT_DATA__` from HTML pages, and browser DOM. All real-money price data confirmed accurate against displayed UI values.
+
+## Do this first: pick your access path
+
+| Goal | Best approach | Latency |
+|------|--------------|---------|
+| Top N coins by market cap | Internal listing API | ~200ms |
+| Single coin price/stats/ATH | Internal detail API | ~100ms |
+| Global market metrics | Internal global-metrics API | ~65ms |
+| All coins on homepage (101 items) | `__NEXT_DATA__` main page | ~700ms |
+| Coin detail + full stats | `__NEXT_DATA__` currency page | ~700ms |
+| Historical OHLCV | Internal historical API | ~160ms |
+| Exchange pairs for a coin | Internal market-pairs API | ~200ms |
+| News/articles | Internal content API | ~220ms |
+
+**Never use the browser for read-only CMC tasks.** The internal API at `api.coinmarketcap.com` is accessible with no API key, no special headers, no auth — plain `http_get` works.
+
+**Do NOT use `pro-api.coinmarketcap.com`** — that is the paid API requiring a key.
+
+---
+
+## Path 1: Internal listing API (fastest for ranked coins)
+
+Returns CMC-ranked coins with full price data in one call. No auth needed.
+
+```python
+import json
+
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/cryptocurrency/listing"
+    "?start=1&limit=100&sortBy=market_cap&sortType=desc&convert=USD"
+))
+
+coins = resp['data']['cryptoCurrencyList']    # list of coin objects
+total_available = resp['data']['totalCount']  # 8374 as of 2026-04-18
+
+for c in coins:
+    usd = next(q for q in c['quotes'] if q['name'] == 'USD')
+    print(
+        f"#{c['cmcRank']} {c['symbol']}: "
+        f"${usd['price']:,.2f} | "
+        f"MCap ${usd['marketCap']/1e9:.1f}B | "
+        f"Vol24h ${usd['volume24h']/1e9:.1f}B | "
+        f"24h {usd['percentChange24h']:+.2f}% | "
+        f"CS {c['circulatingSupply']:,.0f}"
+    )
+```
+
+### Coin object fields
+
+Top-level (`c` in the loop above):
+```
+id, name, symbol, slug, cmcRank, marketPairCount,
+circulatingSupply, selfReportedCirculatingSupply,
+totalSupply, maxSupply, isActive, lastUpdated, dateAdded,
+quotes, isAudited, auditInfoList, badges
+```
+
+Per-quote fields (inside `c['quotes']`, filtered by `name == 'USD'`):
+```
+name, price, volume24h, volumePercentChange, marketCap,
+percentChange1h, percentChange24h, percentChange7d,
+percentChange30d, percentChange60d, percentChange90d,
+percentChange1y, ytdPriceChangePercentage,
+fullyDilluttedMarketCap, marketCapByTotalSupply,
+dominance, turnover, lastUpdated
+```
+
+### Query parameters
+
+```python
+# Pagination
+"?start=1&limit=100"        # page 1 of 100
+"?start=101&limit=100"      # page 2
+
+# Sort
+"sortBy=market_cap"         # default
+"sortBy=volume_24h"
+"sortBy=percent_change_24h"
+"sortBy=price"
+"sortBy=circulating_supply"
+"sortType=desc"             # or asc
+
+# Currency conversion (affects quote prices returned)
+"convert=USD"               # USD prices
+"convert=BTC"               # BTC-denominated
+
+# Filter by type
+"cryptoType=all"            # default — coins + tokens
+"cryptoType=coins"          # layer-1s only (633 results)
+"cryptoType=tokens"         # ERC-20 etc.
+
+# Filter by tag (DeFi, NFT, etc.)
+"tagSlugs=defi"             # 2698 results
+"tagSlugs=nft"
+```
+
+---
+
+## Path 2: Internal detail API (single coin, full stats)
+
+Best for fetching one coin's complete data including ATH, ATL, 52-week high/low, volume ranks.
+
+```python
+import json
+
+# Look up by CMC coin ID (BTC=1, ETH=1027, XRP=52, SOL=5426, BNB=1839)
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/cryptocurrency/detail?id=1"
+))
+data = resp['data']
+s = data['statistics']
+
+print(f"Price:             ${s['price']:,.2f}")
+print(f"Rank:              #{s['rank']}")
+print(f"Market Cap:        ${s['marketCap']:,.0f}")
+print(f"Volume 24h:        ${s['volume24h']:,.0f}")
+print(f"Circulating Supply:{s['circulatingSupply']:,.0f}")
+print(f"Total Supply:      {s['totalSupply']:,.0f}")
+print(f"Max Supply:        {s['maxSupply']:,.0f}")
+print(f"24h Change:        {s['priceChangePercentage24h']:+.2f}%")
+print(f"7d Change:         {s['priceChangePercentage7d']:+.2f}%")
+print(f"ATH:               ${s['highAllTime']:,.2f} on {s['highAllTimeTimestamp']}")
+print(f"ATL:               ${s['lowAllTime']:,.4f} on {s['lowAllTimeTimestamp']}")
+print(f"52w High:          ${s['high52w']:,.2f}")
+print(f"52w Low:           ${s['low52w']:,.2f}")
+print(f"MCap Dominance:    {s['marketCapDominance']:.2f}%")
+```
+
+### All statistics fields
+
+```
+price, priceChangePercentage1h, priceChangePercentage24h,
+priceChangePercentage7d, priceChangePercentage30d,
+priceChangePercentage60d, priceChangePercentage90d,
+priceChangePercentage1y, priceChangePercentageAll,
+marketCap, marketCapChangePercentage24h,
+fullyDilutedMarketCap, mintedMarketCap,
+circulatingSupply, totalSupply, maxSupply,
+marketCapDominance, rank, roi,
+low24h, high24h, low7d, high7d, low30d, high30d,
+low52w, high52w, low90d, high90d,
+lowAllTime, highAllTime,
+lowAllTimeChangePercentage, highAllTimeChangePercentage,
+lowAllTimeTimestamp, highAllTimeTimestamp,
+lowYesterday, highYesterday, openYesterday, closeYesterday,
+priceChangePercentageYesterday, volumeYesterday,
+ytdPriceChangePercentage, volumeRank, volumeMcRank,
+volume24h, volume24hReported, volume7d, volume7d Reported,
+volume30d, volume30dReported, turnover
+```
+
+### Top-level data fields (beyond statistics)
+
+```
+id, name, symbol, slug, category, description, dateAdded,
+volume, volumeChangePercentage24h, cexVolume, dexVolume,
+urls (website, explorer, twitter, reddit, etc.),
+tags, platforms, relatedCoins, wallets,
+holders, watchCount, watchListRanking
+```
+
+---
+
+## Path 3: Global market metrics
+
+```python
+import json
+
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/global-metrics/quotes/latest"
+))
+data = resp['data']
+q = data['quotes'][0]   # USD quote (cryptoId=2781)
+
+print(f"Total Market Cap:  ${q['totalMarketCap']/1e12:.2f}T")
+print(f"Total Volume 24h:  ${q['totalVolume24H']/1e9:.1f}B")
+print(f"Altcoin MCap:      ${q['altcoinMarketCap']/1e12:.2f}T")
+print(f"DeFi MCap:         ${q['defiMarketCap']/1e9:.1f}B")
+print(f"DeFi Vol 24h:      ${q['defiVolume24H']/1e9:.1f}B")
+print(f"Stablecoin MCap:   ${q['stablecoinMarketCap']/1e9:.1f}B")
+print(f"Derivatives Vol:   ${q['derivativesVolume24H']/1e9:.1f}B")
+print(f"BTC Dominance:     {data['btcDominance']:.2f}%")
+print(f"ETH Dominance:     {data['ethDominance']:.2f}%")
+print(f"Active Cryptos:    {data['activeCryptoCurrencies']}")
+print(f"Total Cryptos:     {data['totalCryptoCurrencies']}")
+print(f"Active Exchanges:  {data['activeExchanges']}")
+print(f"Active Pairs:      {data['activeMarketPairs']}")
+
+# Yesterday comparison
+print(f"\nMCap Yesterday:    ${q['totalMarketCapYesterday']/1e12:.2f}T")
+print(f"MCap Change:       {q['totalMarketCapYesterdayPercentageChange']:+.2f}%")
+```
+
+---
+
+## Path 4: Historical OHLCV (candlestick data)
+
+```python
+import json, time
+
+now = int(time.time())
+
+# Daily candles for BTC over last 7 days
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/cryptocurrency/historical"
+    f"?id=1&convertId=2781&timeStart={now - 7*86400}&timeEnd={now}&interval=daily"
+))
+candles = resp['data']['quotes']   # list of OHLCV dicts
+
+for candle in candles:
+    q = candle['quote']
+    print(
+        f"{candle['timeOpen'][:10]} "
+        f"O={q['open']:,.0f} H={q['high']:,.0f} "
+        f"L={q['low']:,.0f} C={q['close']:,.0f} "
+        f"V=${q['volume']/1e9:.1f}B MCap=${q['marketCap']/1e12:.2f}T"
+    )
+```
+
+Candle quote fields: `open, high, low, close, volume, marketCap, circulatingSupply, timestamp`
+
+Supported intervals: `daily`, `1h` (hourly). `5m` returns HTTP 500 — not supported.
+
+`convertId=2781` = USD. `timeStart`/`timeEnd` are Unix timestamps.
+
+---
+
+## Path 5: Exchange market pairs for a coin
+
+```python
+import json
+
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/cryptocurrency/market-pairs/latest"
+    "?id=1&start=1&limit=10&sort=volume"
+))
+data = resp['data']
+print(f"Total pairs for {data['name']}: {data['numMarketPairs']}")
+
+for pair in data['marketPairs']:
+    print(
+        f"  {pair['exchangeName']:20} {pair['marketPair']:12} "
+        f"${pair['price']:,.2f} Vol=${pair['volumeUsd']/1e6:.1f}M"
+    )
+```
+
+Pair fields: `rank, exchangeId, exchangeName, exchangeSlug, marketId, marketPair, category (spot/futures), baseSymbol, quoteSymbol, baseCurrencyId, quoteCurrencyId, price, volumeUsd, effectiveLiquidity, lastUpdated, volumeBase, volumeQuote, depthUsdNegativeTwo, depthUsdPositiveTwo, feeType, isVerified, type (cex/dex)`
+
+---
+
+## Path 6: Exchange listings
+
+```python
+import json
+
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/exchange/listing"
+    "?start=1&limit=20&sortBy=score&sortType=desc"
+))
+exchanges = resp['data']['exchanges']
+for ex in exchanges:
+    print(f"  {ex['name']:30} score={ex.get('score')} trafficScore={ex.get('trafficScore')}")
+```
+
+Exchange fields: `id, name, slug, dexStatus, platformId, status, score, trafficScore, countries, fiats, filteredTotalVol24h`
+
+---
+
+## Path 7: Price conversion (cross-rate)
+
+```python
+import json
+
+# Convert 1 BTC → USD
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/tools/price-conversion"
+    "?amount=1&id=1&convert_id=2781"
+))
+result = resp['data']
+usd_price = result['quote'][0]['price']
+print(f"1 {result['symbol']} = ${usd_price:,.2f} USD")
+
+# Convert ETH → BTC
+resp2 = json.loads(http_get(
+    "https://api.coinmarketcap.com/data-api/v3/tools/price-conversion"
+    "?amount=1&id=1027&convert_id=1"
+))
+btc_price = resp2['data']['quote'][0]['price']
+print(f"1 ETH = {btc_price:.6f} BTC")
+```
+
+`id` = source coin CMC ID, `convert_id` = target currency CMC ID (2781=USD, 1=BTC, 1027=ETH, 825=USDT)
+
+---
+
+## Path 8: News / articles
+
+```python
+import json
+
+# News for a specific coin
+resp = json.loads(http_get(
+    "https://api.coinmarketcap.com/content/v3/news?coins=1&limit=10"
+))
+for article in resp['data']:
+    meta = article['meta']
+    print(f"  [{meta['sourceName']}] {meta['title']}")
+    print(f"    {article['createdAt'][:10]} — {meta['sourceUrl']}")
+```
+
+Article fields: `slug, cover, assets, createdAt` + nested `meta` with `title, subtitle, sourceName, sourceUrl, language, type, status, id, createdAt, updatedAt, releasedAt`
+
+Omit `coins=` param for general crypto news. Supports `limit` up to observed 50+ without errors.
+
+---
+
+## Path 9: __NEXT_DATA__ from HTML pages
+
+Use when you need data that isn't in the API (e.g. Fear & Greed index, CMC100 index, trending categories).
+
+### Main page (`coinmarketcap.com/`)
+
+```python
+import json, re
+
+html = http_get("https://coinmarketcap.com/")
+m = re.search(r'<script id="__NEXT_DATA__"[^>]+>([\s\S]*?)</script>', html)
+nd = json.loads(m.group(1))
+props = nd['props']
+
+# Global market metrics (same data as global-metrics API, faster from HTML)
+gm = props['pageProps']['globalMetrics']
+print(f"Total cryptos: {gm['numCryptocurrencies']}")
+print(f"BTC dominance: {gm['btcDominance']:.2f}%")
+print(f"Total MCap:    ${gm['marketCap']/1e12:.2f}T")
+print(f"Total Vol 24h: ${gm['totalVol']/1e9:.1f}B")
+
+# Spot prices for BTC/ETH/USD/SATS/BITS (the "ticker bar" data)
+# props['quotesLatestData'] — 5 items with short field names
+for q in props['quotesLatestData']:
+    print(f"  {q['symbol']}: p={q['p']} p24h={q['p24h']:+.3f}%")
+    # fields: id, symbol, p (price), p1h, p24h, p7d, p30d, p60d, p90d, pytd, t
+
+# Top 101 coins with full USD quotes — from dehydratedState
+queries = props['dehydratedState']['queries']
+homepage_q = next(q for q in queries if q['queryKey'] == ['homepage-data', 1, 100])
+listing = homepage_q['state']['data']['data']['listing']
+coins = listing['cryptoCurrencyList']   # 101 coins
+total = listing['totalCount']
+
+for c in coins:
+    if c['symbol'] == 'BTC':
+        usd = next(q for q in c['quotes'] if q['name'] == 'USD')
+        print(f"BTC: #{c['cmcRank']} ${usd['price']:,.2f}")
+        break
+
+# Page-level shared data (Fear & Greed index, CMC20, altcoin index)
+psd = props['pageProps']['pageSharedData']
+print("pageSharedData keys:", list(psd.keys()))
+# keys: topCategories, fearGreedIndexData, cmc100, cmc20, faqData, altcoinIndex, halvingInfo, deviceInfo
+```
+
+**Gotcha — regex pattern**: Use `[^>]+` to match the `crossorigin="anonymous"` attribute on the script tag. `type="application/json"` alone will miss it:
+```python
+# CORRECT
+m = re.search(r'<script id="__NEXT_DATA__"[^>]+>([\s\S]*?)</script>', html)
+
+# WRONG — returns None because of crossorigin attr
+m = re.search(r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', html, re.DOTALL)
+```
+
+**`quotesLatestData` has only 5 entries** (SATS, BITS, BTC, ETH, USD) — it's the currency selector bar, not the full market ranking. For the full ranked listing use `dehydratedState`.
+
+**`cmcRank` is at coin top level**, not inside the USD quote object. The `cmcRank` field inside the quote dict is `None`.
+
+### Individual coin page (`/currencies/{slug}/`)
+
+```python
+import json, re
+
+html = http_get("https://coinmarketcap.com/currencies/bitcoin/")
+m = re.search(r'<script id="__NEXT_DATA__"[^>]+>([\s\S]*?)</script>', html)
+nd = json.loads(m.group(1))
+
+# All stats under props.pageProps.detailRes.detail.statistics
+stats = nd['props']['pageProps']['detailRes']['detail']['statistics']
+
+print(f"Price:     ${stats['price']:,.2f}")
+print(f"Rank:      #{stats['rank']}")
+print(f"MCap:      ${stats['marketCap']:,.0f}")
+print(f"Vol 24h:   ${stats['volume24h']:,.0f}")
+print(f"Circ Sup:  {stats['circulatingSupply']:,.0f}")
+print(f"24h:       {stats['priceChangePercentage24h']:+.2f}%")
+print(f"ATH:       ${stats['highAllTime']:,.2f} ({stats['highAllTimeTimestamp']})")
+print(f"ATL:       ${stats['lowAllTime']:.4f}")
+```
+
+`detailRes.detail` also contains: `name, symbol, slug, description, tags, urls (website/explorer/twitter/reddit), platforms, relatedCoins, holders, watchCount`
+
+**Note**: The currency page has no JSON-LD blocks — zero `<script type="application/ld+json">` elements.
+
+---
+
+## Common coin IDs
+
+| ID | Symbol | Name |
+|----|--------|------|
+| 1 | BTC | Bitcoin |
+| 1027 | ETH | Ethereum |
+| 52 | XRP | XRP |
+| 825 | USDT | Tether |
+| 1839 | BNB | BNB |
+| 3408 | USDC | USD Coin |
+| 5426 | SOL | Solana |
+| 74 | DOGE | Dogecoin |
+| 2781 | USD | US Dollar (for convert_id) |
+
+Find IDs from the listing API: `c['id']` or from the detail API URL by looking up a slug first via the listing API's `c['slug']` field.
+
+---
+
+## Anti-bot / rate limits
+
+**Main site (`coinmarketcap.com`):**
+- `http_get` works with the default `Mozilla/5.0` UA — no Cloudflare, no bot detection triggered.
+- Page loads are ~700ms for 690–710KB of HTML+`__NEXT_DATA__`.
+
+**Internal API (`api.coinmarketcap.com`):**
+- No auth headers required. No `X-Request-Id` or `X-Forwarded-For` needed.
+- 25 rapid sequential calls with zero rate limiting or errors — no throttle observed at that volume.
+- Typical latency: 65–250ms per call.
+- `error_code: '0'` and `error_message: 'SUCCESS'` in every response; no `credit_count` consumed.
+
+**v2 API (`api.coinmarketcap.com/v2/`):**
+- Returns HTTP 401 Unauthorized — requires API key. Do not use.
+
+**Pro API (`pro-api.coinmarketcap.com`):**
+- Paid, requires `X-CMC_PRO_API_KEY` header. Do not test or call.
+
+---
+
+## Gotchas
+
+- **No JSON-LD on any page tested** — coin pages have zero `<script type="application/ld+json">` elements. Don't look for schema.org markup.
+
+- **`__NEXT_DATA__` regex**: Must use `[^>]+` between `__NEXT_DATA__"` and `>` — the tag has `crossorigin="anonymous"` which breaks a naive `type="application/json">` match.
+
+- **`cmcRank` location on homepage listing**: It's `c['cmcRank']` (top-level), NOT inside `c['quotes'][n]['cmcRank']` (that field is always `None`).
+
+- **5m/sub-hourly OHLCV not available**: Interval `5m` returns HTTP 500. Use `1h` for sub-daily and `daily` for longer ranges.
+
+- **v2 API is auth-only**: `api.coinmarketcap.com/v2/...` requires API key (401). The equivalent data is available via `data-api/v3/` without auth.
+
+- **`convert` param accepts symbols not just IDs** in the listing API, but `convert_id` in the price-conversion API requires numeric IDs (e.g. `2781` not `USD`).
+
+- **Circulating supply**: `c['circulatingSupply']` at the coin top level in the listing response — not inside the quote. The quote has `marketCap` which equals `price * circulatingSupply`.
+
+- **Multiple quotes per coin**: The listing API returns multiple quote objects when you request multiple convert currencies. Always filter by `q['name'] == 'USD'` (or your target currency) before reading price fields.
+
+- **Pagination**: `start` is 1-indexed (not 0-indexed). `start=1&limit=100` returns items 1–100, `start=101&limit=100` returns items 101–200.

--- a/domain-skills/dev-to/scraping.md
+++ b/domain-skills/dev-to/scraping.md
@@ -1,0 +1,323 @@
+# DEV Community (dev.to) — Data Extraction
+
+`https://dev.to` — developer blogging platform. Everything useful is available via a public REST API with no auth required. No browser needed for any read task.
+
+## Do this first
+
+**Use the REST API — it returns clean JSON in ~150–250ms with no browser, no login, no JS rendering.**
+
+```python
+import json
+articles = json.loads(http_get("https://dev.to/api/articles?per_page=10&tag=python"))
+# Each article: id, title, description, url, cover_image, tag_list, tags,
+#               published_at, published_timestamp, readable_publish_date,
+#               reading_time_minutes, positive_reactions_count,
+#               public_reactions_count, comments_count, user, organization,
+#               flare_tag, collection_id, slug, path, canonical_url,
+#               social_image, language, subforem_id
+```
+
+The API serves **V0 (beta) by default** and emits a `Warning: 299` header on every response. Suppress it silently with the V1 `Accept` header (same data, no deprecated warning):
+
+```python
+import json
+import urllib.request, gzip
+
+def dev_get(url):
+    h = {
+        "User-Agent": "Mozilla/5.0",
+        "Accept-Encoding": "gzip",
+        "Accept": "application/vnd.forem.api-v1+json",
+    }
+    with urllib.request.urlopen(urllib.request.Request(url, headers=h), timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+articles = json.loads(dev_get("https://dev.to/api/articles?per_page=10&tag=python"))
+```
+
+Or just use `http_get` directly if you don't care about the warning header noise.
+
+---
+
+## Common workflows
+
+### Articles by tag
+
+```python
+import json
+articles = json.loads(http_get("https://dev.to/api/articles?per_page=10&tag=python"))
+# Paginate with &page=2, &page=3 etc. (1-indexed)
+for a in articles:
+    print(a['id'], a['positive_reactions_count'], a['title'][:60])
+```
+
+Confirmed working tags: `python`, `javascript`, `typescript`, `rust`, `go`, `webdev`, `tutorial`, `react`, `devops`, `ai`, `beginners`.
+
+### Top articles by time window
+
+```python
+import json
+# top=N means "top articles from the last N days"
+top_day   = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=1"))
+top_week  = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=7"))
+top_month = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=30"))
+top_year  = json.loads(http_get("https://dev.to/api/articles?per_page=10&top=365"))
+```
+
+### Articles by username
+
+```python
+import json
+articles = json.loads(http_get("https://dev.to/api/articles?per_page=10&username=ben"))
+# Paginates cleanly: page=1, page=2 etc. Return distinct IDs, no overlap.
+```
+
+### New and rising articles
+
+```python
+import json
+fresh  = json.loads(http_get("https://dev.to/api/articles?per_page=10&state=fresh"))   # very new
+rising = json.loads(http_get("https://dev.to/api/articles?per_page=10&state=rising"))  # gaining traction
+# state=all returns 0 results (requires auth, not useful unauthenticated)
+```
+
+### Single article by ID (adds body_html and body_markdown)
+
+```python
+import json
+article = json.loads(http_get("https://dev.to/api/articles/3442047"))
+# Full article adds two fields not in list response:
+#   body_html     — rendered HTML (safe to display directly)
+#   body_markdown — raw Markdown source
+print(len(article['body_html']), len(article['body_markdown']))
+```
+
+### Single article by username/slug
+
+```python
+import json
+# path field from list response is "/username/slug"
+article = json.loads(http_get("https://dev.to/api/articles/ben/some-article-slug"))
+```
+
+### Tags — popular list with colors
+
+```python
+import json
+tags = json.loads(http_get("https://dev.to/api/tags?per_page=10"))
+# Fields: id, name, bg_color_hex, text_color_hex, short_summary
+# Sorted by popularity. Paginate with &page=2 etc.
+for t in tags:
+    print(t['name'], t['bg_color_hex'], t['text_color_hex'])
+# e.g. webdev  #562765  #ffffff
+#      javascript  #f7df1e  #000000
+#      ai  #17fd1a  #ffffff
+```
+
+### User profile
+
+```python
+import json
+user = json.loads(http_get("https://dev.to/api/users/by_username?url=ben"))
+# Fields: type_of, id, username, name, twitter_username, github_username,
+#         summary, location, website_url, joined_at, profile_image
+print(user['id'], user['username'], user['summary'])
+# e.g. 1  ben  "A Canadian software developer who thinks he's funny."
+```
+
+`joined_at` is a human string like `"Dec 27, 2015"` — not ISO 8601. Parse with `datetime.strptime(user['joined_at'], "%b %d, %Y")`.
+
+### Comments on an article
+
+```python
+import json
+comments = json.loads(http_get("https://dev.to/api/comments?a_id=3442047"))
+# Returns top-level comments only (replies nested under children key)
+# Fields per comment: id_code (string, not int!), type_of, body_html,
+#                     created_at, user (dict), children (list of same shape)
+for c in comments:
+    print(c['id_code'], c['user']['username'], c['created_at'])
+    for reply in c.get('children', []):
+        print("  reply:", reply['id_code'], reply['user']['username'])
+```
+
+### Single comment by id_code
+
+```python
+import json
+comment = json.loads(http_get("https://dev.to/api/comments/36lnc"))
+# Same fields as above: id_code, body_html, created_at, user, children
+```
+
+### Bulk tag fetch (parallel)
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+tags = ['python', 'javascript', 'typescript', 'rust', 'go',
+        'devops', 'webdev', 'tutorial', 'productivity', 'react']
+
+def fetch_tag(tag):
+    data = json.loads(http_get(f"https://dev.to/api/articles?per_page=5&tag={tag}"))
+    return tag, data
+
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = dict(ex.map(lambda t: fetch_tag(t), tags))
+# 10 tags × 5 articles each: ~0.67s total with max_workers=3
+```
+
+---
+
+## Endpoint reference
+
+| Endpoint | Auth | Key params | Latency |
+|----------|------|-----------|---------|
+| `GET /api/articles` | None | `tag`, `username`, `top`, `state`, `page`, `per_page` | ~200ms |
+| `GET /api/articles/{id}` | None | — | ~80ms |
+| `GET /api/articles/{username}/{slug}` | None | — | ~200ms |
+| `GET /api/tags` | None | `page`, `per_page` | ~190ms |
+| `GET /api/users/by_username?url={username}` | None | — | ~190ms |
+| `GET /api/comments?a_id={article_id}` | None | — | ~160ms |
+| `GET /api/comments/{id_code}` | None | — | ~150ms |
+| `GET /api/listings` | None | `category`, `page`, `per_page` | ~260ms (returns 0) |
+
+**Listings endpoint returns 0 results.** The `/api/listings` endpoint is documented but returns an empty array for all categories (`jobs`, `forsale`, `education`, `cfp`) without auth. Skip it.
+
+---
+
+## Pagination
+
+All list endpoints paginate with `page=` (1-indexed) and `per_page=`:
+
+```python
+import json
+
+def get_all_articles_by_tag(tag, max_pages=5):
+    results = []
+    for page in range(1, max_pages + 1):
+        batch = json.loads(http_get(
+            f"https://dev.to/api/articles?per_page=30&tag={tag}&page={page}"
+        ))
+        if not batch:
+            break
+        results.extend(batch)
+    return results
+```
+
+- `per_page` supports up to **1000** (confirmed). No documented max, but 1000 works in testing.
+- No `total_count` field in list responses — you paginate until an empty array.
+- Page ordering is consistent — confirmed no ID overlap between page 1 and page 2.
+
+---
+
+## Article field reference
+
+All fields returned in list responses (single article adds `body_html` and `body_markdown`):
+
+```
+id                      int    — article ID, stable, use for single-article fetch
+title                   str
+description             str    — auto-excerpt, never null
+slug                    str    — URL slug component
+path                    str    — "/username/slug"
+url                     str    — full canonical URL
+canonical_url           str    — same as url for native posts; author's site URL for cross-posts
+cover_image             str|null — CDN URL or null (~30% of articles have no cover image)
+social_image            str    — always present (generated if no cover_image)
+tag_list                list   — e.g. ['python', 'ai', 'tutorial']  ← use this for code
+tags                    str    — same tags as comma-separated string "python, ai, tutorial"
+published_at            str    — ISO 8601 UTC e.g. "2026-04-18T03:49:36Z"
+published_timestamp     str    — identical to published_at
+readable_publish_date   str    — human string e.g. "Apr 18"
+reading_time_minutes    int
+positive_reactions_count int   — hearts/likes count
+public_reactions_count  int    — total reactions (usually same as positive_reactions_count)
+comments_count          int
+user                    dict   — name, username, twitter_username, github_username,
+                                 user_id, website_url, profile_image, profile_image_90
+organization            dict|null — present when posted under an org: name, username, slug,
+                                     profile_image, profile_image_90
+flare_tag               dict|null — {name, bg_color_hex, text_color_hex} — discussion/challenge badge
+collection_id           int|null  — series/collection ID if part of a series
+language                str    — e.g. "en"
+subforem_id             int|null
+crossposted_at          str|null — ISO datetime if cross-posted
+edited_at               str|null
+last_comment_at         str|null
+created_at              str    — ISO 8601
+type_of                 str    — always "article"
+```
+
+---
+
+## Rate limits
+
+- **Burst limit: ~6 rapid sequential requests**, then HTTP 429.
+- **Recovery: `Retry-After: 1` second** — wait 1s after a 429 and you're good again.
+- No `X-RateLimit-*` headers in 200 responses — you only see `Retry-After` on the 429 itself.
+- With `ThreadPoolExecutor(max_workers=3)`, 10 concurrent requests succeed without hitting the limit.
+- No difference in limits between V0 (default) and V1 (`Accept` header) — same underlying rate limit.
+- **No auth token tested** — all endpoints above work without `api_key`. Authenticated requests likely have higher limits.
+
+Safe pattern for bulk fetching:
+
+```python
+import json, time
+from concurrent.futures import ThreadPoolExecutor
+
+def safe_fetch(url):
+    for attempt in range(3):
+        try:
+            return json.loads(http_get(url))
+        except Exception as e:
+            if '429' in str(e):
+                time.sleep(1)   # Retry-After is 1s
+                continue
+            raise
+    return []
+
+urls = [
+    f"https://dev.to/api/articles?per_page=10&tag={tag}"
+    for tag in ['python', 'javascript', 'typescript', 'rust']
+]
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(safe_fetch, urls))
+```
+
+---
+
+## Gotchas
+
+- **`tag_list` (list) vs `tags` (string)** — both fields always present. `tag_list` is a Python list; `tags` is the same data as a comma-separated string. Use `tag_list` in code.
+
+- **Comments have `id_code`, not `id`** — comment identifiers are alphanumeric strings like `"36lnc"`, not integers. The integer `id` field is absent from comment objects. Use `id_code` to fetch a specific comment via `GET /api/comments/{id_code}`.
+
+- **Comments endpoint returns top-level only** — replies are nested under `children` recursively, not returned as a flat list. A thread with 100 total comments may only show 60 top-level objects; walk `children` recursively to count all.
+
+- **`cover_image` can be null** — ~30% of articles have no cover image. Always guard: `a.get('cover_image') or a['social_image']` for a guaranteed image URL.
+
+- **`flare_tag` is null for most articles** — only discussion/challenge posts carry it. It's a dict `{name, bg_color_hex, text_color_hex}` when present.
+
+- **`published_at` == `published_timestamp`** — both fields contain identical ISO 8601 UTC strings. `readable_publish_date` is human-only (`"Apr 18"`, no year).
+
+- **`joined_at` on user profile is not ISO** — it's `"Dec 27, 2015"`. Parse: `datetime.strptime(u['joined_at'], "%b %d, %Y")`.
+
+- **`state=all` returns 0 results unauthenticated** — it's for the authenticated user's own feed. `state=fresh` and `state=rising` work without auth.
+
+- **`top=N` means last N days** — `top=1` is last 24h, `top=7` is last week, `top=30` is last month, `top=365` is last year. Results differ from the `state=` param.
+
+- **V0 warning header on every response** — `Warning: 299 - This endpoint is part of the V0 (beta) API…` appears on all responses without the `Accept` header. It's harmless but noisy. Suppress with `"Accept": "application/vnd.forem.api-v1+json"`.
+
+- **No `total_count` in list responses** — paginate until an empty array. There is no way to know upfront how many total results exist.
+
+- **Listings endpoint returns empty** — `GET /api/listings` and all category variants return `[]` without auth. Documented but non-functional publicly.
+
+- **`/api/articles/{id}/comments` returns 404** — comments must be fetched via `GET /api/comments?a_id={id}`, not as a sub-resource of articles.
+
+- **`canonical_url` may point off-site** — for cross-posted articles, `canonical_url` is the author's original blog URL, not dev.to. Use `url` for the dev.to link.
+
+- **`organization` field is null for personal posts** — only present when the article was posted under an org account. Check before accessing sub-fields.

--- a/domain-skills/genius/scraping.md
+++ b/domain-skills/genius/scraping.md
@@ -1,0 +1,511 @@
+# Genius — Data Extraction
+
+Field-tested against genius.com on 2026-04-18.
+No authentication required for any approach documented here.
+
+---
+
+## Anti-Bot: http_get Fails, Custom UA Required
+
+`http_get` uses `User-Agent: Mozilla/5.0` (bare string). Genius returns HTTP 403 for that UA on both HTML pages and internal API endpoints. Adding any OS token (e.g. `(Macintosh; Intel Mac OS X 10_15_7)`) immediately lifts the block — no cookies, no session, no JavaScript required.
+
+```python
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    """Drop-in replacement for http_get on genius.com endpoints."""
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+```
+
+Use `genius_get` everywhere in this document instead of bare `http_get`.
+
+---
+
+## Approach 1 (Fastest): Internal JSON API — No Auth, No Browser
+
+Genius's own website calls `genius.com/api/*` (not `api.genius.com`) from
+its server-side rendering layer. These endpoints are public and require only
+a browser-like User-Agent. They return rich structured JSON in ~0.13s.
+
+### Song metadata
+
+```python
+import json
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+
+def genius_song(song_id):
+    """Fetch full song metadata by Genius song ID."""
+    data = json.loads(genius_get(f"https://genius.com/api/songs/{song_id}"))
+    return data["response"]["song"]
+
+song = genius_song(1063)
+# All fields available in one call (no auth):
+# song["title"]                          → "Bohemian Rhapsody"
+# song["full_title"]                     → "Bohemian Rhapsody by Queen"
+# song["artist_names"]                   → "Queen"
+# song["primary_artist"]["name"]         → "Queen"
+# song["primary_artist"]["id"]           → 563
+# song["primary_artist"]["url"]          → "https://genius.com/artists/Queen"
+# song["release_date"]                   → "1975-10-31"
+# song["release_date_for_display"]       → "October 31, 1975"
+# song["release_date_components"]        → {"year": 1975, "month": 10, "day": 31}
+# song["stats"]["pageviews"]             → 11067562
+# song["stats"]["contributors"]          → 516
+# song["stats"]["accepted_annotations"]  → 20
+# song["pyongs_count"]                   → 703
+# song["annotation_count"]              → 33
+# song["comment_count"]                 → 253
+# song["album"]["name"]                 → "Studio Collection"   (varies by region)
+# song["albums"][0]["name"]             → "A Night at the Opera"  (first = original)
+# song["url"]                           → "https://genius.com/Queen-bohemian-rhapsody-lyrics"
+# song["path"]                          → "/Queen-bohemian-rhapsody-lyrics"
+# song["song_art_image_url"]            → "https://images.genius.com/718de9d..."
+# song["explicit"]                      → False
+# song["language"]                      → "en"
+# song["lyrics_state"]                  → "complete"
+# song["lyrics_verified"]              → False
+# song["spotify_uuid"]                  → "7tFiyTwD0nx5a1eklYtX2J"
+# song["youtube_url"]                   → "https://www.youtube.com/watch?v=fJ9rUzIMcZQ"
+# song["writer_artists"]                → [{"name": "Freddie Mercury", ...}]
+# song["producer_artists"]              → [{"name": "Roy Thomas Baker"}, {"name": "Queen"}]
+# song["featured_artists"]             → []
+
+# Primary album (first in list = original release):
+primary_album = song["albums"][0]["name"]   # "A Night at the Opera"
+```
+
+### Search
+
+```python
+def genius_search(query, per_page=5):
+    """Search Genius. Returns sections: top_hit, song, lyric, artist, album, video, article, user."""
+    url = f"https://genius.com/api/search/multi?per_page={per_page}&q={urllib.parse.quote(query)}"
+    data = json.loads(genius_get(url))
+    return data["response"]["sections"]
+
+import urllib.parse
+sections = genius_search("Bohemian Rhapsody Queen", per_page=5)
+# sections is a list of dicts with keys: "type", "hits"
+# Each hit has: "type", "result"
+# For type="song", result has: id, full_title, url, primary_artist, stats, ...
+
+for section in sections:
+    if section["type"] == "song":
+        for hit in section["hits"]:
+            r = hit["result"]
+            print(r["full_title"], r["url"], r["id"])
+        # Bohemian Rhapsody by Queen  https://genius.com/Queen-bohemian-rhapsody-lyrics  1063
+        break
+
+# Simpler search (song section only):
+def genius_search_songs(query, per_page=5):
+    sections = genius_search(query, per_page)
+    for s in sections:
+        if s["type"] == "song":
+            return [h["result"] for h in s["hits"]]
+    return []
+```
+
+### Artist songs (paginated)
+
+```python
+def genius_artist_songs(artist_id, per_page=20, sort="popularity"):
+    """Fetch paginated list of songs for an artist. sort: 'popularity' or 'title'."""
+    page = 1
+    while True:
+        url = (f"https://genius.com/api/artists/{artist_id}/songs"
+               f"?per_page={per_page}&page={page}&sort={sort}")
+        data = json.loads(genius_get(url))["response"]
+        songs = data["songs"]
+        if not songs:
+            break
+        yield from songs
+        if data["next_page"] is None:
+            break
+        page = data["next_page"]
+
+# Example: get top 5 Queen songs by popularity
+for song in list(genius_artist_songs(563, per_page=5))[:5]:
+    print(f"{song['full_title']} — {song['stats']['pageviews']:,} views")
+# Bohemian Rhapsody by Queen — 11,067,663 views
+# Don't Stop Me Now by Queen — 2,453,240 views
+# Under Pressure by Queen & David Bowie — 1,972,606 views
+# Somebody to Love by Queen — 1,241,740 views
+# Killer Queen by Queen — 1,146,813 views
+```
+
+---
+
+## Approach 2: Lyrics from HTML — Regex on data-lyrics-container
+
+The lyrics live in `<div data-lyrics-container="true">` elements on the song's
+lyrics page. There are usually 3–5 such divs (the song is split across sections).
+Each div can contain nested child divs for annotation highlights — including a
+`data-exclude-from-selection="true"` header div that must be stripped first.
+
+```python
+import re, json
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+
+def _remove_excluded_divs(html):
+    """Strip all <div data-exclude-from-selection="true"> subtrees (contributor headers)."""
+    while True:
+        idx = html.find('data-exclude-from-selection="true"')
+        if idx == -1:
+            break
+        tag_start = html.rfind("<div", 0, idx)
+        depth, pos = 0, tag_start
+        while pos < len(html):
+            if html[pos:pos+4] == "<div":
+                depth += 1; pos += 4
+            elif html[pos:pos+6] == "</div>":
+                depth -= 1; pos += 6
+                if depth == 0:
+                    html = html[:tag_start] + html[pos:]
+                    break
+            else:
+                pos += 1
+        else:
+            break
+    return html
+
+def _extract_div_content(html, marker):
+    """Extract all <div> subtrees that contain the given attribute marker."""
+    parts = []
+    start = 0
+    while True:
+        idx = html.find(marker, start)
+        if idx == -1:
+            break
+        tag_start = html.rfind("<div", 0, idx)
+        depth, pos = 0, tag_start
+        while pos < len(html):
+            if html[pos:pos+4] == "<div":
+                depth += 1; pos += 4
+            elif html[pos:pos+6] == "</div>":
+                depth -= 1; pos += 6
+                if depth == 0:
+                    parts.append(html[tag_start:pos])
+                    break
+            else:
+                pos += 1
+        start = idx + 1
+    return parts
+
+def _html_to_text(html_str):
+    """Convert lyrics HTML to plain text, preserving line breaks."""
+    text = re.sub(r"<br\s*/?>", "\n", html_str)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = (text
+            .replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+            .replace("&#39;", "'").replace("&quot;", '"').replace("&#x27;", "'")
+            .replace("&#x2F;", "/").replace("&nbsp;", " "))
+    # Collapse multiple blank lines to one
+    lines = [l.strip() for l in text.split("\n")]
+    result, prev_blank = [], False
+    for line in lines:
+        if not line:
+            if not prev_blank:
+                result.append("")
+            prev_blank = True
+        else:
+            result.append(line)
+            prev_blank = False
+    return "\n".join(result).strip()
+
+def genius_lyrics(url):
+    """
+    Scrape lyrics from a Genius song URL.
+
+    url: the canonical lyrics URL, e.g. 'https://genius.com/Queen-bohemian-rhapsody-lyrics'
+    Returns: plain-text lyrics string with section headers like [Verse 1], [Chorus].
+    """
+    html = genius_get(url)
+    cleaned = _remove_excluded_divs(html)
+    containers = _extract_div_content(cleaned, 'data-lyrics-container="true"')
+    parts = []
+    for c in containers:
+        text = _html_to_text(c).strip()
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
+
+lyrics = genius_lyrics("https://genius.com/Queen-bohemian-rhapsody-lyrics")
+# Returns 2076 chars, 62 lines, structured as:
+# [Intro]
+# Is this the real life? Is this just fantasy?
+# Caught in a landslide, no escape from reality
+# ...
+# [Verse 1]
+# Mama, just killed a man
+# ...
+# [Outro]
+# Nothing really matters to me
+# Any way the wind blows
+```
+
+**Performance:** Lyrics page is ~1.2 MB. One `genius_get` call takes ~0.18s.
+No rate limiting observed across 10 rapid sequential requests.
+
+---
+
+## Approach 3: Combined Workflow — Metadata + Lyrics
+
+The fastest complete extraction pattern: one API call for all metadata,
+one HTML call for lyrics. Song ID can be derived several ways.
+
+```python
+import json, re, urllib.parse
+from helpers import http_get
+
+def genius_get(url, extra_headers=None):
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return http_get(url, headers=headers)
+
+def genius_song_id_from_url(lyrics_url):
+    """
+    Extract Genius song ID from a lyrics page URL without fetching it.
+    Returns None if not determinable — fall back to fetching the page.
+    """
+    # Not possible from the slug alone; must fetch the page or use search.
+    # From the HTML: <meta content="genius://songs/{id}" name="twitter:app:url:iphone">
+    html = genius_get(lyrics_url)
+    m = re.search(r'content="genius://songs/(\d+)"', html)
+    return int(m.group(1)) if m else None
+
+def genius_full(query):
+    """
+    Search for a song, return metadata + lyrics in two HTTP calls.
+    """
+    # Call 1: search for song
+    sections = json.loads(
+        genius_get(f"https://genius.com/api/search/multi?per_page=3&q={urllib.parse.quote(query)}")
+    )["response"]["sections"]
+    song_result = None
+    for s in sections:
+        if s["type"] == "song" and s["hits"]:
+            song_result = s["hits"][0]["result"]
+            break
+    if not song_result:
+        return None
+
+    song_id = song_result["id"]
+    lyrics_url = song_result["url"]
+
+    # Call 2: full metadata from internal API
+    meta = json.loads(genius_get(f"https://genius.com/api/songs/{song_id}"))["response"]["song"]
+
+    # Call 3: lyrics from HTML
+    lyrics = genius_lyrics(lyrics_url)   # uses the function from Approach 2
+
+    return {
+        "id":           meta["id"],
+        "title":        meta["title"],
+        "artist":       meta["primary_artist"]["name"],
+        "artist_id":    meta["primary_artist"]["id"],
+        "album":        meta["albums"][0]["name"] if meta.get("albums") else None,
+        "release_date": meta["release_date"],           # "1975-10-31"
+        "pageviews":    meta["stats"]["pageviews"],      # 11067562
+        "contributors": meta["stats"]["contributors"],   # 516
+        "writers":      [a["name"] for a in meta["writer_artists"]],
+        "producers":    [a["name"] for a in meta["producer_artists"]],
+        "spotify_uuid": meta["spotify_uuid"],
+        "youtube_url":  meta["youtube_url"],
+        "song_art_url": meta["song_art_image_url"],
+        "lyrics_url":   meta["url"],
+        "lyrics":       lyrics,
+    }
+
+result = genius_full("Queen Bohemian Rhapsody")
+# {
+#   "id":           1063,
+#   "title":        "Bohemian Rhapsody",
+#   "artist":       "Queen",
+#   "artist_id":    563,
+#   "album":        "A Night at the Opera",
+#   "release_date": "1975-10-31",
+#   "pageviews":    11067562,
+#   "contributors": 516,
+#   "writers":      ["Freddie Mercury"],
+#   "producers":    ["Roy Thomas Baker", "Queen"],
+#   "spotify_uuid": "7tFiyTwD0nx5a1eklYtX2J",
+#   "youtube_url":  "https://www.youtube.com/watch?v=fJ9rUzIMcZQ",
+#   "song_art_url": "https://images.genius.com/718de9d1fbcaae9f3c9b1bf483bfa8f1.1000x1000x1.png",
+#   "lyrics_url":   "https://genius.com/Queen-bohemian-rhapsody-lyrics",
+#   "lyrics":       "[Intro]\nIs this the real life?..."
+# }
+```
+
+---
+
+## URL and ID Patterns
+
+| Resource    | URL pattern                                   | Notes                            |
+|-------------|-----------------------------------------------|----------------------------------|
+| Song page   | `genius.com/{Artist}-{song-slug}-lyrics`      | Slug is lowercased, hyphenated   |
+| Artist page | `genius.com/artists/{Artist}`                 | Title-cased artist name          |
+| Album page  | `genius.com/albums/{Artist}/{album-slug}`     |                                  |
+| Song API    | `genius.com/api/songs/{id}`                   | Internal; no auth required       |
+| Artist API  | `genius.com/api/artists/{id}`                 | Internal; no auth required       |
+| Artist songs| `genius.com/api/artists/{id}/songs?...`       | per_page, page, sort params      |
+| Search API  | `genius.com/api/search/multi?per_page=N&q=...`| Internal; multi-section results  |
+
+**Extracting song ID from a known lyrics URL:**
+
+```python
+# The slug alone cannot be decoded to an ID. Must fetch HTML or search.
+# From lyrics page HTML (fastest — one line):
+song_id = re.search(r'content="genius://songs/(\d+)"', html).group(1)
+
+# Or from __PRELOADED_STATE__ (same page, equally reliable):
+song_id = re.search(r'\\"song\\":\s*(\d+)', html).group(1)
+
+# Or from search API (no HTML required):
+sections = json.loads(genius_get(f"https://genius.com/api/search/multi?per_page=1&q={query}"))
+# then walk sections for type="song"
+```
+
+---
+
+## What Requires a Browser
+
+The following are **not available** via `genius_get` / HTTP:
+
+- **Search results page** (`/search?q=...`): renders client-side only. The
+  returned HTML contains no song results matching the query. Use the internal
+  search API (`/api/search/multi`) instead — it works without a browser.
+
+- **Public API** (`api.genius.com`): returns HTTP 401 without a Bearer token
+  even with a browser-like User-Agent. Must register at genius.com/developers
+  to obtain a client access token. The internal site API (`genius.com/api/*`)
+  is the no-auth alternative and returns equivalent data.
+
+- **Annotations content**: annotation HTML is embedded in `__PRELOADED_STATE__`
+  but the JSON is multi-escaped (six levels of backslash nesting) and cannot
+  be reliably parsed with plain string operations. Annotation IDs are
+  available but their body text is not easily extractable.
+
+- **Login-gated features**: user library, personalization, editor tools.
+
+---
+
+## Public API (api.genius.com) — Requires Bearer Token
+
+If you have a token (free registration at genius.com/developers):
+
+```python
+def genius_api(path, token):
+    """Call the official public API. path example: '/songs/1063'"""
+    import json
+    from helpers import http_get
+    url = f"https://api.genius.com{path}"
+    return json.loads(http_get(url, headers={"Authorization": f"Bearer {token}"}))
+
+# Returns same structure as the internal /api/* endpoints.
+# Endpoints: /songs/{id}, /artists/{id}, /artists/{id}/songs, /search?q=...
+# Without a token: HTTP 401 with body:
+# {"meta": {"status": 401, "message": "This call requires an access_token..."}}
+```
+
+---
+
+## Gotchas
+
+- **`http_get` returns 403**: The default `User-Agent: Mozilla/5.0` (bare) is
+  blocked. Add any OS string — `(Macintosh; Intel Mac OS X 10_15_7)` is
+  sufficient. Use the `genius_get` wrapper from this document.
+
+- **`data-lyrics-container` split across 3–5 divs**: Don't look for a single
+  lyrics block. Use `_extract_div_content` on all occurrences, then join.
+  Empty containers (`<div ...></div>`, 87 bytes) appear between sections —
+  the `if text:` guard skips them cleanly.
+
+- **`data-exclude-from-selection` header in first container**: The first
+  lyrics container includes a contributor credit header div. It must be
+  stripped before text extraction or the output will begin with
+  `"516 ContributorsTranslations..."` instead of `"[Intro]"`.
+
+- **`album` field vs `albums[0]`**: `song["album"]` is the "primary" album
+  used by Genius's album link (often a compilation or reissue). `song["albums"][0]`
+  is the first album in the full list and is typically the original release.
+  Verified: for Bohemian Rhapsody, `album.name` = "Studio Collection" but
+  `albums[0].name` = "A Night at the Opera".
+
+- **`__PRELOADED_STATE__` is not parseable**: The state is embedded as
+  `JSON.parse('...')` where the inner JSON is escaped six levels deep
+  (`\\\\\"` for a literal quote inside HTML content). Standard string
+  replacement fails due to `\\'` and `\$` sequences. Don't try to parse it —
+  use the `/api/songs/{id}` endpoint instead.
+
+- **No `__NEXT_DATA__`**: Genius does not use Next.js. There is no
+  `<script id="__NEXT_DATA__">` on any page.
+
+- **No JSON-LD**: Genius does not emit `<script type="application/ld+json">`.
+  Open Graph tags are present but minimal (only `og:title`, `og:image`,
+  `og:description`, `og:url`, `og:type`). Use the API for structured data.
+
+- **Search page is client-side only**: `GET /search?q=...` returns an HTML
+  shell with ~5 unrelated song links (trending, not query-matched). The actual
+  search results are fetched client-side by JavaScript. Use `/api/search/multi`
+  instead — it works without a browser and returns properly filtered results.
+
+- **Rate limiting**: No rate limiting observed across 10 rapid sequential
+  requests to `/api/songs/{id}` (avg 0.13s/request). Song lyrics pages
+  average 0.18s. No Retry-After headers observed.
+
+- **Cloudflare**: Present (confirmed by `<meta itemprop="cf-country">` and
+  `cf-cache-status` tags), but in pass-through mode — no JS challenge, no
+  CAPTCHA. A browser-like User-Agent is all that's needed.

--- a/domain-skills/glassdoor/scraping.md
+++ b/domain-skills/glassdoor/scraping.md
@@ -1,0 +1,543 @@
+# Glassdoor — Company Data, Reviews, Jobs & Salaries
+
+Field-tested against glassdoor.com on 2026-04-18.
+
+## Anti-bot verdict: browser required, no http_get workaround exists
+
+**`http_get` returns HTTP 403 on every Glassdoor URL without exception.**
+
+Tested endpoints (all 403):
+- `/Reviews/Google-Reviews-E9079.htm`
+- `/Overview/Working-at-Google-EI_IE9079.htm`
+- `/Job/jobs.htm?sc.keyword=software+engineer`
+- `/Salaries/software-engineer-salary-SRCH_KO0,17.htm`
+- `/graph` (GraphQL)
+- `sitemap.xml`
+
+UAs tested (all blocked): `Mozilla/5.0`, full Chrome 124, Googlebot, `curl/7.88.1`.
+
+**Stack:** Cloudflare Bot Management (`Server: cloudflare`, `Cf-Mitigated: challenge`).
+Challenge type: `managed` (JS-executed browser fingerprint check, no CAPTCHA widget, no user click
+required in a real browser). Cookie-only bypass also fails — the `__cf_bm` cookie returned in the
+403 response is bound to the browser TLS fingerprint and does not grant access when replayed.
+
+`api.glassdoor.com` (the old public partner API) returned `410 Gone` — permanently shut down.
+
+**Use `goto()` + `wait()` exclusively. Never use `http_get` for Glassdoor.**
+
+---
+
+## Do this first: open in a new tab, wait for CF to resolve
+
+```python
+new_tab("https://www.glassdoor.com/Reviews/Google-Reviews-E9079.htm")
+wait_for_load()
+wait(5)  # CF managed challenge runs for ~2-4s after readyState=complete
+```
+
+`wait(5)` is mandatory. CF's managed challenge executes JS fingerprinting probes after the DOM
+is ready. Extracting before this resolves returns an empty or partial page.
+
+Verify you are past the challenge before extracting:
+
+```python
+title = js("document.title")
+url = page_info()["url"]
+if "Security" in title or "__cf_chl_tk" in url:
+    # CF challenge did not resolve yet — wait longer
+    wait(5)
+    title = js("document.title")
+    assert "Security" not in title, "Still on CF block page"
+```
+
+---
+
+## URL patterns
+
+| Goal | URL |
+|---|---|
+| Company reviews | `/Reviews/{Company-slug}-Reviews-E{employer_id}.htm` |
+| Company overview | `/Overview/Working-at-{Company-slug}-EI_IE{employer_id}.htm` |
+| Company jobs | `/Jobs/{Company-slug}-Jobs-E{employer_id}.htm` |
+| Keyword job search | `/Job/jobs.htm?sc.keyword={keyword}` |
+| Keyword + location | `/Job/jobs.htm?sc.keyword={keyword}&locT=C&locKeyword={city}` |
+| Remote jobs | `/Job/jobs.htm?sc.keyword={keyword}&remoteWorkType=1` |
+| Job search page 2+ | append `&p=2`, `&p=3` |
+| Salary page | `/Salaries/{role-slug}-salary-SRCH_KO0,{len}.htm` |
+
+Employer IDs and company slugs are stable. Example: Google = `EI_IE9079`, slug = `Google`.
+
+Find the employer ID from a search result URL or the company's Glassdoor page URL.
+
+---
+
+## Workflow 1: Job search — extract result cards
+
+Glassdoor renders job cards client-side. Wait 5 seconds after load before extracting.
+
+```python
+import json
+from urllib.parse import quote_plus
+
+query = "software engineer"
+new_tab(f"https://www.glassdoor.com/Job/jobs.htm?sc.keyword={quote_plus(query)}")
+wait_for_load()
+wait(5)   # CF challenge + JS render
+
+# Dismiss cookie banner if present (GDPR regions)
+dismiss_cookie_banner()
+
+jobs = js("""
+(function() {
+  // Primary selector as of 2026-04
+  var cards = document.querySelectorAll('li[data-jobid]');
+  if (!cards.length) {
+    // Fallback: class-based (Next.js CSS modules use hashed suffixes — match prefix)
+    cards = document.querySelectorAll('[class*="JobsList_jobListItem"]');
+  }
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+    var jobId  = c.getAttribute('data-jobid') || '';
+    var titleEl = c.querySelector('[data-test="job-title"], a[class*="JobCard_jobTitle"]');
+    var compEl  = c.querySelector('[data-test="employer-name"], [class*="JobCard_employer"]');
+    var locEl   = c.querySelector('[data-test="emp-location"], [class*="JobCard_location"]');
+    var salEl   = c.querySelector('[data-test="detailSalary"], [class*="salary"], .salaryEstimate');
+    var ratingEl = c.querySelector('[data-test="rating"], [class*="ratingNumber"]');
+    var linkEl  = c.querySelector('a[href*="/job-listing/"], a[href*="glassdoor.com/job"]');
+    out.push({
+      jobId,
+      title:   titleEl  ? titleEl.innerText.trim()  : '',
+      company: compEl   ? compEl.innerText.trim()   : '',
+      location: locEl   ? locEl.innerText.trim()    : '',
+      salary:  salEl    ? salEl.innerText.trim()    : '',
+      rating:  ratingEl ? ratingEl.innerText.trim() : '',
+      url:     linkEl   ? linkEl.href               : '',
+    });
+  }
+  return JSON.stringify(out.filter(j => j.title));
+})()
+""")
+
+results = json.loads(jobs)
+for r in results:
+    print(r["title"], "|", r["company"], "|", r["location"])
+```
+
+**If `results` is empty:** take a screenshot and check which page you are on. Glassdoor often
+serves a different layout under A/B tests. The screenshot will reveal the actual card selector.
+
+```python
+screenshot("/tmp/glassdoor_jobs.png")
+# Inspect the image, then adjust the querySelectorAll selector above
+```
+
+---
+
+## Workflow 2: Job search pagination
+
+Glassdoor paginates via `&p=N` on the job search URL.
+
+```python
+import json
+from urllib.parse import quote_plus
+
+query = "data scientist"
+all_jobs = []
+
+for page in range(1, 4):   # pages 1-3, ~10 cards each
+    url = f"https://www.glassdoor.com/Job/jobs.htm?sc.keyword={quote_plus(query)}&p={page}"
+    goto(url)
+    wait_for_load()
+    wait(5 if page == 1 else 3)  # first page needs CF wait; subsequent pages are faster
+
+    if page == 1:
+        dismiss_cookie_banner()
+
+    batch_json = js("""
+    (function() {
+      var cards = document.querySelectorAll('li[data-jobid], [class*="JobsList_jobListItem"]');
+      var out = [];
+      for (var i = 0; i < cards.length; i++) {
+        var c = cards[i];
+        var jobId   = c.getAttribute('data-jobid') || '';
+        var titleEl = c.querySelector('[data-test="job-title"], a[class*="JobCard_jobTitle"]');
+        var compEl  = c.querySelector('[data-test="employer-name"]');
+        var locEl   = c.querySelector('[data-test="emp-location"]');
+        var salEl   = c.querySelector('[data-test="detailSalary"], [class*="salary"]');
+        var linkEl  = c.querySelector('a[href*="/job-listing/"]');
+        out.push({
+          jobId,
+          title:    titleEl ? titleEl.innerText.trim() : '',
+          company:  compEl  ? compEl.innerText.trim()  : '',
+          location: locEl   ? locEl.innerText.trim()   : '',
+          salary:   salEl   ? salEl.innerText.trim()   : '',
+          url:      linkEl  ? linkEl.href               : '',
+        });
+      }
+      return JSON.stringify(out.filter(j => j.title));
+    })()
+    """)
+
+    batch = json.loads(batch_json)
+    if not batch:
+        break   # no more results
+    all_jobs.extend(batch)
+
+print(f"Collected {len(all_jobs)} jobs across {page} pages")
+```
+
+---
+
+## Workflow 3: Company overview — rating and review count
+
+Navigate to the company Overview or Reviews page. These pages require login for full content but the
+summary header (overall rating, review count, recommend %) is visible without login.
+
+```python
+import json, re
+
+# Example: Google (employer_id=9079)
+employer_id = 9079
+company_slug = "Google"
+
+goto(f"https://www.glassdoor.com/Overview/Working-at-{company_slug}-EI_IE{employer_id}.htm")
+wait_for_load()
+wait(5)   # CF challenge
+
+# Try __NEXT_DATA__ first — fastest and most complete
+next_data_raw = js("document.getElementById('__NEXT_DATA__') ? document.getElementById('__NEXT_DATA__').textContent : null")
+
+if next_data_raw:
+    nd = json.loads(next_data_raw)
+    # Company data lives under props.pageProps — path varies by page type
+    # Try employer overview path
+    props = nd.get("props", {}).get("pageProps", {})
+    employer = props.get("employer") or props.get("employerOverview")
+    if employer:
+        print("Rating:", employer.get("overallRating"))
+        print("Reviews:", employer.get("reviewCount") or employer.get("numberOfReviews"))
+        print("Name:", employer.get("name") or employer.get("shortName"))
+else:
+    # Fall back to DOM selectors
+    summary = js("""
+    (function() {
+      var ratingEl  = document.querySelector('[data-test="rating"], .ratingNumber, [class*="ratingNum"]');
+      var countEl   = document.querySelector('[data-test="reviewCount"], .reviewCount, [class*="reviewCount"]');
+      var nameEl    = document.querySelector('h1[data-test="employer-name"], [class*="EmployerProfile_name"]');
+      var recEl     = document.querySelector('[data-test="recommend"], [class*="recommend"]');
+      return JSON.stringify({
+        rating:  ratingEl ? ratingEl.innerText.trim() : '',
+        reviews: countEl  ? countEl.innerText.trim()  : '',
+        name:    nameEl   ? nameEl.innerText.trim()   : '',
+        recommend: recEl  ? recEl.innerText.trim()    : '',
+      });
+    })()
+    """)
+    print(json.loads(summary))
+```
+
+---
+
+## Workflow 4: Company reviews page — extract individual reviews
+
+Reviews pages show up to ~10 reviews per page without login. A login modal appears after scrolling.
+Extract before scrolling.
+
+```python
+import json
+
+employer_id = 9079
+company_slug = "Google"
+
+goto(f"https://www.glassdoor.com/Reviews/{company_slug}-Reviews-E{employer_id}.htm")
+wait_for_load()
+wait(5)
+
+dismiss_cookie_banner()
+
+reviews = js("""
+(function() {
+  // Review cards — confirmed selector pattern
+  var cards = document.querySelectorAll('[id^="empReview_"], [data-test="review-card"], [class*="ReviewCard"]');
+  if (!cards.length) {
+    cards = document.querySelectorAll('article[class*="review"]');
+  }
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+
+    // Overall star rating (1-5)
+    var starsEl = c.querySelector('[data-test="review-rating"], [class*="starRating"], span[class*="ratingNumber"]');
+    var stars = starsEl ? starsEl.innerText.trim() : '';
+
+    // Pros / Cons text
+    var prosEl = c.querySelector('[data-test="pros"], [class*="pros"], p[class*="pros"]');
+    var consEl = c.querySelector('[data-test="cons"], [class*="cons"], p[class*="cons"]');
+    var pros = prosEl ? prosEl.innerText.trim() : '';
+    var cons = consEl ? consEl.innerText.trim() : '';
+
+    // Review title
+    var titleEl = c.querySelector('[data-test="review-title"], h2[class*="reviewTitle"], [class*="title"] a');
+    var title = titleEl ? titleEl.innerText.trim() : '';
+
+    // Job title of reviewer
+    var jobTitleEl = c.querySelector('[data-test="reviewer-job-title"], [class*="reviewerInfo"], [class*="authorJobTitle"]');
+    var jobTitle = jobTitleEl ? jobTitleEl.innerText.trim() : '';
+
+    // Date
+    var dateEl = c.querySelector('time, [data-test="review-date"], [class*="reviewDate"]');
+    var date = dateEl ? (dateEl.getAttribute('datetime') || dateEl.innerText.trim()) : '';
+
+    if (pros || cons || title) {
+      out.push({stars, title, jobTitle, pros, cons, date});
+    }
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+results = json.loads(reviews)
+for r in results:
+    print(f"{r['stars']}★ | {r['title']} | {r['jobTitle']}")
+    print(f"  + {r['pros'][:100]}")
+    print(f"  - {r['cons'][:100]}")
+```
+
+---
+
+## Workflow 5: Salary page — extract reported salary data
+
+```python
+import json
+from urllib.parse import quote_plus
+
+# Salary pages use slug + character-count in the URL (n = len(role_slug))
+role = "software-engineer"
+n = len(role)  # 17 for "software-engineer"
+
+goto(f"https://www.glassdoor.com/Salaries/{role}-salary-SRCH_KO0,{n}.htm")
+wait_for_load()
+wait(5)
+
+# Try __NEXT_DATA__ for structured salary data
+next_data_raw = js("document.getElementById('__NEXT_DATA__') ? document.getElementById('__NEXT_DATA__').textContent : null")
+
+if next_data_raw:
+    nd = json.loads(next_data_raw)
+    # Salary data is typically under props.pageProps.salaryData or .salaryEstimate
+    props = nd.get("props", {}).get("pageProps", {})
+    salary_data = props.get("salaryData") or props.get("payData")
+    if salary_data:
+        print(json.dumps(salary_data, indent=2))
+
+# DOM fallback
+salary_summary = js("""
+(function() {
+  var medianEl = document.querySelector('[data-test="salary-estimate"], [class*="salaryEstimate"], [class*="median"]');
+  var rangeEl  = document.querySelector('[data-test="salary-range"],  [class*="salaryRange"]');
+  var countEl  = document.querySelector('[data-test="salary-count"],  [class*="salaryCount"]');
+  return JSON.stringify({
+    median:  medianEl ? medianEl.innerText.trim() : '',
+    range:   rangeEl  ? rangeEl.innerText.trim()  : '',
+    count:   countEl  ? countEl.innerText.trim()  : '',
+  });
+})()
+""")
+print(json.loads(salary_summary))
+```
+
+---
+
+## Handling the login modal
+
+Glassdoor shows a sign-in modal:
+- On Reviews/Salary pages: after viewing ~3-5 items (scroll-triggered)
+- On job detail pages: often immediately
+
+Dismiss it before extracting anything that requires scrolling:
+
+```python
+def dismiss_glassdoor_login_modal():
+    """Close the Glassdoor sign-in modal. Safe to call if no modal is present."""
+    closed = js("""
+    (function() {
+      var selectors = [
+        '[alt="Close"]',
+        'button[class*="modal_closeIcon"]',
+        '[data-test="close-modal"]',
+        '[aria-label="Close"]',
+        'button[data-test="CloseButton"]',
+        '[class*="CloseButton"]',
+      ];
+      for (var i = 0; i < selectors.length; i++) {
+        var btn = document.querySelector(selectors[i]);
+        if (btn && btn.offsetParent !== null) {
+          btn.click();
+          return selectors[i];
+        }
+      }
+      return null;
+    })()
+    """)
+    if closed:
+        wait(1)
+    return closed
+
+def dismiss_cookie_banner():
+    """Dismiss GDPR consent overlay. Safe to call even if no banner is present."""
+    dismissed = js("""
+    (function() {
+      var selectors = [
+        'button[data-test="accept-cookies"]',
+        '#onetrust-accept-btn-handler',
+        'button[id*="accept-all"]',
+        'button[class*="accept"]',
+        'button[class*="consent"]',
+      ];
+      for (var i = 0; i < selectors.length; i++) {
+        var btn = document.querySelector(selectors[i]);
+        if (btn && btn.offsetParent !== null) {
+          btn.click();
+          return selectors[i];
+        }
+      }
+      return null;
+    })()
+    """)
+    if dismissed:
+        wait(1)
+    return dismissed
+```
+
+For Reviews/Salary pages: call `dismiss_glassdoor_login_modal()` immediately after the initial
+wait, before any scrolling. Once you scroll down, the modal blocks the page and the X button
+may itself be outside the viewport.
+
+---
+
+## Detecting whether you are past the CF challenge
+
+After `goto()` + `wait(5)`, confirm you are on the real page:
+
+```python
+def glassdoor_is_cf_blocked() -> bool:
+    """True if the CF managed challenge is still running."""
+    title = js("document.title") or ""
+    url   = page_info()["url"]
+    return "Security" in title or "__cf_chl_tk" in url
+
+# Usage
+goto("https://www.glassdoor.com/Reviews/Google-Reviews-E9079.htm")
+wait_for_load()
+wait(5)
+
+if glassdoor_is_cf_blocked():
+    wait(10)   # give CF extra time
+    if glassdoor_is_cf_blocked():
+        screenshot("/tmp/glassdoor_cf_block.png")
+        raise RuntimeError("CF challenge did not resolve — check screenshot")
+```
+
+---
+
+## Glassdoor company ID lookup
+
+Glassdoor uses numeric employer IDs (e.g., Google = 9079, Apple = 1138, Meta = 40772).
+To find the ID for any company:
+
+```python
+from urllib.parse import quote_plus
+
+company_name = "OpenAI"
+goto(f"https://www.glassdoor.com/Search/results.htm?keyword={quote_plus(company_name)}&locT=N")
+wait_for_load()
+wait(5)
+
+# Extract company cards from search results
+companies = js("""
+(function() {
+  var cards = document.querySelectorAll('[data-test="employer-card"], [class*="EmployerCard"], [class*="employer-card"]');
+  var out = [];
+  for (var i = 0; i < cards.length; i++) {
+    var c = cards[i];
+    var link = c.querySelector('a[href*="Overview"], a[href*="Reviews"]');
+    if (!link) continue;
+    var href = link.href;
+    // Extract employer ID: EI_IE{id} or E{id}
+    var m = href.match(/E(?:I_IE)?(\d+)/);
+    var empId = m ? m[1] : '';
+    var nameEl = c.querySelector('[class*="EmployerCard_name"], h2, [class*="name"]');
+    out.push({
+      empId,
+      name: nameEl ? nameEl.innerText.trim() : '',
+      href,
+    });
+  }
+  return JSON.stringify(out);
+})()
+""")
+
+import json
+for c in json.loads(companies):
+    print(c["empId"], c["name"], c["href"][:60])
+```
+
+---
+
+## Gotchas
+
+- **`http_get` is permanently blocked.** Cloudflare Bot Management blocks every IP-level request
+  with a JS managed challenge. No User-Agent, cookie, or header combination bypasses it. The
+  `__cf_bm` cookie returned in the 403 response is TLS-fingerprint-bound and cannot be replayed.
+  `api.glassdoor.com` is 410 Gone (shut down). Only real Chrome via CDP works.
+
+- **`wait(5)` minimum after `wait_for_load()`.** CF's managed challenge runs for 2-4 seconds after
+  `readyState = complete`. Extracting too early returns the challenge page HTML, not Glassdoor
+  content. If you get empty results or the title is "Security | Glassdoor", wait longer.
+
+- **Login modal triggers on scroll, not on load.** Extract all visible content immediately on page
+  load before any scrolling. Call `dismiss_glassdoor_login_modal()` right after the initial wait —
+  before issuing any `scroll()` calls.
+
+- **Glassdoor shows ~10 cards without login.** Reviews and salary pages are severely limited
+  without an account. Job search cards are more accessible (~10-15 per page). If you need 30+
+  reviews, a logged-in session is required.
+
+- **CSS class names use Next.js hashed suffixes.** Selectors like `[class*="JobCard_jobTitle"]`
+  match despite the hash suffix (e.g., `JobCard_jobTitle__abc12`). Never hardcode the full hashed
+  class name — it changes with deployments. Always use `[class*="prefix"]`.
+
+- **`__NEXT_DATA__` is the fast path.** When accessible, Glassdoor's Next.js pages embed all page
+  data in `<script id="__NEXT_DATA__" type="application/json">`. Parse it before falling back to
+  DOM queries. Data path varies by page type: look under `props.pageProps.employer`,
+  `props.pageProps.salaryData`, `props.pageProps.jobListings`, etc.
+
+- **Company URL slugs and IDs are stable.** The employer ID (e.g., `9079` for Google) never
+  changes. Slugs occasionally change when a company rebrands — always verify by following the
+  canonical redirect from a search result.
+
+- **Rate limiting.** Glassdoor rate-limits by IP after ~5 company-page loads per minute.
+  Use `wait(5)` between consecutive company page navigations. Salary and reviews pages are heavier
+  — use `wait(8)` between those.
+
+- **Salary URL requires character-count parameter.** The `SRCH_KO0,{n}` fragment encodes
+  `0` (start of role name) and `n` (end, i.e., `len(role_slug)`). For `"software-engineer"` (17
+  chars): `SRCH_KO0,17`. Wrong count returns a 404.
+
+- **`locKeyword` vs `locId` for location filter.** `locKeyword=San+Francisco` works without
+  knowing Glassdoor's internal city ID. `locT=C` means city-type location. For metro areas,
+  also try `locT=M`. Omit `locId` unless you have the exact numeric ID from a Glassdoor URL.
+
+- **PerimeterX is also active as a secondary layer.** After passing CF, Glassdoor runs behavioral
+  fingerprinting. Rapid automated scrolling, mouse movement, or navigation patterns may trigger a
+  secondary block. Mitigate with `wait(2)` between actions and avoid scripted mouse movement.
+
+- **Review and salary data require login on some accounts.** Anonymous sessions get a subset of
+  data. If a field returns empty consistently, the page may require authentication before surfacing
+  that data in the DOM or `__NEXT_DATA__`.
+
+- **`goto()` vs `new_tab()` for first navigation.** Use `new_tab()` for the very first Glassdoor
+  page in a session. If the harness is attached to a non-Glassdoor tab, `goto()` can silently
+  fail to pass the CF challenge because the existing tab may not have a clean origin context.
+  After the first successful load, `goto()` works fine for subsequent Glassdoor navigations.

--- a/domain-skills/gutenberg/scraping.md
+++ b/domain-skills/gutenberg/scraping.md
@@ -1,0 +1,383 @@
+# Project Gutenberg — Scraping & Data Extraction
+
+`https://www.gutenberg.org` — 78 000+ free public-domain ebooks. Every workflow here is pure `http_get` — no browser needed.
+
+## Do this first
+
+**Use the Gutendex REST API (`gutendex.com`) for all search and discovery. It is one call, returns clean JSON, and requires no auth. Go to gutenberg.org URLs only to fetch actual file content.**
+
+```python
+import json
+
+# Search by title/author keyword
+data = json.loads(http_get("https://gutendex.com/books/?search=pride+and+prejudice"))
+# data['count'] = 6 (total matches)
+# data['results'] = list of up to 32 book objects
+book = data['results'][0]
+# book['id'] = 1342  ← use this ID for all further calls
+# book['formats']['text/plain; charset=utf-8'] = direct txt URL
+
+# Fetch the plain-text content of that book
+text = http_get(book['formats']['text/plain; charset=utf-8'])
+# Returns 763 083 chars including Project Gutenberg header/footer boilerplate
+```
+
+For a known book ID, skip search entirely:
+
+```python
+book = json.loads(http_get("https://gutendex.com/books/1342/"))
+```
+
+## Common workflows
+
+### Search by keyword and get the first result
+
+```python
+import json
+
+data = json.loads(http_get("https://gutendex.com/books/?search=frankenstein"))
+if data['results']:
+    b = data['results'][0]
+    print(b['id'], b['title'], b['authors'][0]['name'])
+    # 84  Frankenstein; or, the modern prometheus  Shelley, Mary Wollstonecraft
+    txt_url = b['formats'].get('text/plain; charset=utf-8')
+    if txt_url:
+        text = http_get(txt_url)
+```
+
+### Get the most downloaded books (popularity ranking)
+
+```python
+import json
+
+data = json.loads(http_get("https://gutendex.com/books/?sort=popular"))
+for b in data['results'][:10]:
+    authors = ', '.join(a['name'] for a in b['authors'])
+    print(f"[{b['id']}] {b['title']} — {authors} ({b['download_count']:,} downloads)")
+# [84]    Frankenstein                      — Shelley, Mary Wollstonecraft  (178,271)
+# [45304] The City of God, Volume I         — Augustine, of Hippo, Saint    (147,663)
+# [2701]  Moby Dick; Or, The Whale          — Melville, Herman              (112,302)
+# [1342]  Pride and Prejudice               — Austen, Jane                  (107,502)
+# [768]   Wuthering Heights                 — Brontë, Emily                  (72,775)
+# [1513]  Romeo and Juliet                  — Shakespeare, William           (70,272)
+# [11]    Alice's Adventures in Wonderland  — Carroll, Lewis                 (65,243)
+# [64317] The Great Gatsby                  — Fitzgerald, F. Scott           (60,632)
+# [100]   Complete Works of Shakespeare     — Shakespeare, William           (60,527)
+# [1260]  Jane Eyre: An Autobiography       — Brontë, Charlotte              (57,602)
+```
+
+### Browse by genre / topic
+
+```python
+import json
+
+# 'topic' matches both subjects and bookshelves fields
+data = json.loads(http_get("https://gutendex.com/books/?topic=science+fiction"))
+# data['count'] = 3473 total results, 32 per page
+
+data = json.loads(http_get("https://gutendex.com/books/?topic=detective+fiction"))
+# data['count'] = 111
+# data['results'][0]: id=1661 The Adventures of Sherlock Holmes — Doyle, Arthur Conan
+
+# Filter by language (ISO 639-1 code)
+data = json.loads(http_get("https://gutendex.com/books/?languages=fr&topic=roman"))
+# data['count'] = 254 French books with 'roman' in topic
+```
+
+### Paginate through results
+
+```python
+import json
+
+url = "https://gutendex.com/books/?topic=science+fiction"
+books = []
+while url:
+    data = json.loads(http_get(url))
+    books.extend(data['results'])
+    url = data['next']   # None on last page
+    # data['previous'] is also populated after page 1
+    # e.g. data['next'] = "https://gutendex.com/books/?page=3&topic=science+fiction"
+# All 3473 sci-fi books loaded across ~109 pages of 32 each
+```
+
+### Fetch multiple specific books by ID
+
+```python
+import json
+
+data = json.loads(http_get("https://gutendex.com/books/?ids=1342,11,84"))
+# Returns exactly those 3 books, count=3
+for b in data['results']:
+    print(b['id'], b['title'])
+# 84    Frankenstein; or, the modern prometheus
+# 1342  Pride and Prejudice
+# 11    Alice's Adventures in Wonderland
+```
+
+### Read the plain text of a book (boilerplate stripped)
+
+```python
+raw = http_get("https://www.gutenberg.org/cache/epub/1342/pg1342.txt")
+# 763 083 chars total including PG licence header and footer
+
+START = "*** START OF THE PROJECT GUTENBERG EBOOK"
+END   = "*** END OF THE PROJECT GUTENBERG EBOOK"
+s = raw.find(START)
+e = raw.find(END)
+if s != -1:
+    content = raw[raw.index('\n', s) + 1 : e].strip()
+    # 743 241 chars of actual novel text
+```
+
+The cache URL is the most reliable direct path. The `formats` dict in Gutendex also provides a redirect URL that resolves to the same file:
+
+```python
+# Both of these return identical content (763 083 chars):
+http_get("https://www.gutenberg.org/ebooks/1342.txt.utf-8")          # redirect
+http_get("https://www.gutenberg.org/cache/epub/1342/pg1342.txt")     # direct cache
+```
+
+### Download formats available per book
+
+Every book's `formats` dict maps MIME type to URL. All URLs resolve to `/cache/epub/{id}/` files via redirect.
+
+| MIME type | URL pattern (after redirect) | Typical size |
+|---|---|---|
+| `text/plain; charset=utf-8` | `pg{id}.txt` | ~750 KB |
+| `text/html` | `pg{id}-images.html` | ~850 KB |
+| `application/epub+zip` | `pg{id}-images-3.epub` | ~25 MB |
+| `application/x-mobipocket-ebook` | `pg{id}-images-kf8.mobi` | ~25 MB |
+| `application/rdf+xml` | `{id}.rdf` via gutenberg.org | metadata XML |
+| `image/jpeg` | `pg{id}.cover.medium.jpg` | cover image |
+| `application/octet-stream` | `pg{id}-h.zip` | HTML+images zip |
+
+```python
+import json
+
+b = json.loads(http_get("https://gutendex.com/books/1342/"))
+# Grab every downloadable format URL:
+for mime, url in b['formats'].items():
+    print(mime, '->', url)
+# text/html                         -> https://www.gutenberg.org/ebooks/1342.html.images
+# application/epub+zip              -> https://www.gutenberg.org/ebooks/1342.epub3.images
+# application/x-mobipocket-ebook   -> https://www.gutenberg.org/ebooks/1342.kf8.images
+# application/rdf+xml               -> https://www.gutenberg.org/ebooks/1342.rdf
+# image/jpeg                        -> https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg
+# application/octet-stream          -> https://www.gutenberg.org/cache/epub/1342/pg1342-h.zip
+# text/plain; charset=utf-8         -> https://www.gutenberg.org/ebooks/1342.txt.utf-8
+```
+
+### Fetch RDF/XML metadata for a book
+
+```python
+import re
+
+rdf = http_get("https://www.gutenberg.org/cache/epub/1342/pg1342.rdf")
+# Also available as: http_get("https://www.gutenberg.org/ebooks/1342.rdf")
+
+title     = re.search(r'<dcterms:title>(.*?)</dcterms:title>', rdf, re.DOTALL)
+creator   = re.findall(r'<pgterms:name>(.*?)</pgterms:name>', rdf)
+birth     = re.findall(r'<pgterms:birthdate[^>]*>(\d+)', rdf)
+death     = re.findall(r'<pgterms:deathdate[^>]*>(\d+)', rdf)
+issued    = re.search(r'<dcterms:issued[^>]*>(.*?)</dcterms:issued>', rdf)
+rights    = re.search(r'<dcterms:rights>(.*?)</dcterms:rights>', rdf)
+downloads = re.search(r'<pgterms:downloads[^>]*>(\d+)</pgterms:downloads>', rdf)
+language  = re.search(r'<dcterms:language>.*?<rdf:value>(.*?)</rdf:value>', rdf, re.DOTALL)
+subjects  = re.findall(r'<dcterms:subject>.*?<rdf:value>(.*?)</rdf:value>.*?</dcterms:subject>', rdf, re.DOTALL)
+
+print(title.group(1))          # Pride and Prejudice
+print(creator)                 # ['Austen, Jane']
+print(birth, death)            # ['1775'] ['1817']
+print(issued.group(1))         # 1998-06-01
+print(rights.group(1))         # Public domain in the USA.
+print(int(downloads.group(1))) # 107502
+print(subjects[:3])            # ['England -- Fiction', 'Young women -- Fiction', 'Love stories']
+```
+
+Note: `<dcterms:language>` value is a subject string, not a language code. For language codes use the Gutendex `languages` field instead.
+
+### Search the HTML catalog (25 results per page)
+
+Use this only when you need to leverage Gutenberg's own search index (author:, title:, subject: prefix syntax).
+
+```python
+import re, json
+
+html = http_get(
+    "https://www.gutenberg.org/ebooks/search/"
+    "?query=shakespeare&sort_order=downloads"
+)
+# sort_order options: downloads, title, release_date, last_update, random
+
+entries = re.findall(r'<li class="booklink">(.*?)</li>', html, re.DOTALL)
+books = []
+for e in entries:
+    book_id   = re.search(r'/ebooks/(\d+)', e)
+    title     = re.search(r'<span class="title">(.*?)</span>', e)
+    author    = re.search(r'<span class="subtitle">(.*?)</span>', e)
+    downloads = re.search(r'<span class="extra">([^<]+)</span>', e)
+    books.append({
+        'id':        int(book_id.group(1)) if book_id else None,
+        'title':     title.group(1) if title else '',
+        'author':    author.group(1) if author else '',
+        'downloads': downloads.group(1).strip() if downloads else '',
+    })
+
+# books[0] = {'id': 1513, 'title': 'Romeo and Juliet',
+#             'author': 'William Shakespeare', 'downloads': '74316 downloads'}
+
+# Paginate with start_index (25 per page)
+html_p2 = http_get(
+    "https://www.gutenberg.org/ebooks/search/"
+    "?query=shakespeare&sort_order=downloads&start_index=26"
+)
+```
+
+### Browse a bookshelf (curated genre list)
+
+```python
+import re
+
+# Bookshelf 68 = Science Fiction
+html = http_get("https://www.gutenberg.org/ebooks/bookshelf/68")
+titles = re.findall(r'<span class="title">(.*?)</span>', html)
+# ['Twenty Thousand Leagues under the Sea', 'The War of the Worlds',
+#  'The Time Machine', 'Thuvia, Maid of Mars', ...]
+```
+
+### OPDS catalog (machine-readable Atom feed)
+
+```python
+import re
+
+feed = http_get("https://www.gutenberg.org/ebooks/search.opds/?query=dracula")
+# Returns Atom XML, 7 entries per page (including 1 metadata entry)
+entries = re.findall(r'<entry>(.*?)</entry>', feed, re.DOTALL)
+for e in entries:
+    title = re.search(r'<title>(.*?)</title>', e)
+    entry_id = re.search(r'<id>(.*?)</id>', e)
+    if title and entry_id and 'opds' in entry_id.group(1):
+        book_id = re.search(r'/ebooks/(\d+)\.opds', entry_id.group(1))
+        print(book_id.group(1), title.group(1))
+# 345  Dracula
+```
+
+## Gutendex API — full response schema
+
+Validated against a real call to `GET https://gutendex.com/books/1342/`:
+
+```json
+{
+  "id": 1342,
+  "title": "Pride and Prejudice",
+  "authors": [
+    {"name": "Austen, Jane", "birth_year": 1775, "death_year": 1817}
+  ],
+  "summaries": ["...automatically generated summary..."],
+  "editors": [],
+  "translators": [],
+  "subjects": [
+    "Courtship -- Fiction",
+    "Domestic fiction",
+    "England -- Fiction",
+    "Love stories",
+    "Sisters -- Fiction",
+    "Women -- England -- Fiction",
+    "Young women -- Fiction"
+  ],
+  "bookshelves": [
+    "Best Books Ever Listings",
+    "Category: British Literature",
+    "Category: Classics of Literature",
+    "Category: Novels",
+    "Category: Romance",
+    "Harvard Classics"
+  ],
+  "languages": ["en"],
+  "copyright": false,
+  "media_type": "Text",
+  "formats": {
+    "text/html":                       "https://www.gutenberg.org/ebooks/1342.html.images",
+    "application/epub+zip":            "https://www.gutenberg.org/ebooks/1342.epub3.images",
+    "application/x-mobipocket-ebook": "https://www.gutenberg.org/ebooks/1342.kf8.images",
+    "application/rdf+xml":             "https://www.gutenberg.org/ebooks/1342.rdf",
+    "image/jpeg":                      "https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg",
+    "application/octet-stream":        "https://www.gutenberg.org/cache/epub/1342/pg1342-h.zip",
+    "text/plain; charset=utf-8":       "https://www.gutenberg.org/ebooks/1342.txt.utf-8"
+  },
+  "download_count": 107502
+}
+```
+
+List response wrapper (from `GET /books/`):
+
+```json
+{
+  "count": 6,
+  "next": null,
+  "previous": null,
+  "results": [...]
+}
+```
+
+`count` is the total across all pages. `next` / `previous` are fully-formed URLs ready to pass to `http_get`, or `null` when absent.
+
+## Gutendex query parameters
+
+All parameters combine freely.
+
+| Parameter | Example | Notes |
+|---|---|---|
+| `search` | `search=moby+dick` | Matches title and author |
+| `ids` | `ids=1342,11,84` | Comma-separated; returns only those books |
+| `languages` | `languages=fr` | ISO 639-1 code; comma-separated for multiple |
+| `topic` | `topic=science+fiction` | Matches subjects + bookshelves |
+| `author_year_start` | `author_year_start=1800` | Author born on/after year |
+| `author_year_end` | `author_year_end=1850` | Author born on/before year |
+| `copyright` | `copyright=false` | `false`=public domain, `true`=copyrighted |
+| `sort` | `sort=popular` | `popular` (default), `ascending`, `descending` |
+| `page` | `page=2` | 1-based; 32 results per page (not configurable) |
+
+`page_size` is not supported — always 32 results per page regardless.
+
+## Finding book IDs
+
+Three ways, in order of preference:
+
+1. **Gutendex search** — returns `id` directly in JSON.
+2. **Gutenberg HTML catalog** — `book_id = re.search(r'/ebooks/(\d+)', entry)`. IDs in the URL.
+3. **URL pattern** — `https://www.gutenberg.org/ebooks/{id}` — if you already know the ID from any source.
+
+Notable IDs validated in tests: `84` (Frankenstein), `1342` (Pride and Prejudice), `11` (Alice in Wonderland), `2701` (Moby Dick), `64317` (The Great Gatsby), `1513` (Romeo and Juliet), `100` (Complete Works of Shakespeare), `1661` (Adventures of Sherlock Holmes), `345` (Dracula).
+
+## Rate limits
+
+Gutendex (`gutendex.com`) returns no `X-RateLimit-*` headers. Server is Apache/2.4.58 on Ubuntu. Rapid sequential calls can trigger connection resets — observed a timeout on the second call in a tight loop. Add a small delay between calls when paginating:
+
+```python
+import time, json
+
+url = "https://gutendex.com/books/?sort=popular"
+while url:
+    data = json.loads(http_get(url))
+    # ... process data['results'] ...
+    url = data['next']
+    if url:
+        time.sleep(0.5)   # be respectful — no published rate limit but timeouts observed
+```
+
+For gutenberg.org file downloads (txt, epub, etc.) there is no documented rate limit but Gutenberg asks not to use automated bulk downloading; use their [offline catalogs](https://www.gutenberg.org/ebooks/offline_catalogs.html) for bulk access.
+
+## Gotchas
+
+- **`.opf` 404**: `https://www.gutenberg.org/cache/epub/1342/pg1342.opf` returns 404. Use `.rdf` instead — same path prefix, same data in RDF/XML.
+- **`formats` URLs redirect**: URLs like `https://www.gutenberg.org/ebooks/1342.txt.utf-8` are redirect endpoints that resolve to `/cache/epub/1342/pg1342.txt`. Either form works with `http_get` (urllib follows redirects automatically), but the `/cache/epub/` direct URL avoids an extra round trip.
+- **Two text files**: `/files/1342/1342-0.txt` (older Project Gutenberg edition, 729 KB) and `/cache/epub/1342/pg1342.txt` (modern edition, 763 KB) contain different versions of the same book. The Gutendex `formats` entry always points to the cache/modern version.
+- **Boilerplate**: Every `.txt` file opens with a PG licence header and closes with a footer. Strip with `START`/`END` markers (see "Read the plain text" section above).
+- **`summaries` field is AI-generated**: The `summaries` array in Gutendex responses contains automatically generated summaries, not the author's original blurb.
+- **`copyright: false`** means public domain in the USA. Non-US copyright status is not tracked.
+- **`page_size` ignored**: Passing `?page_size=5` to Gutendex has no effect — always returns 32 results.
+- **Gutendex `sort=ascending/descending`** sorts by ID (oldest/newest book in the catalog), not by title or author name.
+- **Catalog search `author:` prefix**: `?query=author:dickens` searches within author names but Gutenberg's relevance ranking is fuzzy and can return unexpected results. For precise author lookup use Gutendex `?search=charles+dickens`.
+- **OPDS pagination**: Only 7 entries per page (1 metadata + 6 books). Slow for bulk extraction — use Gutendex instead.
+- **HTML catalog `start_index`**: Pagination is 25 per page. Next page = `start_index=26`, then `51`, `76`, etc. The value appears in the rendered HTML (`re.findall(r'start_index=(\d+)', html)` returns the next page's value).

--- a/domain-skills/howlongtobeat/scraping.md
+++ b/domain-skills/howlongtobeat/scraping.md
@@ -1,0 +1,473 @@
+# HowLongToBeat — Scraping & Data Extraction
+
+Field-tested against howlongtobeat.com on 2026-04-18. All code blocks validated with live requests.
+
+## Do this first
+
+**Use the search API — it returns structured JSON with all completion times in one POST call.**
+
+HLTB runs a token-gated POST endpoint at `/api/find`. You must first fetch a session token from `/api/find/init`, then include it in the search request. Both steps are plain HTTP — no browser required.
+
+```python
+import json, re, urllib.request, time
+from helpers import http_get
+
+UA = "Mozilla/5.0"
+
+def get_token():
+    """Fetch a fresh session token. Token encodes IP+UA+timestamp, reusable for ~15 min."""
+    url = f"https://howlongtobeat.com/api/find/init?t={int(time.time()*1000)}"
+    data = http_get(url, headers={"Referer": "https://howlongtobeat.com/"})
+    return json.loads(data)  # {token, hpKey, hpVal}
+
+def search_hltb(title, size=20, page=1, token_data=None):
+    """
+    Search HLTB for games. Returns raw API dict:
+    {count, pageCurrent, pageTotal, pageSize, data: [...]}
+    token_data can be reused across searches (fetch once, use many times).
+    """
+    if token_data is None:
+        token_data = get_token()
+    hp_key, hp_val = token_data['hpKey'], token_data['hpVal']
+    payload = {
+        "searchType": "games",
+        "searchTerms": title.split(),
+        "searchPage": page,
+        "size": size,
+        "searchOptions": {
+            "games": {
+                "userId": 0, "platform": "", "sortCategory": "popular",
+                "rangeCategory": "main", "rangeTime": {"min": None, "max": None},
+                "gameplay": {"perspective": "", "flow": "", "genre": "", "difficulty": ""},
+                "rangeYear": {"min": "", "max": ""}, "modifier": ""
+            },
+            "users": {"sortCategory": "postcount"},
+            "lists": {"sortCategory": "follows"},
+            "filter": "", "sort": 0, "randomizer": 0
+        },
+        "useCache": True,
+        hp_key: hp_val      # honeypot field — key and value vary per token
+    }
+    req = urllib.request.Request(
+        "https://howlongtobeat.com/api/find",
+        data=json.dumps(payload).encode(),
+        headers={
+            "User-Agent": UA,
+            "Content-Type": "application/json",
+            "Origin": "https://howlongtobeat.com",
+            "Referer": "https://howlongtobeat.com/",
+            "x-auth-token": token_data['token'],
+            "x-hp-key": hp_key,
+            "x-hp-val": hp_val,
+        },
+        method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read().decode())
+
+# Usage
+tok = get_token()
+
+result = search_hltb("elden ring", token_data=tok, size=3)
+for g in result['data']:
+    print(g['game_id'], g['game_name'], g['release_world'])
+    print(f"  Main: {g['comp_main']/3600:.1f}h  +Extras: {g['comp_plus']/3600:.1f}h  100%: {g['comp_100']/3600:.1f}h")
+
+# Confirmed output (2026-04-18):
+# 68151 Elden Ring 2022
+#   Main: 60.0h  +Extras: 101.2h  100%: 135.5h
+# 160589 Elden Ring: Nightreign 2025
+#   Main: 28.1h  +Extras: 40.1h  100%: 66.9h
+# 139385 Elden Ring: Shadow of the Erdtree 2024
+#   Main: 25.7h  +Extras: 39.0h  100%: 51.1h
+```
+
+Token is reusable — fetch it once and pass it to multiple `search_hltb()` calls. No need to re-fetch per search.
+
+---
+
+## Fastest approach: search + parse in one helper
+
+```python
+import json, re, urllib.request, time
+from helpers import http_get
+
+UA = "Mozilla/5.0"
+
+def hltb_search(title, size=5):
+    """One-shot: get token + search, return list of dicts with hours."""
+    url = f"https://howlongtobeat.com/api/find/init?t={int(time.time()*1000)}"
+    tok = json.loads(http_get(url, headers={"Referer": "https://howlongtobeat.com/"}))
+    hp_key, hp_val = tok['hpKey'], tok['hpVal']
+    payload = {
+        "searchType": "games", "searchTerms": title.split(), "searchPage": 1, "size": size,
+        "searchOptions": {
+            "games": {"userId": 0, "platform": "", "sortCategory": "popular",
+                      "rangeCategory": "main", "rangeTime": {"min": None, "max": None},
+                      "gameplay": {"perspective": "", "flow": "", "genre": "", "difficulty": ""},
+                      "rangeYear": {"min": "", "max": ""}, "modifier": ""},
+            "users": {"sortCategory": "postcount"}, "lists": {"sortCategory": "follows"},
+            "filter": "", "sort": 0, "randomizer": 0
+        },
+        "useCache": True, hp_key: hp_val
+    }
+    req = urllib.request.Request(
+        "https://howlongtobeat.com/api/find", data=json.dumps(payload).encode(),
+        headers={"User-Agent": UA, "Content-Type": "application/json",
+                 "Origin": "https://howlongtobeat.com", "Referer": "https://howlongtobeat.com/",
+                 "x-auth-token": tok['token'], "x-hp-key": hp_key, "x-hp-val": hp_val},
+        method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = json.loads(r.read().decode())
+
+    def h(secs):
+        return round(secs / 3600, 1) if secs else None
+
+    return [
+        {
+            "game_id":      g["game_id"],
+            "name":         g["game_name"],
+            "type":         g["game_type"],         # "game" | "dlc" | "expansion" | "hack"
+            "year":         g["release_world"],
+            "platforms":    g["profile_platform"],
+            "main":         h(g["comp_main"]),       # Main Story hours (polled average)
+            "main_plus":    h(g["comp_plus"]),       # Main + Extras hours
+            "completionist":h(g["comp_100"]),        # Completionist hours
+            "all_styles":   h(g["comp_all"]),        # All playstyles combined
+            "main_count":   g["comp_main_count"],    # Number of submissions
+            "plus_count":   g["comp_plus_count"],
+            "comp_count":   g["comp_100_count"],
+            "review_score": g["review_score"],       # 0–100
+            "image_url":    f"https://howlongtobeat.com/games/{g['game_image']}",
+            "page_url":     f"https://howlongtobeat.com/game/{g['game_id']}",
+        }
+        for g in data["data"]
+    ]
+
+# Verified results (2026-04-18):
+print(hltb_search("the witcher 3")[0])
+# {'game_id': 10270, 'name': 'The Witcher 3: Wild Hunt', 'type': 'game', 'year': 2015,
+#  'main': 51.6, 'main_plus': 103.8, 'completionist': 174.4, 'all_styles': 103.8,
+#  'main_count': 2681, 'plus_count': 6708, 'comp_count': 2327, 'review_score': 93, ...}
+
+print(hltb_search("gone home")[0])
+# {'game_id': 4010, 'name': 'Gone Home', 'main': 2.0, 'main_plus': 2.5, 'completionist': 3.1, ...}
+```
+
+---
+
+## Game detail page (full stat breakdown, speedrun data, per-platform times)
+
+When you have a `game_id`, fetch the game page and extract `__NEXT_DATA__` for the complete dataset — includes median/avg/low/high times, speedrun data, co-op/multiplayer times, and per-platform breakdowns.
+
+```python
+import json, re
+from helpers import http_get
+
+def get_game_detail(game_id):
+    """
+    Fetch complete game data from the HLTB game page.
+    Returns pageProps['game']['data'] with keys: 'game', 'individuality', 'relationships'.
+    """
+    html = http_get(f"https://howlongtobeat.com/game/{game_id}")
+    nd = json.loads(re.search(
+        r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL
+    ).group(1))
+    return nd['props']['pageProps']['game']['data']
+
+data = get_game_detail(10270)   # Witcher 3
+g = data['game'][0]
+
+# Core completion times (all in seconds — divide by 3600 for hours)
+print(g['comp_main'] / 3600)       # 51.6  — Main Story (polled avg)
+print(g['comp_main_med'] / 3600)   # 50.0  — Main Story median
+print(g['comp_main_l'] / 3600)     # 32.7  — Main Story low
+print(g['comp_main_h'] / 3600)     # 85.8  — Main Story high
+print(g['comp_main_count'])        # 2681  — submission count
+
+print(g['comp_plus'] / 3600)       # 103.8 — Main + Extras
+print(g['comp_100'] / 3600)        # 174.4 — Completionist
+print(g['comp_all'] / 3600)        # 103.8 — All Styles
+
+# Speedrun times
+print(g['comp_lvl_spd'])           # 1 if speedrun data exists, 0 if not
+print(g['comp_speed'] / 3600)      # 19.2  — any% (polled avg)
+print(g['comp_speed_min'] / 3600)  # 3.2   — fastest submission
+print(g['comp_speed_max'] / 3600)  # 30.0  — slowest speedrun
+print(g['comp_speed_count'])       # 15    — speedrun submissions
+
+print(g['comp_speed100'] / 3600)   # 59.4  — 100% speedrun
+print(g['comp_speed100_count'])    # 4
+
+# Multiplayer / co-op invested time
+print(g['comp_lvl_co'])            # 1 if co-op data exists
+print(g['comp_lvl_mp'])            # 1 if multiplayer data exists
+print(g['invested_co'] / 3600)     # hours in co-op mode
+print(g['invested_mp'] / 3600)     # hours in competitive multiplayer
+print(g['invested_co_count'])      # submission count
+
+# Metadata
+print(g['profile_dev'])            # "CD Projekt RED"
+print(g['profile_pub'])            # "CD Projekt, Warner Bros..."
+print(g['profile_platform'])       # "Nintendo Switch, PC, PlayStation 4, ..."
+print(g['profile_genre'])          # "Third-Person, Action, Open World, Role-Playing"
+print(g['profile_steam'])          # 292030  — Steam App ID (0 if not on Steam)
+print(g['release_world'])          # "2015-05-19"
+print(g['rating_esrb'])            # "M"
+print(g['review_score'])           # 93  (0–100)
+print(g['count_comp'])             # 26007  — times completed
+print(g['count_backlog'])          # 31083
+
+# Per-platform breakdown (individuality)
+for plat in data['individuality']:
+    print(plat['platform'],
+          int(plat['comp_main'])/3600,    # main hours
+          int(plat['comp_plus'])/3600,    # +extras hours
+          int(plat['comp_100'])/3600,     # 100% hours
+          plat['count_comp'])             # completions on this platform
+# Example:
+# Nintendo Switch  57.0h  112.3h  194.9h  236
+# PC, PS4, Xbox One  52.9h  110.0h  179.4h  11136
+# PS5, Xbox Series X/S  52.1h  92.5h  168.8h  343
+
+# DLC / expansion completion times
+for rel in data['relationships'][:3]:
+    print(rel['game_id'], rel['game_name'], rel['game_type'],
+          rel['comp_main']/3600 if rel['comp_main'] else None)
+```
+
+---
+
+## Common workflows
+
+### Quick lookup: name → completion times
+
+```python
+import json, re, urllib.request, time
+from helpers import http_get
+
+UA = "Mozilla/5.0"
+
+def get_times(title):
+    """Return Main/+Extras/100% hours for the top search match."""
+    tok_url = f"https://howlongtobeat.com/api/find/init?t={int(time.time()*1000)}"
+    tok = json.loads(http_get(tok_url, headers={"Referer": "https://howlongtobeat.com/"}))
+    hp_key, hp_val = tok['hpKey'], tok['hpVal']
+    payload = {
+        "searchType": "games", "searchTerms": title.split(), "searchPage": 1, "size": 1,
+        "searchOptions": {
+            "games": {"userId": 0, "platform": "", "sortCategory": "popular",
+                      "rangeCategory": "main", "rangeTime": {"min": None, "max": None},
+                      "gameplay": {"perspective": "", "flow": "", "genre": "", "difficulty": ""},
+                      "rangeYear": {"min": "", "max": ""}, "modifier": ""},
+            "users": {"sortCategory": "postcount"}, "lists": {"sortCategory": "follows"},
+            "filter": "", "sort": 0, "randomizer": 0
+        },
+        "useCache": True, hp_key: hp_val
+    }
+    req = urllib.request.Request(
+        "https://howlongtobeat.com/api/find", data=json.dumps(payload).encode(),
+        headers={"User-Agent": UA, "Content-Type": "application/json",
+                 "Origin": "https://howlongtobeat.com", "Referer": "https://howlongtobeat.com/",
+                 "x-auth-token": tok['token'], "x-hp-key": hp_key, "x-hp-val": hp_val},
+        method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = json.loads(r.read().decode())
+    if not data['data']:
+        return None
+    g = data['data'][0]
+    h = lambda s: round(s/3600, 1) if s else None
+    return {
+        "id": g['game_id'], "name": g['game_name'],
+        "main": h(g['comp_main']), "main_plus": h(g['comp_plus']),
+        "completionist": h(g['comp_100'])
+    }
+
+# Verified:
+print(get_times("celeste"))
+# {'id': 42818, 'name': 'Celeste', 'main': 8.3, 'main_plus': 14.6, 'completionist': 39.2}
+print(get_times("stardew valley"))
+# {'id': 34716, 'name': 'Stardew Valley', 'main': 53.4, 'main_plus': 94.6, 'completionist': 171.5}
+print(get_times("hades"))
+# {'id': 62941, 'name': 'Hades', 'main': 23.4, 'main_plus': 48.5, 'completionist': 95.0}
+```
+
+### Paginated search (all results for a query)
+
+`count` = total matches, `pageTotal` = total pages with current `size`. The same token works across all pages.
+
+```python
+def search_all_pages(title, size=20):
+    """Yield every search result for a query across all pages."""
+    tok_url = f"https://howlongtobeat.com/api/find/init?t={int(time.time()*1000)}"
+    tok = json.loads(http_get(tok_url, headers={"Referer": "https://howlongtobeat.com/"}))
+    hp_key, hp_val = tok['hpKey'], tok['hpVal']
+
+    page = 1
+    while True:
+        payload = {
+            "searchType": "games", "searchTerms": title.split(),
+            "searchPage": page, "size": size,
+            "searchOptions": {
+                "games": {"userId": 0, "platform": "", "sortCategory": "popular",
+                          "rangeCategory": "main", "rangeTime": {"min": None, "max": None},
+                          "gameplay": {"perspective": "", "flow": "", "genre": "", "difficulty": ""},
+                          "rangeYear": {"min": "", "max": ""}, "modifier": ""},
+                "users": {"sortCategory": "postcount"}, "lists": {"sortCategory": "follows"},
+                "filter": "", "sort": 0, "randomizer": 0
+            },
+            "useCache": True, hp_key: hp_val
+        }
+        req = urllib.request.Request(
+            "https://howlongtobeat.com/api/find", data=json.dumps(payload).encode(),
+            headers={"User-Agent": UA, "Content-Type": "application/json",
+                     "Origin": "https://howlongtobeat.com", "Referer": "https://howlongtobeat.com/",
+                     "x-auth-token": tok['token'], "x-hp-key": hp_key, "x-hp-val": hp_val},
+            method="POST"
+        )
+        with urllib.request.urlopen(req, timeout=20) as r:
+            data = json.loads(r.read().decode())
+        yield from data['data']
+        if page >= data['pageTotal']:
+            break
+        page += 1
+
+# "mario" returns 308 results across 16 pages (size=20)
+mario_games = list(search_all_pages("mario", size=20))
+print(len(mario_games))   # 308
+```
+
+### Batch lookup by game ID (parallel)
+
+```python
+import json, re, urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+def fetch_game(game_id):
+    html = http_get(f"https://howlongtobeat.com/game/{game_id}")
+    nd = json.loads(re.search(
+        r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL
+    ).group(1))
+    g = nd['props']['pageProps']['game']['data']['game'][0]
+    return {
+        "id": g['game_id'], "name": g['game_name'],
+        "main": round(g['comp_main']/3600, 1) if g['comp_main'] else None,
+        "main_plus": round(g['comp_plus']/3600, 1) if g['comp_plus'] else None,
+        "completionist": round(g['comp_100']/3600, 1) if g['comp_100'] else None,
+    }
+
+ids = [10270, 68151, 42818, 26803, 34716]   # Witcher3, Elden Ring, Celeste, DS3, Stardew
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_game, ids))
+
+for r in results:
+    print(f"[{r['id']}] {r['name']}: {r['main']}h / {r['main_plus']}h / {r['completionist']}h")
+
+# Confirmed output:
+# [10270] The Witcher 3: Wild Hunt: 51.6h / 103.8h / 174.4h
+# [68151] Elden Ring: 60.0h / 101.2h / 135.5h
+# [42818] Celeste: 8.3h / 14.6h / 39.2h
+# [26803] Dark Souls III: 31.2h / 48.4h / 100.5h
+# [34716] Stardew Valley: 53.4h / 94.6h / 171.5h
+```
+
+---
+
+## Search response field reference
+
+Every item in `data[]` from `/api/find`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `game_id` | int | HLTB internal game ID |
+| `game_name` | str | Full game title |
+| `game_alias` | str | Alternate title / edition name |
+| `game_type` | str | `"game"` \| `"dlc"` \| `"expansion"` \| `"hack"` |
+| `game_image` | str | Image filename → `https://howlongtobeat.com/games/{game_image}` |
+| `release_world` | int | Release year (just the year integer, not a date) |
+| `profile_platform` | str | Comma-separated platform list |
+| `comp_main` | int | Main Story seconds (polled average), 0 if no data |
+| `comp_plus` | int | Main + Extras seconds |
+| `comp_100` | int | Completionist seconds |
+| `comp_all` | int | All Styles combined seconds |
+| `comp_main_count` | int | Submission count for Main Story |
+| `comp_plus_count` | int | Submission count for Main + Extras |
+| `comp_100_count` | int | Submission count for Completionist |
+| `comp_all_count` | int | Total submissions across all categories |
+| `comp_lvl_sp` | int | 1 if single-player data exists |
+| `comp_lvl_co` | int | 1 if co-op data exists |
+| `comp_lvl_mp` | int | 1 if multiplayer data exists |
+| `invested_co` | int | Average co-op time in seconds |
+| `invested_mp` | int | Average multiplayer time in seconds |
+| `count_comp` | int | Total completions logged |
+| `count_backlog` | int | Users with game in backlog |
+| `count_playing` | int | Currently playing |
+| `count_speedrun` | int | Speedrun entries |
+| `count_review` | int | Review count |
+| `review_score` | int | Community review score 0–100 |
+| `profile_popular` | int | Popularity rank |
+
+Additional fields in `__NEXT_DATA__` game page only:
+
+| Field | Description |
+|-------|-------------|
+| `comp_main_med/avg/l/h` | Median / average / low / high for main time |
+| `comp_plus_med/avg/l/h` | Same for Main + Extras |
+| `comp_100_med/avg/l/h` | Same for Completionist |
+| `comp_speed` | Speedrun any% average seconds |
+| `comp_speed_min/max/med` | Speedrun spread |
+| `comp_speed100` | 100% speedrun average |
+| `comp_speed_count` | Speedrun submission count |
+| `comp_lvl_spd` | 1 if speedrun data exists |
+| `profile_dev` | Developer name |
+| `profile_pub` | Publisher name |
+| `profile_genre` | Comma-separated genres |
+| `profile_steam` | Steam App ID (0 if not on Steam) |
+| `release_world` | Full release date `"YYYY-MM-DD"` |
+| `rating_esrb` | ESRB rating string (may be empty) |
+| `count_replay` | Times replayed |
+| `count_total` | Total user entries |
+
+---
+
+## Anti-bot measures
+
+- **Cloudflare** is present (confirmed by `CF-Ray` response header), but does not block plain HTTP with a browser UA.
+- **Token system**: Every search requires a fresh token from `/api/find/init`. Token encodes `timestamp::IP|UA|hpKey|hmacHash`. The server validates that the UA used to fetch the token matches the UA used in the search POST.
+- **Honeypot field**: `hpKey` and `hpVal` from the init response must appear as a top-level field in the POST body (e.g., `{"ign_7671546b": "a6679ea54598d502", ...}`). The key name rotates per request.
+- **Required headers on search POST**: `Origin: https://howlongtobeat.com` AND `Referer: https://howlongtobeat.com/` — missing either causes HTTP 403 or 404. `x-auth-token`, `x-hp-key`, `x-hp-val` are also required.
+- **Required header on init GET**: `Referer: https://howlongtobeat.com/` — missing causes HTTP 403.
+- **Token reuse**: A single token works for multiple searches and multiple pages. No per-request token fetch needed.
+- **No CAPTCHA** observed during testing with standard UA strings.
+- **Rate limits**: Not triggered during testing (token fetches + 10+ searches sequentially). Fetching many game pages in parallel (5 workers) worked without 429s.
+
+---
+
+## Gotchas
+
+- **Completion times are in seconds** — all `comp_*` fields are integer seconds. Divide by 3600 for hours. `0` means no data (not 0 hours).
+
+- **`release_world` is a year int in search, a full date in game page** — in the `/api/find` response, `release_world` is an integer year (e.g., `2015`). In `__NEXT_DATA__` on the game page, it's `"2015-05-19"`.
+
+- **UA fingerprinting** — the token from `/api/find/init` encodes the User-Agent. The search POST must use the identical UA that fetched the token, or you'll get HTTP 403. Since `http_get` sends `Mozilla/5.0`, use that same string for the search POST.
+
+- **Honeypot key name rotates** — `hpKey` is something like `ign_7671546b` (changes each token fetch). Always read it from the init response and use it dynamically. Never hardcode it.
+
+- **Both `x-hp-key`/`x-hp-val` headers AND the body field are required** — the server checks the request headers (`x-hp-key`, `x-hp-val`) against the dynamic key in the POST body. If either is wrong or missing, you get HTTP 404 (wrong body value) or HTTP 403 (missing/wrong header).
+
+- **`game_type` in search results** — can be `"game"`, `"dlc"`, `"expansion"`, or `"hack"`. Search results mix these by default. Filter with `if g['game_type'] == 'game'` if you only want base games.
+
+- **Games with no submission data** — `comp_main`, `comp_plus`, `comp_100` are `0` (not `None`) when no users have submitted times. Always check `if g['comp_main']:` before dividing.
+
+- **`individuality` (per-platform) data** — available only in `__NEXT_DATA__` on the game page, not in search results. `comp_main` etc. are strings, not ints, in this sub-object — cast with `int(plat['comp_main'])`.
+
+- **`profile_platform` in search** — a comma-separated string that HLTB displays. Not structured. Use game page `individuality` for per-platform time breakdowns.
+
+- **Token expiry** — if a long-running loop gets HTTP 403 with `{"error":"Session expired or invalid fingerprint"}`, call `get_token()` again and retry. Token lifetime appears to be ~15 minutes based on the timestamp embedded in the decoded value.
+
+- **No slug-based URLs** — HLTB uses integer `game_id` for all game pages, not slugs. There is no `title-to-slug` mapping; use search to find the `game_id` first.
+
+- **`sortCategory` options** — `"popular"` ranks by community engagement (best for "top result = intended game"). `"name"` sorts alphabetically. Other values (`"madnessTime"`, `"mainThenExtras"`) exist but return same results as `"name"` in testing.

--- a/domain-skills/itch-io/scraping.md
+++ b/domain-skills/itch-io/scraping.md
@@ -1,0 +1,436 @@
+# itch.io — Scraping & Data Extraction
+
+Field-tested against itch.io on 2026-04-18. All code blocks validated with live requests.
+
+---
+
+## TL;DR — fastest approaches by task
+
+| Task | Method | Notes |
+|---|---|---|
+| Browse listings (36/page) | `http_get` HTML | Works, no key, no bot block |
+| Game detail (name, price, rating) | `http_get` + JSON-LD | `<script type="application/ld+json">` Product block |
+| Info table (tags, genre, status) | `http_get` + regex on `game_info_panel_widget` | Always present |
+| Top N games from any category | RSS `.xml` feed | Cleaner than HTML for bulk |
+| API (key endpoints) | `http_get` + key in path | Free keys at itch.io/docs/api |
+| Download/purchase counts | Not public | Owners only via dashboard |
+
+`http_get` works on all itch.io game and browse pages with no extra headers needed.
+No Cloudflare, no JS challenge, no CAPTCHA on standard game/browse routes.
+
+---
+
+## Approach 1 (Fastest for listings): RSS feeds — 36 games per call, clean XML
+
+Every browse URL has an `.xml` RSS variant. Returns price, pub/update dates, platforms, thumbnail. No HTML parsing.
+
+```python
+import re
+from helpers import http_get
+
+def parse_rss(url):
+    """
+    Parse any itch.io RSS listing feed.
+    url examples:
+      https://itch.io/games/top-rated.xml
+      https://itch.io/games/newest.xml
+      https://itch.io/games/featured.xml
+      https://itch.io/games/on-sale.xml
+      https://itch.io/games/free.xml
+      https://itch.io/games/tag-puzzle.xml    # any tag slug works
+      https://itch.io/games/top-rated.xml?page=2
+    """
+    xml = http_get(url)
+    items = []
+    for m in re.finditer(r'<item>(.*?)</item>', xml, re.DOTALL):
+        ix = m.group(1)
+        def get(tag, s=ix):
+            tm = re.search(rf'<{tag}>(.*?)</{tag}>', s, re.DOTALL)
+            return tm.group(1).strip() if tm else None
+        items.append({
+            'url':         get('guid'),
+            'title':       get('plainTitle'),          # clean title, no [tags]
+            'price':       get('price'),               # "$0.00", "$7.99", etc.
+            'currency':    get('currency'),            # "USD"
+            'pub_date':    get('pubDate'),
+            'update_date': get('updateDate'),
+            'image':       get('imageurl'),            # 315x250 thumbnail
+            'platforms': {
+                k: get(k) == 'yes'
+                for k in ['windows', 'osx', 'linux', 'android', 'html']
+                if get(k) is not None
+            },
+        })
+    return items
+
+# Confirmed output:
+items = parse_rss("https://itch.io/games/top-rated.xml")
+# items[0] -> {
+#   'url':         'https://gbpatch.itch.io/our-life',
+#   'title':       'Our Life: Beginnings & Always',
+#   'price':       '$0.00',
+#   'currency':    'USD',
+#   'pub_date':    'Fri, 07 Jun 2019 23:47:57 GMT',
+#   'update_date': 'Sun, 22 May 2022 15:48:27 GMT',
+#   'image':       'https://img.itch.zone/aW1nLzcwMTIxNDMucG5n/315x250%23c/BalGQb.png',
+#   'platforms':   {'windows': True, 'osx': True, 'linux': True, 'android': True},
+# }
+```
+
+**RSS limitations:** no rating score or count. Use HTML scraping (Approach 2) when you need ratings.
+
+---
+
+## Approach 2: HTML listings — ratings, genre, price, 36 games per page
+
+```python
+import re
+from helpers import http_get
+
+def parse_game_cards(html):
+    """
+    Extract all game cards from any itch.io browse/listing/search/profile HTML page.
+    Works on:
+      https://itch.io/games/top-rated
+      https://itch.io/games/newest
+      https://itch.io/games/featured
+      https://itch.io/games/on-sale
+      https://itch.io/games/free
+      https://itch.io/games/tag-puzzle      (genre/tag path)
+      https://itch.io/search?q=platformer   (search — 54 cards per page)
+      https://<author>.itch.io              (author profile)
+    All accept ?page=N for pagination.
+    """
+    games = []
+    for m in re.finditer(r'data-game_id="(\d+)"', html):
+        game_id = m.group(1)
+        start = m.start()
+        chunk = html[start:start + 3000]
+
+        # Title + URL — attribute order differs between page 1 and pages 2+
+        title_m = re.search(
+            r'class="title game_link"[^>]*href="([^"]+)"[^>]*>([^<]+)</a>', chunk
+        )
+        if not title_m:
+            title_m = re.search(
+                r'href="([^"]+)"[^>]*class="title game_link"[^>]*>([^<]+)</a>', chunk
+            )
+
+        rating_m  = re.search(
+            r'data-tooltip="([\d.]+) average rating from ([\d,]+) total ratings"', chunk
+        )
+        genre_m   = re.search(r'class="game_genre">([^<]+)</div>', chunk)
+        price_m   = re.search(r'class="price_value">([^<]+)</div>', chunk)
+        desc_m    = re.search(r'class="game_text" title="([^"]+)"', chunk)
+        img_m     = re.search(r'data-lazy_src="([^"]+)"', chunk)
+        platforms = re.findall(r'title="Download for ([^"]+)"', chunk)
+
+        games.append({
+            'id':           game_id,
+            'url':          title_m.group(1) if title_m else None,
+            'title':        title_m.group(2).strip() if title_m else None,
+            'rating':       float(rating_m.group(1)) if rating_m else None,
+            'rating_count': int(rating_m.group(2).replace(',', '')) if rating_m else None,
+            'genre':        genre_m.group(1) if genre_m else None,
+            'price':        price_m.group(1) if price_m else 'Free',
+            'description':  desc_m.group(1) if desc_m else None,
+            'thumbnail':    img_m.group(1) if img_m else None,
+            'platforms':    platforms,      # ['Windows', 'macOS', 'Linux', 'Android']
+        })
+    return games
+
+# Usage:
+html = http_get("https://itch.io/games/top-rated")
+games = parse_game_cards(html)
+# games[0] -> {
+#   'id': '434554', 'url': 'https://gbpatch.itch.io/our-life',
+#   'title': 'Our Life: Beginnings & Always',
+#   'rating': 4.94, 'rating_count': 7191,
+#   'genre': 'Visual Novel', 'price': 'Free',
+#   'platforms': ['Windows', 'Linux', 'macOS', 'Android'],
+# }
+
+# Paid game example:
+html = http_get("https://itch.io/games/top-rated?page=5")
+games = parse_game_cards(html)
+# Returns games where price_m captures '$7.99' when present
+```
+
+### CSS selector reference (for browser/JS use)
+
+```
+.game_cell                        — one card per game
+.game_cell[data-game_id]          — get game ID from attribute
+.game_cell .title.game_link       — title text + href
+.game_cell .game_rating           — rating container
+.game_cell .game_rating[data-tooltip]  — "4.94 average rating from 7,191 total ratings"
+.game_cell .star_fill             — inline style width: NN% (rating as percentage of 5)
+.game_cell .rating_count          — "(7,191)"
+.game_cell .game_genre            — genre text
+.game_cell .price_tag .price_value — price e.g. "$7.99" (absent = Free)
+.game_cell .game_text             — one-line description (also in title attr)
+.game_cell .game_author a         — author name + href
+.game_cell img.lazy_loaded        — thumbnail (src in data-lazy_src before JS runs)
+```
+
+**Gotcha — attribute order flips on page >= 2.** Page 1 uses `class="..." data-game_id="..."`, page 2+ uses `data-game_id="..." class="..."`. The regex above handles both. If you use a CSS selector engine, `[data-game_id]` is unambiguous.
+
+**Gotcha — ratings absent on some listing types.** The tag/genre browse pages (e.g. `/games/tag-puzzle`) sometimes omit the rating tooltip on the card even when the game has ratings. Fetch the detail page for the authoritative rating.
+
+---
+
+## Approach 3: Game detail page — JSON-LD Product schema
+
+The cleanest source for individual game data. All confirmed fields:
+
+```python
+import json, re
+from helpers import http_get
+
+def extract_game_detail(url):
+    """
+    Fetch full metadata for a single itch.io game.
+    url format: https://<author>.itch.io/<game-slug>
+    """
+    html = http_get(url)
+
+    # --- JSON-LD (always present, covers name/description/price/rating) ---
+    ld_product = None
+    for block in re.findall(
+        r'<script[^>]*type="application/ld\+json"[^>]*>(.*?)</script>',
+        html, re.DOTALL
+    ):
+        ld = json.loads(block.strip())
+        if ld.get('@type') == 'Product':
+            ld_product = ld
+            break
+
+    # --- Info panel table (Status, Platforms, Genre, Tags, Author, etc.) ---
+    info = {}
+    panel_m = re.search(
+        r'class="game_info_panel_widget[^"]*"[^>]*><table>(.*?)</table>',
+        html, re.DOTALL
+    )
+    if panel_m:
+        for row in re.finditer(
+            r'<tr><td>([^<]+)</td><td>(.*?)</td></tr>',
+            panel_m.group(1), re.DOTALL
+        ):
+            key = row.group(1).strip()
+            val = re.sub(r'<[^>]+>', '', row.group(2)).strip()
+            # Multi-value fields become lists (Tags, Platforms, Genre, Links)
+            info[key] = [v.strip() for v in val.split(',')] if ',' in val else val
+
+    # --- Cover image ---
+    cover_m = re.search(r'<meta property="og:image" content="([^"]+)"', html)
+
+    offers = (ld_product or {}).get('offers', {})
+    agg    = (ld_product or {}).get('aggregateRating', {})
+
+    return {
+        'url':          url,
+        'name':         (ld_product or {}).get('name'),
+        'description':  (ld_product or {}).get('description'),
+        'price':        offers.get('price'),          # "0.00" for free, "7.99" for paid
+        'currency':     offers.get('priceCurrency'),  # "USD"
+        'rating':       agg.get('ratingValue'),       # "4.9" string
+        'rating_count': agg.get('ratingCount'),       # int
+        'cover':        cover_m.group(1) if cover_m else None,
+        'info':         info,
+    }
+
+# Free game:
+r = extract_game_detail("https://gbpatch.itch.io/our-life")
+# {
+#   'name': 'Our Life: Beginnings & Always',
+#   'description': 'Grow from childhood to adulthood with the lonely boy next door...',
+#   'price': None, 'currency': None,   <- no 'offers' block for free games
+#   'rating': '4.9', 'rating_count': 7191,
+#   'cover': 'https://img.itch.zone/aW1hZ2Uv.../347x500/7HqrvV.jpg',
+#   'info': {
+#     'Status':    'Released',
+#     'Platforms': ['Windows', 'macOS', 'Linux', 'Android'],
+#     'Rating':    'Rated 4.9 out of 5 stars(7,191 total ratings)',
+#     'Author':    'GBPatch',
+#     'Genre':     ['Visual Novel', 'Interactive Fiction'],
+#     'Tags':      ['Amare', 'Comedy', 'Dating Sim', 'Gay', 'LGBT', ...],
+#     'Links':     'Steam',
+#   }
+# }
+
+# Paid game:
+r = extract_game_detail("https://adamgryu.itch.io/a-short-hike")
+# {
+#   'name': 'A Short Hike',
+#   'price': '7.99', 'currency': 'USD',
+#   'rating': '4.9', 'rating_count': 4307,
+#   'info': {
+#     'Status':          'Released',
+#     'Platforms':       ['Windows', 'macOS', 'Linux'],
+#     'Release date':    'Jul 30, 2019',
+#     'Genre':           ['Adventure', 'Platformer'],
+#     'Made with':       'Unity',
+#     'Tags':            ['3D', 'Atmospheric', 'Cute', 'Relaxing', 'Short', ...],
+#     'Average session': 'About an hour',
+#     'Languages':       ['English', 'Spanish; Latin America', 'French', ...],
+#     'Inputs':          ['Keyboard', 'Mouse', 'Xbox controller', ...],
+#     'Accessibility':   ['Subtitles', 'Configurable controls'],
+#     'Links':           ['Steam', 'Homepage', 'Soundtrack', 'Twitter/X'],
+#   }
+# }
+```
+
+**JSON-LD available fields:**
+
+| Field | Free game | Paid game |
+|---|---|---|
+| `@type` | `Product` | `Product` |
+| `name` | yes | yes |
+| `description` | yes | yes |
+| `aggregateRating.ratingValue` | yes | yes |
+| `aggregateRating.ratingCount` | yes | yes |
+| `offers.price` | absent | yes ("7.99") |
+| `offers.priceCurrency` | absent | yes ("USD") |
+| `offers.seller.name` | absent | yes (author name) |
+| `offers.seller.url` | absent | yes (author profile URL) |
+
+---
+
+## Pagination
+
+Browse pages: `?page=N`. Detect end of results by HTTP 404 (page too high) or absent `<link rel="next">`.
+
+```python
+import re
+from helpers import http_get
+
+def paginate_listing(base_url, max_pages=10):
+    """
+    Scrape multiple pages from any itch.io browse URL.
+    base_url: https://itch.io/games/top-rated  (no ?page= suffix)
+    Returns flat list of game dicts.
+    Stops when HTTP 404 or no <link rel="next"> found.
+    """
+    all_games = []
+    page = 1
+    while page <= max_pages:
+        url = base_url if page == 1 else f"{base_url}?page={page}"
+        try:
+            html = http_get(url)
+        except Exception:
+            break   # 404 = past last page
+        all_games.extend(parse_game_cards(html))
+        if not re.search(r'<link[^>]+rel="next"[^>]*/>', html):
+            break
+        page += 1
+    return all_games
+
+# Confirmed: page 1 has <link href="?page=2" rel="next"/>
+#            page 2 has <link rel="prev" href="/games/top-rated"/> and <link rel="next" href="?page=3"/>
+#            past last page returns HTTP 404
+# top-rated has at least 200 pages (each 36 games); page 300+ -> 404
+```
+
+---
+
+## Browse URL patterns
+
+All confirmed working via `http_get`:
+
+```python
+BASE = "https://itch.io/games"
+
+# Sort orders
+f"{BASE}/top-rated"      # all-time top rated (rated by community, 0–5 stars)
+f"{BASE}/newest"         # most recently published
+f"{BASE}/featured"       # itch.io staff picks
+f"{BASE}/on-sale"        # discounted games
+f"{BASE}/free"           # free games only
+
+# Genre/tag paths (append .xml for RSS)
+f"{BASE}/tag-puzzle"     # tag slug — prefix with 'tag-'
+f"{BASE}/genre-action"   # genre — prefix with 'genre-' (less common)
+
+# Combine: tag + sort via separate pages (no combined URL that survives http_get)
+# Note: https://itch.io/games/top-rated/tag-puzzle -> HTTP 403
+# Note: ?tag= query param does NOT filter server-side (returns same games)
+
+# Pagination
+f"{BASE}/top-rated?page=2"
+f"{BASE}/tag-puzzle?page=3"
+
+# RSS equivalents (36 items, no pagination needed for small sets)
+f"{BASE}/top-rated.xml"
+f"{BASE}/tag-puzzle.xml"
+f"{BASE}/tag-puzzle.xml?page=2"
+
+# Search (54 results/page, no server-side pagination beyond page 1 via http_get)
+"https://itch.io/search?q=platformer"
+
+# Author profile
+"https://<author-slug>.itch.io"
+```
+
+---
+
+## API (requires key)
+
+itch.io has an official REST API. A free key is issued per-account with no rate limit published.
+Get one at: `https://itch.io/user/settings/api-keys`
+
+Base URL: `https://itch.io/api/1/<key>/`
+
+```python
+import json
+from helpers import http_get
+
+ITCH_KEY = "your_api_key_here"   # from https://itch.io/user/settings/api-keys
+
+def api(path):
+    return json.loads(http_get(f"https://itch.io/api/1/{ITCH_KEY}/{path}"))
+
+# Authenticated user info
+api("me")
+# -> {"user": {"id": ..., "username": "...", "url": "...", "display_name": "...", ...}}
+
+# Games owned by authenticated user
+api("my-games")
+# -> {"games": [{"id": ..., "title": "...", "url": "...", "created_at": "...",
+#                "published": true/false, "min_price": 0, ...}, ...]}
+
+# Download keys for a game (owner only)
+api("game/434554/download_keys")
+
+# Credentials (for authenticated purchases)
+api("game/434554/credentials")
+```
+
+**Error structure:** invalid/missing key returns `{"errors": ["invalid key"]}` with HTTP 200.
+Non-existent endpoints return HTTP 404.
+
+**No unauthenticated game lookup API.** `https://itch.io/api/1/x/games` -> HTTP 404.
+Use HTML scraping or RSS for unauthenticated game data.
+
+---
+
+## Gotchas
+
+1. **Attribute order flips page 1 vs 2+.** On page 1, game cards use `class="game_cell ..." data-game_id="..."`. On pages 2+, the order is `data-game_id="..." class="game_cell ..."`. Always match `data-game_id` independently of class ordering.
+
+2. **Ratings absent on tag/genre listing pages.** The `data-tooltip` with rating is often missing from card HTML on `/games/tag-*` pages even though the game has ratings. Fetch the detail page for `aggregateRating` via JSON-LD.
+
+3. **`price_value` absent = Free.** Paid games have `<div class="price_tag meta_tag" title="Pay $7.99 or more..."><div class="price_value">$7.99</div></div>`. Free games have no such element. Default to `'Free'` when absent.
+
+4. **Free-game JSON-LD has no `offers` block.** Only paid games include the `offers` object. For free games, use absence of `offers` as the signal, not presence of `price: 0`.
+
+5. **`/games/top-rated/tag-puzzle` returns HTTP 403.** Cannot combine sort + tag in a path. Use separate `/games/tag-puzzle` (top-rated is the default sort anyway).
+
+6. **`?tag=` query param is ignored server-side.** `https://itch.io/games/top-rated?tag=puzzle` returns the same games as `?top-rated`. Use `/games/tag-puzzle` path instead.
+
+7. **Download/purchase counts are not public.** No count field appears anywhere in the public HTML, JSON-LD, RSS, or unauthenticated API. Game owners see their stats in the dashboard only.
+
+8. **Search beyond page 1 is AJAX-only.** `https://itch.io/search?q=X&page=2` via `http_get` returns the same 54 results as page 1. To get more search results use the browser and scroll/click "load more".
+
+9. **RSS is capped at 36 items per page.** Paginate with `?page=N`. Very high page numbers (300+) return HTTP 404 on browse pages.
+
+10. **Unicode zero-width space in some titles.** `\u200b` (zero-width space) appears at the start of certain titles (e.g. "​Our Life: Beginnings & Always"). Strip with `.replace('\u200b', '').strip()` or `.strip()` alone won't remove it — use `title.replace('\u200b', '').strip()`.

--- a/domain-skills/letterboxd/scraping.md
+++ b/domain-skills/letterboxd/scraping.md
@@ -1,0 +1,349 @@
+# Letterboxd — Film Data Scraping
+
+`https://letterboxd.com` — film logging, rating, and review site. Film pages and user profile root pages are publicly accessible via `http_get` (~200–350ms). Most sub-pages (reviews, ratings, user film lists, browse/genre pages) return 403 and require the browser.
+
+## Access path decision table
+
+| Goal | Method | Latency |
+|------|--------|---------|
+| Film metadata (title, year, director, cast, genres, rating) | `http_get` + JSON-LD | ~200–350ms |
+| Film synopsis, poster, OG data | `http_get` + meta tags | same request |
+| Film popular reviews (top 12 inline) | `http_get` film page | same request |
+| User profile stats (film count, followers) | `http_get` user root | ~150ms |
+| Recent global activity stream | `http_get /films/` | ~200ms |
+| User watched film list | browser (`/{username}/films/`) | |
+| Ratings distribution histogram | browser (`/film/{slug}/ratings/`) | |
+| All reviews (paginated) | browser (`/film/{slug}/reviews/`) | |
+| Popular / browse / genre film lists | browser (`/films/popular/`, etc.) | |
+| Director / actor pages | browser (`/director/{slug}/`, `/actor/{slug}/`) | |
+| User diary / lists | browser (`/{username}/diary/`, `/{username}/lists/`) | |
+
+**Letterboxd's public API** (`api.letterboxd.com/api/v0/`) returns 401 on all endpoints — it requires OAuth2 client credentials (apply at letterboxd.com/api-beta/).
+
+**Cloudflare Turnstile** is configured in the page JS but is not blocking `http_get` on accessible pages. It only activates on the login form.
+
+---
+
+## Path 1: Film page via http_get (fastest for metadata + ratings)
+
+Film pages at `letterboxd.com/film/{slug}/` are fully accessible. The JSON-LD block (Movie schema) contains everything you need in one parse.
+
+**URL slug format:** lowercase title, spaces replaced with hyphens. For disambiguation (same title, different year) append `-{year}`: e.g. `parasite-2019`, `alien-1979`.
+
+```python
+import json, re, html as htmllib
+from helpers import http_get
+
+def extract_film_data(slug):
+    """
+    Fetch and parse a Letterboxd film page.
+    slug examples: 'the-godfather', 'parasite-2019', 'inception', '2001-a-space-odyssey'
+    """
+    html = http_get(f"https://letterboxd.com/film/{slug}/")
+    result = {}
+
+    # --- JSON-LD (primary source) ---
+    jsonld_raw = re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.DOTALL)
+    for block in jsonld_raw:
+        # Strip CDATA wrapper that Letterboxd wraps around JSON-LD
+        cleaned = re.sub(r'/\*\s*<!\[CDATA\[.*?\*/\s*', '', block, flags=re.DOTALL)
+        cleaned = re.sub(r'/\*\s*\]\]>.*?\*/', '', cleaned, flags=re.DOTALL)
+        try:
+            data = json.loads(cleaned.strip())
+        except json.JSONDecodeError:
+            continue
+        if data.get('@type') != 'Movie':
+            continue
+
+        result['title']     = data['name']
+        result['year']      = data['releasedEvent'][0]['startDate'] if data.get('releasedEvent') else None
+        result['directors'] = [d['name'] for d in data.get('director', [])]
+        result['genres']    = data.get('genre', [])
+        result['countries'] = [c['name'] for c in data.get('countryOfOrigin', [])]
+        result['studios']   = [s['name'] for s in data.get('productionCompany', [])]
+        result['actors']    = [a['name'] for a in data.get('actors', [])]
+        result['poster_url'] = data.get('image')
+        result['url']       = data.get('url')
+        r = data.get('aggregateRating', {})
+        result['rating']       = r.get('ratingValue')   # float 0.0–5.0
+        result['rating_count'] = r.get('ratingCount')   # int, total ratings cast
+        result['review_count'] = r.get('reviewCount')   # int, written reviews only
+
+    # --- OG / meta tags (fast fallback, redundant) ---
+    og = lambda prop: next(iter(re.findall(
+        rf'<meta[^>]+property="og:{prop}"[^>]+content="([^"]*)"', html)), None)
+    result['og_title']  = og('title')    # includes year: "The Godfather (1972)"
+    result['synopsis']  = htmllib.unescape(og('description') or '')
+    result['og_image']  = og('image')    # large 1200x675 crop
+
+    # --- Film ID (internal numeric ID) ---
+    m = re.search(r'data-film-id="(\d+)"', html)
+    result['film_id'] = m.group(1) if m else None
+
+    # --- Tagline ---
+    m = re.search(r'<h4 class="tagline">([^<]+)</h4>', html)
+    result['tagline'] = htmllib.unescape(m.group(1)) if m else None
+
+    # --- Themes (from tab-genres section) ---
+    m = re.search(r'<h3><span>Themes</span></h3>.*?<p>(.*?)</p>', html, re.DOTALL)
+    result['themes'] = re.findall(r'class="text-slug">([^<]+)</a>', m.group(1)) if m else []
+
+    # --- Languages ---
+    result['languages'] = re.findall(r'href="/films/language/[^/]+/"[^>]*>([^<]+)</a>', html)
+
+    # --- Fans count ---
+    m = re.search(r'class="accessory"[^>]*>\s*([\d,KkMm]+)\s*fans</a>', html)
+    result['fans'] = m.group(1) if m else None  # e.g. "133K"
+
+    # --- Popular reviews (top 12 inline on the page) ---
+    result['reviews'] = []
+    for vid, person, block in re.findall(
+        r'<article class="production-viewing[^"]*"[^>]*data-viewing-id="(\d+)"[^>]*data-person="([^"]+)">(.*?)</article>',
+        html, re.DOTALL
+    ):
+        dm = re.search(r'<strong class="displayname">([^<]+)</strong>', block)
+        tm = re.search(r'class="body-text -prose -reset[^"]*"[^>]*>(.*?)</div>', block, re.DOTALL)
+        lm = re.search(r'data-count="(\d+)"', block)
+        result['reviews'].append({
+            'viewing_id':   vid,
+            'username':     person,
+            'display_name': dm.group(1) if dm else person,
+            'review':       re.sub(r'<[^>]+>', '', tm.group(1)).strip() if tm else '',
+            'likes':        int(lm.group(1)) if lm else 0,
+        })
+
+    return result
+```
+
+### Verified output (2026-04-18)
+
+```python
+data = extract_film_data('the-godfather')
+# {
+#   'title': 'The Godfather',
+#   'year': '1972',
+#   'directors': ['Francis Ford Coppola'],
+#   'genres': ['Crime', 'Drama'],
+#   'countries': ['USA'],
+#   'studios': ['Paramount Pictures', 'Alfran Productions'],
+#   'actors': ['Marlon Brando', 'Al Pacino', 'James Caan', ...],  # full cast list
+#   'rating': 4.52,
+#   'rating_count': 2619662,
+#   'review_count': 372579,
+#   'fans': '133K',
+#   'film_id': '51818',
+#   'tagline': "An offer you can't refuse.",
+#   'genres': ['Crime', 'Drama'],
+#   'themes': ['Crime, drugs and gangsters', 'Gritty crime and ruthless gangsters', ...],
+#   'languages': ['English', 'Latin', 'English', 'Italian'],  # may have dupes; deduplicate
+#   'og_title': 'The Godfather (1972)',
+#   'synopsis': 'Spanning the years 1945 to 1955...',
+#   'poster_url': 'https://a.ltrbxd.com/resized/film-poster/.../51818-the-godfather-0-230-0-345-crop.jpg...',
+#   'og_image': 'https://a.ltrbxd.com/resized/sm/upload/.../the-godfather-1200-1200-675-675-crop-000000.jpg...',
+#   'reviews': [
+#     {'username': 'wizardchurch', 'display_name': 'Hannah', 'likes': 30944,
+#      'review': 'haha they made that scene from zootopia into a movie'},
+#     ...  # 12 total
+#   ]
+# }
+
+data = extract_film_data('parasite-2019')
+# title: 'Parasite', year: '2019', rating: 4.53, rating_count: 5264520, review_count: 690652
+# fans: '175K', directors: ['Bong Joon Ho'], countries: ['South Korea']
+
+data = extract_film_data('inception')
+# title: 'Inception', year: '2010', rating: 4.23, rating_count: 3913620
+```
+
+---
+
+## Path 2: User profile via http_get
+
+Only the user root page `letterboxd.com/{username}/` is accessible. Sub-pages (`/films/`, `/diary/`, `/lists/`) return 403.
+
+```python
+import re, html as htmllib
+from helpers import http_get
+
+def extract_user_profile(username):
+    html = http_get(f"https://letterboxd.com/{username}/")
+
+    # Display name
+    dm = re.search(r'class="displayname tooltip"[^>]*><span class="label">([^<]+)</span>', html)
+
+    # Stats block (Films / This year / Lists / Following / Followers)
+    stats = re.findall(
+        r'<span class="value">(\d[\d,]*)</span>'
+        r'<span class="definition[^"]*">([^<]+)</span>',
+        html
+    )
+
+    # Favorites from OG description
+    od = re.search(r'<meta[^>]+property="og:description"[^>]+content="([^"]*)"', html)
+    favorites = []
+    if od:
+        fm = re.search(r'Favorites:\s*([^.]+)\.', od.group(1))
+        if fm:
+            favorites = [f.strip() for f in fm.group(1).split(',')]
+
+    # Film IDs of films shown on profile page (recent activity)
+    film_ids_on_page = list(set(re.findall(r'data-film-id="(\d+)"', html)))
+
+    return {
+        'username':    username,
+        'display_name': dm.group(1) if dm else None,
+        'stats':       {label.strip(): int(val.replace(',', '')) for val, label in stats},
+        'favorites':   favorites,
+        'film_ids_on_page': film_ids_on_page,
+    }
+```
+
+### Verified output
+
+```python
+data = extract_user_profile('dave')
+# {
+#   'username': 'dave',
+#   'display_name': 'Dave Vis',
+#   'stats': {'Films': 2553, 'This year': 63, 'Lists': 155, 'Following': 77, 'Followers': 34512},
+#   'favorites': ['High and Low (1963)', 'Burning (2018)', 'My Neighbor Totoro (1988)', 'Mulholland Drive (2001)'],
+#   'film_ids_on_page': ['51818', '47756', ...]  # ~32 film IDs from recent activity blocks
+# }
+```
+
+---
+
+## Path 3: Global activity stream from /films/
+
+`letterboxd.com/films/` returns the recent global activity feed — approximately 6 full viewing entries, plus many more film slugs from the UI. Use this to discover recently-logged films.
+
+```python
+import re, html as htmllib
+from helpers import http_get
+
+def extract_activity_stream():
+    html = http_get("https://letterboxd.com/films/")
+    entries = []
+    for owner, obj_id, block in re.findall(
+        r'class="production-viewing[^"]*"[^>]*data-owner="([^"]+)"[^>]*data-object-id="([^"]+)"[^>]*>(.*?)</article>',
+        html, re.DOTALL
+    ):
+        film_m = re.search(
+            r'data-item-name="([^"]*)".*?data-item-slug="([^"]*)".*?data-film-id="(\d+)"',
+            block, re.DOTALL
+        )
+        if film_m:
+            entries.append({
+                'owner':     owner,
+                'film_name': htmllib.unescape(film_m.group(1)),
+                'film_slug': film_m.group(2),
+                'film_id':   film_m.group(3),
+            })
+    return entries
+
+# Returns ~6 entries. Film names are in "Title (Year)" format.
+# Example: [{'owner': 'sidduww', 'film_name': 'The Drama (2026)',
+#            'film_slug': 'the-drama', 'film_id': '1205494'}, ...]
+```
+
+---
+
+## Path 4: Browser for list pages and sub-pages (403 via http_get)
+
+These pages require the browser — use `goto()` + `wait_for_load()` + `wait(2)`:
+
+```python
+from helpers import goto, wait_for_load, wait, js
+import json
+
+# Popular films
+goto("https://letterboxd.com/films/popular/")
+wait_for_load()
+wait(2)
+
+films = json.loads(js("""
+(function() {
+  var items = Array.from(document.querySelectorAll('li.film-list-entry, li[class*="poster-container"]'));
+  return JSON.stringify(items.slice(0, 30).map(function(el) {
+    var poster = el.querySelector('[data-item-slug]') || el.querySelector('[data-film-slug]');
+    return {
+      name: poster ? (poster.dataset.itemName || poster.dataset.filmName) : null,
+      slug: poster ? (poster.dataset.itemSlug || poster.dataset.filmSlug) : null,
+      film_id: poster ? poster.dataset.filmId : null
+    };
+  }).filter(function(x){ return x.slug; }));
+})()
+"""))
+
+# User watched films list (paginated, 72/page)
+goto("https://letterboxd.com/dave/films/")
+wait_for_load()
+wait(2)
+
+films = json.loads(js("""
+(function() {
+  var items = Array.from(document.querySelectorAll('li[data-film-id]'));
+  return JSON.stringify(items.map(function(el) {
+    return {
+      film_id:   el.dataset.filmId,
+      film_slug: el.dataset.targetLink ? el.dataset.targetLink.replace(/\\/film\\/|\\/$/g,'') : null,
+      rating:    el.dataset.ownerRating || null
+    };
+  }));
+})()
+"""))
+
+# User diary entries
+goto("https://letterboxd.com/dave/diary/")
+wait_for_load()
+wait(2)
+
+# For paginated browsing, check next page link
+next_page_url = js("""
+(function() {
+  var a = document.querySelector('a.next');
+  return a ? a.href : null;
+})()
+""")
+# Returns URL for next page or null. Load it with goto(next_page_url).
+```
+
+---
+
+## Gotchas
+
+**JSON-LD is wrapped in CDATA comments** — `json.loads(block)` will fail without stripping the wrapper. Always strip `/* <![CDATA[ */` and `/* ]]> */` first:
+```python
+cleaned = re.sub(r'/\*\s*<!\[CDATA\[.*?\*/\s*', '', block, flags=re.DOTALL)
+cleaned = re.sub(r'/\*\s*\]\]>.*?\*/', '', cleaned, flags=re.DOTALL)
+data = json.loads(cleaned.strip())
+```
+
+**JSON-LD `name` is bare title, not "Title (Year)"** — `data['name']` returns `'Parasite'`, not `'Parasite (2019)'`. Year is in `data['releasedEvent'][0]['startDate']`. The OG `og:title` meta tag does include the year.
+
+**OG description contains HTML entities** — `og:description` and `tagline` use `&#039;` etc. Always call `html.unescape()` on them.
+
+**`languages` list can have duplicates** — e.g. Parasite returns `['Korean', 'English', 'German', 'Korean']`. Call `list(dict.fromkeys(result['languages']))` to deduplicate while preserving order.
+
+**Disambiguation slugs** — when two films share a title, Letterboxd appends the year to the slug: `parasite-2019` (Bong's film), vs `parasite` (1982 film). If your slug 404s, try appending `-{year}`.
+
+**403 pages** — `/film/{slug}/reviews/`, `/film/{slug}/ratings/`, `/film/{slug}/cast/`, `/film/{slug}/details/`, `/{username}/films/`, `/films/popular/`, `/films/by/rating/`, `/genre/{slug}/`, `/director/{slug}/`, `/actor/{slug}/` all return 403 to `http_get`. These require the browser.
+
+**CSI endpoints are 403** — Letterboxd loads the ratings histogram via `/csi/film/{slug}/rating-histogram/` which returns 403 without a session cookie. Access ratings distribution via browser on `/film/{slug}/ratings/`.
+
+**`/csi/` and `/ajax/` endpoints need session cookies** — these are used to populate the ratings histogram, friend activity, and popular review sections after page load. Only the inline HTML data (top 12 popular reviews) is available via `http_get`.
+
+**Cloudflare Turnstile is present but passive** — the `configuration.cloudflare.turnstile` object is in the page JS, but it only activates on the login form. It does not block unauthenticated reads on public film/user pages.
+
+**The official API requires OAuth** — `api.letterboxd.com/api/v0/` returns 401 on all endpoints. Apply for API access at letterboxd.com/api-beta/ to get client credentials.
+
+**Fans count is abbreviated** — `'133K'`, `'175K'`. Parse with:
+```python
+def parse_abbrev(s):
+    s = s.strip().upper()
+    if s.endswith('K'): return int(float(s[:-1]) * 1000)
+    if s.endswith('M'): return int(float(s[:-1]) * 1000000)
+    return int(s.replace(',', ''))
+```
+
+**Film slug from unknown title** — Letterboxd has no public search API. Construct the slug by lowercasing the title and replacing spaces with hyphens, then `http_get` and check for a 403/404 vs a valid JSON-LD block.

--- a/domain-skills/medium/scraping.md
+++ b/domain-skills/medium/scraping.md
@@ -1,0 +1,414 @@
+# Medium — Data Extraction
+
+`https://medium.com` — blogging platform. Three access paths tested and validated: the undocumented `?format=json` endpoint (fastest for article + publication data), the undocumented GraphQL API (best for targeted metric lookups), and RSS feeds (best for recent posts lists without auth). No browser needed for any read-only task.
+
+## Do this first: pick your access path
+
+| Goal | Best approach | Latency |
+|------|--------------|---------|
+| Article metadata + full body | `?format=json` on article URL | ~400ms |
+| Article metrics only (claps, visibility) | GraphQL `post(id:)` | ~275ms |
+| Author profile + follower count | GraphQL `user(username:)` | ~220ms |
+| Recent posts for a user (up to 10) | `?format=json` on profile URL | ~240ms |
+| Recent posts for a publication | `?format=json` on publication URL | ~300ms |
+| Paginated post list (feed) | RSS feed | ~260ms |
+| Full article body as HTML | RSS `content:encoded` field | ~260ms |
+| Publication subscriber count | `?format=json` on publication URL | ~300ms |
+
+**Never use a browser for read-only Medium tasks.** All article content, metadata, and metrics are available over HTTP. Browser is only needed for authenticated actions (clapping, posting, account management).
+
+---
+
+## The XSSI prefix
+
+Every `?format=json` response starts with the anti-hijacking prefix `])}while(1);</x>` before the JSON. **Strip it before parsing.** The helper below handles this.
+
+```python
+import urllib.request, gzip, json, re
+
+def medium_json(url):
+    """Fetch any Medium URL with ?format=json and return parsed dict.
+    Strips the XSSI prefix ])}while(1);</x> automatically.
+    Works on: article URLs, user profile URLs, publication URLs.
+    Does NOT work on: search pages, /latest, profile stream API.
+    """
+    sep = '&' if '?' in url else '?'
+    req = urllib.request.Request(
+        url + sep + 'format=json',
+        headers={
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            "Accept": "application/json, */*",
+            "Accept-Encoding": "gzip",
+        }
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        raw = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            raw = gzip.decompress(raw)
+        text = raw.decode()
+    # Strip everything before the first {
+    return json.loads(re.sub(r'^[^\{]+', '', text))
+```
+
+---
+
+## Path 1: `?format=json` — article metadata + body (fastest for articles)
+
+Append `?format=json` to any article URL. Returns full metadata, virtuals (metrics), and the complete article body in a structured `bodyModel`. No auth required for public and subscriber-locked articles alike — the metadata and full body are always returned, but paywalled body content in a browser would be truncated.
+
+```python
+data = medium_json("https://medium.com/@karpathy/software-2-0-a64152b37c35")
+payload = data['payload']
+val     = payload['value']        # article fields
+refs    = payload['references']   # User, Social, SocialStats dicts keyed by ID
+
+# --- Article fields ---
+title       = val['title']                              # "Software 2.0"
+article_id  = val['id']                                 # "a64152b37c35"
+creator_id  = val['creatorId']                          # "ac9d9a35533e"
+slug        = val['uniqueSlug']                         # "software-2-0-a64152b37c35"
+url         = val['canonicalUrl']                       # "https://medium.com/@karpathy/..."
+first_pub   = val['firstPublishedAt']                   # unix ms: 1510438733751
+last_pub    = val['latestPublishedAt']                  # unix ms: 1615659523264
+visibility  = val['visibility']                         # 0=public, 2=subscriber-locked
+is_locked   = val['isSubscriptionLocked']               # True if paywalled
+locked_src  = val['lockedPostSource']                   # 0=free, 1=Medium Partner Program
+
+# --- Metrics (in val['virtuals']) ---
+virtuals    = val['virtuals']
+clap_count  = virtuals['totalClapCount']                # 60865 (all claps, including multi-clap)
+recommends  = virtuals['recommends']                    # 8846 (unique clappers)
+read_time   = virtuals['readingTime']                   # 8.79811320754717 (minutes, float)
+word_count  = virtuals['wordCount']                     # 2146
+
+# --- Tags ---
+tags = [t['slug'] for t in virtuals['tags']]
+# ['machine-learning', 'artificial-intelligence', 'programming', 'software-development', 'future']
+
+# --- Author (from references) ---
+user = refs['User'][creator_id]
+author_name = user['name']          # "Andrej Karpathy"
+author_handle = user['username']    # "karpathy"
+author_bio  = user['bio']           # "I like to train deep neural nets on large datasets."
+author_twitter = user['twitterScreenName']  # "karpathy"
+
+# --- Follower count (from SocialStats) ---
+ss = refs['SocialStats'][creator_id]
+follower_count  = ss['usersFollowedByCount']   # 60027
+following_count = ss['usersFollowedCount']     # 183
+```
+
+### Detect paywall
+
+```python
+# Paywalled (Medium Partner Program): isSubscriptionLocked=True, visibility=2, lockedPostSource=1
+# Free: isSubscriptionLocked=False, visibility=0, lockedPostSource=0
+is_paywalled = val['isSubscriptionLocked']   # True / False
+```
+
+Confirmed on real TDS articles: paywalled articles return `isSubscriptionLocked=True`, `visibility=2`, `lockedPostSource=1`. Free articles: all three are `False`/`0`.
+
+### Article body
+
+The full body is in `val['content']['bodyModel']['paragraphs']` — a list of dicts:
+
+```python
+paragraphs = val['content']['bodyModel']['paragraphs']
+
+# Paragraph types (confirmed for this article):
+# type=1  -> body text (P)
+# type=3  -> heading (H1/H2)
+# type=4  -> image (text is empty; metadata has image ID)
+
+# Reconstruct plain text:
+text_paras = [p['text'] for p in paragraphs if p.get('text')]
+full_text   = '\n\n'.join(text_paras)
+```
+
+---
+
+## Path 2: GraphQL API — targeted metric lookups
+
+`POST https://medium.com/_/graphql` with a JSON body. No auth, no CSRF token required.
+Returns HTTP 200 with JSON even for unauthenticated queries. Invalid fields return HTTP 400 — do not assume a field exists without testing first.
+
+```python
+import json, urllib.request, gzip
+
+def gql(query):
+    body = json.dumps({"query": query}).encode()
+    req  = urllib.request.Request(
+        "https://medium.com/_/graphql",
+        data=body,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        raw = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            raw = gzip.decompress(raw)
+        return json.loads(raw.decode())
+```
+
+### Fetch article metrics (fastest)
+
+```python
+result = gql("""
+{
+  post(id: "a64152b37c35") {
+    title
+    id
+    firstPublishedAt
+    latestPublishedAt
+    visibility
+    uniqueSlug
+    canonicalUrl
+    mediumUrl
+    isLocked
+    clapCount
+    readingTime
+    wordCount
+  }
+}
+""")
+post = result['data']['post']
+# post['visibility']  -> "PUBLIC" | "LOCKED"  (string, not numeric)
+# post['isLocked']    -> False | True
+# post['clapCount']   -> 60865  (same as totalClapCount in format=json)
+# post['readingTime'] -> 8.79811320754717  (minutes)
+# post['wordCount']   -> 2146
+```
+
+**Confirmed working `post()` fields:** `title`, `id`, `createdAt`, `updatedAt`, `firstPublishedAt`, `latestPublishedAt`, `visibility`, `uniqueSlug`, `canonicalUrl`, `mediumUrl`, `isLocked`, `clapCount`, `readingTime`, `wordCount`
+
+**Nested object that works:** `topics { name slug }`, `creator { name username }`, `collection { name id slug description domain creator { name username } }`
+
+**Fields that return HTTP 400 (not available):** `tags`, `author`, `recommends`, `content`, `publication`, `responses`, `sequence`
+
+### Fetch author profile
+
+```python
+result = gql("""
+{
+  user(username: "karpathy") {
+    name
+    username
+    id
+    bio
+    imageId
+    twitterScreenName
+    mediumMemberAt
+    socialStats {
+      followerCount
+      followingCount
+    }
+  }
+}
+""")
+user = result['data']['user']
+# user['name']                       -> "Andrej Karpathy"
+# user['id']                         -> "ac9d9a35533e"
+# user['bio']                        -> "I like to train deep neural nets on large datasets."
+# user['twitterScreenName']          -> "karpathy"
+# user['socialStats']['followerCount'] -> 60028
+# user['mediumMemberAt']             -> 0 (not a member); nonzero = unix ms join date
+```
+
+**Confirmed working `user()` fields:** `name`, `username`, `id`, `bio`, `imageId`, `twitterScreenName`, `mediumMemberAt`, `socialStats { followerCount followingCount }`
+
+**Fields that return HTTP 400:** `followerCount` (top-level), `followingCount` (top-level), `postCount`
+
+### Fetch collection (publication) by ID
+
+The GraphQL `collection()` query only accepts `id`, not `slug`. Get the ID from `?format=json` on the publication page.
+
+```python
+# TDS Archive id: 7f60cf5620c9  (from medium.com/towards-data-science?format=json)
+result = gql("""
+{
+  collection(id: "7f60cf5620c9") {
+    name
+    id
+    slug
+    description
+    domain
+    creator { name username }
+  }
+}
+""")
+coll = result['data']['collection']
+# coll['name'] -> "TDS Archive"
+# coll['slug'] -> "data-science"
+```
+
+---
+
+## Path 3: RSS feeds (best for recent posts list + article bodies)
+
+Works with plain `http_get`. Returns up to 10 most recent posts. Full article HTML is in `content:encoded`. No clap count or visibility info in RSS.
+
+```python
+import re
+from helpers import http_get
+
+def parse_rss_items(rss_xml):
+    """Extract items from Medium RSS feed. Returns list of dicts."""
+    def cdata(tag, text):
+        m = re.search(rf'<{tag}[^>]*><!\[CDATA\[(.*?)\]\]></{tag}>', text, re.DOTALL)
+        return m.group(1).strip() if m else None
+
+    items = []
+    for raw in re.findall(r'<item>(.*?)</item>', rss_xml, re.DOTALL):
+        # link is plain text (not CDATA)
+        link_m = re.search(r'<link>(.*?)</link>', raw, re.DOTALL)
+        items.append({
+            'title':    cdata('title', raw),
+            'link':     link_m.group(1).strip() if link_m else None,
+            'pubDate':  cdata('pubDate', raw),
+            'creator':  cdata('dc:creator', raw),
+            'tags':     re.findall(r'<category><!\[CDATA\[(.*?)\]\]></category>', raw),
+            'body_html': cdata('content:encoded', raw),   # full article HTML
+        })
+    return items
+
+# User feed (up to 10 latest posts)
+rss = http_get("https://medium.com/feed/@karpathy")
+posts = parse_rss_items(rss)
+# posts[0]['title']    -> "Software 2.0"
+# posts[0]['pubDate']  -> "Sat, 11 Nov 2017 22:18:53 GMT"
+# posts[0]['creator']  -> "Andrej Karpathy"
+# posts[0]['tags']     -> ['programming', 'software-development', 'artificial-intelligence', 'future', 'machine-learning']
+# posts[0]['link']     -> "https://karpathy.medium.com/software-2-0-a64152b37c35?source=rss-..."
+# posts[0]['body_html'] -> full article body as HTML string (~15KB for this article)
+
+# Publication feed (up to 10 latest posts)
+rss_pub = http_get("https://medium.com/feed/towards-data-science")
+pub_posts = parse_rss_items(rss_pub)
+```
+
+**RSS limitations:**
+- RSS does not include clap count, view count, or paywall status.
+- `body_html` contains the full article body as HTML, including `<p>`, `<strong>`, `<a>`, `<img>` tags.
+- Pagination is not supported — RSS always returns the 10 most recent posts.
+
+---
+
+## Path 4: `?format=json` on user profile — recent posts with metrics
+
+Better than RSS when you need clap counts alongside post list. Returns up to `limit` posts (default 10) plus full author metadata.
+
+```python
+data = medium_json("https://medium.com/@karpathy?limit=10")
+payload = data['payload']
+
+user = payload['user']
+# user['name']     -> "Andrej Karpathy"
+# user['username'] -> "karpathy"
+# user['bio']      -> "I like to train deep neural nets on large datasets."
+
+refs = payload['references']
+ss   = refs['SocialStats'][user['userId']]
+# ss['usersFollowedByCount'] -> 60028 (followers)
+# ss['usersFollowedCount']   -> 183   (following)
+
+posts = refs.get('Post', {})  # dict keyed by post ID
+for pid, p in posts.items():
+    v = p['virtuals']
+    print(p['title'], v['totalClapCount'], round(v['readingTime'], 1))
+
+# Paginate: use paging['next'] from payload
+paging = payload['paging']
+next_params = paging['next']
+# next_params = {'limit': 10, 'to': '1495652975362', 'source': 'overview', 'page': 2, 'ignoredIds': []}
+# Append as query params to the same profile URL to get next page
+next_url = (
+    f"https://medium.com/@{user['username']}"
+    f"?limit={next_params['limit']}&to={next_params['to']}"
+    f"&source={next_params['source']}&page={next_params['page']}"
+)
+data2 = medium_json(next_url)
+# Note: karpathy has only 8 total posts — pagination returns same refs on page 2
+```
+
+---
+
+## Path 5: `?format=json` on publication page
+
+Returns publication metadata and recent posts with metrics.
+
+```python
+data = medium_json("https://medium.com/towards-data-science")
+payload = data['payload']
+
+coll = payload['collection']
+# coll['name']            -> "TDS Archive"
+# coll['slug']            -> "data-science"
+# coll['description']     -> full description string
+# coll['subscriberCount'] -> 828527
+# coll['metadata']['followerCount'] -> 828527
+# coll['tags']            -> ['DATA SCIENCE', 'MACHINE LEARNING', ...]
+
+posts = payload['references'].get('Post', {})
+for pid, p in posts.items():
+    v = p['virtuals']
+    print(p['title'], v['totalClapCount'], p['isSubscriptionLocked'])
+# Also includes: p['visibility'] (0=free, 2=paywalled)
+
+# Paginate (same pattern as user profile)
+paging = payload['paging']
+# paging['next'] = {'to': '1738573325936', 'page': 3}
+```
+
+---
+
+## Retrieving the article ID from a URL
+
+The `id` is the last 12 hex chars of a Medium article URL slug:
+
+```python
+import re
+
+url = "https://medium.com/@karpathy/software-2-0-a64152b37c35"
+article_id = re.search(r'-([a-f0-9]{12})$', url.rstrip('/').split('?')[0])
+if article_id:
+    article_id = article_id.group(1)   # "a64152b37c35"
+```
+
+This ID is the same across all URL forms (`medium.com/@user/slug`, `user.medium.com/slug`, `medium.com/publication/slug`).
+
+---
+
+## Gotchas
+
+- **HTTP 403 on plain `http_get`** — The default `http_get` helper sends `User-Agent: Mozilla/5.0` which Medium accepts for most endpoints, but article HTML pages (without `?format=json`) return 403. Always use `?format=json` for article and profile pages.
+
+- **`?format=json` works; profile stream API does not** — `https://medium.com/_/api/users/{id}/profile/stream` returns HTTP 403 for unauthenticated requests. Use `?format=json` on the profile URL instead.
+
+- **`?format=json` on search pages returns 403 or broken JSON** — `medium.com/search?q=...&format=json` and `medium.com/search/posts?q=...&format=json` both fail. Search is not available without auth.
+
+- **GraphQL `collection()` requires ID, not slug** — `collection(slug: "towards-data-science")` returns HTTP 400. You must use the numeric ID (e.g. `"7f60cf5620c9"`). Get it from `?format=json` on the publication page: `payload['collection']['id']`.
+
+- **GraphQL `tags` field on `post()` returns HTTP 400** — Use `topics { name slug }` instead. Topics are a subset of tags but work without auth.
+
+- **GraphQL visibility is a string, not a number** — `post().visibility` returns `"PUBLIC"` or `"LOCKED"` (string). The `?format=json` `value.visibility` field uses integers: `0`=public, `2`=locked. Both agree on the lock status.
+
+- **`totalClapCount` vs `recommends`** — `totalClapCount` (60865) counts all claps (Medium allows up to 50 claps per reader). `recommends` (8846) counts unique clappers. The GraphQL `clapCount` field equals `totalClapCount`, not `recommends`.
+
+- **RSS returns at most 10 items, no clap counts** — RSS is best for getting recent article links + full HTML body. Use `?format=json` profile if you need metrics.
+
+- **RSS link contains tracking params** — `posts[0]['link']` includes `?source=rss-{userId}------2`. Strip with `.split('?')[0]` if you need a clean URL.
+
+- **`content:encoded` in RSS is full HTML, not plaintext** — Strip HTML tags if you want plaintext: `re.sub(r'<[^>]+>', '', body_html)`.
+
+- **Medium subdomains** — Some users have custom subdomains (`karpathy.medium.com`). Both `medium.com/@karpathy/...` and `karpathy.medium.com/...` resolve to the same article; `?format=json` works on both.
+
+- **towardsdatascience.com is no longer Medium** — TDS moved to its own WordPress site. `towardsdatascience.com/article-slug?format=json` returns full WordPress HTML, not Medium JSON. Use `medium.com/towards-data-science` for the archived Medium publication.
+
+- **No public search API** — Medium has no Algolia equivalent. Finding articles by keyword requires either a browser, or fetching a user/publication feed and filtering locally.
+
+- **Timestamps are unix milliseconds** — `firstPublishedAt`, `createdAt`, `latestPublishedAt` are all in milliseconds. Convert: `datetime.fromtimestamp(val['firstPublishedAt'] / 1000, tz=timezone.utc)`.

--- a/domain-skills/metacritic/scraping.md
+++ b/domain-skills/metacritic/scraping.md
@@ -1,0 +1,477 @@
+# Metacritic — Scraping & Data Extraction
+
+Field-tested against metacritic.com on 2026-04-18. All code blocks validated with live requests.
+
+## Do this first
+
+**Use the backend API — it returns clean JSON with both scores in one call, no HTML parsing.**
+
+Metacritic's internal backend API is publicly accessible with a stable key embedded in every page. It covers games, movies, and TV shows.
+
+```python
+import json
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+
+def get_game_scores(slug):
+    """slug = URL slug e.g. 'elden-ring', 'the-last-of-us'"""
+    base = f"https://backend.metacritic.com"
+    product = json.loads(http_get(
+        f"{base}/games/metacritic/{slug}/web"
+        f"?componentName=product&componentType=Product&apiKey={API_KEY}"
+    ))
+    user_stats = json.loads(http_get(
+        f"{base}/reviews/metacritic/user/games/{slug}/stats/web"
+        f"?componentName=user-score-summary&componentType=ScoreSummary&apiKey={API_KEY}"
+    ))
+    item = product["data"]["item"]
+    crit = item["criticScoreSummary"]
+    user = user_stats["data"]["item"]
+    return {
+        "title": item["title"],
+        "platform": item["platform"],           # lead platform
+        "platforms": item["platforms"],          # list with per-platform scores
+        "metascore": crit["score"],              # int 0–100 or None
+        "critic_reviews": crit["reviewCount"],  # int
+        "critic_sentiment": crit["sentiment"],   # e.g. "Universal acclaim"
+        "user_score": user["score"],             # float 0.0–10.0 or None
+        "user_reviews": user["reviewCount"],     # int
+        "user_sentiment": user["sentiment"],
+        "release_date": item["releaseDate"],     # "YYYY-MM-DD"
+    }
+
+print(get_game_scores("the-last-of-us"))
+# {'title': 'The Last of Us', 'platform': 'PlayStation 3',
+#  'metascore': 95, 'critic_reviews': 98,
+#  'user_score': 9.2, 'user_reviews': 17207, ...}
+```
+
+Use the browser **only** if you need music pages — `metacritic.com/music/*` returns HTTP 403 to `http_get` (Cloudflare blocks those routes). Games, movies, and TV all work with plain HTTP.
+
+---
+
+## Fastest approach: JSON-LD (critic score + review count only)
+
+If you only need the Metascore and critic review count and don't need the user score, JSON-LD is the single-call option — no API key, no separate request:
+
+```python
+import json, re
+
+url = "https://www.metacritic.com/game/elden-ring/"   # or /movie/ or /tv/
+html = http_get(url)
+
+block = re.findall(
+    r'<script[^>]*type="application/ld\+json"[^>]*>(.*?)</script>',
+    html, re.DOTALL
+)[0]
+ld = json.loads(block)
+
+agg = ld["aggregateRating"]
+print(ld["name"])                   # "Elden Ring"
+print(agg["ratingValue"])           # 96  (metascore)
+print(agg["reviewCount"])           # 93  (critic reviews count)
+print(ld.get("gamePlatform"))       # ['Xbox One', 'PC', 'PlayStation 4', 'Xbox Series X', 'PlayStation 5']
+print(ld.get("genre"))              # "Action RPG"
+print(ld.get("contentRating"))      # "M"
+print(ld.get("datePublished"))      # "2022-02-25"
+```
+
+**JSON-LD limitations:**
+- Only contains Metascore and critic review count — **no user score, no user review count**.
+- For multi-platform games, `ratingValue` is the lead platform score; all platforms are listed in `gamePlatform` but without individual scores.
+- `@type` is `VideoGame` for games, `Movie` for movies, `TVSeries` for TV shows.
+
+---
+
+## Common workflows
+
+### Get scores for a single title (backend API)
+
+```python
+import json
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+BASE = "https://backend.metacritic.com"
+
+# Games
+def game_scores(slug):
+    p = json.loads(http_get(f"{BASE}/games/metacritic/{slug}/web?componentName=product&componentType=Product&apiKey={API_KEY}"))
+    u = json.loads(http_get(f"{BASE}/reviews/metacritic/user/games/{slug}/stats/web?componentName=user-score-summary&componentType=ScoreSummary&apiKey={API_KEY}"))
+    c = p["data"]["item"]["criticScoreSummary"]
+    us = u["data"]["item"]
+    return {"metascore": c["score"], "critic_reviews": c["reviewCount"],
+            "user_score": us["score"], "user_reviews": us["reviewCount"]}
+
+# Movies
+def movie_scores(slug):
+    p = json.loads(http_get(f"{BASE}/movies/metacritic/{slug}/web?componentName=product&componentType=Product&apiKey={API_KEY}"))
+    u = json.loads(http_get(f"{BASE}/reviews/metacritic/user/movies/{slug}/stats/web?componentName=user-score-summary&componentType=ScoreSummary&apiKey={API_KEY}"))
+    c = p["data"]["item"]["criticScoreSummary"]
+    us = u["data"]["item"]
+    return {"metascore": c["score"], "critic_reviews": c["reviewCount"],
+            "user_score": us["score"], "user_reviews": us["reviewCount"]}
+
+# TV shows
+def show_scores(slug):
+    p = json.loads(http_get(f"{BASE}/shows/metacritic/{slug}/web?componentName=product&componentType=Product&apiKey={API_KEY}"))
+    u = json.loads(http_get(f"{BASE}/reviews/metacritic/user/shows/{slug}/stats/web?componentName=user-score-summary&componentType=ScoreSummary&apiKey={API_KEY}"))
+    c = p["data"]["item"]["criticScoreSummary"]
+    us = u["data"]["item"]
+    return {"metascore": c["score"], "critic_reviews": c["reviewCount"],
+            "user_score": us["score"], "user_reviews": us["reviewCount"]}
+
+# Verified results:
+print(game_scores("the-last-of-us"))
+# {'metascore': 95, 'critic_reviews': 98, 'user_score': 9.2, 'user_reviews': 17207}
+print(movie_scores("the-godfather"))
+# {'metascore': 100, 'critic_reviews': 16, 'user_score': 9.2, 'user_reviews': 4450}
+print(show_scores("breaking-bad"))
+# {'metascore': 87, 'critic_reviews': 98, 'user_score': 9.4, 'user_reviews': 19070}
+```
+
+### Parallel fetching (multiple titles at once)
+
+10 API calls in 0.68s with 5 workers — no rate-limit errors:
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+import urllib.request, gzip
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+
+def _fetch(url):
+    h = {"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"}
+    with urllib.request.urlopen(urllib.request.Request(url, headers=h), timeout=15) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip": data = gzip.decompress(data)
+        return json.loads(data.decode())
+
+def batch_game_scores(slugs, workers=5):
+    """Fetch critic+user scores for multiple game slugs in parallel."""
+    BASE = "https://backend.metacritic.com"
+    AK = f"apiKey={API_KEY}"
+
+    def fetch_one(slug):
+        c = _fetch(f"{BASE}/reviews/metacritic/critic/games/{slug}/stats/web?componentName=critic-score-summary&componentType=ScoreSummary&{AK}")
+        u = _fetch(f"{BASE}/reviews/metacritic/user/games/{slug}/stats/web?componentName=user-score-summary&componentType=ScoreSummary&{AK}")
+        ci = c["data"]["item"]
+        ui = u["data"]["item"]
+        return {"slug": slug, "metascore": ci["score"], "critic_reviews": ci["reviewCount"],
+                "user_score": ui["score"], "user_reviews": ui["reviewCount"]}
+
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        return list(ex.map(fetch_one, slugs))
+
+results = batch_game_scores([
+    "the-last-of-us", "elden-ring", "god-of-war",
+    "red-dead-redemption-2", "the-witcher-3-wild-hunt"
+])
+# the-last-of-us: meta=95/98critics, user=9.2/17207
+# elden-ring: meta=96/86critics, user=8.4/23344
+# god-of-war: meta=94/118critics, user=9.0/30439
+# red-dead-redemption-2: meta=97/99critics, user=9.0/35306
+# the-witcher-3-wild-hunt: meta=92/79critics, user=9.1/19370
+```
+
+### Search by title
+
+```python
+import json, urllib.parse
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+
+def search(query, media_type=None, limit=10):
+    """
+    media_type: None='all', 'games' (mcoTypeId=13), 'movies' (2), 'shows' (1)
+    Returns list of {title, type, slug, premiereYear, metascore, user_score}
+    """
+    type_map = {"games": 13, "movies": 2, "shows": 1}
+    q = urllib.parse.quote(query)
+    type_param = f"&mcoTypeId={type_map[media_type]}" if media_type else "&mcoTypeId=1%2C2%2C3%2C13"
+    url = (
+        f"https://backend.metacritic.com/finder/metacritic/search/{q}/web"
+        f"?offset=0&limit={limit}&sortBy=META_SCORE&sortDirection=DESC"
+        f"{type_param}&componentName=search&componentType=SearchResult"
+        f"&apiKey={API_KEY}"
+    )
+    data = json.loads(http_get(url))
+    items = data["data"]["items"]
+    return [
+        {
+            "title": i["title"],
+            "type": i["type"],          # "game-title", "movie", "tv-show"
+            "slug": i["slug"],
+            "year": i.get("premiereYear"),
+            "metascore": i.get("criticScoreSummary", {}).get("score"),
+            "user_score": i.get("userScore"),  # None in search results (use stats API for this)
+        }
+        for i in items
+    ]
+
+results = search("elden ring", media_type="games")
+# [{'title': 'Elden Ring', 'type': 'game-title', 'slug': 'elden-ring', 'year': 2022, 'metascore': 96, ...}]
+```
+
+**Note:** `userScore` is `None` in search results. Call the stats API with the `slug` to get it.
+
+### Browse/list titles by score
+
+```python
+import json
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+
+def browse_games(sort_by="-metaScore", year_min=None, year_max=None, offset=0, limit=24):
+    """
+    sort_by: '-metaScore' | '-releaseDate' | '-popularityCount'
+    Returns up to `limit` games with criticScoreSummary and userScore.
+    Total available: ~14,160 games.
+    """
+    params = f"sortBy={sort_by}&mcoTypeId=13&offset={offset}&limit={limit}"
+    if year_min: params += f"&releaseYearMin={year_min}"
+    if year_max: params += f"&releaseYearMax={year_max}"
+    url = f"https://backend.metacritic.com/finder/metacritic/web?{params}&componentName=finder&componentType=Finder&apiKey={API_KEY}"
+    data = json.loads(http_get(url))
+    total = data["data"]["totalResults"]
+    items = data["data"]["items"]
+    return total, [
+        {
+            "title": i["title"],
+            "slug": i["slug"],
+            "year": i.get("premiereYear"),
+            "metascore": i.get("criticScoreSummary", {}).get("score"),
+            "critic_reviews": i.get("criticScoreSummary", {}).get("reviewCount"),
+            "user_score": i.get("userScore", {}).get("score") if isinstance(i.get("userScore"), dict) else i.get("userScore"),
+        }
+        for i in items
+    ]
+
+total, games = browse_games(year_min=2023, year_max=2024)
+print(f"{total} games 2023-2024")   # 953
+for g in games[:3]:
+    print(g)
+# {'title': "Baldur's Gate 3", 'year': 2023, 'metascore': 96, 'user_score': 9.2}
+# {'title': 'The Legend of Zelda: Tears of the Kingdom', 'year': 2023, 'metascore': 96, ...}
+```
+
+Finder API totals (confirmed 2026-04-18):
+- Games (mcoTypeId=13): 14,160
+- Movies (mcoTypeId=2): 17,152
+- TV Shows (mcoTypeId=1): 3,392
+
+### Get per-platform scores for multi-platform games
+
+```python
+import json
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+
+def game_platforms(slug):
+    url = (
+        f"https://backend.metacritic.com/games/metacritic/{slug}/web"
+        f"?componentName=product&componentType=Product&apiKey={API_KEY}"
+    )
+    data = json.loads(http_get(url))
+    platforms = data["data"]["item"]["platforms"]
+    return [
+        {
+            "name": p["name"],
+            "slug": p["slug"],
+            "is_lead": p["isLeadPlatform"],
+            "metascore": p["criticScoreSummary"]["score"],        # None if <4 reviews
+            "critic_reviews": p["criticScoreSummary"]["reviewCount"],
+            "release_date": p["releaseDate"],
+        }
+        for p in platforms
+    ]
+
+print(game_platforms("elden-ring"))
+# [{'name': 'Xbox One', 'slug': 'xbox-one', 'is_lead': False, 'metascore': None, ...},
+#  {'name': 'PC', 'slug': 'pc', 'is_lead': False, 'metascore': 94, 'critic_reviews': 63},
+#  {'name': 'PlayStation 4', 'slug': 'playstation-4', 'is_lead': False, 'metascore': None, 'critic_reviews': 1},
+#  {'name': 'Xbox Series X', 'slug': 'xbox-series-x', 'is_lead': False, 'metascore': 96, 'critic_reviews': 19},
+#  {'name': 'PlayStation 5', 'slug': 'playstation-5', 'is_lead': True, 'metascore': 96, 'critic_reviews': 93}]
+```
+
+### Get critic reviews (paginated)
+
+```python
+import json
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+
+def get_critic_reviews(slug, media="games", offset=0, limit=10, sort="date"):
+    """sort: 'date' | 'score' | 'publication'"""
+    url = (
+        f"https://backend.metacritic.com/reviews/metacritic/critic/{media}/{slug}/web"
+        f"?offset={offset}&limit={limit}&sort={sort}"
+        f"&componentName=latest-critic-reviews&componentType=CriticReviewList&apiKey={API_KEY}"
+    )
+    data = json.loads(http_get(url))
+    total = data["data"]["totalResults"]   # e.g. 98
+    items = data["data"]["items"]
+    return total, [
+        {
+            "score": r["score"],                # int 0–100
+            "publication": r["publicationName"],
+            "quote": r["quote"],
+            "date": r["date"],
+            "url": r.get("url"),
+        }
+        for r in items
+    ]
+
+total, reviews = get_critic_reviews("the-last-of-us", sort="score")
+print(f"{total} critic reviews")   # 98
+print(reviews[0])
+# {'score': 97, 'publication': 'GamingXP', 'quote': 'Flawless in its ambition...', 'date': '...'}
+```
+
+### Get user reviews (paginated)
+
+```python
+import json
+
+API_KEY = "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+
+def get_user_reviews(slug, media="games", offset=0, limit=10, order_by="score", order_type="desc"):
+    """order_by: 'score' | 'date' | 'helpfulness'"""
+    url = (
+        f"https://backend.metacritic.com/reviews/metacritic/user/{media}/{slug}/web"
+        f"?offset={offset}&limit={limit}&orderBy={order_by}&orderType={order_type}"
+        f"&componentName=top-user-reviews&componentType=UserReviewList&apiKey={API_KEY}"
+    )
+    data = json.loads(http_get(url))
+    total = data["data"]["totalResults"]   # e.g. 2983 for The Last of Us
+    items = data["data"]["items"]
+    return total, [
+        {
+            "score": r["score"],   # int 0–10
+            "quote": r["quote"],
+            "date": r["date"],
+            "spoiler": r.get("spoiler", False),
+        }
+        for r in items
+    ]
+
+total, reviews = get_user_reviews("the-last-of-us")
+print(f"{total} user reviews")   # 2983
+```
+
+### NUXT_DATA extraction (alternative, no API key)
+
+If you need to avoid the backend API (e.g., the API key rotates), the HTML page embeds all score data in `<script id="__NUXT_DATA__">` as a flat pool with integer cross-references. This is more fragile but requires no API key:
+
+```python
+import json, re
+
+url = "https://www.metacritic.com/game/the-last-of-us/"
+html = http_get(url)
+
+pool = json.loads(
+    re.search(r'<script[^>]*id="__NUXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL).group(1)
+)
+
+def deref(pool, idx, depth=0, visited=None):
+    if visited is None: visited = set()
+    if not isinstance(idx, int) or idx in visited or depth > 4: return idx
+    visited.add(idx)
+    val = pool[idx]
+    if isinstance(val, dict):
+        return {k: deref(pool, v, depth+1, visited) if isinstance(v, int) else v for k, v in val.items()}
+    elif isinstance(val, list) and len(val) == 2 and isinstance(val[0], str) and val[0] in ('Ref','Reactive','ShallowReactive','ShallowRef'):
+        return deref(pool, val[1], depth+1, visited)
+    elif isinstance(val, list):
+        return [deref(pool, v, depth+1, visited) if isinstance(v, int) else v for v in val]
+    return val
+
+# Find components
+components_idx = next(
+    pool[i] for i, v in enumerate(pool)
+    if isinstance(v, list) and len(v) > 3 and all(isinstance(x, int) for x in v[:3])
+    and isinstance(pool[v[0]], dict) and 'data' in pool[v[0]] and 'meta' in pool[v[0]]
+)
+
+def find_component(pool, name):
+    for i, val in enumerate(pool):
+        if not isinstance(val, dict) or 'data' not in val or 'meta' not in val: continue
+        meta = pool[val['meta']] if isinstance(val.get('meta'), int) else {}
+        if not isinstance(meta, dict): continue
+        cname = pool[meta.get('componentName')] if isinstance(meta.get('componentName'), int) else ''
+        if cname == name: return deref(pool, val['data'])
+    return None
+
+critic = find_component(pool, 'critic-score-summary')
+user = find_component(pool, 'user-score-summary')
+print("Metascore:", critic['item']['score'])        # 95
+print("Critic reviews:", critic['item']['reviewCount'])  # 98
+print("User score:", user['item']['score'])         # 9.2
+print("User reviews:", user['item']['reviewCount']) # 17207
+```
+
+---
+
+## URL slug patterns
+
+Metacritic slugs are lowercased, spaces replaced with hyphens, special chars dropped:
+
+| Title | Slug |
+|-------|------|
+| `The Last of Us` | `the-last-of-us` |
+| `Baldur's Gate 3` | `baldurs-gate-3` |
+| `Elden Ring: Shadow of the Erdtree` | `elden-ring-shadow-of-the-erdtree` |
+| `Breaking Bad` | `breaking-bad` |
+| `The Godfather` | `the-godfather` |
+
+Derive slug from the page URL: everything between the media-type path and the trailing slash.
+
+```python
+import re
+
+def slug_from_url(url):
+    # Works for /game/, /movie/, /tv/
+    m = re.search(r'/(?:game|movie|tv)/([^/]+)/', url)
+    return m.group(1) if m else None
+
+slug_from_url("https://www.metacritic.com/game/the-last-of-us/")  # "the-last-of-us"
+```
+
+---
+
+## Anti-bot measures
+
+- **Cloudflare** is in front of both `metacritic.com` and `backend.metacritic.com` (confirmed via `CF-Ray` and `Server: cloudflare` headers).
+- **Frontend pages** (`metacritic.com/*`): Require a non-empty User-Agent. `Mozilla/5.0` works. `python-requests/...` or empty UA returns HTTP 403.
+- **Backend API** (`backend.metacritic.com`): Same rule — any non-empty User-Agent works, including `curl/7.84.0` and `python-requests/2.31.0`. Only truly empty UA gets 403.
+- **Music pages** (`metacritic.com/music/*`): HTTP 403 even with valid User-Agent — Cloudflare blocks that path category. The backend API for music also 404s. Use the browser via CDP for music pages.
+- **Cache**: Frontend pages are Cloudflare-cached (10 minute TTL, `Cache-Control: public, max-age=600`). Backend API responses are not cached (`CF-Cache-Status: MISS`).
+- **No CAPTCHA** observed during testing with any of the approaches above.
+- **No rate limit** hit during testing: 10 sequential calls at 3.6 calls/sec, 10 parallel calls in 0.68s — all succeeded.
+- **PerimeterX**: Not detected in response headers or HTML.
+
+---
+
+## Gotchas
+
+- **API key is embedded in every Metacritic page HTML** — find it by searching for `apiKey=` in `backend.metacritic.com` URLs. The key `1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u` was confirmed active as of 2026-04-18. If it rotates, fetch any Metacritic page and extract it: `re.search(r'apiKey=([A-Za-z0-9]+)', html).group(1)`.
+
+- **userScore is None in search results** — the `/finder/metacritic/search/` endpoint returns `userScore: null` for all results. Call the stats API separately with the slug to get user score + review count.
+
+- **Metascore None means < 4 reviews** — the backend API returns `score: null` (not 0) when a title has fewer than 4 critic reviews. Always check `if score is not None` before using.
+
+- **Multi-platform games: JSON-LD shows lead platform score** — for a game on PS5 and Xbox, `aggregateRating.ratingValue` in JSON-LD is the lead platform's score (the platform marked `isLeadPlatform: True` in the backend API). All platforms are listed in `gamePlatform` but without individual scores. Use the product API's `platforms` array for per-platform breakdown.
+
+- **Music is blocked** — `metacritic.com/music/*` returns HTTP 403 even with a real browser User-Agent. The backend API for albums (`/albums/metacritic/...`) also returns 404. Music data requires a real browser session via CDP.
+
+- **NUXT_DATA pool deref is fragile** — the pool structure is a flat array where every value is either a primitive or an integer index pointing elsewhere in the array. Component locations shift between page loads but the component names (`critic-score-summary`, `user-score-summary`) are stable.
+
+- **`http_get` default UA is `Mozilla/5.0`** — this works for Metacritic. No need to override it.
+
+- **Backend API `componentName` and `componentType` params are required** — omitting them returns HTTP 400. Use the exact values shown in the code examples above.
+
+- **Finder `userScore` format**: In finder/browse results, `userScore` is `{"score": 9.1}` (a dict with just `score`). In the stats API, it's a full object with `reviewCount`, `sentiment`, etc. In search results, it's `null`.
+
+- **Media type URL paths**: games=`/games/`, movies=`/movies/`, TV shows=`/shows/`. There is no `/tv/` path in the backend API (the frontend uses `/tv/` but the API uses `/shows/`).
+
+- **Finder API does not support free-text search** — the `q=` param is silently ignored and returns 0 results. Use the `/finder/metacritic/search/{query}/web` endpoint for title search.

--- a/domain-skills/open-library/scraping.md
+++ b/domain-skills/open-library/scraping.md
@@ -1,0 +1,472 @@
+# Open Library — Book Data Extraction
+
+`https://openlibrary.org` — Internet Archive's free book catalog. All endpoints are public JSON APIs — no auth, no browser, no scraping required.
+
+## Do this first
+
+**Every task is a direct HTTP call — never open the browser.**
+
+```python
+import json
+from helpers import http_get
+
+# Search by title
+results = json.loads(http_get("https://openlibrary.org/search.json?q=dune&limit=5"))
+# results['numFound']  == 49090
+# results['docs']      == list of work objects
+# results['start']     == 0  (offset for pagination)
+```
+
+The search API is your entry point for everything. It returns work-level records (all editions grouped). To get edition details, follow the `key` to the Works or Books API.
+
+---
+
+## Common workflows
+
+### Search by query, author, title, or ISBN
+
+```python
+import json
+from helpers import http_get
+
+# Free-text search
+r = json.loads(http_get("https://openlibrary.org/search.json?q=dune+frank+herbert&limit=5"))
+
+# Author search
+r = json.loads(http_get(
+    "https://openlibrary.org/search.json?author=tolkien&limit=5"
+    "&fields=title,author_name,first_publish_year,isbn"
+))
+# fields=* returns all available fields; default returns ~15
+
+# Title + author combined
+r = json.loads(http_get(
+    "https://openlibrary.org/search.json?title=dune&author=frank+herbert&limit=3"
+    "&fields=title,author_name,edition_count,first_publish_year"
+))
+# r['docs'][0]['title']              == 'Dune'
+# r['docs'][0]['author_name']        == ['Frank Herbert']
+# r['docs'][0]['first_publish_year'] == 1965
+# r['docs'][0]['edition_count']      == 120
+
+# ISBN lookup (returns 0–2 results for the same work)
+r = json.loads(http_get("https://openlibrary.org/search.json?isbn=9780743273565"))
+# r['numFound']            == 2
+# r['docs'][0]['title']    == 'The Great Gatsby'
+# r['docs'][0]['key']      == '/works/OL468431W'
+```
+
+**Sort options** (`&sort=`): `new` (recently added), `old`, `random`, `editions` (most editions), `scans` (most scans). Default is relevance.
+
+**Language filter**: `&language=fre` (ISO 639-2/B codes: `eng`, `fre`, `ger`, `spa`, `ita`, etc.)
+
+**Pagination**: `&limit=N&offset=N`. Max limit not enforced but keep under 100 for reliability.
+
+#### Search doc fields (default — ~15 keys always present)
+
+| Field | Type | Notes |
+|---|---|---|
+| `key` | str | `/works/OL893415W` — use for Works API |
+| `title` | str | Work title |
+| `author_name` | list[str] | e.g. `['Frank Herbert']` |
+| `author_key` | list[str] | e.g. `['OL79034A']` |
+| `first_publish_year` | int | |
+| `edition_count` | int | Number of editions across all languages |
+| `cover_i` | int | Cover image ID — use with covers API |
+| `cover_edition_key` | str | e.g. `OL7353617M` |
+| `language` | list[str] | ISO codes of all editions |
+| `ia` | list[str] | Internet Archive identifiers (when has_fulltext=true) |
+| `ebook_access` | str | `'public'`, `'borrowable'`, `'no_ebook'` |
+| `has_fulltext` | bool | |
+
+#### Extra fields with `&fields=*`
+
+```python
+# With fields=* you also get:
+# 'isbn'                   list[str]   All ISBNs across editions
+# 'publisher'              list[str]   All publishers ever
+# 'publish_date'           list[str]   All publish dates (strings, inconsistent formats)
+# 'publish_year'           list[int]   Parsed years
+# 'subject'                list[str]   Subject headings
+# 'person'                 list[str]   Subject persons (e.g. 'Big Brother')
+# 'place'                  list[str]   Subject places
+# 'time'                   list[str]   Subject times
+# 'number_of_pages_median' int         Median page count across editions
+# 'ratings_average'        float       e.g. 4.29
+# 'ratings_count'          int
+# 'want_to_read_count'     int
+# 'already_read_count'     int
+# 'currently_reading_count'int
+# 'readinglog_count'       int         Total of all reading log entries
+# 'first_sentence'         list[str]
+# 'id_goodreads'           list[str]
+# 'id_librarything'        list[str]
+# 'id_wikidata'            list[str]
+# 'ddc'                    list[str]   Dewey Decimal Classification
+# 'lcc'                    list[str]   Library of Congress Classification
+# 'lccn'                   list[str]
+```
+
+---
+
+### Bulk ISBN lookups (parallel)
+
+```python
+import json
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+
+isbns = ['9780743273565', '9780451524935', '9780618346257']
+
+def lookup_isbn(isbn):
+    url = f"https://openlibrary.org/search.json?isbn={isbn}&fields=title,author_name,first_publish_year,key"
+    r = json.loads(http_get(url))
+    if r['docs']:
+        d = r['docs'][0]
+        return {'isbn': isbn, 'title': d.get('title'), 'author': d.get('author_name', [None])[0],
+                'year': d.get('first_publish_year'), 'key': d.get('key')}
+    return {'isbn': isbn, 'found': False}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    books = list(ex.map(lookup_isbn, isbns))
+
+# [{'isbn': '9780743273565', 'title': 'The Great Gatsby', 'author': 'F. Scott Fitzgerald', 'year': 1920, ...},
+#  {'isbn': '9780451524935', 'title': 'Nineteen Eighty-Four', 'author': 'George Orwell',      'year': 1949, ...},
+#  {'isbn': '9780618346257', 'title': 'The Fellowship of the Ring', 'author': 'J.R.R. Tolkien', 'year': 1954, ...}]
+```
+
+---
+
+### Works API (editions grouped by title)
+
+Returns all metadata for a work (all editions combined). Get the work ID from `key` in search results.
+
+```python
+import json
+from helpers import http_get
+
+work_id = 'OL893415W'  # from search doc['key'] = '/works/OL893415W'
+work = json.loads(http_get(f"https://openlibrary.org/works/{work_id}.json"))
+
+# work['title']           == 'Dune'
+# work['key']             == '/works/OL893415W'
+# work['covers']          == [11481354, 12375564, 11157826]  ← cover IDs for covers API
+# work['subjects']        == ['Dune (Imaginary place)', 'Fiction', ...]
+# work['subject_places']  == [...]   ← geographic subjects (may be absent)
+# work['subject_people']  == [...]   ← person subjects (may be absent)
+# work['subject_times']   == [...]   ← time subjects (may be absent)
+# work['authors']         == [{'author': {'key': '/authors/OL79034A'}, 'type': {...}}]
+# work['description']     → either str OR {'type': '/type/text', 'value': str}  ← see gotchas
+# work['created']         == {'type': '/type/datetime', 'value': '2009-10-15T11:34:21.437031'}
+# work['last_modified']   same shape as created
+```
+
+Helper for the description field (which has two possible shapes):
+
+```python
+def get_description(work: dict) -> str:
+    desc = work.get('description', '')
+    if isinstance(desc, dict):
+        return desc.get('value', '')
+    return desc or ''
+```
+
+#### Works editions (paginated list of all editions)
+
+```python
+editions_resp = json.loads(http_get(
+    f"https://openlibrary.org/works/{work_id}/editions.json?limit=10&offset=0"
+))
+# editions_resp['size']    == 120      (total edition count)
+# editions_resp['entries'] == [...]    (up to limit items)
+# editions_resp['links']   == {'self': '...', 'work': '...', 'next': '...', 'prev': '...'}
+# ← use links['next'] for pagination when offset+limit < size
+
+e = editions_resp['entries'][0]
+# e['title']           == 'Duna'
+# e['publishers']      == ['Editora Aleph']
+# e['publish_date']    == '19/08/2017'   ← inconsistent format, string
+# e['isbn_13']         == ['9788576573135']
+# e['isbn_10']         == ['857657313X']
+# e['covers']          == [10368109]
+# e['number_of_pages'] == 680
+# e['languages']       == [{'key': '/languages/por'}]
+# e['key']             == '/books/OL28969075M'
+# e['physical_format'] == 'Paperback'   (often missing)
+# e['notes']           → str or {'value': str}  (often missing)
+```
+
+---
+
+### Books API (specific edition)
+
+Two sub-APIs: direct JSON for raw data, or `api/books` for enriched data.
+
+#### Direct edition JSON
+
+```python
+import json
+from helpers import http_get
+
+edition_id = 'OL7353617M'  # from editions list e['key'] or cover_edition_key in search
+edition = json.loads(http_get(f"https://openlibrary.org/books/{edition_id}.json"))
+
+# edition['title']           == 'Fantastic Mr. Fox'
+# edition['publishers']      == ['Puffin']
+# edition['publish_date']    == 'October 1, 1988'
+# edition['isbn_13']         == ['9780140328721']
+# edition['isbn_10']         == ['0140328726']
+# edition['number_of_pages'] == 96
+# edition['covers']          == [...]   ← cover IDs
+# edition['languages']       == [{'key': '/languages/eng'}]
+# edition['works']           == [{'key': '/works/OL45804W'}]
+# edition['authors']         == [{'key': '/authors/OL34184A'}]
+# edition['identifiers']     == {'goodreads': [...], 'librarything': [...]}
+# edition['first_sentence']  == {'value': '...'} or str  (often missing)
+# edition['ocaid']           == 'fantast00dahl'  ← Internet Archive ID (if available)
+```
+
+#### Bibkeys API (enriched, multiple books at once)
+
+```python
+# jscmd=data: cleaned up dict with cover URLs pre-built
+r = json.loads(http_get(
+    "https://openlibrary.org/api/books"
+    "?bibkeys=ISBN:9780743273565,ISBN:9780451524935"
+    "&format=json&jscmd=data"
+))
+# r == {'ISBN:9780743273565': {...}, 'ISBN:9780451524935': {...}}
+
+book = r['ISBN:9780743273565']
+# book['title']           == 'The Great Gatsby'
+# book['authors']         == [{'url': '...', 'name': 'F. Scott Fitzgerald'}]
+# book['publish_date']    == '2021'
+# book['publishers']      == [{'name': 'Independently Published'}]
+# book['number_of_pages'] == 208
+# book['url']             == 'http://openlibrary.org/books/OL46773254M/The_Great_Gatsby'
+# book['key']             == '/books/OL46773254M'
+# book['cover']           == {'small': '...S.jpg', 'medium': '...M.jpg', 'large': '...L.jpg'}
+# book['identifiers']     == {'isbn_13': [...], 'openlibrary': [...]}
+# book['subjects']        == [{'name': 'Modern fiction', 'url': '...'}, ...]
+# book['subject_places']  == None  ← often null even with jscmd=data
+
+# jscmd=details: raw edition JSON + extra fields
+r2 = json.loads(http_get(
+    "https://openlibrary.org/api/books"
+    "?bibkeys=ISBN:9780743273565&format=json&jscmd=details"
+))
+item = r2['ISBN:9780743273565']
+# item['bib_key']      == 'ISBN:9780743273565'
+# item['info_url']     == 'http://openlibrary.org/books/OL...'
+# item['preview']      == 'noview' | 'restricted' | 'full'
+# item['preview_url']  == URL to read on OL or IA
+# item['thumbnail_url']== 'https://covers.openlibrary.org/b/id/14314120-S.jpg'
+# item['details']      → raw edition JSON (same as /books/OL...M.json)
+
+# Supported bibkey prefixes: ISBN:, OCLC:, LCCN:, OLID: (e.g. OLID:OL46773254M)
+```
+
+---
+
+### Authors API
+
+```python
+import json
+from helpers import http_get
+
+# Lookup by known author key
+author = json.loads(http_get("https://openlibrary.org/authors/OL26320A.json"))
+# OL26320A is J.R.R. Tolkien (note: not Frank Herbert as originally stated — verify with search)
+
+# author['name']           == 'J.R.R. Tolkien'
+# author['fuller_name']    == 'John Ronald Reuel Tolkien'
+# author['personal_name']  == 'J. R. R. Tolkien'
+# author['birth_date']     == '3 January 1892'   ← string, not parsed
+# author['death_date']     == '2 September 1973'
+# author['bio']            → str or {'type': '/type/text', 'value': str}
+# author['photos']         == [6155606, 6433524, ...]   ← photo IDs for covers API
+# author['links']          == [{'title': '...', 'url': '...', 'type': {...}}, ...]
+# author['remote_ids']     == {'wikidata': 'Q892', 'viaf': '95218067', ...}
+# author['alternate_names']== ['J. R. R. Tolkien', 'TOLKIEN', ...]
+# author['key']            == '/authors/OL26320A'
+# author['wikipedia']      → URL string or None
+
+# Author works (paginated)
+works = json.loads(http_get("https://openlibrary.org/authors/OL26320A/works.json?limit=5"))
+# works['size']    == 415
+# works['entries'] == [{title, key, covers, authors, created, ...}, ...]
+# works['links']   == {'self': '...', 'next': '...'}
+```
+
+#### Author search
+
+```python
+r = json.loads(http_get("https://openlibrary.org/search/authors.json?q=tolkien"))
+# r['numFound'] == 40
+# r['docs'][0]:
+#   'name'                   == 'Christopher Tolkien'
+#   'key'                    == 'OL2623360A'     ← NOTE: no /authors/ prefix here
+#   'birth_date'             == '21 November 1924'
+#   'death_date'             == '16 January 2020'
+#   'top_work'               == 'The War of the Ring'
+#   'work_count'             == 43
+#   'top_subjects'           == [...]
+#   'alternate_names'        == [...]
+#   'ratings_average'        float
+#   'want_to_read_count'     int
+#   'already_read_count'     int
+#   'currently_reading_count'int
+```
+
+---
+
+### Cover images
+
+Covers are served directly as JPEG — redirect to Internet Archive CDN. No auth needed.
+
+```
+# Book covers — three key types:
+https://covers.openlibrary.org/b/id/{cover_id}-{size}.jpg      # by cover ID (most reliable)
+https://covers.openlibrary.org/b/isbn/{isbn}-{size}.jpg        # by ISBN
+https://covers.openlibrary.org/b/olid/{edition_id}-{size}.jpg  # by edition OLID (unreliable — see gotchas)
+
+# Author photos:
+https://covers.openlibrary.org/a/id/{photo_id}-{size}.jpg
+
+# Sizes: S (small), M (medium), L (large)
+```
+
+```python
+import urllib.request
+
+def get_cover_bytes(cover_id: int, size: str = 'M') -> bytes | None:
+    """Fetch cover image bytes. Returns None if no cover (43-byte GIF placeholder)."""
+    url = f"https://covers.openlibrary.org/b/id/{cover_id}-{size}.jpg"
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        data = resp.read()
+    return None if len(data) == 43 else data   # 43-byte GIF = no cover placeholder
+
+# Or just get the URL for embedding:
+def cover_url(cover_id: int, size: str = 'M') -> str:
+    return f"https://covers.openlibrary.org/b/id/{cover_id}-{size}.jpg"
+
+# Usage:
+from helpers import http_get
+import json
+work = json.loads(http_get("https://openlibrary.org/works/OL893415W.json"))
+if work.get('covers'):
+    img = get_cover_bytes(work['covers'][0], 'L')   # first cover, large
+    # img is ~20–80KB JPEG bytes, redirected from ia*.archive.org
+```
+
+To get cover by ISBN directly (e.g. for UI without a full book lookup):
+```python
+# Medium-size cover by ISBN:
+url = f"https://covers.openlibrary.org/b/isbn/{isbn}-M.jpg"
+# Redirects to Internet Archive CDN, content-type: image/jpeg
+# Use ?default=false to get 404 instead of 1×1 GIF placeholder for missing covers
+url_safe = f"https://covers.openlibrary.org/b/isbn/{isbn}-M.jpg?default=false"
+```
+
+---
+
+### Subjects API
+
+```python
+import json
+from helpers import http_get
+
+# Subject slugs: lowercase, underscores for spaces
+r = json.loads(http_get("https://openlibrary.org/subjects/science_fiction.json?limit=5"))
+# r['name']          == 'science fiction'
+# r['subject_type']  == 'subject'   ← also: 'person', 'place', 'time'
+# r['work_count']    == 20973
+# r['works']         == [{title, key, cover_id, authors, edition_count, ...}, ...]
+
+w = r['works'][0]
+# w['title']           == 'Alice\'s Adventures in Wonderland'
+# w['key']             == '/works/OL138052W'
+# w['cover_id']        == 10527843
+# w['cover_edition_key']== 'OL...'
+# w['authors']         == [{'key': '/authors/OL22098A', 'name': 'Lewis Carroll'}]
+# w['edition_count']   == 3546
+# w['first_publish_year']== ...
+# w['has_fulltext']    == True | False
+# w['ia']              == 'identifier'   (Internet Archive ID when available)
+
+# Pagination: &offset=N
+# Place subject:
+r2 = json.loads(http_get("https://openlibrary.org/subjects/place:london.json?limit=5"))
+# r2['subject_type'] == 'place', r2['work_count'] == 23927
+
+# Person subject:
+# https://openlibrary.org/subjects/person:napoleon.json?limit=5
+# Time subject:
+# https://openlibrary.org/subjects/time:middle_ages.json?limit=5
+
+# Combine with ebooks=true to filter to only freely readable books:
+r3 = json.loads(http_get("https://openlibrary.org/subjects/science_fiction.json?limit=5&ebooks=true"))
+# r3['works'][i]['has_fulltext'] == True for all results
+```
+
+---
+
+### Trending books
+
+```python
+import json
+from helpers import http_get
+
+for period in ['daily', 'weekly', 'monthly']:
+    r = json.loads(http_get(f"https://openlibrary.org/trending/{period}.json?limit=10"))
+    # r['works']  == list of search-doc-style objects
+    # r['days']   == int (time window)
+    # r['hours']  == int
+    # Same fields as search docs (title, author_name, cover_i, key, ...)
+    print(period, r['works'][0]['title'])  # e.g. 'Atomic Habits'
+```
+
+---
+
+## Rate limits
+
+No authentication required. No API key. No explicit rate limit published.
+
+Observed in testing: 5 requests completed in ~1 second with no throttling, no 429s. The API is served from CDN/Solr — in practice you can make 10–20 parallel requests without issue. For bulk operations (hundreds of ISBNs), use `ThreadPoolExecutor(max_workers=5)` to be a good citizen.
+
+**No `User-Agent` override needed** — the default `Mozilla/5.0` from `http_get` is accepted by all Open Library endpoints (unlike Nominatim which blocks it).
+
+---
+
+## Gotchas
+
+**`description` field has two shapes.** Both are real — check at runtime:
+```python
+desc = work.get('description', '')
+text = desc.get('value', '') if isinstance(desc, dict) else (desc or '')
+```
+
+**`/works/OL45804W` is Fantastic Mr. Fox, not Dune.** The OL IDs in the original prompt were placeholders. Always resolve real IDs via the search API rather than hardcoding them.
+
+**Author search `key` has no prefix.** `/search/authors.json` returns `key: 'OL26320A'`, but the Authors API and all other APIs use `/authors/OL26320A`. Add the prefix manually when constructing follow-up URLs.
+
+**Missing cover → 43-byte GIF placeholder, not 404.** Without `?default=false`, the covers API returns a 1×1 transparent GIF instead of HTTP 404 for unknown IDs. Check `len(data) == 43` to detect missing covers.
+
+**`covers.openlibrary.org/b/olid/{work_id}` is unreliable.** OLID-based cover URLs for work IDs (OL...W) return the placeholder even when covers exist. Always use `b/id/{cover_id}` (from `work['covers'][0]`) or `b/isbn/{isbn}` instead.
+
+**Bibkeys API picks one edition per ISBN.** When the same ISBN appears on multiple editions (reprint, reissue), `api/books?bibkeys=ISBN:...` returns one — and it may not be the most common edition.
+
+**`publish_date` is a raw string.** Values like `'October 1, 1988'`, `'19/08/2017'`, `'2021'`, and `'1965-01-01'` all appear. Don't parse without normalization.
+
+**`/works/.../editions.json` pagination uses `links.next`.** Unlike search (which uses `offset=`), check `links['next']` in the response to know if more pages exist:
+```python
+resp = json.loads(http_get("https://openlibrary.org/works/OL893415W/editions.json?limit=50"))
+while 'next' in resp.get('links', {}):
+    resp = json.loads(http_get("https://openlibrary.org" + resp['links']['next']))
+    # process resp['entries']
+```
+
+**404 for non-existent IDs.** `/works/OL99999999W.json`, `/books/OL99999999M.json`, and `/authors/OL99999999A.json` all raise `HTTPError: HTTP Error 404: Not Found`. Wrap in try/except.
+
+**Search `docs` default fields are minimal.** The default response includes ~15 fields. Add `&fields=*` to get all 100+ Solr fields (ratings, ISBNs, publishers, subjects, Goodreads IDs, etc.). Alternatively specify exactly what you need: `&fields=title,isbn,ratings_average`.

--- a/domain-skills/openstreetmap/scraping.md
+++ b/domain-skills/openstreetmap/scraping.md
@@ -1,0 +1,490 @@
+# OpenStreetMap — Nominatim Geocoding + Overpass API
+
+Two fully public, no-auth APIs. Everything is a direct HTTP call — never need a browser.
+
+- **Nominatim**: geocoding (place name → lat/lon and reverse). Rate limit: 1 req/s.
+- **Overpass API**: spatial query engine over the full OSM dataset. Rate limit: 2 concurrent slots per IP on the public instance.
+
+**Do not use `http_get` without overriding `User-Agent`** — its default `Mozilla/5.0` is blocked by both APIs with HTTP 403. Pass `headers={"User-Agent": "browser-harness/1.0"}` on every call.
+
+---
+
+## Fastest path: forward geocode a place
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+
+def geocode(query: str, limit: int = 3) -> list[dict]:
+    q = urllib.parse.quote(query)
+    raw = http_get(
+        f"https://nominatim.openstreetmap.org/search?q={q}&format=json&limit={limit}&addressdetails=1",
+        headers=UA
+    )
+    return json.loads(raw)  # [] when nothing found
+
+results = geocode("Eiffel Tower")
+# results[0]['display_name']  == 'Tour Eiffel, 5, Avenue Anatole France, ..., 75007, France'
+# results[0]['lat']            == '48.8582599'   ← STRING, not float
+# results[0]['lon']            == '2.2945006'    ← STRING, not float
+# results[0]['type']           == 'tower'
+# results[0]['class']          == 'man_made'
+# results[0]['importance']     == 0.6205937724353116
+# results[0]['osm_type']       == 'way'
+# results[0]['osm_id']         == 5013364
+# results[0]['boundingbox']    == ['48.8574753', '48.8590453', '2.2933119', '2.2956897']  ← all strings
+# results[0]['address']['city']     == 'Paris'
+# results[0]['address']['postcode'] == '75007'
+# results[0]['address']['country']  == 'France'
+# results[0]['address']['country_code'] == 'fr'
+```
+
+---
+
+## Nominatim: all three query modes
+
+### 1. Forward geocode (free-text)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+
+raw = http_get(
+    "https://nominatim.openstreetmap.org/search?q=Eiffel+Tower&format=json&limit=3&addressdetails=1",
+    headers=UA
+)
+results = json.loads(raw)
+# Returns [] when nothing found — no exception
+
+# Useful optional params:
+# &addressdetails=1   → adds 'address' dict to each result (city, postcode, road, etc.)
+# &extratags=1        → adds 'extratags' dict (website, wikidata, phone, etc.)
+# &namedetails=1      → adds 'namedetails' dict (name:en, name:fr, etc.)
+# &countrycodes=fr,de → restrict to countries (comma-separated ISO 3166-1 alpha-2)
+# &viewbox=2.2,48.8,2.4,48.9 &bounded=1  → restrict to bounding box (lon_min,lat_min,lon_max,lat_max)
+```
+
+### 2. Reverse geocode (lat/lon → address)
+
+```python
+raw = http_get(
+    "https://nominatim.openstreetmap.org/reverse?lat=48.8584&lon=2.2945&format=json",
+    headers=UA
+)
+result = json.loads(raw)
+# result['display_name']  == 'Avenue Gustave Eiffel, Quartier du Gros-Caillou, ..., France'
+# result['address']['road']         == 'Avenue Gustave Eiffel'
+# result['address']['city']         == 'Paris'
+# result['address']['postcode']     == '75007'
+# result['address']['country']      == 'France'
+# result['address']['country_code'] == 'fr'
+# result['address']['state']        == 'Île-de-France'
+# result['lat'], result['lon']  → strings (not floats)
+
+# Optional: &zoom=N (0-18) controls granularity of the returned address
+# zoom=3 → country, zoom=10 → city, zoom=18 → street/building (default)
+```
+
+### 3. Structured search (field-based)
+
+```python
+raw = http_get(
+    "https://nominatim.openstreetmap.org/search?city=Paris&country=France&format=json&limit=1",
+    headers=UA
+)
+result = json.loads(raw)[0]
+# result['name']          == 'Paris'
+# result['lat']           == '48.8534951'
+# result['lon']           == '2.3483915'
+# result['type']          == 'administrative'
+# result['place_rank']    == 12  (lower = broader: 4=country, 8=state, 12=city, 30=POI)
+# result['addresstype']   == 'city'
+# result['boundingbox']   == ['48.8155755', '48.9021560', '2.2241220', '2.4697602']
+
+# Supported structured params: street, city, county, state, country, postalcode
+```
+
+### 4. Lookup by OSM ID
+
+```python
+# Prefix: N=node, W=way, R=relation
+raw = http_get(
+    "https://nominatim.openstreetmap.org/lookup?osm_ids=W5013364&format=json",
+    headers=UA
+)
+result = json.loads(raw)
+# Returns list. Eiffel Tower way: result[0]['name'] == 'Tour Eiffel'
+# Supports up to 50 IDs: osm_ids=W5013364,N123456,R789
+```
+
+---
+
+## Nominatim response field reference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `place_id` | int | Internal Nominatim ID — do not cache long-term, can change |
+| `osm_type` | str | `"node"`, `"way"`, or `"relation"` |
+| `osm_id` | int | The OSM element ID |
+| `lat` | **str** | Latitude as string — convert with `float(r['lat'])` |
+| `lon` | **str** | Longitude as string — convert with `float(r['lon'])` |
+| `display_name` | str | Full human-readable address string |
+| `name` | str | Short name of the place |
+| `type` | str | OSM type tag value: `"tower"`, `"administrative"`, `"restaurant"`, etc. |
+| `class` | str | OSM key: `"man_made"`, `"boundary"`, `"amenity"`, `"highway"`, etc. |
+| `addresstype` | str | Semantic category: `"city"`, `"road"`, `"man_made"`, etc. |
+| `place_rank` | int | Hierarchy rank: 4=country, 8=state, 12=city, 16=suburb, 30=POI |
+| `importance` | float | 0–1 relevance score (higher = more notable) |
+| `boundingbox` | list[str] | `[south_lat, north_lat, west_lon, east_lon]` — all strings, note unusual order |
+| `licence` | str | ODbL attribution string — include in user-facing output |
+| `address` | dict | Only present with `&addressdetails=1` or in reverse results |
+
+`address` dict common keys: `road`, `house_number`, `quarter`, `suburb`, `city_district`, `city`, `state`, `postcode`, `country`, `country_code`, `ISO3166-2-lvl4/6`.
+
+---
+
+## Overpass API: query OSM data by tags
+
+Overpass is a read-only query engine over the full OSM planet. It supports finding POIs by tag, radius, bounding box, and combinations.
+
+**Endpoint**: `https://overpass-api.de/api/interpreter`
+**Backup instances** (use when main is overloaded, which happens often):
+- `https://overpass.openstreetmap.fr/api/interpreter` — requires non-Mozilla User-Agent
+
+**http_get works for GET requests** — pass `headers={"User-Agent": "browser-harness/1.0"}`. For POST, use `urllib` directly (see example below).
+
+### GET query (simplest for http_get)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_get(query: str) -> dict:
+    url = f"{OVERPASS}?data={urllib.parse.quote(query)}"
+    raw = http_get(url, headers=UA)
+    if not raw.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML returned): {raw[:200]}")
+    return json.loads(raw)
+
+# Find cafes in central Paris (bbox: south_lat, west_lon, north_lat, east_lon)
+r = overpass_get('[out:json][timeout:25];node["amenity"="cafe"](48.855,2.295,48.862,2.308);out 10;')
+# r['version']    == 0.6
+# r['generator']  == 'Overpass API 0.7.62.7 375dc00a'
+# r['elements']   → list of matching OSM elements
+
+for cafe in r['elements']:
+    print(cafe['tags'].get('name'), cafe['lat'], cafe['lon'])
+# 'Café de l\'Alma' 48.8609068 2.3015143
+# 'Le Campanella'   48.8585847 2.3032822
+# 'Kozy Bosquet'    48.855445  2.3054013
+
+# Find restaurants within 500m radius of a point (around filter)
+r = overpass_get(
+    '[out:json][timeout:25];node["amenity"="restaurant"](around:500,37.7749,-122.4194);out 10;'
+)
+for rest in r['elements']:
+    print(rest['tags'].get('name'), rest['tags'].get('cuisine',''))
+# 'Nepalese Indian Cusine' 'indian;nepali'
+# 'Local Diner' 'coffee_shop;italian;burger;seafood'
+# 'Moya Cafe' ''
+```
+
+### POST query (for complex QL, avoids URL length limits)
+
+```python
+import json, urllib.parse, urllib.request, gzip
+from helpers import http_get  # http_get is GET-only; use urllib for POST
+
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_post(query: str) -> dict:
+    """POST to Overpass — no URL length limits, preferred for multi-statement QL."""
+    data = urllib.parse.urlencode({"data": query}).encode()
+    req = urllib.request.Request(
+        OVERPASS, data=data, method="POST",
+        headers={
+            "User-Agent": "browser-harness/1.0",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept-Encoding": "gzip",
+        }
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        body = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+    body = body.decode()
+    if not body.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML): {body[:300]}")
+    return json.loads(body)
+
+# Example: cafes in Paris bbox
+r = overpass_post('[out:json][timeout:25];node["amenity"="cafe"](48.855,2.295,48.862,2.308);out 5;')
+print(len(r['elements']))  # 5 (or up to 5)
+```
+
+### Overpass element structure
+
+Every element in `r['elements']` is a dict with at minimum:
+
+```python
+{
+    "type": "node",          # "node", "way", or "relation"
+    "id": 308684349,         # int — OSM element ID (stable, use for dedup)
+    "lat": 48.8609068,       # float — ONLY present for node type
+    "lon": 2.3015143,        # float — ONLY present for node type
+    "tags": {                # dict — all OSM tags on this element
+        "amenity": "cafe",
+        "name": "Café de l'Alma",
+        "name:fr": "Café de l'Alma",
+        "outdoor_seating": "yes",
+        "payment:credit_cards": "yes",
+        "phone": "+33 1 45 51 56 74",
+        "opening_hours": "Mo-Sa 08:00-23:00; Su 09:00-19:00",  # optional
+        "website": "https://...",                               # optional
+        "wheelchair": "yes"                                     # optional
+    }
+}
+```
+
+For `way` elements, use `out center;` to get a `center` dict with lat/lon instead of a node list:
+
+```python
+# way element with out center:
+{
+    "type": "way",
+    "id": 338411946,
+    "center": {"lat": 48.8660087, "lon": 2.3153233},  # centroid of the polygon
+    "nodes": [3454913623, 3454913707, ...],            # node IDs forming the boundary
+    "tags": {"amenity": "cafe", "name": "Café 1902", ...}
+}
+
+# Query to get both nodes and ways with lat/lon:
+query = '[out:json][timeout:25];(node["amenity"="cafe"](48.85,2.29,48.87,2.32);way["amenity"="cafe"](48.85,2.29,48.87,2.32););out center 20;'
+r = overpass_get(query)
+for el in r['elements']:
+    if el['type'] == 'node':
+        lat, lon = el['lat'], el['lon']
+    else:  # way
+        lat, lon = el['center']['lat'], el['center']['lon']
+    print(el['tags'].get('name'), lat, lon)
+```
+
+### Overpass QL quick reference
+
+```
+[out:json][timeout:25]      # Required header: JSON output, 25s timeout
+[maxsize:52428800]          # Optional: 50MB max result size (default is server limit)
+
+node["amenity"="cafe"](south,west,north,east);out N;
+#  ↑ bbox order: south_lat, west_lon, north_lat, east_lon
+#  Note: DIFFERENT from Nominatim's boundingbox field which is [south,north,west,east]
+
+node["amenity"="cafe"](around:RADIUS_METERS,LAT,LON);out N;
+
+node["amenity"~"cafe|restaurant"](bbox);out N;    # regex match on tag value
+node[!"name"](bbox);out N;                        # elements WITHOUT the 'name' tag
+node["name"~"Star",i](bbox);out N;               # case-insensitive regex
+
+# Union of types:
+(node["amenity"="cafe"](bbox); way["amenity"="cafe"](bbox););out center N;
+
+# Multiple tags (AND logic):
+node["amenity"="cafe"]["outdoor_seating"="yes"](bbox);out N;
+```
+
+---
+
+## OSM tile server (reference only, no scraping)
+
+```
+https://{a,b,c}.tile.openstreetmap.org/{z}/{x}/{y}.png
+```
+
+- Subdomains `a`, `b`, `c` for load balancing
+- `z` = zoom level 0–19, `x`/`y` = tile coordinates
+- Returns 256×256 PNG tiles
+- Policy: max 2 req/s per IP, non-commercial use, must display OSM attribution
+- Tile coordinate calculator: `https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames`
+- Bulk tile downloading is prohibited — use Overpass or data extracts instead
+
+```python
+# Convert lat/lon to tile coordinates
+import math
+
+def lat_lon_to_tile(lat, lon, zoom):
+    n = 2 ** zoom
+    x = int((lon + 180) / 360 * n)
+    y = int((1 - math.log(math.tan(math.radians(lat)) + 1 / math.cos(math.radians(lat))) / math.pi) / 2 * n)
+    return x, y
+
+x, y = lat_lon_to_tile(48.8582, 2.2945, 14)
+url = f"https://a.tile.openstreetmap.org/14/{x}/{y}.png"
+# url == 'https://a.tile.openstreetmap.org/14/8281/5646.png'
+```
+
+---
+
+## Rate limits
+
+| API | Limit | Enforcement | 429 behavior |
+|-----|-------|-------------|--------------|
+| Nominatim | 1 req/s | Soft — rapid requests work but you get delayed/dropped | Returns HTTP 403 if your IP is banned (not 429) |
+| Overpass (main) | 2 concurrent slots per IP | Hard — 3rd concurrent req returns HTML error immediately | HTML error page with `rate_limited` in body |
+| Overpass (main) | Also: query complexity quota | Resets over time (~per hour) | HTML error page with `rate_limited` |
+| Tile server | 2 req/s per IP | Soft/hard | IP block |
+
+**Check your Overpass quota**:
+```python
+raw = http_get("https://overpass-api.de/api/status", headers={"User-Agent": "browser-harness/1.0"})
+print(raw)
+# Connected as: 1728118854
+# Rate limit: 2
+# 2 slots available now.
+# Slot available after: 2026-04-18T11:00:00Z, in 30 seconds.
+```
+
+**Handle rate limiting in production**:
+```python
+import time
+
+def overpass_get_with_retry(query: str, max_retries: int = 3) -> dict:
+    for attempt in range(max_retries):
+        url = f"https://overpass.openstreetmap.fr/api/interpreter?data={urllib.parse.quote(query)}"
+        raw = http_get(url, headers={"User-Agent": "browser-harness/1.0"})
+        if raw.startswith("{"):
+            return json.loads(raw)
+        if "rate_limited" in raw or "too busy" in raw:
+            wait = 2 ** attempt * 10  # 10s, 20s, 40s
+            time.sleep(wait)
+            continue
+        raise RuntimeError(f"Overpass error: {raw[:200]}")
+    raise RuntimeError("Overpass: too many retries")
+```
+
+---
+
+## Complete working example
+
+```python
+import json, time, urllib.parse, urllib.request, gzip
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+NOMINATIM = "https://nominatim.openstreetmap.org"
+OVERPASS   = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def geocode(query: str, limit: int = 1) -> list[dict]:
+    """Forward geocode — returns [] if nothing found."""
+    q = urllib.parse.quote(query)
+    raw = http_get(f"{NOMINATIM}/search?q={q}&format=json&limit={limit}&addressdetails=1", headers=UA)
+    return json.loads(raw)
+
+def reverse_geocode(lat: float, lon: float) -> dict:
+    """Reverse geocode — always returns a result (nearest road/place)."""
+    raw = http_get(f"{NOMINATIM}/reverse?lat={lat}&lon={lon}&format=json", headers=UA)
+    return json.loads(raw)
+
+def overpass_get(query: str) -> list[dict]:
+    """Run an Overpass QL query, return elements list."""
+    url = f"{OVERPASS}?data={urllib.parse.quote(query)}"
+    raw = http_get(url, headers=UA)
+    if not raw.startswith("{"):
+        raise RuntimeError(f"Overpass error: {raw[:200]}")
+    return json.loads(raw)["elements"]
+
+def overpass_post(query: str) -> list[dict]:
+    """POST variant — avoids URL length limits for complex queries."""
+    data = urllib.parse.urlencode({"data": query}).encode()
+    req = urllib.request.Request(
+        OVERPASS, data=data, method="POST",
+        headers={"User-Agent": "browser-harness/1.0",
+                 "Content-Type": "application/x-www-form-urlencoded",
+                 "Accept-Encoding": "gzip"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        body = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+    body = body.decode()
+    if not body.startswith("{"):
+        raise RuntimeError(f"Overpass error: {body[:300]}")
+    return json.loads(body)["elements"]
+
+# --- Usage examples (validated 2026-04-18) ---
+
+# 1. Geocode a landmark
+places = geocode("Eiffel Tower", limit=3)
+# places[0]['lat']  == '48.8582599'  (string)
+# places[0]['lon']  == '2.2945006'   (string)
+# places[0]['display_name'] == 'Tour Eiffel, 5, Avenue Anatole France, ..., 75007, France'
+# places[0]['address']['city'] == 'Paris'
+lat = float(places[0]['lat'])
+lon = float(places[0]['lon'])
+
+# 2. Reverse geocode the coordinates
+addr = reverse_geocode(lat, lon)
+# addr['address']['road']    == 'Avenue Gustave Eiffel'
+# addr['address']['city']    == 'Paris'
+# addr['address']['postcode']== '75007'
+# addr['address']['country'] == 'France'
+
+# 3. Find nearby cafes (wait 1s between nominatim and overpass if same script)
+time.sleep(1)
+cafes = overpass_get(
+    f"[out:json][timeout:25];node[\"amenity\"=\"cafe\"](around:500,{lat},{lon});out 10;"
+)
+for cafe in cafes:
+    print(f"{cafe['tags'].get('name','?'):30s}  {cafe['lat']:.4f}, {cafe['lon']:.4f}")
+# Café de l'Alma                  48.8609, 2.3015
+# Le Campanella                   48.8586, 2.3033
+
+# 4. Structured city lookup + find restaurants in bounding box
+time.sleep(1)
+paris = geocode("Paris, France")[0]
+bb = paris['boundingbox']  # [south_lat, north_lat, west_lon, east_lon] ← Nominatim order!
+# For Overpass: need (south_lat, west_lon, north_lat, east_lon) ← DIFFERENT order
+south, north, west, east = bb[0], bb[1], bb[2], bb[3]
+# Restrict to center slice to avoid massive result set
+center_bbox = f"48.855,2.295,48.865,2.315"
+rests = overpass_post(
+    f"[out:json][timeout:25];node[\"amenity\"=\"restaurant\"]({center_bbox});out 5;"
+)
+print(f"Found {len(rests)} restaurants near Paris center")
+```
+
+---
+
+## Gotchas
+
+**`http_get` default UA (`Mozilla/5.0`) is blocked by both APIs.** Always pass `headers={"User-Agent": "browser-harness/1.0"}`. The `headers` kwarg in `http_get` does a `.update()` so it properly overrides the default. Confirmed: Mozilla/5.0 → 403 on Nominatim; `browser-harness/1.0` → 200.
+
+**Blocked User-Agent patterns on Nominatim**: `Mozilla/5.0`, `python-requests/*`, `Wget/*`. Accepted: any non-generic app-style UA like `browser-harness/1.0`, `MyApp/2.0`, `curl/7.x`. Nominatim policy requires a descriptive UA with contact info, but in practice any non-library string passes.
+
+**Nominatim lat/lon are strings, Overpass lat/lon are floats.** Always convert Nominatim coordinates: `float(result['lat'])`. Overpass element `lat`/`lon` are native Python floats — no conversion needed.
+
+**Nominatim `boundingbox` field order is `[south_lat, north_lat, west_lon, east_lon]` — NOT `[south, west, north, east]`.** Overpass bbox uses `(south_lat, west_lon, north_lat, east_lon)`. When feeding a Nominatim bounding box into Overpass, you must reorder: `f"({bb[0]},{bb[2]},{bb[1]},{bb[3]})"`.
+
+**`overpass-api.de` main instance is frequently overloaded.** Returns HTTP 504 (timeout) or an HTML error page with `rate_limited` when busy. The FR mirror (`overpass.openstreetmap.fr`) is usually more responsive but also blocks `Mozilla/5.0`. Always detect non-JSON responses: `if not raw.startswith("{")`.
+
+**Overpass error responses are HTML, not JSON.** The API returns HTTP 200 with an HTML error page when rate-limited or when the server is too busy. Always check `raw.startswith("{")` before parsing.
+
+**Overpass rate limit: 2 concurrent slots, NOT 2 requests/s.** You can run 2 queries simultaneously. A 3rd concurrent query immediately returns an error. Sequential queries with no sleep between them work fine as long as each completes before the next starts.
+
+**`out N;` limits results to N elements — use it.** Without a limit, large bounding boxes can return thousands of elements and hit the 512MB memory limit, returning a `maxsize` error. Default safe limit: `out 50;` for exploration, `out 500;` for bulk collection.
+
+**Overpass QL bbox order is `(south, west, north, east)` — latitude FIRST.** This is the opposite of the standard GeoJSON convention `[west, south, east, north]`. The `around:` filter uses `(around:METERS,LAT,LON)` — note lat before lon.
+
+**`name` tag in Overpass is the local-language name.** For Paris cafes this is French. English names may appear under `name:en` but are often absent. Never assume `name` is in English.
+
+**Nominatim `/reverse` always returns the nearest result** — it never returns an empty response (unlike `/search`). If the coordinates are in the ocean, it still returns the nearest coastline or country.
+
+**`place_id` is internal and ephemeral** — do not store it for long-term use. Use `osm_type` + `osm_id` for stable references (e.g., `way/5013364` for the Eiffel Tower).
+
+**Overpass `http_get` POST workaround**: `http_get` only supports GET. For POST requests (needed to avoid URL length limits for complex multi-statement QL), use `urllib.request.Request` directly as shown in the `overpass_post()` example above.

--- a/domain-skills/quora/scraping.md
+++ b/domain-skills/quora/scraping.md
@@ -1,0 +1,364 @@
+# Quora — Data Extraction
+
+`https://www.quora.com` — Q&A platform. One reliable access path: `http_get` with a Chrome UA against question, answer, topic, and profile pages. Quora SSR-renders all public data into `window.ansFrontendGlobals.data.inlineQueryResults` via `.push()` calls. No browser needed for read-only tasks.
+
+## Do this first: pick your access path
+
+| Goal | Best approach | Latency |
+|------|--------------|---------|
+| Question metadata + first ~3 ranked answers | `http_get` question page + parse push payloads | ~600ms |
+| Single answer (full text + upvotes + views) | `http_get` answer permalink | ~400ms |
+| Answer count for a question | question page, payload with `answerCount` | same request as above |
+| Topic metadata (id, name, follower count) | `http_get` topic page + parse push payloads | ~400ms |
+| User profile (name, follower/following, credential) | `http_get` profile page + parse push payloads | ~500ms |
+| Keyword search results | NOT available via http_get — server returns no result data | N/A |
+
+**Never use a browser for read-only Quora tasks.** All question, answer, topic, and profile data is server-rendered. Browser is only needed for authenticated actions (posting, upvoting, following) or for getting more than the first ~3 answers on a question page (the rest load via XHR pagination).
+
+---
+
+## UA requirement: Chrome or Firefox — NOT bare Mozilla/5.0
+
+```
+bare "Mozilla/5.0"  -> HTTP 403
+Googlebot UA        -> HTTP 403
+Chrome UA           -> HTTP 200  (confirmed working)
+Firefox UA          -> HTTP 200  (confirmed working)
+```
+
+Use this header bundle for all requests:
+
+```python
+import urllib.request, gzip, json, re
+
+CHROME_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/123.0.0.0 Safari/537.36"
+)
+
+def quora_get(url):
+    """Fetch any public Quora page. Returns HTML string.
+    Requires Chrome/Firefox UA — bare Mozilla/5.0 returns 403.
+    """
+    req = urllib.request.Request(url, headers={
+        "User-Agent": CHROME_UA,
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Encoding": "gzip",
+        "Accept-Language": "en-US,en;q=0.9",
+    })
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+```
+
+---
+
+## The data format: `ansFrontendGlobals.data.inlineQueryResults`
+
+Quora SSR embeds all page data as a series of `.push("...")` calls inside `<script>` blocks. Each call pushes a JSON-encoded string (with escaped quotes) into `inlineQueryResults`. There are no JSON-LD blocks, no `__NEXT_DATA__`, no React hydration state — only these push calls.
+
+```python
+def extract_quora_payloads(html):
+    """Extract and parse all push() payloads from a Quora page.
+    Returns list of dicts (already decoded from double JSON encoding).
+    """
+    raw_payloads = re.findall(r'\.push\("((?:[^"\\]|\\.)*)"\)', html)
+    results = []
+    for raw in raw_payloads:
+        try:
+            # Two levels of encoding: outer JS string escape, inner JSON
+            inner = json.loads('"' + raw + '"')   # decode JS string escaping
+            results.append(json.loads(inner))      # decode actual JSON
+        except Exception:
+            pass
+    return results
+```
+
+A question page returns **16 payloads**. A profile or topic page returns **3 payloads**. The payloads that matter are identified by their `data` keys, not by position (positions are stable across requests for the same page type, but best to key on content).
+
+---
+
+## Path 1: Question page — metadata + first answers (fastest)
+
+```python
+def quora_question(url):
+    """
+    Scrape a Quora question page.
+    Returns:
+      question: {qid, id, title, url, slug, topics}
+      answers:  list of answer dicts (first ~3 ranked answers only)
+      answer_count: total answer count (all answers, not just loaded)
+      related_questions: list of question title strings
+    Only the first ~3 highest-ranked answers are SSR'd.
+    The rest require XHR pagination (browser or session cookies needed).
+    """
+    html = quora_get(url)
+    payloads = extract_quora_payloads(html)
+
+    def spans_to_text(json_str):
+        """Quora stores all text as serialized span objects."""
+        try:
+            doc = json.loads(json_str)
+            parts = []
+            for sec in doc.get('sections', []):
+                for span in sec.get('spans', []):
+                    if span.get('text'):
+                        parts.append(span['text'])
+                parts.append('\n')
+            return ''.join(parts).strip()
+        except Exception:
+            return json_str
+
+    def author_display_name(author_dict):
+        names = author_dict.get('names', [])
+        if names:
+            n = names[0]
+            return f"{n.get('givenName', '')} {n.get('familyName', '')}".strip()
+        return None
+
+    result = {'question': {}, 'answers': [], 'answer_count': None, 'related_questions': []}
+
+    for payload in payloads:
+        data = payload.get('data', payload)
+
+        # Question metadata — keyed by presence of 'qid' inside 'question'
+        if 'question' in data and isinstance(data['question'], dict):
+            q = data['question']
+            if q.get('qid') and not result['question']:
+                result['question'] = {
+                    'qid':   q.get('qid'),
+                    'id':    q.get('id'),
+                    'title': spans_to_text(q.get('title', '')),
+                    'url':   q.get('url'),
+                    'slug':  q.get('slug'),
+                    'topics': [t['name'] for t in q.get('navigationTopics', [])],
+                }
+
+        # Total answer count — keyed by 'answerCount'
+        if 'answerCount' in data:
+            result['answer_count'] = data['answerCount']
+            rq = (data.get('bottomRelatedQuestionsInfo') or {}).get('relatedQuestions', [])
+            result['related_questions'] = [spans_to_text(r['title']) for r in rq]
+
+        # Answer nodes — keyed by node.__typename == 'QuestionAnswerItem2'
+        node = data.get('node', {})
+        if isinstance(node, dict) and node.get('__typename') == 'QuestionAnswerItem2':
+            answer = node.get('answer', {})
+            if answer.get('aid'):
+                a_author = answer.get('author') or {}
+                cred = answer.get('authorCredential') or {}
+                result['answers'].append({
+                    'aid':              answer.get('aid'),
+                    'index':            node.get('index'),
+                    'author_name':      author_display_name(a_author),
+                    'author_profile':   a_author.get('profileUrl'),
+                    'author_uid':       a_author.get('uid'),
+                    'author_credential': cred.get('translatedString'),
+                    'num_upvotes':      answer.get('numUpvotes'),
+                    'num_views':        answer.get('numViews'),
+                    'num_shares':       answer.get('numShares'),
+                    'num_comments':     answer.get('numDisplayComments'),
+                    'creation_time_us': answer.get('creationTime'),  # microseconds since epoch
+                    'viewer_has_access': answer.get('viewerHasAccess'),
+                    'perma_url':        answer.get('permaUrl'),
+                    'text':             spans_to_text(answer.get('content', '{}')),
+                })
+
+    return result
+```
+
+### Example output
+
+```python
+result = quora_question("https://www.quora.com/What-is-the-meaning-of-life")
+
+# result['question']:
+# {
+#   'qid': 2861,
+#   'id': 'UXVlc3Rpb25AMDoyODYx',
+#   'title': 'What is the meaning of life?',
+#   'url': '/What-is-the-meaning-of-life',
+#   'slug': 'What-is-the-meaning-of-life',
+#   'topics': ['Philosophy', 'The Big Unanswered Questions', 'Meaning of Life', ...]
+# }
+
+# result['answer_count']:  413
+
+# result['answers'][0]:
+# {
+#   'aid': 2779675,
+#   'index': 1,
+#   'author_name': 'Shubhankar Srivastava',
+#   'author_profile': '/profile/Shubhankar-Srivastava',
+#   'author_uid': 5381038,
+#   'author_credential': 'works at D. E. Shaw',
+#   'num_upvotes': 589,
+#   'num_views': 24085,
+#   'num_shares': 0,
+#   'num_comments': 8,
+#   'creation_time_us': 1373364681312036,   # divide by 1e6 for seconds
+#   'viewer_has_access': True,
+#   'perma_url': '/What-is-the-meaning-of-life/answer/Shubhankar-Srivastava',
+#   'text': 'Every morning in Africa, a deer wakes up...'
+# }
+```
+
+### Convert creation_time_us to datetime
+
+```python
+from datetime import datetime, timezone
+ts_sec = result['answers'][0]['creation_time_us'] / 1_000_000
+dt = datetime.fromtimestamp(ts_sec, tz=timezone.utc)
+# datetime(2013, 7, 9, 9, 31, 21, tzinfo=timezone.utc)
+```
+
+---
+
+## Path 2: Single answer permalink
+
+Fetching `quora.com/{question-slug}/answer/{author-slug}` directly returns only that one answer's full data in 3 payloads instead of 16. Use this when you already know the answer URL.
+
+```python
+def quora_answer(answer_url):
+    """
+    Fetch a single answer by its permalink.
+    URL format: https://www.quora.com/{question-slug}/answer/{author-profile-slug}
+    Returns answer dict with: aid, num_upvotes, num_views, text, author info.
+    """
+    html = quora_get(answer_url)
+    payloads = extract_quora_payloads(html)
+
+    for payload in payloads:
+        data = payload.get('data', {})
+        if 'answer' in data and isinstance(data['answer'], dict):
+            a = data['answer']
+            author = a.get('author') or {}
+            names = author.get('names', [{}])
+            n = names[0] if names else {}
+            return {
+                'aid':          a.get('aid'),
+                'num_upvotes':  a.get('numUpvotes'),
+                'num_views':    a.get('numViews'),
+                'author_name':  f"{n.get('givenName','')} {n.get('familyName','')}".strip(),
+                'author_uid':   author.get('uid'),
+                'text':         _spans_to_text(a.get('content', '{}')),
+            }
+    return {}
+
+# Example:
+# quora_answer("https://www.quora.com/What-is-the-meaning-of-life/answer/Pararth-Shah")
+# -> {'aid': 4734237, 'num_upvotes': 234, 'num_views': 100643, 'author_name': 'Pararth Shah', ...}
+```
+
+---
+
+## Path 3: Topic page
+
+```python
+def quora_topic(topic_url):
+    """
+    Fetch topic metadata from a Quora topic page.
+    URL format: https://www.quora.com/topic/{topic-slug}
+    Returns: tid, name, num_followers, url, is_following, has_leaderboard.
+    NOTE: The topic page itself only renders topic metadata, NOT the question feed.
+    Question feed requires browser (XHR-loaded via React).
+    """
+    html = quora_get(topic_url)
+    payloads = extract_quora_payloads(html)
+
+    for payload in payloads:
+        data = payload.get('data', {})
+        if 'topic' in data and isinstance(data['topic'], dict):
+            t = data['topic']
+            return {
+                'tid':           t.get('tid'),
+                'id':            t.get('id'),
+                'name':          t.get('name'),
+                'url':           t.get('url'),
+                'num_followers': t.get('numFollowers'),
+                'is_following':  t.get('isFollowing'),
+                'has_leaderboard': t.get('hasLeaderboard'),
+                'photo_url':     t.get('photoUrl'),
+                'is_locked':     t.get('isLocked'),
+            }
+    return {}
+
+# Example:
+# quora_topic("https://www.quora.com/topic/Python-programming-language")
+# -> {'tid': 13292, 'name': 'Python Programming Language', 'num_followers': 10, ...}
+```
+
+---
+
+## Path 4: User profile page
+
+```python
+def quora_profile(profile_url):
+    """
+    Fetch user profile data from https://www.quora.com/profile/{username}
+    Returns: uid, name, credential, follower_count, following_count, profile_image_url.
+    """
+    html = quora_get(profile_url)
+    payloads = extract_quora_payloads(html)
+
+    for payload in payloads:
+        data = payload.get('data', {})
+        if 'user' in data and isinstance(data['user'], dict):
+            u = data['user']
+            names = u.get('names', [{}])
+            n = names[0] if names else {}
+            cred = u.get('profileCredential') or {}
+            return {
+                'uid':             u.get('uid'),
+                'id':              u.get('id'),
+                'name':            f"{n.get('givenName','')} {n.get('familyName','')}".strip(),
+                'profile_url':     u.get('profileUrl'),
+                'follower_count':  u.get('followerCount'),
+                'following_count': u.get('followingCount'),
+                'profile_image':   u.get('profileImageUrl'),
+                'credential':      cred.get('experience'),
+                'is_verified':     u.get('isVerified'),
+                'is_anon':         u.get('isAnon'),
+                'is_ai_account':   u.get('isAiAccount'),
+                'deactivated':     u.get('deactivated'),
+            }
+    return {}
+
+# Example:
+# quora_profile("https://www.quora.com/profile/Pararth-Shah")
+# -> {'uid': 4683832, 'name': 'Pararth Shah', 'follower_count': 5154,
+#     'following_count': 83, 'credential': 'Unfinished symphony.', ...}
+```
+
+---
+
+## Gotchas
+
+- **Bare Mozilla/5.0 UA returns HTTP 403** — Always use a full Chrome or Firefox UA string. The default `http_get` helper's `"User-Agent": "Mozilla/5.0"` will be blocked. Do not use `http_get` directly; use the `quora_get` wrapper above.
+
+- **Googlebot UA returns HTTP 403** — Quora blocks crawler UAs. Only real browser UAs work.
+
+- **Double JSON encoding** — Each `.push()` argument is a JavaScript string literal containing JSON. To parse: first `json.loads('"' + raw + '"')` to decode the JS string escaping (converts `\\"` to `"`), then `json.loads(inner)` to parse the actual JSON object. Skipping either step produces parse errors.
+
+- **All text fields are serialized span objects** — `question.title`, `answer.content`, `user.descriptionQtextDocument.legacyJson`, etc. are all JSON strings containing a `{"sections": [{"spans": [...]}]}` document, not plain text. Always parse through `spans_to_text()`.
+
+- **Question page only SSR's the first ~3 answers** — The `answers` list in the result will contain at most 3 entries (the top-ranked answers). The `answer_count` field shows the true total (e.g. 413). To get more answers you need browser-based XHR pagination (Quora sends additional answers via GraphQL calls that require session auth in practice).
+
+- **`viewer_has_access: false` still includes full content** — Even when `viewerHasAccess` is `False` (answers from Quora+ Spaces / tribe-only content), the `content` field is still present in the SSR payload and the full text is readable. The flag only controls client-side gating in the browser.
+
+- **`creation_time_us` is microseconds, not milliseconds** — Divide by `1_000_000` (not `1_000`) to get a Unix timestamp in seconds. Confirmed: `1373364681312036 / 1e6 = 1373364681.3` (July 2013).
+
+- **`numFollowers` on topic pages may be 0 even for major topics** — The field reflects the logged-in user's follow state for some topics and appears to undercount. Treat as approximate.
+
+- **Search pages do not yield result data** — `https://www.quora.com/search?q=...` returns 3 payloads with viewer/network info only — no search results in the SSR payload. Search results are loaded client-side and are not accessible via http_get.
+
+- **Profile pages do not include the user's answer list** — The profile page SSR payload returns user metadata only. The list of a user's answers is loaded via XHR pagination. To get answers for a specific question, use the question URL directly.
+
+- **IDs are base64-encoded Relay global IDs** — `id: "UXVlc3Rpb25AMDoyODYx"` decodes to `"Question@0:2861"`. The numeric `qid`/`uid`/`aid`/`tid` fields are more useful for constructing URLs and deduplication. Use `qid` and `aid` as stable identifiers.
+
+- **`permaUrl` may be an absolute URL for Spaces answers** — Most answers have `permaUrl: "/Question-slug/answer/Author-Name"` (relative). Answers posted in a Quora Space have a full absolute URL like `"https://spacename.quora.com/Question-slug"`. Handle both forms.
+
+- **No public REST or GraphQL API** — Quora's internal `graphql/gql_para_POST` endpoint requires a valid `quora-formkey` header derived from the session, making it inaccessible without a real authenticated session. The SSR push-payload approach is the only reliable unauthenticated path.

--- a/domain-skills/rawg/scraping.md
+++ b/domain-skills/rawg/scraping.md
@@ -1,0 +1,352 @@
+# RAWG — Scraping & Data Extraction
+
+Field-tested against rawg.io on 2026-04-18.
+`https://rawg.io` — world's largest video game database with 500K+ games.
+
+---
+
+## API status — key required, no workaround
+
+`https://api.rawg.io/api/` requires a valid API key on every request.
+Empty key, dummy key, and header spoofing all return **HTTP 401**. Confirmed:
+
+```
+api.rawg.io/api/games?page_size=5          -> 401
+api.rawg.io/api/games?page_size=5&key=     -> 401
+api.rawg.io/api/games?page_size=5&key=DEMO -> 401
+rawg.io/api/games?page_size=5              -> 401
+# Referer/Origin headers make no difference
+```
+
+Free API keys are available at `https://rawg.io/apidocs` after signing up at
+`https://rawg.io/signup` (no credit card, ~1 minute). Free tier: **20,000 requests/month**.
+Set the key in `.env` as `RAWG_API_KEY=<your_key>`.
+
+---
+
+## Approach 1 (Fastest, no key): HTML scraping via `window.CLIENT_PARAMS`
+
+The website server-renders all game data into `window.CLIENT_PARAMS` in the page HTML.
+One `http_get` call, pure JSON parse, no browser required.
+Confirmed working on all tested game pages.
+
+### Single game page
+
+```python
+import json
+from helpers import http_get
+
+def extract_game(slug):
+    """
+    Fetch full game data from rawg.io/games/{slug}.
+    Handles canonical-slug redirects (e.g. 'disco-elysium-the-final-cut'
+    transparently becomes 'disco-elysium-final-cut').
+    Returns game dict or None.
+    """
+    resp = http_get(f"https://rawg.io/games/{slug}")
+    idx = resp.find('window.CLIENT_PARAMS = {')
+    if idx < 0:
+        return None
+    chunk = resp[idx + len('window.CLIENT_PARAMS = '):]
+    # Extract JSON by counting braces
+    depth, end = 0, 0
+    for i, c in enumerate(chunk):
+        if c == '{': depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+    params = json.loads(chunk[:end])
+    initial_state = params['initialState']
+    entities = initial_state['entities']
+    games = entities.get('games', {})
+    # game.slug has 'g-' prefix and reflects the canonical slug after any redirect
+    canonical_key = initial_state.get('game', {}).get('slug', '')
+    game = games.get(canonical_key)
+    if not game:
+        game = games.get(f'g-{slug}')
+    if not game:
+        for g in games.values():
+            if isinstance(g, dict) and g.get('slug') == slug:
+                return g
+    return game
+
+game = extract_game('the-witcher-3-wild-hunt')
+# All fields confirmed present:
+# game['name']             -> 'The Witcher 3: Wild Hunt'
+# game['id']               -> 3328
+# game['slug']             -> 'the-witcher-3-wild-hunt'
+# game['rating']           -> 4.64          (RAWG community score, 0-5)
+# game['rating_top']       -> 5
+# game['ratings_count']    -> 7184
+# game['metacritic']       -> 92            (None if no score)
+# game['released']         -> '2015-05-18'
+# game['updated']          -> '2026-04-17T23:18:04'
+# game['playtime']         -> 43            (average hours)
+# game['website']          -> 'https://thewitcher.com/en/witcher3'
+# game['background_image'] -> 'https://media.rawg.io/media/games/618/618c2031a07bbff6b4f611f10b6bcdbc.jpg'
+# game['added']            -> 22198         (count of users who added to library)
+# game['esrb_rating']      -> {'id': 4, 'name': 'Mature', 'slug': 'mature'}
+# game['genres']           -> [{'id': 4, 'name': 'Action', 'slug': 'action'}, ...]
+# game['platforms']        -> ['playstation5', 'xbox-series-x', 'pc', ...]  (slugs, cross-ref entities)
+# game['parent_platforms'] -> ['pc', 'playstation', 'xbox', 'mac', 'nintendo']
+# game['developers']       -> [{'id': 9023, 'name': 'CD PROJEKT RED', 'slug': '...'}]
+# game['publishers']       -> [{'id': 7411, 'name': 'CD PROJEKT RED', 'slug': '...'}]
+# game['tags']             -> [{'id': 31, 'name': 'Singleplayer', ...}, ...]
+# game['description_raw']  -> plain-text description (detail page only)
+# game['description']      -> HTML description
+# game['ratings']          -> [{'title': 'exceptional', 'percent': 76.53}, ...]
+# game['metacritic_platforms'] -> [{'metascore': 93, 'platform': {...}}, ...]
+```
+
+### Extract specific fields
+
+```python
+def game_summary(slug):
+    g = extract_game(slug)
+    if not g:
+        return None
+    return {
+        'id':           g['id'],
+        'name':         g['name'],
+        'slug':         g['slug'],
+        'rating':       g['rating'],
+        'metacritic':   g['metacritic'],
+        'released':     g['released'],
+        'playtime_hrs': g['playtime'],
+        'website':      g.get('website'),
+        'esrb':         (g.get('esrb_rating') or {}).get('name'),
+        'genres':       [ge['name'] for ge in g.get('genres', []) if isinstance(ge, dict)],
+        'platforms':    g.get('parent_platforms', []),
+        'developers':   [d['name'] for d in g.get('developers', []) if isinstance(d, dict)],
+        'publishers':   [p['name'] for p in g.get('publishers', []) if isinstance(p, dict)],
+        'tags':         [t['name'] for t in g.get('tags', []) if isinstance(t, dict)][:10],
+        'image':        g.get('background_image'),
+    }
+
+# Confirmed results:
+print(game_summary('red-dead-redemption-2'))
+# {'id': 28, 'name': 'Red Dead Redemption 2', 'rating': 4.59, 'metacritic': 96,
+#  'released': '2018-10-26', 'playtime_hrs': 21,
+#  'esrb': 'Mature',
+#  'genres': ['Action'],
+#  'platforms': ['pc', 'playstation', 'xbox'],
+#  'developers': ['Rockstar Games'], 'publishers': ['Rockstar Games'],
+#  'tags': ['Singleplayer', 'Multiplayer', 'Atmospheric', 'Great Soundtrack', 'Co-op', ...]}
+```
+
+### Top 40 games from the listing page
+
+The listing page always returns the same ~40 popular games regardless of URL params
+(ordering/search/genres params are client-side only — the server returns the same SSR payload).
+
+```python
+def top_games():
+    """Returns list of 40 game dicts from rawg.io/games listing page."""
+    resp = http_get("https://rawg.io/games")
+    idx = resp.find('window.CLIENT_PARAMS = {')
+    if idx < 0:
+        return []
+    chunk = resp[idx + len('window.CLIENT_PARAMS = '):]
+    depth, end = 0, 0
+    for i, c in enumerate(chunk):
+        if c == '{': depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+    params = json.loads(chunk[:end])
+    return list(params['initialState']['entities'].get('games', {}).values())
+
+games = top_games()
+# 40 games, each with: id, slug, name, released, rating, rating_top, ratings_count,
+# metacritic, playtime, added, genres (full objects), parent_platforms (slugs),
+# platforms (slugs), tags (full objects), esrb_rating, background_image, short_screenshots
+# NOTE: listing omits description, website, developers, publishers vs detail pages
+
+for g in games[:5]:
+    print(f"{g['name']} | rating={g['rating']} | metacritic={g['metacritic']}")
+# Grand Theft Auto V | rating=4.47 | metacritic=92
+# The Witcher 3: Wild Hunt | rating=4.64 | metacritic=92
+# Portal 2 | rating=4.58 | metacritic=95
+# Counter-Strike: Global Offensive | rating=3.57 | metacritic=81
+# Tomb Raider (2013) | rating=4.06 | metacritic=86
+```
+
+### Bulk / concurrent fetching
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+slugs = ['portal-2', 'dark-souls-iii', 'minecraft', 'hades', 'celeste']
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(extract_game, slugs))
+# Tested: 4 games in ~2.8s at max_workers=4
+# Occasional timeout at high concurrency — keep max_workers<=3 to stay reliable
+```
+
+---
+
+## Approach 2: REST API (requires free key)
+
+All endpoints live at `https://api.rawg.io/api/`. Append `&key=YOUR_API_KEY` to every request.
+
+### Get a free key
+
+1. Sign up at `https://rawg.io/signup`
+2. Visit `https://rawg.io/apidocs` — click "Get API key"
+3. The key is a 40-char hex string
+4. Store as `RAWG_API_KEY` in `.env`
+
+### Games list / search
+
+```python
+import json, os
+from helpers import http_get
+
+KEY = os.environ['RAWG_API_KEY']
+
+# Search
+results = json.loads(http_get(
+    f"https://api.rawg.io/api/games?search=witcher&page_size=5&key={KEY}"
+))
+# results['count']   -> total matching games
+# results['next']    -> next page URL (pagination)
+# results['results'] -> list of game objects
+
+# Top-rated
+top = json.loads(http_get(
+    f"https://api.rawg.io/api/games?ordering=-metacritic&page_size=10&key={KEY}"
+))
+
+# By date range
+recent = json.loads(http_get(
+    f"https://api.rawg.io/api/games?dates=2024-01-01,2024-12-31&ordering=-added&page_size=20&key={KEY}"
+))
+
+# By platform (PC=4, PS4=18, Xbox One=1, Switch=7)
+pc_games = json.loads(http_get(
+    f"https://api.rawg.io/api/games?platforms=4&ordering=-rating&page_size=10&key={KEY}"
+))
+```
+
+### Game detail
+
+```python
+# By ID (faster if you have it)
+game = json.loads(http_get(f"https://api.rawg.io/api/games/3328?key={KEY}"))
+# game['name'], game['rating'], game['metacritic'], game['description_raw'], ...
+
+# By slug
+game = json.loads(http_get(
+    f"https://api.rawg.io/api/games/the-witcher-3-wild-hunt?key={KEY}"
+))
+```
+
+### API response fields (same as HTML scraping)
+
+```
+id, slug, name, released, tba, background_image,
+rating (0-5 RAWG community), rating_top, ratings, ratings_count,
+metacritic, playtime, added, added_by_status,
+platforms (list of {platform:{id,name,slug}, released_at}),
+parent_platforms (list of {platform:{id,name,slug}}),
+genres (list of {id,name,slug}),
+tags (list of {id,name,slug,language,games_count}),
+developers (list of {id,name,slug}),
+publishers (list of {id,name,slug}),
+stores (list of {id,store:{id,name,slug}}),
+esrb_rating ({id,name,slug}),
+website, description_raw, description, screenshots_count,
+movies_count, creators_count, achievements_count,
+metacritic_url, metacritic_platforms
+```
+
+### Platforms and Genres lists
+
+```python
+# All platforms
+platforms = json.loads(http_get(f"https://api.rawg.io/api/platforms?key={KEY}"))
+# results: [{id, name, slug, games_count, year_start, year_end, ...}]
+
+# Parent platforms only
+parents = json.loads(http_get(f"https://api.rawg.io/api/platforms/lists/parents?key={KEY}"))
+
+# Genres
+genres = json.loads(http_get(f"https://api.rawg.io/api/genres?key={KEY}"))
+# results: [{id, name, slug, games_count, image_background}]
+```
+
+### Pagination
+
+```python
+def get_all_pages(url_template, max_pages=5):
+    """Paginate through API results."""
+    results = []
+    url = url_template + "&page=1"
+    for _ in range(max_pages):
+        data = json.loads(http_get(url))
+        results.extend(data.get('results', []))
+        if not data.get('next'):
+            break
+        url = data['next']
+    return results
+```
+
+---
+
+## Gotchas
+
+- **API is fully blocked without a key** — `401` for every endpoint, including empty key and
+  `rawg.io/api/` (non-`api.rawg.io` subdomain). No auth bypass exists.
+
+- **URL params are client-side on listing pages** — `rawg.io/games?ordering=-rating` and
+  `rawg.io/games?search=witcher` return identical 40-game SSR payloads. Params only affect
+  the React client after hydration. Use the API for real filtering, or scrape individual game
+  pages by slug.
+
+- **Slug canonical redirects** — Some slugs redirect internally:
+  `disco-elysium-the-final-cut` → `disco-elysium-final-cut`. The URL you fetch returns HTTP 200
+  but the routing state inside `CLIENT_PARAMS` reflects the canonical path. Always use
+  `initial_state['game']['slug']` as the lookup key (it already has the `g-` prefix),
+  not a constructed `'g-' + url_slug`.
+
+- **`g-` prefix on entity keys** — Game entities in `CLIENT_PARAMS.initialState.entities.games`
+  are keyed as `g-{slug}` (e.g. `g-the-witcher-3-wild-hunt`), not bare slugs.
+  The game state slug field also carries this prefix: `{'slug': 'g-the-witcher-3-wild-hunt'}`.
+
+- **Listing page gives 40 games, detail pages give full fields** — `description`, `website`,
+  `developers`, `publishers` are absent from the listing page payload. Only present on
+  individual game pages.
+
+- **Concurrent requests: keep max_workers ≤ 3** — At `max_workers=5` with 10 requests,
+  some pages timed out (20s default) or returned 502. Sequential or 3-worker parallel is
+  reliable. A brief `time.sleep(0.5)` between sequential requests avoids 502 spikes.
+
+- **`platforms` field in game entities uses slugs, `platform_entities` has full objects** —
+  In the HTML payload, `game['platforms']` is a list of slug strings
+  (`['playstation5', 'pc', ...]`). Full platform details live in
+  `entities.platforms[slug]` as `{'platform': {id, name, slug, ...}, 'released_at': '...'}`.
+  `game['parent_platforms']` is also a list of slug strings (`['pc', 'playstation', ...]`).
+
+- **`metacritic` is `None` for games without a score** — Always check `if game['metacritic']`
+  before using. Many indie/older games have no Metacritic score.
+
+- **`esrb_rating` is `None` for non-US-rated games** — Common for Japanese games and
+  anything outside the ESRB's jurisdiction.
+
+- **`god-of-war` slug resolves to God of War I (PS2, 2005)** — The PS4 2018 title uses
+  `god-of-war-4` or has its own entity key. Always verify the game name in the response.
+
+- **Free API tier: 20,000 requests/month** — Roughly 650/day. Listing endpoint returns
+  20 results per page by default (max `page_size=40`). For bulk data collection, the HTML
+  scraping approach has no documented rate limit but times out under heavy parallel load.
+
+- **`description_raw` vs `description`** — `description` is HTML with escaped unicode
+  (`\u003C` = `<`). `description_raw` is plain text, easier to work with. Both present
+  on detail pages only.
+
+- **`updated` field reflects last RAWG edit, not release date** — Use `released` for
+  the release date. `updated` changes frequently as the community edits entries.

--- a/domain-skills/soundcloud/scraping.md
+++ b/domain-skills/soundcloud/scraping.md
@@ -1,0 +1,362 @@
+# SoundCloud — Data Extraction
+
+Field-tested against soundcloud.com on 2026-04-18.
+No authentication required for any approach documented here. All code uses `http_get` (pure HTTP, no browser).
+
+---
+
+## Approach 1 (Fastest): oEmbed API — No Auth, No Client ID
+
+`https://soundcloud.com/oembed?url=<resource_url>&format=json`
+
+Returns JSON in ~0.3s. Works for **tracks, playlists/sets, and user profiles**. No key required.
+
+```python
+from helpers import http_get
+import json
+
+def soundcloud_oembed(resource_url):
+    """Fetch oEmbed metadata for any public SoundCloud URL.
+
+    Works for:
+      - https://soundcloud.com/{user}/{track-slug}
+      - https://soundcloud.com/{user}/sets/{playlist-slug}
+      - https://soundcloud.com/{user}
+    """
+    url = f"https://soundcloud.com/oembed?url={resource_url}&format=json"
+    return json.loads(http_get(url))
+
+# Track
+track = soundcloud_oembed("https://soundcloud.com/forss/flickermood")
+# {
+#   "version": 1.0,
+#   "type": "rich",
+#   "provider_name": "SoundCloud",
+#   "provider_url": "https://soundcloud.com",
+#   "height": 400,
+#   "width": "100%",
+#   "title": "Flickermood by Forss",
+#   "description": "From the Soulhack album...",
+#   "thumbnail_url": "https://i1.sndcdn.com/artworks-000067273316-smsiqx-t500x500.jpg",
+#   "html": "<iframe width=\"100%\" height=\"400\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=...\">",
+#   "author_name": "Forss",
+#   "author_url": "https://soundcloud.com/forss"
+# }
+
+# Playlist/set
+pl = soundcloud_oembed("https://soundcloud.com/forss/sets/soulhack")
+# title="Soulhack by Forss", description="My 2003 debut album...", height=450
+
+# User profile
+user = soundcloud_oembed("https://soundcloud.com/forss")
+# title="Forss", description="Artist & Founder SoundCloud", height=450
+```
+
+### oEmbed fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `title` | str | "{Track Title} by {Artist}" for tracks, "{Name}" for users |
+| `author_name` | str | Artist/user display name |
+| `author_url` | str | Profile URL |
+| `thumbnail_url` | str | Artwork at 500×500px (t500x500) |
+| `description` | str | Track/profile description (may contain HTML entities) |
+| `html` | str | Embed iframe for the SoundCloud player widget |
+| `height` | int | 400 for tracks, 450 for playlists and users |
+| `width` | str | Always `"100%"` |
+
+---
+
+## Approach 2: Page Hydration (`__sc_hydration`) — Rich Metadata, No Client ID
+
+Every SoundCloud page embeds a JSON array in a `<script>` tag as `window.__sc_hydration`. This contains full API-grade metadata with no key required.
+
+```python
+from helpers import http_get
+import json, re
+
+def extract_hydration(page_url):
+    """Extract __sc_hydration JSON from any SoundCloud page."""
+    html = http_get(page_url)
+    match = re.search(r'window\.__sc_hydration\s*=\s*(\[.*?\]);\s*<', html, re.DOTALL)
+    if not match:
+        return []
+    return json.loads(match.group(1))
+
+def get_hydration_by_type(page_url, hydratable):
+    """Get the 'data' dict for a specific hydratable type."""
+    for obj in extract_hydration(page_url):
+        if obj.get('hydratable') == hydratable:
+            return obj.get('data')
+    return None
+
+# Track page — hydration key is 'sound'
+track = get_hydration_by_type("https://soundcloud.com/forss/flickermood", "sound")
+# track['id']             = 293
+# track['title']          = "Flickermood"
+# track['playback_count'] = 962685
+# track['likes_count']    = 2592
+# track['duration']       = 213886  (milliseconds)
+# track['genre']          = "Electronic"
+# track['created_at']     = "2007-09-22T14:45:46Z"
+# track['artwork_url']    = "https://i1.sndcdn.com/artworks-000067273316-smsiqx-large.jpg"
+# track['waveform_url']   = "https://wave.sndcdn.com/cWHNerOLlkUq_m.json"
+# track['streamable']     = True
+# track['downloadable']   = True
+# track['license']        = "all-rights-reserved"
+# track['tag_list']       = "downtempo"
+# track['urn']            = "soundcloud:tracks:293"
+# track['media']          = {'transcodings': [...]}  (HLS/progressive stream URLs — need auth)
+# track['user']           = {full user object nested}
+
+# User page — hydration key is 'user'
+user = get_hydration_by_type("https://soundcloud.com/forss", "user")
+# user['id']               = 183
+# user['username']         = "Forss"
+# user['full_name']        = "Eric Quidenus-Wahlforss"
+# user['followers_count']  = 132203
+# user['track_count']      = 26
+# user['verified']         = True
+# user['city']             = "Berlin"
+# user['country_code']     = "DE"
+# user['description']      = "Artist & Founder SoundCloud"
+# user['creator_subscription'] = {'product': {'id': 'creator-pro-unlimited'}}
+# user['badges']           = {'pro_unlimited': True, 'verified': True}
+
+# Playlist/set page — hydration key is 'playlist'
+playlist = get_hydration_by_type("https://soundcloud.com/forss/sets/soulhack", "playlist")
+# playlist['id']           = 18
+# playlist['title']        = "Soulhack"
+# playlist['track_count']  = 11
+# playlist['tracks']       = [full track objects list]
+# playlist['is_album']     = True/False
+# playlist['genre']        = "Electronic"
+```
+
+### All hydration keys on a typical page
+
+| `hydratable` | Content |
+|---|---|
+| `sound` | Full track object (on track pages) |
+| `playlist` | Full playlist + all tracks (on set pages) |
+| `user` | Full user object (on any page with a profile) |
+| `apiClient` | `{'id': '<client_id>', 'isExpiring': False}` — the client_id |
+| `geoip` | Viewer country/city/coordinates |
+| `features` | Feature flags dict |
+| `anonymousId` | Session tracking ID (not useful) |
+
+---
+
+## Approach 3: API v2 — Full Query Power (Requires Client ID)
+
+The `client_id` lives in every page's `__sc_hydration` under the `apiClient` key. It is **stable across all pages and sessions** — extract once and reuse.
+
+```python
+from helpers import http_get
+import json, re
+
+def get_client_id(page_url="https://soundcloud.com"):
+    """Extract client_id from any SoundCloud page's __sc_hydration."""
+    html = http_get(page_url)
+    match = re.search(r'window\.__sc_hydration\s*=\s*(\[.*?\]);\s*<', html, re.DOTALL)
+    if not match:
+        raise ValueError("No hydration found")
+    for obj in json.loads(match.group(1)):
+        if obj.get('hydratable') == 'apiClient':
+            return obj['data']['id']
+    raise ValueError("apiClient not found in hydration")
+
+CLIENT_ID = get_client_id()  # "efg2kjLJnAJpInbN6P3hsHzispI1SKQH" (example — extract fresh)
+
+def sc_api(path, **params):
+    """Call api-v2.soundcloud.com. Returns parsed JSON."""
+    params['client_id'] = CLIENT_ID
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    return json.loads(http_get(f"https://api-v2.soundcloud.com/{path}?{qs}"))
+```
+
+### Resolve any URL to a resource
+
+```python
+# Resolve a permalink URL to get its resource with full metadata
+track = sc_api("resolve", url="https://soundcloud.com/forss/flickermood")
+# Returns: {'kind': 'track', 'id': 293, 'title': 'Flickermood', ...}
+
+user = sc_api("resolve", url="https://soundcloud.com/forss")
+# Returns: {'kind': 'user', 'id': 183, 'username': 'Forss', ...}
+```
+
+### Track lookup
+
+```python
+# Single track by numeric ID
+track = sc_api("tracks/293")
+
+# Bulk track lookup (comma-separated IDs — returns list)
+tracks = sc_api("tracks", ids="293,290,48031525")
+# Returns a JSON array directly (not wrapped in 'collection')
+for t in tracks:
+    print(t['id'], t['title'], t['playback_count'])
+```
+
+### Search
+
+```python
+# Tracks
+results = sc_api("search/tracks", q="jazz", limit=20)
+# results['collection']    = list of track objects
+# results['total_results'] = 5293248
+# results['next_href']     = pagination URL (see below)
+
+# Users
+results = sc_api("search/users", q="jazz", limit=10)
+
+# Playlists/sets
+results = sc_api("search/playlists", q="jazz", limit=10)
+
+# Paginate with next_href
+def paginate(first_response):
+    """Yield all pages of a collection response."""
+    yield from first_response.get('collection', [])
+    next_href = first_response.get('next_href')
+    while next_href:
+        page = json.loads(http_get(f"{next_href}&client_id={CLIENT_ID}"))
+        yield from page.get('collection', [])
+        next_href = page.get('next_href')
+```
+
+### Trending charts
+
+```python
+# Trending tracks across all genres
+trending = sc_api("charts", kind="trending",
+                  genre="soundcloud:genres:all-music", limit=20)
+for item in trending['collection']:
+    t = item['track']
+    print(f"{t['title']} — score={item['score']:.4f}")
+
+# Genre options: soundcloud:genres:all-music, soundcloud:genres:electronic,
+#                soundcloud:genres:hiphoprap, soundcloud:genres:ambient, etc.
+```
+
+### User resources
+
+```python
+user_id = 183  # numeric ID from resolve or hydration
+
+# User's tracks
+tracks = sc_api(f"users/{user_id}/tracks", limit=20)
+# tracks['collection'] = list of track objects
+
+# User's playlists
+playlists = sc_api(f"users/{user_id}/playlists", limit=10)
+
+# User's likes
+likes = sc_api(f"users/{user_id}/likes", limit=10)
+
+# Related tracks for a track
+related = sc_api("tracks/293/related", limit=10)
+# related['collection'] = list of track objects
+```
+
+### Waveform data
+
+```python
+# Waveform URL comes from track['waveform_url']
+waveform_url = "https://wave.sndcdn.com/cWHNerOLlkUq_m.json"
+waveform = json.loads(http_get(waveform_url))
+# {
+#   'width': 1800,   # number of sample points
+#   'height': 140,   # max amplitude value
+#   'samples': [11, 86, 91, 80, ...]  # 1800 amplitude values
+# }
+```
+
+---
+
+## Full track fields from `__sc_hydration` / API v2
+
+```
+id               int     Numeric track ID (e.g. 293)
+urn              str     "soundcloud:tracks:293"
+title            str     Track title
+description      str     May contain HTML entities/tags
+genre            str     Genre string
+tag_list         str     Space-separated tags
+created_at       str     ISO 8601 UTC
+last_modified    str     ISO 8601 UTC
+release_date     str     ISO 8601 UTC (original release)
+display_date     str     ISO 8601 UTC (shown to users)
+duration         int     Milliseconds
+full_duration    int     Milliseconds (untruncated)
+playback_count   int
+likes_count      int
+reposts_count    int
+comment_count    int
+download_count   int
+artwork_url      str     e.g. .../artworks-...-large.jpg (replace 'large' with 't500x500' for 500px)
+waveform_url     str     https://wave.sndcdn.com/....json
+permalink        str     Slug (e.g. "flickermood")
+permalink_url    str     Full canonical URL
+streamable       bool
+downloadable     bool
+license          str     e.g. "all-rights-reserved", "cc-by"
+sharing          str     "public" or "private"
+state            str     "finished" | "processing" | "failed"
+monetization_model str   "AD_SUPPORTED" | "SUB_HIGH_TIER" | "NOT_APPLICABLE"
+embeddable_by    str     "all" | "me" | "none"
+user             dict    Nested user object (id, username, avatar_url, verified, ...)
+user_id          int     Owner numeric ID
+publisher_metadata dict  {artist, publisher, isrc, contains_music, ...}
+media            dict    {'transcodings': [...]}  — stream URLs (require OAuth, not usable without login)
+label_name       str     Record label
+purchase_url     str     External buy link
+station_urn      str     "soundcloud:system-playlists:track-stations:{id}"
+```
+
+---
+
+## Gotchas
+
+**client_id is required for api-v2.soundcloud.com** — requests without it return HTTP 401. Always extract from `__sc_hydration['apiClient']['id']`.
+
+**client_id source: hydration, not JS bundles** — the JS bundles on `a-v2.sndcdn.com` do NOT contain the `client_id` pattern. The only reliable source is the `apiClient` object in the page hydration. It is stable across all pages (same value from homepage, track pages, user pages) and does not appear to rotate on short timescales.
+
+**Artwork URL sizes** — hydration/API returns `...-large.jpg` (100×100). Replace the size suffix to get larger images:
+- `-large.jpg` → 100×100
+- `-t300x300.jpg` → 300×300
+- `-t500x500.jpg` → 500×500 (oEmbed returns this size)
+
+**Regex must use `re.DOTALL`** — the `__sc_hydration` JSON spans multiple lines. Without `re.DOTALL`, the `.` in the regex won't match newlines.
+
+**Stream URLs (media.transcodings) are gated** — the HLS/progressive audio stream URLs in `track['media']['transcodings']` require an OAuth token even to fetch a stream manifest. They cannot be played without a logged-in session.
+
+**Bulk track lookup returns a list, not collection** — `GET /tracks?ids=...` returns a JSON array directly. Do NOT look for `.get('collection')`.
+
+**Search `total_results` can be huge** — results like 5M+ are normal for broad queries. Use `next_href` for pagination; do not calculate offsets manually.
+
+**oEmbed description contains HTML** — SoundCloud descriptions may include `&nbsp;` and anchor tags. Decode with `html.unescape()` if you need plain text.
+
+**HTTP 400 on some endpoints** — `/tracks/{id}/comments` returns 400 without OAuth headers. Timed comments are not accessible without login.
+
+**No browser required** — all documented approaches work with plain `http_get`. SoundCloud does not require JavaScript rendering for metadata extraction.
+
+**Rate limits** — 20 rapid sequential API v2 requests completed without errors in testing. SoundCloud does not publish official rate limits; stay under ~50 req/s for sustained scraping. oEmbed is more lenient than api-v2.
+
+---
+
+## Quick Reference
+
+| Goal | Approach | Auth |
+|------|----------|------|
+| Track title/author/thumbnail from URL | oEmbed | None |
+| Full track metadata + play counts | `__sc_hydration` `sound` key | None |
+| Full user profile + stats | `__sc_hydration` `user` key | None |
+| Full playlist with all tracks | `__sc_hydration` `playlist` key | None |
+| Search tracks/users/playlists | API v2 `/search/*` | client_id |
+| Trending charts | API v2 `/charts` | client_id |
+| Bulk track lookup by IDs | API v2 `/tracks?ids=` | client_id |
+| User's track list | API v2 `/users/{id}/tracks` | client_id |
+| Resolve permalink to resource | API v2 `/resolve?url=` | client_id |
+| Waveform amplitude data | Direct fetch of `waveform_url` | None |
+| Audio stream playback | OAuth login required | Login |

--- a/domain-skills/spotify/scraping.md
+++ b/domain-skills/spotify/scraping.md
@@ -1,0 +1,339 @@
+# Spotify — Data Extraction
+
+Field-tested against open.spotify.com on 2026-04-18.
+No authentication required for any approach documented here.
+
+---
+
+## Approach 1 (Fastest): oEmbed API — No Auth, No Browser
+
+`https://open.spotify.com/oembed?url=<resource_url>`
+
+Returns JSON in ~0.25s. Works for tracks, albums, playlists, and artists. Does **not** work for episodes/shows.
+
+```python
+from helpers import http_get
+import json
+
+def spotify_oembed(resource_type, resource_id):
+    """Fetch oEmbed metadata for a Spotify resource.
+
+    resource_type: 'track', 'album', 'playlist', or 'artist'
+    resource_id:   Spotify ID (22-char alphanumeric)
+    """
+    resource_url = f"https://open.spotify.com/{resource_type}/{resource_id}"
+    url = f"https://open.spotify.com/oembed?url={resource_url}"
+    data = json.loads(http_get(url))
+    return data
+
+# Example: track
+track = spotify_oembed("track", "4PTG3Z6ehGkBFwjybzWkR8")
+# {
+#   "title":           "Never Gonna Give You Up",
+#   "thumbnail_url":   "https://image-cdn-ak.spotifycdn.com/image/ab67616100005174...",
+#   "thumbnail_width": 320,
+#   "thumbnail_height": 320,
+#   "type":            "rich",
+#   "html":            "<iframe ...src=\"https://open.spotify.com/embed/track/4PTG3Z6...\"...>",
+#   "iframe_url":      "https://open.spotify.com/embed/track/4PTG3Z6ehGkBFwjybzWkR8?utm_source=oembed",
+#   "width":           456,
+#   "height":          152,
+#   "version":         "1.0",
+#   "provider_name":   "Spotify",
+#   "provider_url":    "https://spotify.com"
+# }
+
+# Artist (height is 352 — taller widget)
+artist = spotify_oembed("artist", "0gxyHStUsqpMadRV0Di1Qt")
+# title="Rick Astley", thumbnail_url=<artist photo URL>
+
+# Album
+album = spotify_oembed("album", "4LH4d3cOWNNsVw41Gqt2kv")
+# title="The Dark Side of the Moon", thumbnail_url=<album art URL>
+
+# Playlist
+pl = spotify_oembed("playlist", "37i9dQZF1DXcBWIGoYBM5M")
+# title="Today's Top Hits", thumbnail_url=<playlist cover URL>
+```
+
+### Bulk fetching (ThreadPoolExecutor)
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import json
+from helpers import http_get
+
+track_ids = [
+    "4PTG3Z6ehGkBFwjybzWkR8",
+    "7qiZfU4dY1lWllzX7mPBI3",
+    "0VjIjW4GlUZAMYd2vXMi3b",
+]
+
+def fetch_oembed(tid):
+    url = f"https://open.spotify.com/oembed?url=https://open.spotify.com/track/{tid}"
+    try:
+        return json.loads(http_get(url))
+    except Exception as e:
+        return {"error": str(e), "id": tid}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_oembed, track_ids))
+# 5 tracks: ~1.3s total, ~0.26s per track
+```
+
+---
+
+## Approach 2: Static HTML — Rich Metadata via http_get
+
+Every open.spotify.com page (track, album, playlist, artist) serves full HTML with no JS requirement. The HTML contains JSON-LD and Open Graph tags that provide structured data.
+
+### Track page — all extractable fields
+
+```python
+from helpers import http_get
+import json, re
+
+def scrape_track(track_id):
+    url = f"https://open.spotify.com/track/{track_id}"
+    html = http_get(url)
+
+    # ---- JSON-LD (most structured) ----
+    ld_raw = re.search(r'<script type="application/ld\+json"[^>]*>(.*?)</script>', html, re.DOTALL)
+    ld = json.loads(ld_raw.group(1)) if ld_raw else {}
+
+    # ---- Open Graph / music: meta tags ----
+    metas = {}
+    for m in re.finditer(r'<meta\s+(?:property|name)="([^"]+)"\s+content="([^"]*)"', html):
+        key, val = m.group(1), m.group(2)
+        if key not in metas:
+            metas[key] = val
+
+    musician_urls = re.findall(r'<meta\s+(?:property|name)="music:musician"\s+content="([^"]*)"', html)
+    allowed_countries = re.findall(r'<meta\s+property="og:restrictions:country:allowed"\s+content="([^"]*)"', html)
+
+    return {
+        "title":          metas.get("og:title"),
+        "artist":         metas.get("music:musician_description"),
+        "artist_urls":    musician_urls,               # spotify artist page URLs
+        "album_url":      metas.get("music:album"),    # spotify album page URL
+        "track_number":   metas.get("music:album:track"),
+        "duration_s":     int(metas.get("music:duration", 0)),
+        "release_date":   metas.get("music:release_date"),  # YYYY-MM-DD
+        "cover_art":      metas.get("og:image"),       # 640px JPG
+        "audio_preview":  metas.get("og:audio"),       # 30s MP3 (may be None)
+        "spotify_url":    metas.get("og:url"),
+        "description":    metas.get("og:description"),
+        "eligible_regions": allowed_countries,
+        "ld_name":        ld.get("name"),
+        "ld_date":        ld.get("datePublished"),
+    }
+
+# Tested on track/4PTG3Z6ehGkBFwjybzWkR8 (Never Gonna Give You Up):
+# {
+#   "title":         "Never Gonna Give You Up",
+#   "artist":        "Rick Astley",
+#   "artist_urls":   ["https://open.spotify.com/artist/0gxyHStUsqpMadRV0Di1Qt"],
+#   "album_url":     "https://open.spotify.com/album/6eUW0wxWtzkFdaEFsTJto6",
+#   "track_number":  "1",
+#   "duration_s":    214,
+#   "release_date":  "1987-11-12",
+#   "cover_art":     "https://i.scdn.co/image/ab67616d0000b27315ebbedaacef61af244262a8",
+#   "audio_preview": "https://p.scdn.co/mp3-preview/b4c682084c3fd05538726d0a126b7e14b6e92c83",
+#   "spotify_url":   "https://open.spotify.com/track/4PTG3Z6ehGkBFwjybzWkR8",
+#   "eligible_regions": [185 country codes],
+# }
+```
+
+### Artist page — fields available
+
+```python
+def scrape_artist(artist_id):
+    url = f"https://open.spotify.com/artist/{artist_id}"
+    html = http_get(url)
+
+    ld_raw = re.search(r'<script type="application/ld\+json"[^>]*>(.*?)</script>', html, re.DOTALL)
+    ld = json.loads(ld_raw.group(1)) if ld_raw else {}
+
+    metas = {}
+    for m in re.finditer(r'<meta\s+(?:property|name)="([^"]+)"\s+content="([^"]*)"', html):
+        if m.group(1) not in metas:
+            metas[m.group(1)] = m.group(2)
+
+    return {
+        "name":              metas.get("og:title"),
+        "monthly_listeners": metas.get("og:description"),  # "Artist · 6.7M monthly listeners."
+        "image":             metas.get("og:image"),         # full-size artist photo
+        "spotify_url":       metas.get("og:url"),
+        "description":       ld.get("description"),
+    }
+
+# Tested on Rick Astley (artist/0gxyHStUsqpMadRV0Di1Qt):
+# {
+#   "name":              "Rick Astley",
+#   "monthly_listeners": "Artist · 6.7M monthly listeners.",
+#   "image":             "https://i.scdn.co/image/ab6761610000e5ebe834a63a0cfa3c0f57a9a434",
+# }
+```
+
+---
+
+## Approach 3: Embed Page — Structured JSON with Track Lists
+
+`https://open.spotify.com/embed/{type}/{id}` returns a small Next.js SSR page. Its `__NEXT_DATA__` script tag contains a fully-parsed entity object. This is the only no-auth route that returns track listings for albums, playlists, and artists.
+
+```python
+from helpers import http_get
+import json, re
+
+def scrape_embed(resource_type, resource_id):
+    """
+    resource_type: 'track', 'album', 'playlist', or 'artist'
+    Returns the entity dict from __NEXT_DATA__.
+    """
+    url = f"https://open.spotify.com/embed/{resource_type}/{resource_id}"
+    html = http_get(url)
+    m = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    data = json.loads(m.group(1))
+    return data['props']['pageProps']['state']['data']['entity']
+
+# ---- TRACK ----
+entity = scrape_embed("track", "4PTG3Z6ehGkBFwjybzWkR8")
+# entity keys: type, name, uri, id, title, artists, releaseDate, duration,
+#              isPlayable, isExplicit, audioPreview, hasVideo, visualIdentity
+# {
+#   "name":     "Never Gonna Give You Up",
+#   "uri":      "spotify:track:4PTG3Z6ehGkBFwjybzWkR8",
+#   "artists":  [{"name": "Rick Astley", "uri": "spotify:artist:0gxyHStUsqpMadRV0Di1Qt"}],
+#   "duration": 213573,   # milliseconds
+#   "releaseDate": {"isoString": "1987-11-12T00:00:00Z"},
+#   "isPlayable": True,
+#   "isExplicit": False,
+#   "audioPreview": {"url": "https://p.scdn.co/mp3-preview/b4c682..."},
+#   "visualIdentity": {
+#     "image": [
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d00001e02...", "maxWidth": 300, "maxHeight": 300},
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d000048...", "maxWidth": 64,  "maxHeight": 64},
+#       {"url": "https://image-cdn-fa.spotifycdn.com/image/ab67616d0000b27...", "maxWidth": 640, "maxHeight": 640},
+#     ]
+#   }
+# }
+
+# ---- ALBUM (includes full track list) ----
+entity = scrape_embed("album", "6fu8fvc7O4p8Gb8KMTBTUW")
+# entity.trackList — list of all album tracks, e.g. 12 items:
+# [{
+#   "uri":          "spotify:track:4e1zdmsDwNBNe9rk7HHC0i",
+#   "title":        "Prelude for Piano No. 1 in E-Flat Major",
+#   "subtitle":     "Eduard Abramyan,\u00a0Sona Shaboyan",
+#   "duration":     107426,
+#   "isPlayable":   True,
+#   "audioPreview": {"url": "https://p.scdn.co/mp3-preview/d03c37..."},
+#   "entityType":   "track"
+# }, ...]
+
+# ---- PLAYLIST (includes up to 50 tracks) ----
+entity = scrape_embed("playlist", "37i9dQZF1DXcBWIGoYBM5M")
+# entity.trackList — 50 items
+# entity.subtitle  — "Spotify"
+# entity.authors   — [{"name": "Spotify"}]
+
+# ---- ARTIST (includes top 10 tracks) ----
+entity = scrape_embed("artist", "0gxyHStUsqpMadRV0Di1Qt")
+# entity.trackList — 10 top tracks, same shape as album trackList
+# entity.subtitle  — "Top tracks"
+```
+
+### Bonus: Anonymous access token (embedded in every embed page)
+
+The embed page SSR data includes a short-lived anonymous Spotify Web Player access token. The token is valid (~1 hour) but **anonymous tokens are severely rate-limited for api.spotify.com/v1 calls** (observed `Retry-After: 79561` seconds on the tracks endpoint after a few requests).
+
+```python
+def get_embed_token(resource_type="track", resource_id="4PTG3Z6ehGkBFwjybzWkR8"):
+    """Extract the anonymous access token from an embed page."""
+    url = f"https://open.spotify.com/embed/{resource_type}/{resource_id}"
+    html = http_get(url)
+    m = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    data = json.loads(m.group(1))
+    session = data['props']['pageProps']['state']['settings']['session']
+    return {
+        "access_token":  session['accessToken'],
+        "expires_ms":    session['accessTokenExpirationTimestampMs'],
+        "is_anonymous":  session['isAnonymous'],          # always True
+        "client_id":     data['props']['pageProps']['config']['clientId'],
+    }
+
+# Returned fields (verified 2026-04-18):
+# access_token: "BQBfxv..." (a standard Spotify Bearer token, ~160 chars)
+# expires_ms:   1776512455031 (~1 hour TTL)
+# is_anonymous: True
+# client_id:    "ab9ad0d96a624805a7d51e8868df1f97"
+
+# WARNING: Do NOT use this token to hammer api.spotify.com/v1 — anonymous tokens
+# share a global rate-limit bucket. One call can trigger a 22-hour ban window.
+# Use the embed page __NEXT_DATA__ directly instead (Approach 3 above).
+```
+
+---
+
+## What Requires a Browser
+
+The following are **not accessible** via http_get and require the CDP browser:
+
+- Lyrics (login-gated; JSON-LD confirms: `isAccessibleForFree: false`)
+- Search (`/search?q=...`) — loads client-side only, no meaningful HTML on first response
+- User library / listening history — requires OAuth
+- Full audio playback — requires OAuth + Widevine DRM
+- Podcast episodes — oEmbed returns 404; embed page `__NEXT_DATA__` lacks `state.data.entity`
+- Track recommendations beyond the top-10 artist view
+- Artist discography / full album list
+
+If browser access is needed for search:
+
+```python
+goto("https://open.spotify.com/search")
+wait_for_load()
+wait(2)
+# Type into the search box
+js("document.querySelector('input[data-testid=\"search-input\"]').focus()")
+type_text("never gonna give you up")
+wait(1)
+# Results appear in [data-testid="top-results-card"] or similar dynamic selectors
+```
+
+---
+
+## URL Patterns
+
+| Resource  | URL pattern                                    | ID format         |
+|-----------|------------------------------------------------|-------------------|
+| Track     | `https://open.spotify.com/track/{id}`          | 22-char alphanum  |
+| Album     | `https://open.spotify.com/album/{id}`          | 22-char alphanum  |
+| Artist    | `https://open.spotify.com/artist/{id}`         | 22-char alphanum  |
+| Playlist  | `https://open.spotify.com/playlist/{id}`       | 22-char alphanum  |
+| oEmbed    | `https://open.spotify.com/oembed?url={resource_url}` | any of above |
+| Embed     | `https://open.spotify.com/embed/{type}/{id}`   | same ID           |
+
+Extract Spotify ID from any URL:
+
+```python
+import re
+def spotify_id(url):
+    m = re.search(r'spotify\.com/(?:embed/)?(?:track|album|artist|playlist)/([A-Za-z0-9]{22})', url)
+    return m.group(1) if m else None
+```
+
+---
+
+## Gotchas
+
+- **oEmbed 404 for valid IDs**: A 404 from oEmbed can mean the resource is region-locked or not available for embedding, not necessarily that the ID is wrong. Verified: track `3n3Ppam7vgaVa1iaRUIOKE` returns 404 on oEmbed despite existing on Spotify.
+- **oEmbed 404 for artists**: Only works with valid, existing artist IDs. The artist ID `4gzpq5DumSF1a1LpGLBBl5` returns 404 — verify IDs from canonical Spotify URLs before using.
+- **oEmbed does not support episodes**: `open.spotify.com/episode/{id}` always returns 404 from the oEmbed endpoint.
+- **Embed page for episodes**: The embed page SSR for episodes does not include `state.data.entity` in the expected structure — parse defensively.
+- **Anonymous token rate limiting**: The access token from embed pages is valid but severely rate-limited for `api.spotify.com/v1`. Observed `Retry-After: 79561` (~22 hours) after 2-3 rapid API calls. Use embed `__NEXT_DATA__` data instead of the API.
+- **`get_access_token` endpoint blocked**: `https://open.spotify.com/get_access_token?reason=transport&productType=web_player` returns HTTP 403 from plain http_get regardless of headers. Token must be sourced from the embed page HTML.
+- **`music:musician` meta tag dedup**: `re.findall` on `music:musician` returns all artist URLs. `dict(re.finditer(...))` would only keep the last one — always use `findall` for multi-value tags.
+- **Cover art CDN differences**: oEmbed thumbnail uses `image-cdn-ak.spotifycdn.com`; track page `og:image` uses `i.scdn.co`. Both are publicly accessible. The embed `visualIdentity.image` array provides three sizes (64, 300, 640).
+- **No `__NEXT_DATA__` on main open.spotify.com pages**: The SSR `__NEXT_DATA__` pattern only works on `open.spotify.com/embed/*`, not on main track/album/artist pages. Those pages use JSON-LD and Open Graph tags instead.
+- **Track duration units differ**: `music:duration` meta tag is in **seconds** (integer). Embed `__NEXT_DATA__` `entity.duration` is in **milliseconds**.
+- **Rate limits for http_get pages**: No rate limit observed on oEmbed or static HTML pages in testing (10 concurrent requests succeeded; ~0.25s avg per oEmbed call).

--- a/domain-skills/steam/scraping.md
+++ b/domain-skills/steam/scraping.md
@@ -1,0 +1,575 @@
+# Steam — Scraping & Data Extraction
+
+Field-tested against store.steampowered.com on 2026-04-18. All code blocks validated with live requests.
+
+## Fastest approach: App Details API (no auth, no browser)
+
+The `appdetails` endpoint is the primary source for all game data. No API key, no cookies, no auth required. Returns clean JSON for any appid.
+
+```python
+import json
+from helpers import http_get
+
+def get_app(appid, cc="US"):
+    """
+    Fetch full game/DLC/software data by Steam appid.
+    cc = ISO-3166 country code for correct regional pricing (default: US).
+    Returns None if appid not found or no longer on Steam.
+    """
+    resp = http_get(
+        f"https://store.steampowered.com/api/appdetails?appids={appid}&cc={cc}"
+    )
+    data = json.loads(resp)
+    entry = data[str(appid)]
+    if not entry["success"]:
+        return None
+    return entry["data"]
+
+game = get_app(292030)   # The Witcher 3
+# game["name"]               -> "The Witcher 3: Wild Hunt"
+# game["steam_appid"]        -> 292030
+# game["type"]               -> "game" | "dlc" | "demo" | "advertising" | "mod" | "video"
+# game["required_age"]       -> 18    (int, 0 if no restriction)
+# game["is_free"]            -> False
+# game["short_description"]  -> plain-text one-liner
+# game["about_the_game"]     -> HTML
+# game["detailed_description"]-> HTML
+# game["website"]            -> "https://www.thewitcher.com/witcher3"
+# game["header_image"]       -> URL to 460x215px header image
+# game["capsule_image"]      -> URL to smaller capsule image
+# game["background"]         -> URL to store page background
+# game["supported_languages"]-> HTML string with language list (use html.unescape())
+# game["developers"]         -> ["CD PROJEKT RED"]
+# game["publishers"]         -> ["CD PROJEKT RED"]
+# game["platforms"]          -> {"windows": True, "mac": False, "linux": False}
+# game["metacritic"]         -> {"score": 93, "url": "https://www.metacritic.com/..."}
+# game["genres"]             -> [{"id": "3", "description": "RPG"}]
+# game["categories"]         -> [{"id": 2, "description": "Single-player"}, ...]
+# game["release_date"]       -> {"coming_soon": False, "date": "May 18, 2015"}
+# game["dlc"]                -> [355880, 378649, ...]  (list of DLC appids)
+# game["legal_notice"]       -> copyright text
+# game["ratings"]            -> per-region rating board data (ESRB, PEGI, USK, ...)
+# game["content_descriptors"]-> {"ids": [1, 5], "notes": "..."}
+# game["recommendations"]    -> {"total": 812249}
+# game["achievements"]       -> {"total": 78, "highlighted": [...]}
+# game["support_info"]       -> {"url": "...", "email": "..."}
+# game["pc_requirements"]    -> {"minimum": "<html>...", "recommended": "<html>..."}
+# game["mac_requirements"]   -> same structure or []
+# game["linux_requirements"] -> same structure or []
+```
+
+---
+
+## Price overview
+
+Prices are always in **cents** (integer). Use `final_formatted` for display.
+
+```python
+game = get_app(292030)
+po = game.get("price_overview")
+# po is None for free-to-play games (is_free=True)
+
+if po:
+    print(po["currency"])           # "USD"
+    print(po["final"])              # 3999          (cents — $39.99)
+    print(po["initial"])            # 3999          (original price in cents)
+    print(po["discount_percent"])   # 0             (0–100)
+    print(po["final_formatted"])    # "$39.99"       (always present, ready to display)
+    print(po["initial_formatted"])  # ""             (EMPTY when not discounted!)
+                                    # "$49.99"       (only set when discount_percent > 0)
+```
+
+**Critical**: `initial_formatted` is an empty string when `discount_percent == 0`.
+Always use `final_formatted` for displaying current price.
+
+```python
+def price_display(game):
+    """Returns (current_price_str, original_price_str_or_None, discount_pct)."""
+    if game.get("is_free"):
+        return ("Free", None, 0)
+    po = game.get("price_overview")
+    if not po:
+        return ("N/A", None, 0)
+    disc = po["discount_percent"]
+    orig = po["initial_formatted"] if disc > 0 else None
+    return (po["final_formatted"], orig, disc)
+
+# Witcher3: ("$39.99", None, 0)
+# Discounted game: ("$24.99", "$49.99", 50)
+# Dota2: ("Free", None, 0)
+```
+
+### Regional pricing
+
+Pass `cc=` (ISO-3166 country code) to get local currency:
+
+```python
+get_app(292030, cc="GB")["price_overview"]
+# {"currency": "GBP", "initial": 2499, "final": 2499, ..., "final_formatted": "£24.99"}
+
+get_app(292030, cc="DE")["price_overview"]
+# {"currency": "EUR", "initial": 2999, "final": 2999, ..., "final_formatted": "29,99€"}
+```
+
+---
+
+## Bulk / concurrent fetching
+
+10 games in 0.54s with 5 workers — no rate-limit errors observed:
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+def fetch_game(appid, cc="US"):
+    resp = http_get(
+        f"https://store.steampowered.com/api/appdetails?appids={appid}&cc={cc}"
+    )
+    data = json.loads(resp)
+    entry = data[str(appid)]
+    return entry["data"] if entry["success"] else None
+
+appids = [292030, 570, 413150, 427520, 730, 550, 220, 400, 218620, 105600]
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    games = list(ex.map(fetch_game, appids))
+# Completed in ~0.54s
+# games[i] is None if appid not found
+```
+
+**Confirmed field values for common appids:**
+- `570` (Dota 2): `is_free=True`, `price_overview=None`, `required_age=0`
+- `292030` (Witcher 3): `is_free=False`, `required_age=18`, `metacritic.score=93`
+- `413150` (Stardew Valley): `is_free=False`, `required_age=0`, `metacritic=None`
+- `427520` (Factorio): `is_free=False`, `required_age=0`
+
+---
+
+## Partial field fetch (filters=)
+
+Fetch only specific fields to reduce payload size:
+
+```python
+# Price only (tiny response)
+resp = http_get("https://store.steampowered.com/api/appdetails?appids=292030&filters=price_overview")
+data = json.loads(resp)["292030"]["data"]
+# data keys: ["price_overview"]
+
+# Basic metadata (no price, no media)
+resp = http_get("https://store.steampowered.com/api/appdetails?appids=292030&filters=basic")
+# data keys: about_the_game, capsule_image, capsule_imagev5, detailed_description, dlc,
+#            header_image, is_free, legal_notice, linux_requirements, mac_requirements,
+#            name, pc_requirements, required_age, reviews, short_description,
+#            steam_appid, supported_languages, type, website
+
+# Multiple filters comma-separated
+resp = http_get("https://store.steampowered.com/api/appdetails?appids=292030&filters=screenshots,price_overview")
+# data keys: ["price_overview", "screenshots"]
+```
+
+---
+
+## Media fields
+
+### Screenshots
+
+```python
+game = get_app(292030)
+for ss in game["screenshots"]:       # 18 screenshots for Witcher 3
+    print(ss["id"])                  # 0, 1, 2, ...
+    print(ss["path_thumbnail"])      # 600x338 JPEG URL
+    print(ss["path_full"])           # 1920x1080 JPEG URL
+```
+
+### Movies / trailers
+
+```python
+for m in game["movies"]:             # 4 trailers for Witcher 3
+    print(m["id"])                   # integer
+    print(m["name"])                 # trailer title
+    print(m["thumbnail"])            # thumbnail URL
+    print(m["highlight"])            # bool — main trailer flag
+    # m["webm"]  -> None (old format, mostly absent)
+    # m["mp4"]   -> None (old format, mostly absent)
+    # m["dash_av1"]  -> dash_av1 stream URL (present on modern entries)
+    # m["dash_h264"] -> dash_h264 stream URL
+    # m["hls_h264"]  -> HLS stream URL
+```
+
+---
+
+## Ratings and content descriptors
+
+The `ratings` dict contains per-region rating board data for mature games:
+
+```python
+game = get_app(292030)
+
+# ESRB (North America)
+esrb = game["ratings"].get("esrb", {})
+esrb["rating"]          # "m" (lowercase)  -> M for Mature
+esrb["descriptors"]     # "Blood and Gore\r\nIntense Violence\r\nNudity\r\n..."
+esrb["use_age_gate"]    # "true" (string, not bool)
+esrb["required_age"]    # "17" (string, not int)
+
+# PEGI (Europe)
+pegi = game["ratings"].get("pegi", {})
+pegi["rating"]          # "18"
+pegi["descriptors"]     # "Violence\r\nBad language"
+
+# USK (Germany)
+usk = game["ratings"].get("usk", {})
+usk["rating"]           # "18"
+
+# steam_germany (Germany digital-only classification)
+sg = game["ratings"].get("steam_germany", {})
+sg["rating"]            # "16"
+sg["banned"]            # "0"  (1 = banned in Germany)
+
+# igrs (Indonesia)
+igrs = game["ratings"].get("igrs", {})
+igrs["rating"]          # "BANNED" if banned there
+igrs["banned"]          # "1"
+
+# Other keys: oflc, nzoflc, kgrb, dejus, mda, fpb, csrr, crl
+```
+
+Content descriptor IDs (from `content_descriptors.ids`):
+- `1` = Some Nudity or Sexual Content
+- `5` = Frequent Violence or Gore
+
+---
+
+## Age-gated store pages
+
+**The `appdetails` API completely bypasses age gates.** It returns full data for any game regardless of rating or age restriction — no cookies needed.
+
+The **store webpage** (`store.steampowered.com/app/{appid}/`) redirects mature games to an age verification form:
+
+```
+GET https://store.steampowered.com/app/292030/
+-> 302 -> https://store.steampowered.com/agecheck/app/292030/
+```
+
+To bypass the age gate on the store page, send the `birthtime` cookie:
+
+```python
+import urllib.request
+
+def get_store_page(appid):
+    """Fetch game store HTML page, bypassing age gate."""
+    req = urllib.request.Request(
+        f"https://store.steampowered.com/app/{appid}/",
+        headers={
+            "User-Agent": "Mozilla/5.0",
+            "Cookie": "birthtime=631152001; lastagecheckage=1-January-1990"
+        }
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        html = r.read().decode("utf-8", errors="replace")
+        if "agecheck" in r.url:
+            return None   # Age gate not bypassed
+        return html
+```
+
+`birthtime=631152001` = January 1, 1990 in Unix time. Steam accepts any date before the current year minus the required age.
+
+---
+
+## Search
+
+### storesearch API (title search, up to 10 results)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+def search_games(term, cc="US", lang="english"):
+    """
+    Returns up to 10 matching apps/DLC/bundles.
+    No pagination — always exactly 10 results max.
+    """
+    q = urllib.parse.quote(term)
+    resp = http_get(
+        f"https://store.steampowered.com/api/storesearch/?term={q}&l={lang}&cc={cc}"
+    )
+    data = json.loads(resp)
+    return data["items"]
+
+results = search_games("witcher")
+# [
+#   {"type": "app", "name": "The Witcher 3: Wild Hunt", "id": 292030,
+#    "price": {"currency": "USD", "initial": 3999, "final": 3999},
+#    "tiny_image": "https://...", "metascore": "93",
+#    "platforms": {"windows": True, "mac": False, "linux": False},
+#    "streamingvideo": False},
+#   {"type": "sub", ...},  # bundles have type="sub"
+#   ...
+# ]
+```
+
+**Search result fields:**
+- `id` — appid (or subid for bundles)
+- `type` — `"app"` | `"sub"` (bundle)
+- `name` — game title
+- `price` — `{"currency": "USD", "initial": cents, "final": cents}` — `None` for F2P
+- `metascore` — string e.g. `"93"`, `"0"` if no score
+- `platforms` — `{"windows": bool, "mac": bool, "linux": bool}`
+- `tiny_image` — 231x87px capsule image URL
+- `streamingvideo` — bool
+
+**Note:** `price` in search results has only `initial` and `final` — no `discount_percent` or `formatted` strings. Use `appdetails` for full pricing.
+
+---
+
+## Review scores and user reviews
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+def get_reviews(appid, num=10, language="english", filter="recent",
+                review_type="all", purchase_type="all", cursor="*"):
+    """
+    filter: "recent" | "updated" | "all"
+    review_type: "all" | "positive" | "negative"
+    purchase_type: "all" | "steam" | "non_steam_purchase"
+    language: "english" | "all" | ISO code
+    cursor: use returned cursor for next page (URL-encode it)
+    """
+    encoded_cursor = urllib.parse.quote(cursor)
+    resp = http_get(
+        f"https://store.steampowered.com/appreviews/{appid}"
+        f"?json=1&num_per_page={num}&language={language}"
+        f"&filter={filter}&review_type={review_type}"
+        f"&purchase_type={purchase_type}&cursor={encoded_cursor}"
+    )
+    return json.loads(resp)
+
+result = get_reviews(292030, num=5, language="english")
+
+# result["success"]          -> 1 (int, not bool)
+# result["cursor"]           -> "AoJ4rq..."  (base64, URL-encode for next page)
+# result["query_summary"]["review_score"]      -> 9      (0–9 score)
+# result["query_summary"]["review_score_desc"] -> "Overwhelmingly Positive"
+# result["query_summary"]["total_positive"]    -> 226883
+# result["query_summary"]["total_negative"]    -> 7499
+# result["query_summary"]["total_reviews"]     -> 234382  (steam purchase only)
+# result["reviews"]          -> list of review objects
+```
+
+**Review score descriptions (review_score int to string):**
+
+| Score | Description |
+|-------|-------------|
+| 9 | Overwhelmingly Positive |
+| 8 | Very Positive |
+| 7 | Mostly Positive |
+| 6 | Positive (Mixed) |
+| 5 | Mixed |
+| 4 | Mostly Negative |
+| 3 | Negative |
+| 2 | Mostly Negative |
+| 1 | Overwhelmingly Negative |
+| 0 | No reviews |
+
+**Confirmed scores:** Witcher 3 = 9, Counter-Strike 2 = 8, Stardew Valley = 9, Factorio = 9.
+
+### Review object fields
+
+```python
+review = result["reviews"][0]
+review["recommendationid"]           # "221423937"  — unique review ID
+review["voted_up"]                   # True/False  — positive/negative
+review["votes_up"]                   # 213         — helpful votes
+review["votes_funny"]                # 66
+review["weighted_vote_score"]        # 0.8405...   — Steam's helpfulness score
+review["comment_count"]              # 20
+review["steam_purchase"]             # True
+review["received_for_free"]          # False
+review["written_during_early_access"]# False
+review["timestamp_created"]          # 1774209092  (Unix timestamp)
+review["timestamp_updated"]          # Unix timestamp
+review["language"]                   # "english"
+review["review"]                     # review text
+review["app_release_date"]           # Unix timestamp of game release
+
+review["author"]["steamid"]              # "76561198..."
+review["author"]["personaname"]          # display name
+review["author"]["num_games_owned"]      # 1039
+review["author"]["num_reviews"]          # 180
+review["author"]["playtime_forever"]     # 1146  (minutes total)
+review["author"]["playtime_last_two_weeks"] # minutes in last 2 weeks
+review["author"]["playtime_at_review"]   # minutes at time of review
+review["author"]["last_played"]          # Unix timestamp
+```
+
+### Cursor-based pagination
+
+```python
+import urllib.parse, json
+from helpers import http_get
+
+def get_all_reviews(appid, max_pages=5, num_per_page=100, language="all"):
+    """Paginate through reviews using cursor."""
+    cursor = "*"
+    all_reviews = []
+    for _ in range(max_pages):
+        resp = http_get(
+            f"https://store.steampowered.com/appreviews/{appid}"
+            f"?json=1&num_per_page={num_per_page}&language={language}"
+            f"&filter=recent&cursor={urllib.parse.quote(cursor)}"
+        )
+        data = json.loads(resp)
+        batch = data.get("reviews", [])
+        if not batch:
+            break
+        all_reviews.extend(batch)
+        cursor = data.get("cursor", "")
+        if not cursor:
+            break
+    return all_reviews
+```
+
+---
+
+## Featured games
+
+### Featured items (rotating store front)
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get("https://store.steampowered.com/api/featured/"))
+# data["large_capsules"]  -> 1-3 hero banner items
+# data["featured_win"]    -> 10 featured items for Windows
+# data["featured_mac"]    -> macOS featured
+# data["featured_linux"]  -> Linux featured
+# data["status"]          -> 1
+
+item = data["featured_win"][0]
+# item["id"]                -> appid
+# item["name"]              -> game title
+# item["discounted"]        -> bool
+# item["discount_percent"]  -> 0-100
+# item["original_price"]    -> cents
+# item["final_price"]       -> cents
+# item["currency"]          -> "USD"
+# item["windows_available"] -> bool
+# item["mac_available"]     -> bool
+# item["linux_available"]   -> bool
+# item["large_capsule_image"] -> URL
+# item["small_capsule_image"] -> URL
+# item["header_image"]      -> URL
+# item["controller_support"] -> "full" | "partial" | ""
+```
+
+### Featured categories (top sellers, specials, new releases, coming soon)
+
+```python
+data = json.loads(http_get("https://store.steampowered.com/api/featuredcategories/"))
+
+# Named sections (most useful):
+specials    = data["specials"]["items"]      # 10 on-sale games
+top_sellers = data["top_sellers"]["items"]  # 10 top sellers
+new_releases= data["new_releases"]["items"] # 30 new releases
+coming_soon = data["coming_soon"]["items"]  # 10 upcoming games
+
+# Numbered keys "0" through "7" are spotlight banners (deals/events)
+
+item = top_sellers[0]
+# item["id"]                   -> appid
+# item["name"]                 -> game title
+# item["discounted"]           -> bool
+# item["discount_percent"]     -> 0-100
+# item["original_price"]       -> cents (None for upcoming games)
+# item["final_price"]          -> cents (0 for upcoming)
+# item["currency"]             -> "USD"
+# item["discount_expiration"]  -> Unix timestamp (present for active sales)
+# item["windows_available"]    -> bool
+# item["mac_available"]        -> bool
+# item["linux_available"]      -> bool
+# item["header_image"]         -> URL
+```
+
+---
+
+## App list (all Steam apps)
+
+The `ISteamApps/GetAppList` API endpoint (v1, v2, v0001, v0002) currently returns **HTTP 404** from `api.steampowered.com` as of 2026-04-18. The endpoint is effectively retired without a Steamworks API key.
+
+**Workaround:** Use the featured categories and search APIs to discover appids, then batch-fetch via `appdetails`.
+
+```python
+# Discover appids from top sellers + new releases
+import json
+from helpers import http_get
+
+def get_all_store_appids():
+    data = json.loads(http_get("https://store.steampowered.com/api/featuredcategories/"))
+    appids = set()
+    for key in ["specials", "top_sellers", "new_releases", "coming_soon"]:
+        for item in data.get(key, {}).get("items", []):
+            appids.add(item["id"])
+    for key in ["featured_win", "featured_mac", "featured_linux"]:
+        for item in data.get(key, []):
+            appids.add(item["id"])
+    return sorted(appids)
+
+# Returns ~50 store-front appids (enough to seed further discovery)
+```
+
+---
+
+## Rate limits
+
+Steam's public APIs are generous. Confirmed during testing:
+
+- **10 sequential requests in 1.59s** — all HTTP 200, no throttling
+- **10 concurrent requests (5 workers) in 0.54s** — all succeeded
+- **No `Retry-After` header** observed at any concurrency level
+
+Practical limits (undocumented, inferred from community reports):
+- ~200 requests/5 minutes per IP to `appdetails` before soft throttling (returns `success: false`)
+- Review API is more restrictive — keep to ~50 requests/minute
+
+---
+
+## Gotchas
+
+**`success: false` with no data field** — When an appid is invalid, removed, or unreleased, the response is `{"999999": {"success": false}}` with no `data` key. Always check `entry["success"]` before accessing `entry["data"]`.
+
+```python
+entry = json.loads(resp)[str(appid)]
+if not entry["success"]:
+    return None   # game removed or never existed
+game = entry["data"]
+```
+
+**Multiple appids in one call — not supported** — `appids=292030,570` returns HTTP 400. The API only accepts a single appid per call. Use `ThreadPoolExecutor` for bulk fetching.
+
+**`price_overview` is `None` for free games** — When `is_free=True`, the `price_overview` key is absent or `None`. Never index `game["price_overview"]["final"]` without a None check.
+
+**`initial_formatted` is empty string when not on sale** — When `discount_percent == 0`, `initial_formatted` is `""`. Only `final_formatted` is reliably present and non-empty. Use `final_formatted` for display in all cases.
+
+**Store page age gate** — `store.steampowered.com/app/{appid}/` redirects mature games to `/agecheck/app/{appid}/`. The `appdetails` API completely bypasses this — no cookies needed. For browser-based scraping of the store page, send `Cookie: birthtime=631152001; lastagecheckage=1-January-1990`.
+
+**`storesearch` always returns ≤ 10 results** — No pagination. `total` in the response is always 10, not the true result count. For finding specific games, this is sufficient. For catalog browsing, use `appdetails` with known appids.
+
+**`metascore` is string `"0"` in search results, int `93` in appdetails** — Inconsistent types. In `storesearch` results, `metascore` is a string (e.g. `"93"`, `"0"`). In `appdetails`, `metacritic` is a dict `{"score": 93, "url": "..."}` or absent entirely. Always `int()` the storesearch value.
+
+**`appdetails` returns `type: "dlc"` for DLC** — Check `game["type"]` before treating every appid as a standalone game. Type values: `"game"`, `"dlc"`, `"demo"`, `"advertising"`, `"mod"`, `"video"`.
+
+**`ratings` dict uses string booleans** — `use_age_gate` and `required_age` inside `ratings[board]` are strings (`"true"`, `"17"`), not native types. `banned` is also a string `"0"` or `"1"`.
+
+**`ISteamApps/GetAppList` is dead** — HTTP 404 for v1, v2, v0001, v0002 endpoints as of 2026-04-18. Use store front APIs and search to discover appids instead.
+
+**`supported_languages` is HTML** — The field contains escaped HTML like `English<strong>*</strong>, French`. Starred languages have full audio. Use `html.unescape()` and strip tags to get a clean list.
+
+**`release_date.date` is a locale string, not ISO** — Value is `"May 18, 2015"` not `"2015-05-18"`. Parse with `datetime.strptime(d, "%B %d, %Y")` or use regex.
+
+**Review `purchase_type` changes total counts** — `purchase_type=all` includes reviews from non-Steam purchases (physical, Humble, etc.). `purchase_type=steam` is Steam-only. Witcher 3 example: `all`=802,072 reviews, `steam`=234,385.
+
+**Currency requires `cc=` param** — Without `cc=`, you get USD by default. Pass `cc=GB` for GBP, `cc=DE` for EUR, etc. Country codes are ISO-3166 (2-letter, uppercase).

--- a/domain-skills/walmart/scraping.md
+++ b/domain-skills/walmart/scraping.md
@@ -1,0 +1,444 @@
+# Walmart — Product Search & Data Extraction
+
+Field-tested against walmart.com on 2026-04-18 using `http_get` (no browser required).
+All code blocks were run and outputs verified against live responses.
+
+---
+
+## Fastest Approach: `http_get` with `__NEXT_DATA__`
+
+Walmart's Next.js SSR embeds the full search or product payload as JSON in a
+`<script id="__NEXT_DATA__">` tag. **No browser needed for search or product detail pages.**
+~2–3 s per page fetch; no CAPTCHA or session cookies required.
+
+### Critical UA rule
+
+| User-Agent | Result |
+|---|---|
+| `Mozilla/5.0` (bare) | Full HTML + `__NEXT_DATA__` — **use this** |
+| `Mozilla/5.0 ... Chrome/120 ...` (full) | PerimeterX "Robot or human?" challenge (200, 15 KB) |
+| `Safari/17` full UA | Works (full HTML, ~1.15 MB) |
+| `curl/7.x` | PerimeterX challenge |
+| `python-requests/2.31` | PerimeterX challenge |
+
+The bare `Mozilla/5.0` string bypasses PerimeterX. Any UA that looks like a headless
+client or includes a recognizable browser fingerprint triggers the JS challenge page.
+
+### Base fetch helper
+
+```python
+import json, re, gzip, urllib.request
+
+def fetch_walmart(url):
+    """
+    Fetch any walmart.com page.
+    Returns decoded HTML string.
+    Raises RuntimeError if PerimeterX bot challenge is returned.
+    """
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"},
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        html = data.decode()
+    if "Robot or human" in html:
+        raise RuntimeError(f"PerimeterX challenge triggered: {url}")
+    return html
+
+def parse_next_data(html):
+    m = re.search(r'id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+    if not m:
+        raise ValueError("__NEXT_DATA__ not found — page structure may have changed")
+    return json.loads(m.group(1))
+```
+
+---
+
+## Search Results
+
+### URL patterns
+
+```python
+# Keyword search
+"https://www.walmart.com/search?q=laptop"
+
+# Pagination — append &page=N
+"https://www.walmart.com/search?q=laptop&page=2"
+
+# Sort options (confirmed working)
+"https://www.walmart.com/search?q=laptop&sort=best_match"    # default
+"https://www.walmart.com/search?q=laptop&sort=best_seller"
+"https://www.walmart.com/search?q=laptop&sort=price_low"
+"https://www.walmart.com/search?q=laptop&sort=customer_rating"
+
+# Price filter
+"https://www.walmart.com/search?q=laptop&min_price=200&max_price=500"
+
+# Browse by category (department ID path)
+"https://www.walmart.com/browse/electronics/laptops/3944_1089430_3951"
+```
+
+### `__NEXT_DATA__` path to items
+
+```
+data
+  .props.pageProps.initialData.searchResult
+    .aggregatedCount        — int: total matching products (e.g. 18818)
+    .paginationV2.maxPage   — int: last page number
+    .itemStacks[]           — array of stacks (usually 2: sponsored + organic)
+      .items[]              — array of product objects
+```
+
+### Full extractor (field-tested)
+
+```python
+def extract_search_results(html):
+    """
+    Returns (items, total_count, max_page).
+    items is a list of dicts with confirmed fields.
+    """
+    data = parse_next_data(html)
+    sr = data["props"]["pageProps"]["initialData"]["searchResult"]
+
+    items = []
+    for stack in sr.get("itemStacks", []):
+        for item in stack.get("items", []):
+            pi = item.get("priceInfo") or {}
+            img = item.get("imageInfo") or {}
+            rating = item.get("rating") or {}
+            avail = item.get("availabilityStatusV2") or {}
+            items.append({
+                "usItemId":        item.get("usItemId"),           # str, Walmart item ID
+                "name":            item.get("name"),               # str
+                "brand":           item.get("brand"),              # str or None
+                "price":           item.get("price"),              # int, current price in USD
+                "linePrice":       pi.get("linePrice"),            # str "$429.00"
+                "wasPrice":        pi.get("wasPrice") or None,     # str "$699.00" or None
+                "savings":         pi.get("savings") or None,      # str "SAVE $270.00" or None
+                "averageRating":   rating.get("averageRating"),    # float e.g. 4.3
+                "numberOfReviews": rating.get("numberOfReviews"),  # int
+                "availability":    avail.get("value"),             # "IN_STOCK" / "OUT_OF_STOCK"
+                "isSponsored":     bool(item.get("isSponsoredFlag")),
+                "url":             "https://www.walmart.com" + (item.get("canonicalUrl") or "").split("?")[0],
+                "thumbnailUrl":    img.get("thumbnailUrl"),
+            })
+
+    total = sr.get("aggregatedCount")
+    max_page = (sr.get("paginationV2") or {}).get("maxPage")
+    return items, total, max_page
+
+
+# Usage
+html = fetch_walmart("https://www.walmart.com/search?q=laptop")
+items, total, max_page = extract_search_results(html)
+# items: 66 items on page 1, total=18818, max_page=11
+
+# Filter out sponsored
+organic = [i for i in items if not i["isSponsored"]]
+```
+
+### Field notes (confirmed)
+
+- **`usItemId`**: string, matches the numeric ID at the end of `/ip/.../ITEMID` URLs.
+  Some non-product rows (ad widgets) have `usItemId=None` — filter with `if item.get("usItemId")`.
+- **`price`**: integer cents-less price (e.g. `429` for "$429.00"). Use `priceInfo.linePrice` for
+  the formatted string including the dollar sign.
+- **`wasPrice` / `savings`**: only present when item is on sale. Always `None` for full-price items.
+- **`isSponsoredFlag`**: the first batch of results across both itemStacks are frequently sponsored.
+  On a laptop search, ~56 of 66 SSR items carry `isSponsoredFlag: true`.
+- **`rating`**: present on ~91% of items (60/66 in test). `averageRating` is a float; `numberOfReviews` is int.
+- **`canonicalUrl`**: always includes `?classType=...&athbdg=...` query params — strip with `.split("?")[0]`
+  to get a clean URL.
+- **Two itemStacks**: Walmart returns two stacks (`itemStacks[0]` and `itemStacks[1]`). Merge them.
+  `itemStacks[0]` is the primary grid; `itemStacks[1]` is a secondary sponsored/related block.
+
+### Pagination
+
+```python
+for page in range(1, max_page + 1):
+    html = fetch_walmart(f"https://www.walmart.com/search?q=laptop&page={page}")
+    items, _, _ = extract_search_results(html)
+    # process items...
+```
+
+Page responses average ~2.5 s each. No rate-limiting was observed across 3 sequential requests.
+For bulk scraping, add a 1–2 s delay between requests to be safe.
+
+---
+
+## Product Detail Page
+
+### URL pattern
+
+```
+https://www.walmart.com/ip/{slug}/{usItemId}
+```
+
+The slug is ignored in routing — only the numeric `usItemId` matters.
+These work identically:
+```
+https://www.walmart.com/ip/anything/19717318352
+https://www.walmart.com/ip/Apple-MacBook-Neo/19717318352
+```
+
+### `__NEXT_DATA__` path on a product page
+
+```
+data.props.pageProps.initialData.data
+  .product        — core product object
+  .idml           — long description, specs, highlights, warranty
+  .reviews        — rating breakdown + first 10 customer reviews (SSR)
+```
+
+### Full extractor (field-tested)
+
+```python
+def extract_product_detail(html):
+    """
+    Returns a dict with all confirmed product fields.
+    idml.specifications returns all spec rows as a flat dict.
+    reviews returns the SSR-rendered first 10 customer reviews.
+    """
+    data = parse_next_data(html)
+    d = data["props"]["pageProps"]["initialData"]["data"]
+    product = d["product"]
+    idml    = d.get("idml") or {}
+    reviews = d.get("reviews") or {}
+
+    pi = product.get("priceInfo") or {}
+    cp = pi.get("currentPrice") or {}
+    img = product.get("imageInfo") or {}
+    avail = product.get("availabilityStatusV2") or {}
+
+    specs = {
+        spec.get("name"): spec.get("value")
+        for spec in (idml.get("specifications") or [])
+    }
+
+    all_images = [
+        img_item.get("url")
+        for img_item in (img.get("allImages") or [])
+        if img_item.get("url")
+    ]
+
+    customer_reviews = [
+        {
+            "title":    r.get("reviewTitle"),
+            "rating":   r.get("rating"),           # int 1-5 (field is "rating", NOT "overallRating")
+            "text":     r.get("reviewText"),
+            "author":   r.get("userNickname"),
+            "date":     r.get("reviewSubmissionTime"),
+        }
+        for r in (reviews.get("customerReviews") or [])
+    ]
+
+    return {
+        # identity
+        "usItemId":            product.get("usItemId"),
+        "name":                product.get("name"),
+        "brand":               product.get("brand"),
+        "model":               product.get("model"),
+        "upc":                 product.get("upc"),
+        # price
+        "price":               cp.get("price"),            # float, e.g. 599
+        "priceString":         cp.get("priceString"),      # "$599.00"
+        "wasPrice":            (pi.get("wasPrice") or {}).get("priceString"),
+        "savings":             (pi.get("savings") or {}).get("savingsString"),
+        # availability
+        "availability":        avail.get("value"),         # "IN_STOCK" / "OUT_OF_STOCK"
+        "availabilityDisplay": avail.get("display"),       # "In stock"
+        # ratings
+        "averageRating":       product.get("averageRating"),
+        "numberOfReviews":     product.get("numberOfReviews"),
+        # text
+        "shortDescription":    product.get("shortDescription"),
+        "longDescription":     idml.get("longDescription"),  # HTML string
+        # media
+        "thumbnailUrl":        img.get("thumbnailUrl"),
+        "allImages":           all_images,          # up to 10 image URLs
+        # specs
+        "specifications":      specs,               # {"Brand": "Apple", "Processor": "A18 Pro", ...}
+        "highlights":          [                    # top highlighted specs with icons
+            {"name": h.get("name"), "value": h.get("value")}
+            for h in (idml.get("productHighlights") or [])
+        ],
+        # URL
+        "canonicalUrl":        "https://www.walmart.com" + (product.get("canonicalUrl") or ""),
+        # fulfillment
+        "fulfillmentOptions":  product.get("fulfillmentOptions") or [],
+        # reviews (SSR-rendered, first 10)
+        "reviewSummary": {
+            "averageOverallRating":    reviews.get("averageOverallRating"),
+            "totalReviewCount":        reviews.get("totalReviewCount"),
+            "reviewsWithTextCount":    reviews.get("reviewsWithTextCount"),
+            "recommendedPercentage":   reviews.get("recommendedPercentage"),
+        },
+        "customerReviews":     customer_reviews,
+    }
+
+
+# Usage
+url = "https://www.walmart.com/ip/Apple-MacBook-Neo/19717318352"
+html = fetch_walmart(url)
+product = extract_product_detail(html)
+
+# Example output (confirmed live):
+# product["name"]         → "Apple MacBook Neo 13-inch Apple A18 Pro chip..."
+# product["price"]        → 599
+# product["priceString"]  → "$599.00"
+# product["availability"] → "IN_STOCK"
+# product["model"]        → "MHFD4LL/A"
+# product["upc"]          → "195950852745"
+# len(product["specifications"])  → 29 spec rows
+# len(product["allImages"])       → 10
+# product["specifications"]["Processor"] → "A18 Pro"
+```
+
+### Field notes (confirmed)
+
+- **`averageRating` / `numberOfReviews`** on the product node: present for items with reviews.
+  New/few-review items may return `None` for both.
+- **`reviewSummary.averageOverallRating`** in the reviews node often differs slightly from
+  `product.averageRating` — the reviews node is more precise (e.g. `4.75` vs `4.8`).
+- **`customerReviews`** (SSR): always the first 10 reviews. The per-review rating field is `"rating"`
+  (int 1–5), **not** `"overallRating"` (which is always `None`).
+- **`longDescription`**: raw HTML string including `<ul>/<li>` tags. Strip tags before display.
+- **`specifications`**: flat dict — confirmed 29–31 rows for electronics. Key names use display labels
+  (e.g. `"RAM memory"`, `"Screen size"`, `"HD capacity"`).
+- **`wasPrice` / `savings`** on detail page: same as search — `None` when item is not discounted.
+- **No JSON-LD**: Walmart product pages do **not** include `<script type="application/ld+json">`.
+  All structured data lives in `__NEXT_DATA__`.
+
+---
+
+## Anti-Bot: PerimeterX
+
+Walmart uses **PerimeterX** (app ID `PXu6b0qd2S`, confirmed in `runtimeConfig.perimeterX`).
+
+| Signal | Detail |
+|---|---|
+| Bot detector | PerimeterX |
+| Challenge page | "Robot or human?" — 200 OK, 15 KB HTML |
+| Triggered by | Full browser UA strings (Chrome, curl, python-requests) |
+| Bypassed by | `User-Agent: Mozilla/5.0` (bare prefix only) |
+| No JS execution | SSR response is complete — no JS challenge to solve |
+
+Detection in code:
+```python
+if "Robot or human" in html:
+    raise RuntimeError("PerimeterX challenge — switch to browser harness")
+```
+
+If `http_get` starts returning the challenge after a run of successful fetches, switch to the
+browser harness (see below).
+
+---
+
+## Browser Harness Fallback
+
+Use the browser harness when:
+- PerimeterX starts blocking `http_get` on your IP
+- You need to interact with the page (add to cart, filter UI, infinite scroll)
+- You need variant switching (color/size selectors)
+
+```python
+# Browser-based search extraction
+new_tab("https://www.walmart.com/search?q=laptop")
+wait_for_load()
+wait(2)  # JS renders product cards after readyState=complete
+
+# Extract via __NEXT_DATA__ in-browser (identical structure to http_get)
+import json
+nd = js("document.getElementById('__NEXT_DATA__')?.textContent")
+data = json.loads(nd)
+sr = data["props"]["pageProps"]["initialData"]["searchResult"]
+items = []
+for stack in sr.get("itemStacks", []):
+    items.extend(stack.get("items", []))
+```
+
+### Browser selectors (confirmed working for DOM-based extraction)
+
+```python
+# Product cards on search results page
+results = js("""
+  Array.from(document.querySelectorAll('[data-item-id]')).map(el => ({
+    itemId:    el.getAttribute('data-item-id'),
+    name:      el.querySelector('[itemprop="name"]')?.innerText?.trim(),
+    price:     el.querySelector('[itemprop="price"]')?.getAttribute('content'),
+    url:       el.querySelector('a[link-identifier]')?.href,
+  })).filter(r => r.itemId)
+""")
+
+# If [data-item-id] misses items, use the Next.js data attribute alternative:
+results_alt = js("""
+  Array.from(document.querySelectorAll('[data-testid="list-view"]'))
+    .map(el => el.innerText.trim())
+""")
+```
+
+> **Prefer `__NEXT_DATA__` over DOM selectors** even in-browser — the JSON is complete and
+> stable. DOM class names at Walmart are obfuscated and change between deployments.
+
+### Session gotcha
+
+Always open Walmart with `new_tab()` on first visit:
+```python
+new_tab("https://www.walmart.com/search?q=laptop")
+wait_for_load()
+wait(2)
+```
+After that, `goto()` works normally within the same session.
+
+---
+
+## Public API
+
+Walmart's affiliate/partner API (`developer.api.walmart.com`) requires a registered API key
+and returns HTTP 403 without one. No unauthenticated public product API is available.
+The `__NEXT_DATA__` SSR approach replaces any need for the official API for read-only data.
+
+---
+
+## Gotchas
+
+- **UA must be `Mozilla/5.0` bare**: Any fuller string (Chrome, Safari, curl, requests) hits
+  PerimeterX. This is counterintuitive — the *shorter*, less realistic UA is the one that works.
+
+- **Regex must use `id=` attribute match**: The regex
+  `r'<script id="__NEXT_DATA__" type="application/json">...'` fails because the actual tag is
+  `<script id="__NEXT_DATA__">` without `type`. Use:
+  ```python
+  re.search(r'id="__NEXT_DATA__"[^>]*>(.*?)</script>', html, re.DOTALL)
+  ```
+
+- **`usItemId` can be `None`**: ~5/66 items on a page are non-product ad widgets with no `usItemId`.
+  Always filter: `[i for i in items if i.get("usItemId")]`.
+
+- **Two `itemStacks`**: Walmart returns two stacks. Iterate over all stacks or you'll miss
+  ~10 items from the second stack.
+
+- **`canonicalUrl` includes tracking params**: Always strip with `.split("?")[0]`.
+
+- **Review field is `"rating"` not `"overallRating"`**: Each `customerReviews` entry has a `"rating"`
+  int field (1–5). The `"overallRating"` field is always `None`. Don't confuse with
+  `product.averageRating` (the aggregate float).
+
+- **No JSON-LD on product pages**: Zero `<script type="application/ld+json">` tags were found.
+  All structured data is in `__NEXT_DATA__`.
+
+- **`longDescription` is HTML**: Strip tags before text use. May contain promotional/financing copy
+  mixed with real product description.
+
+- **Page sizes vary**: Page 1 returned 66 items across 2 stacks; page 2 returned 55.
+  Do not assume a fixed items-per-page count.
+
+- **`http_get` default already sends `Mozilla/5.0`**: `helpers.http_get()` uses
+  `"User-Agent": "Mozilla/5.0"` by default — no override needed when calling it directly.
+  Only pass a custom `headers=` if you need to change something else.
+
+- **`developer.api.walmart.com`** returns HTTP 403 without an API key. Not usable for
+  unauthenticated scraping.

--- a/domain-skills/weather/scraping.md
+++ b/domain-skills/weather/scraping.md
@@ -1,0 +1,398 @@
+# Weather APIs — Data Extraction
+
+Three free, no-auth weather APIs tested: **wttr.in** (simplest), **Open-Meteo** (most complete), **weather.gov / NWS** (US only, official).
+
+All work with `http_get` — no browser needed.
+
+## Do this first: pick your API
+
+| Goal | Best API | Latency | Notes |
+|------|----------|---------|-------|
+| Quick current + 3-day forecast, any city name | wttr.in `?format=j1` | ~800ms | US + international |
+| Rich hourly/daily/historical, any coordinates | Open-Meteo | ~700ms | 10K req/day free |
+| City name → coordinates | Open-Meteo geocoding | ~700ms | Use with Open-Meteo forecast |
+| Official US forecasts with PoP and text | weather.gov NWS | ~90ms /points + ~70ms /forecast | US only, 2-call flow |
+
+**Never use a browser for any of these APIs.** All return JSON over plain HTTP.
+
+---
+
+## Fastest approach: wttr.in one-call current + 3-day forecast
+
+```python
+import json
+data = json.loads(http_get("https://wttr.in/San+Francisco?format=j1"))
+
+# Current conditions
+cc = data['current_condition'][0]
+print(cc['temp_F'], '°F /', cc['temp_C'], '°C')      # '47', '8'
+print(cc['FeelsLikeF'], '°F feels like')              # '46'
+print(cc['humidity'], '%')                            # '80'
+print(cc['windspeedMiles'], 'mph', cc['winddir16Point'])  # '3', 'SW'
+print(cc['weatherDesc'][0]['value'])                  # 'Partly cloudy'
+print(cc['precipMM'], 'mm precip')                   # '0.0'
+print(cc['visibility'], 'km', cc['visibilityMiles'], 'mi')
+print(cc['pressure'], 'hPa', cc['pressureInches'], 'inHg')
+print(cc['uvIndex'])                                  # '0'
+print(cc['cloudcover'], '%')                          # '50'
+print(cc['observation_time'])                         # '10:48 AM' (UTC)
+print(cc['localObsDateTime'])                         # '2026-04-18 03:34 AM' (local)
+
+# 3-day forecast (today + 2 more)
+for day in data['weather']:
+    print(day['date'], day['maxtempF'], '/', day['mintempF'], '°F')
+    # also: maxtempC, mintempC, avgtempF, avgtempC, sunHour, uvIndex, totalSnow_cm
+    astro = day['astronomy'][0]
+    print('  sunrise:', astro['sunrise'], 'sunset:', astro['sunset'])
+    print('  moon:', astro['moon_phase'], astro['moon_illumination'], '%')
+    # Hourly breakdown (8 entries per day, every 3 hours: time 0,300,600,...,2100)
+    for h in day['hourly']:
+        print(h['time'], h['tempF'], '°F', h['weatherDesc'][0]['value'])
+        # time is '0','300','600',...,'2100' (not HH:MM)
+        # also: chanceofrain, chanceofsnow, chanceofthunder, chanceoffog, humidity, etc.
+
+# Location info
+na = data['nearest_area'][0]
+print(na['areaName'][0]['value'])    # 'San Francisco'
+print(na['country'][0]['value'])     # 'United States of America'
+print(na['latitude'], na['longitude'])  # '37.775', '-122.418' (strings)
+print(na['region'][0]['value'])      # 'California'
+```
+
+**Works with city names, coordinates, airport codes (`~SFO`), and zip codes.**
+
+---
+
+## Open-Meteo: most complete free weather API
+
+### Step 1: city name → coordinates (geocoding)
+
+```python
+import json
+geo = json.loads(http_get("https://geocoding-api.open-meteo.com/v1/search?name=Chicago&count=1"))
+city = geo['results'][0]
+lat  = city['latitude']   # 41.85003
+lon  = city['longitude']  # -87.65005
+tz   = city['timezone']   # 'America/Chicago'
+# Also available: city['elevation'], city['country'], city['country_code'],
+#                 city['admin1'] (state/province), city['population']
+```
+
+Always use `count=1` and take `results[0]` for unambiguous city names. For "San Francisco" `results[0]` is always the California city (pop 864K).
+
+### Current conditions (extended — preferred over current_weather)
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+    f"precipitation,weathercode,windspeed_10m,winddirection_10m,"
+    f"uv_index,surface_pressure"
+    f"&timezone={tz}"
+))
+
+cur   = data['current']
+units = data['current_units']
+# cur keys and units (all confirmed):
+# temperature_2m        °C   (or °F with &temperature_unit=fahrenheit)
+# relative_humidity_2m  %
+# apparent_temperature  °C
+# precipitation         mm
+# weathercode           WMO code int (see table below)
+# windspeed_10m         km/h (or mph with &windspeed_unit=mph)
+# winddirection_10m     °
+# uv_index              (unitless float)
+# surface_pressure      hPa
+# time                  ISO8601 local time (e.g. '2026-04-18T10:45')
+# interval              900 (seconds — 15-min update cadence)
+
+print(cur['temperature_2m'], units['temperature_2m'])   # 8.7 °C
+print(cur['apparent_temperature'])                      # 6.6
+print(cur['relative_humidity_2m'])                      # 80
+print(cur['windspeed_10m'], cur['winddirection_10m'])   # 6.1  242
+print(cur['weathercode'])                               # 0 = clear sky
+```
+
+The older `&current_weather=true` param works too — returns `data['current_weather']` with only temperature, windspeed, winddirection, weathercode, time, is_day, interval.
+
+### Hourly forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&hourly=temperature_2m,dewpoint_2m,apparent_temperature,"
+    f"precipitation_probability,precipitation,rain,showers,snowfall,snow_depth,"
+    f"weathercode,cloudcover,visibility,windspeed_10m,winddirection_10m,"
+    f"windgusts_10m,uv_index"
+    f"&forecast_days=3&timezone={tz}"
+))
+
+hourly = data['hourly']
+units  = data['hourly_units']
+# hourly is a dict of parallel arrays, all same length
+# time entries: ISO8601 strings, one per hour ('2026-04-18T00:00', etc.)
+# 3 forecast days → 72 entries
+
+for i, t in enumerate(hourly['time'][:5]):
+    print(t,
+          hourly['temperature_2m'][i], units['temperature_2m'],
+          hourly['precipitation_probability'][i], units['precipitation_probability'],
+          hourly['windspeed_10m'][i], units['windspeed_10m'])
+
+# Confirmed units (all from live response):
+# temperature_2m              °C      dewpoint_2m          °C
+# apparent_temperature        °C      precipitation_probability  %
+# precipitation               mm      rain                 mm
+# showers                     mm      snowfall             cm
+# snow_depth                  m       weathercode          wmo code
+# cloudcover                  %       visibility           m (not km!)
+# windspeed_10m               km/h    winddirection_10m    °
+# windgusts_10m               km/h    uv_index             (unitless)
+```
+
+`forecast_days` defaults to 7, max is 16.
+
+### Daily forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,"
+    f"apparent_temperature_min,precipitation_sum,rain_sum,snowfall_sum,"
+    f"precipitation_hours,precipitation_probability_max,"
+    f"windspeed_10m_max,windgusts_10m_max,winddirection_10m_dominant,"
+    f"shortwave_radiation_sum,uv_index_max,sunrise,sunset"
+    f"&timezone={tz}&forecast_days=7"
+))
+
+daily = data['daily']
+units = data['daily_units']
+for i, date in enumerate(daily['time']):
+    print(date,
+          daily['temperature_2m_max'][i], '/', daily['temperature_2m_min'][i], units['temperature_2m_max'],
+          f"precip={daily['precipitation_sum'][i]}{units['precipitation_sum']}",
+          f"pop={daily['precipitation_probability_max'][i]}%",
+          f"UV={daily['uv_index_max'][i]}",
+          f"sunrise={daily['sunrise'][i]}",
+          f"sunset={daily['sunset'][i]}")
+# sunrise/sunset are ISO8601 local datetimes ('2026-04-18T06:29')
+# shortwave_radiation_sum in MJ/m²
+```
+
+### Historical data (archive API)
+
+Different subdomain — `archive-api.open-meteo.com`:
+
+```python
+data = json.loads(http_get(
+    "https://archive-api.open-meteo.com/v1/archive"
+    "?latitude=37.7749&longitude=-122.4194"
+    "&start_date=2024-01-01&end_date=2024-01-07"
+    "&daily=temperature_2m_max,precipitation_sum"
+    "&timezone=America/Los_Angeles"
+))
+# Returns same structure as forecast — daily dict of parallel arrays
+# Hourly also works: &hourly=temperature_2m,precipitation,weathercode
+# Data goes back to 1940 for most locations
+```
+
+### Unit overrides
+
+All unit conversions are server-side — just add params:
+
+```
+&temperature_unit=fahrenheit    # default: celsius
+&windspeed_unit=mph             # default: kmh (also: ms, kn)
+&precipitation_unit=inch        # default: mm
+```
+
+---
+
+## weather.gov NWS (US only — 2-call flow)
+
+Required for official NWS text forecasts with probability-of-precipitation text and storm warnings.
+
+```python
+import json, urllib.request, gzip
+
+def nws_get(url):
+    """NWS requires a descriptive User-Agent or returns 403."""
+    h = {
+        "User-Agent": "(myapp.example.com, contact@example.com)",
+        "Accept": "application/geo+json",
+    }
+    req = urllib.request.Request(url, headers=h)
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+# Call 1: resolve lat/lon to forecast office + grid cell (~90ms)
+pts  = json.loads(nws_get("https://api.weather.gov/points/37.7749,-122.4194"))
+prop = pts['properties']
+office = prop['gridId']    # 'MTR'
+gx     = prop['gridX']    # 85
+gy     = prop['gridY']    # 105
+forecast_url = prop['forecast']          # 7-day
+hourly_url   = prop['forecastHourly']    # hourly
+
+# Also available from /points: prop['timeZone'], prop['observationStations'],
+# prop['relativeLocation']['properties']['city'] and ['state']
+
+# Call 2: 7-day forecast (14 half-day periods) (~70ms)
+fc  = json.loads(nws_get(forecast_url))
+for p in fc['properties']['periods']:
+    print(p['name'],            # 'Saturday', 'Saturday Night', 'Sunday', ...
+          p['temperature'], p['temperatureUnit'],     # 74 F
+          p['windSpeed'], p['windDirection'],          # '6 to 14 mph' 'SW'
+          p['shortForecast'],                          # 'Mostly Sunny'
+          p['probabilityOfPrecipitation']['value'],    # 0  (integer percent)
+          p['isDaytime'])                              # True/False
+    # p['detailedForecast'] — plain English paragraph, e.g.
+    # 'Sunny, with a high near 74. Southwest wind 6 to 14 mph.'
+
+# Hourly (156 hours out — ~6.5 days)
+fch = json.loads(nws_get(hourly_url))
+for p in fch['properties']['periods'][:5]:
+    print(p['startTime'],           # '2026-04-18T03:00:00-07:00'
+          p['temperature'], '°F',
+          p['shortForecast'],
+          p['windSpeed'],
+          f"humidity={p['relativeHumidity']['value']}%",
+          f"dewpoint={p['dewpoint']['value']:.1f}°C")
+```
+
+`/points` response is cached `max-age=20500` (~5.7 hours) at the CDN — safe to call once per session and reuse grid coordinates.
+
+---
+
+## WMO weather code table (Open-Meteo `weathercode`)
+
+```python
+WMO_CODES = {
+    0: "Clear sky",
+    1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+    45: "Fog", 48: "Icy fog",
+    51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+    61: "Slight rain", 63: "Moderate rain", 65: "Heavy rain",
+    71: "Slight snow", 73: "Moderate snow", 75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight rain showers", 81: "Moderate rain showers", 82: "Violent rain showers",
+    85: "Slight snow showers", 86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with slight hail", 99: "Thunderstorm with heavy hail",
+}
+
+def wmo_desc(code):
+    return WMO_CODES.get(code, f"Unknown code {code}")
+```
+
+---
+
+## Complete end-to-end pattern: city name → rich forecast
+
+```python
+import json
+
+def get_weather(city: str) -> dict:
+    """City name → current + 7-day daily forecast via Open-Meteo."""
+    # 1. Geocode
+    geo  = json.loads(http_get(
+        f"https://geocoding-api.open-meteo.com/v1/search?name={city.replace(' ', '+')}&count=1"
+    ))
+    if not geo.get('results'):
+        raise ValueError(f"City not found: {city}")
+    loc  = geo['results'][0]
+    lat, lon, tz = loc['latitude'], loc['longitude'], loc['timezone']
+
+    # 2. Forecast (single call: current + daily)
+    data = json.loads(http_get(
+        f"https://api.open-meteo.com/v1/forecast"
+        f"?latitude={lat}&longitude={lon}"
+        f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+        f"precipitation,weathercode,windspeed_10m,winddirection_10m,uv_index"
+        f"&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,"
+        f"precipitation_probability_max,weathercode,sunrise,sunset"
+        f"&timezone={tz}&forecast_days=7"
+    ))
+    return {"location": loc, "current": data['current'],
+            "daily": data['daily'], "units": {
+                "current": data['current_units'],
+                "daily": data['daily_units'],
+            }}
+
+result = get_weather("Tokyo")
+cur = result['current']
+print(f"{result['location']['name']}: {cur['temperature_2m']}°C feels like {cur['apparent_temperature']}°C")
+print(f"Humidity {cur['relative_humidity_2m']}%, wind {cur['windspeed_10m']} km/h")
+```
+
+Total: 2 API calls, ~1400ms combined.
+
+---
+
+## Gotchas
+
+**wttr.in returns HTML (or ANSI art) instead of JSON if you forget `?format=j1`.**
+The `?format=j1` suffix is mandatory for JSON. Without it:
+- Browser `User-Agent` → full HTML page (~21KB)
+- `curl`/`Wget` User-Agent → ANSI escape-code ASCII art (~500B)
+Neither is parseable as JSON.
+
+**wttr.in text formats require a non-browser User-Agent.**
+`http_get()` sends `Mozilla/5.0` — wttr.in responds with an HTML page for `?format=%t`, `?format=3`, `?format=4`.
+Use `Wget/1.21` (or any non-browser UA) for text format endpoints:
+```python
+import urllib.request, gzip
+
+def http_get_wttr(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "Wget/1.21", "Accept": "*/*"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode()
+
+# Text format tokens (URL-encode %): %25l=location, %25C=condition desc,
+# %25t=temp, %25f=feels-like, %25h=humidity, %25w=wind
+print(http_get_wttr("https://wttr.in/London?format=%25t"))           # '+55°F'
+print(http_get_wttr("https://wttr.in/Tokyo?format=3"))               # 'tokyo: ☀️   +69°F'
+print(http_get_wttr("https://wttr.in/Berlin?format=%25l:+%25C+%25t+(feels+%25f)+%25h+%25w"))
+# 'berlin: Sunny +65°F (feels +65°F) 42% ↖5mph'
+```
+
+**wttr.in `format=j1` returns only 3 days** (today + 2). Use Open-Meteo for longer forecasts (up to 16 days).
+
+**wttr.in `nearest_area.areaName` is often wrong.** The returned area name is a reverse-geocoded neighborhood, not the city you queried (`"Mccormickville"` for Chicago, `"Lomita Park"` for SFO airport). Use `request[0].query` for what was actually resolved.
+
+**wttr.in `hourly[].time` is `'0'`, `'300'`, `'600'`...`'2100'`** — not HH:MM strings. Parse as `int(time) // 100` for hours.
+
+**wttr.in `weatherDesc` is a list**: `cc['weatherDesc'][0]['value']`, not a string. Same for `areaName`, `country`, `region`, `weatherIconUrl`.
+
+**wttr.in unknown city returns HTTP 500**, not 404 or a JSON error.
+
+**Open-Meteo default timezone is GMT.** Always pass `&timezone={tz}` or daily `sunrise`/`sunset` values will be in UTC, and daily buckets will be wrong.
+
+**Open-Meteo `visibility` is in metres** (not km). Divide by 1000 to get km.
+
+**Open-Meteo returns HTTP 400 with JSON error body on bad params:**
+```json
+{"reason": "Latitude must be in range of -90 to 90°. Given: 999.0.", "error": true}
+```
+`http_get()` raises an exception on 4xx — catch `urllib.error.HTTPError` and read `e.read()` (may be gzip-compressed) for the reason.
+
+**weather.gov requires a descriptive `User-Agent`.** The NWS API blocks generic `python-urllib` or `Mozilla/5.0` agents sporadically. Always set `User-Agent: (yourapp.com, your@email.com)` or use your actual app name.
+
+**weather.gov is US-only.** `/points/{lat},{lon}` returns HTTP 404 for coordinates outside the US (including territories like Puerto Rico for some grid edges). Fall back to Open-Meteo for non-US locations.
+
+**weather.gov `windSpeed` is a string like `"6 to 14 mph"`**, not a number. Parse with regex if you need a numeric value.
+
+**weather.gov `probabilityOfPrecipitation` is a dict**: `p['probabilityOfPrecipitation']['value']`, with `p['probabilityOfPrecipitation']['unitCode']` = `'wmoUnit:percent'`.
+
+**Open-Meteo rate limit: 10,000 requests/day on the free tier.** The geocoding API and forecast API count separately. No rate limit headers are returned — track usage yourself.
+
+**weather.gov /points response is heavily cached** (`Cache-Control: public, max-age=20500`). Store the office/gridX/gridY and reuse — only call `/points` once per location.


### PR DESCRIPTION
## Summary
- CoinMarketCap: Internal data-api/v3 fully open (no auth, no rate limiting); 9 endpoints documented; __NEXT_DATA__ has full 101-coin listing + Fear&Greed; v2 API returns 401
- Quora: Full Chrome UA required (bare Mozilla/5.0 returns 403); data in push() payloads (double-encoded JSON); first 3 answers SSR'd only; creation_time_us is microseconds; viewer_has_access gate is client-side only
- Itch.io: http_get works without UA tricks; game cards via CSS selectors; RSS feeds exist; API requires key
- Steam: appdetails API only accepts single appid (multiple returns 400); price in cents; age gate bypassed via birthtime cookie; ISteamApps/GetAppList dead as of 2026; reviews use cursor pagination
- HowLongToBeat: Two-step token flow (GET /api/find/init then POST /api/find); token encodes UA (must match); comp_* fields are seconds not hours; zero means no data not zero hours

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds domain-skill guides with tested access paths and anti‑bot notes for CoinMarketCap, Quora, Itch.io, Steam, and HowLongToBeat, enabling fast, reliable scraping without a browser where possible. Also includes new guides for other major sites to standardize approaches across domains.

- **New Features**
  - CoinMarketCap: internal `data-api/v3` fully open (no auth, no rate limiting); `__NEXT_DATA__` fallback; legacy v2 returns 401.
  - Quora: full Chrome UA required; data arrives in `push()` payloads with double‑encoded JSON; only ~3 top answers are SSR; microsecond `creation_time_us`.
  - Itch.io: `http_get` works without UA tricks; game detail via JSON‑LD; RSS feeds for listings; API endpoints require a key.
  - Steam: `appdetails` accepts a single `appid` per call; prices are cents; age gate bypass via `birthtime` cookie; reviews use cursor pagination.
  - HowLongToBeat: two‑step token flow (`GET /api/find/init` then `POST /api/find`); token binds to UA; `comp_*` fields are seconds and zero means “no data.”

<sup>Written for commit 33dcd86207a9dae0d5e1c11f7ac0dc0a59bd863b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

