### PR TITLE
[codex] Clarify README code size section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ See [domain-skills/](domain-skills/) for examples on other websites.
 
 <br><br><br>
 
-## Code Structure
+## How simple is it? (~590 lines of Python)
 
 - `install.md` explains first-time install and browser bootstrap.
 - `SKILL.md` explains day-to-day browser harness usage.
-- `run.py` (~13 lines) executes plain Python with helpers preloaded.
-- `helpers.py` (~192 lines) holds the starting tool calls to interact with the browser and can be modified by the agent.
-- `admin.py` (~139 lines) holds daemon bootstrap and optional remote-browser helpers.
-- `daemon.py` (~220 lines) keeps the CDP websocket and socket bridge alive.
+- `run.py` (~36 lines) executes plain Python with helpers preloaded.
+- `helpers.py` (~195 lines) holds the starting tool calls to interact with the browser and can be modified by the agent.
+- `admin.py` + `daemon.py` (~359 lines) handle daemon bootstrap plus the CDP websocket and socket bridge.
 
 <br><br><br>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The agent writes what's missing, mid-task. No framework, no recipes, no rails. O
 
 **You will never use the browser again.**
 
-## Setup
+## Setup prompt
 
 Paste into Claude Code or Codex:
 


### PR DESCRIPTION
## What changed
- renamed the README section from `Code Structure` to `How simple is it? (~590 lines of Python)`
- updated the listed line counts to match the current files
- combined `admin.py` and `daemon.py` into one summary line

## Why
The README should make the overall code size obvious at a glance and reflect the current repository state.

## Validation
- checked current line counts with `wc -l run.py helpers.py admin.py daemon.py`
- reviewed the README diff locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the README code size section so the total Python footprint is obvious and current, and renamed the setup header to "Setup prompt".
Updated counts to ~592 lines: `run.py` (~36), `helpers.py` (~195), and combined `admin.py` + `daemon.py` (~361).

<sup>Written for commit 819d1c2e3cba3b453923226d0dc759acd951f742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

