### PR TITLE
Print usage hint when bh is run on a TTY

### DIFF
--- a/run.py
+++ b/run.py
@@ -5,6 +5,8 @@ from helpers import *
 
 
 def main():
+    if sys.stdin.isatty():
+        sys.exit("bh reads Python from stdin. Use:\n  bh <<'PY'\n  print(page_info())\n  PY")
     ensure_daemon()
     exec(sys.stdin.read())
 


### PR DESCRIPTION
## Summary
- Print a usage hint when `bh` is invoked on a TTY (no stdin script), so users see how to pipe Python in rather than getting a silent wait.

## Test plan
- [ ] Run `bh` directly in a terminal and confirm the hint is shown.
- [ ] Run `bh <<'PY' ... PY` and confirm normal execution (no hint).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Print a usage hint and exit when `bh` is run on a TTY with no stdin, instead of hanging. This makes it clear that `bh` reads Python from stdin and shows a heredoc example.

<sup>Written for commit 29fa06576c974057256e17bb8c7c0d6cb8ec57ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

