### PR TITLE
readme: remove extra spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <img src="https://r2.browser-use.com/github/ajsdlasnnalsgasld.png" alt="Browser Harness" width="100%" />
 
-<br />
-
 # Browser Harness ♞
 
 The simplest, thinnest, **self-healing** harness that gives LLM **complete freedom** to complete any browser task. Built directly on CDP.


### PR DESCRIPTION
## Summary
- Remove redundant `<br />` after the header image in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant <br /> tag after the header image in `README.md` to eliminate the extra spacing before the title.

<sup>Written for commit f63bb97211c4b534d7290dc3de03e0b4e3a36ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

