### PR TITLE
Fix daemon attaching to invisible omnibox popup

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,9 @@ PY
 
 The code is the doc.
 
+Available interaction skills:
+- `interaction-skills/connection.md` — startup sequence, tab visibility, omnibox popup fix
+
 Available domain skills:
 - `tiktok/upload.md`
 

--- a/daemon.py
+++ b/daemon.py
@@ -96,10 +96,12 @@ class Daemon:
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
-        pages = [t for t in targets if is_real_page(t)] or [t for t in targets if t["type"] == "page"]
+        pages = [t for t in targets if is_real_page(t)]
         if not pages:
-            self.session = None
-            return None
+            # No real pages — create one instead of attaching to omnibox popup
+            tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+            log(f"no real pages found, created about:blank ({tid})")
+            pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
         self.session = (await self.cdp.send_raw(
             "Target.attachToTarget", {"targetId": pages[0]["targetId"], "flatten": True}
         ))["sessionId"]

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -1,0 +1,47 @@
+# Connection & Tab Visibility
+
+## The omnibox popup problem
+
+When Chrome opens fresh, the only CDP `type: "page"` targets are `chrome://inspect` and `chrome://omnibox-popup.top-chrome/` (a 1px invisible viewport). If the daemon attaches to the omnibox popup, all subsequent work — including `new_tab()` and `goto()` — happens on tabs that exist in CDP but may not be visible in the Chrome UI.
+
+The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` which calls `Target.activateTarget` to bring the tab to front.
+
+## Startup sequence
+
+1. Check if a daemon is already running with `daemon_alive()`
+2. If stale sockets exist but daemon is dead, clean them up
+3. List open tabs with `list_tabs()` to see what's available
+4. `ensure_real_tab()` attaches to a real page
+5. `switch_tab(target_id)` both attaches AND activates (brings to front)
+
+```python
+if not daemon_alive():
+    import os
+    for f in ["/tmp/bu-default.sock", "/tmp/bu-default.pid"]:
+        if os.path.exists(f): os.unlink(f)
+    ensure_daemon()
+
+tabs = list_tabs()
+for t in tabs:
+    print(t["url"][:60])
+
+tab = ensure_real_tab()
+```
+
+## Bringing Chrome to front
+
+If Chrome is behind other windows or on another desktop:
+
+```python
+import subprocess
+subprocess.run(["osascript", "-e", 'tell application "Google Chrome" to activate'])
+```
+
+## Navigating
+
+Prefer navigating an existing tab over `new_tab()`. Tabs created via CDP's `Target.createTarget` are visible but may open behind the active tab.
+
+```python
+tab = ensure_real_tab()
+goto("https://example.com")
+```


### PR DESCRIPTION
## Problem
When Chrome opens fresh (or after restart), the only `type: "page"` CDP targets are `chrome://inspect` and `chrome://omnibox-popup.top-chrome/` — a 1px invisible viewport. The daemon's `attach_first_page()` fell back to the popup, making all subsequent work invisible to the user. `new_tab()` and `goto()` from this state create tabs that exist in CDP but aren't visible in Chrome's UI.

## Fix
When no real pages exist, create an `about:blank` tab via `Target.createTarget` instead of falling back to the omnibox popup. One line change in `daemon.py`.

## Tested
| Scenario | Result |
|----------|--------|
| Fresh start, no real tabs | Creates about:blank, viewport 1112x817 |
| Navigate without AppleScript | Tab visible, no workaround needed |
| Stale socket recovery | Auto-reconnects to existing tab |
| Chrome restart from scratch | Creates about:blank, visible |

## Also
Adds `interaction-skills/connection.md` documenting the startup sequence and this gotcha.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the daemon from attaching to Chrome’s invisible omnibox popup on fresh start. Creates a visible `about:blank` tab so new tabs and navigation show up.

- **Bug Fixes**
  - When no real pages exist, create and attach to `about:blank` via CDP (`Target.createTarget`) instead of the omnibox popup. Keeps `new_tab()` and `goto()` visible in the UI.
  - Added `interaction-skills/connection.md` documenting the startup sequence and omnibox popup behavior, and linked it from `SKILL.md`.

<sup>Written for commit 1e2d24b6739e9be02c17837d5a058ab9804c0adc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

