### PR TITLE
SKILL.md: reframe post-task ritual as "Always contribute back"

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -89,7 +89,7 @@ rg -n "tiktok|upload" domain-skills
 
 ## Always contribute back
 
-**If you learned anything non-obvious about how a site works, open a PR to `domain-skills/<site>/` before you finish. Default to contributing.** The harness gets better only because agents file what they learn. If you hesitated for a few steps while figuring something out, the next run should not have to hesitate.
+**If you learned anything non-obvious about how a site works, open a PR to `domain-skills/<site>/` before you finish. Default to contributing.** The harness gets better only because agents file what they learn. If figuring something out cost you a few steps, the next run should not pay the same tax.
 
 Examples of what's worth a PR:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -87,11 +87,36 @@ rg --files domain-skills
 rg -n "tiktok|upload" domain-skills
 ```
 
-## Post-task ritual (self-improving harness)
+## Always contribute back
 
-If needed, modify your own helper functions to fix tools that do not work well on a task, make repeated actions more efficient, or fix recurring browser-interaction problems.
+**If you learned anything non-obvious about how a site works, open a PR to `domain-skills/<site>/` before you finish. Default to contributing.** The harness gets better only because agents file what they learn. If you hesitated for a few steps while figuring something out, the next run should not have to hesitate.
 
-If you spend a couple of corrective steps learning things you would want to know on the next similar task for the same domain, add or update a Markdown skill under `domain-skills/<domain>/` (create the directory if needed) with all reusable learnings that would speed up the next run, such as where to wait for network requests, which interaction patterns worked, and what traps matter. `domain-skills/` is shared across users, so include only sanitized, reusable guidance and never include sensitive data, secrets, or user-specific details. Then open a PR to this public repo.
+Examples of what's worth a PR:
+
+- A **private API** the page calls (XHR/fetch endpoint, request shape, auth) — often 10× faster than DOM scraping.
+- A **stable selector** that beats the obvious one, or an obfuscated CSS-module class to avoid.
+- A **framework quirk** — "the dropdown is a React combobox that only commits on Escape", "this Vue list only renders rows inside its own scroll container, so `scrollIntoView` on the row doesn't work — you have to scroll the container".
+- A **URL pattern** — direct route, required query params (`?lang=en`, `?th=1`), a variant that skips a loader.
+- A **wait** that `wait_for_load()` misses, with the reason.
+- A **trap** — stale drafts, legacy IDs that now return null, unicode quirks, beforeunload dialogs, CAPTCHA surfaces.
+
+### What a domain skill should capture
+
+The *durable* shape of the site — the map, not the diary. Focus on what the next agent on this site needs to know before it starts:
+
+- URL patterns and query params.
+- Private APIs and their payload shape.
+- Stable selectors (`data-*`, `aria-*`, `role`, semantic classes).
+- Site structure — containers, items per page, framework, where state lives.
+- Framework/interaction quirks unique to this site.
+- Waits and the reasons they're needed.
+- Traps and the selectors that *don't* work.
+
+### Do not write
+
+- **Raw pixel coordinates.** They break on viewport, zoom, and layout changes. Describe how to *locate* the target (selector, `scrollIntoView`, `aria-label`, visible text) — never where it happened to be on your screen.
+- **Run narration** or step-by-step of the specific task you just did.
+- **Secrets, cookies, session tokens, user-specific state.** `domain-skills/` is shared and public.
 
 ## What actually works
 


### PR DESCRIPTION
## Summary

- Renames the **Post-task ritual** section to **Always contribute back** and rewrites it as the default procedure — not an optional nicety.
- Adds concrete examples of what's worth a PR (private APIs, framework quirks, stable selectors, URL patterns, waits, traps) so agents know what to look for.
- Adds a short **What a domain skill should capture** schema — the durable shape of the site, not the diary of the run.
- Adds an explicit **Do not write** list — most importantly banning **raw pixel coordinates**, which rot on any viewport/zoom/layout change.
- Narrows scope to `domain-skills/` only. Removed the previous nudges to update `interaction-skills/` or `helpers.py` from this loop — that's a separate decision, not a contribution default.

Inspired by Karpathy's [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) idea of making the agent a disciplined maintainer, adapted to our single-layer `domain-skills/` setup (no index/log/lint — those are already covered by `ls` and `git log`).

## Test plan

- [ ] Read the new section end-to-end on GitHub and confirm the imperative tone reads right.
- [ ] Sanity-check that the examples (React combobox, Vue scroll container, `?th=1`) are grounded in real patterns already seen in `domain-skills/`.
- [ ] Verify the "no raw coordinates" rule would actually flag the weaker parts of `domain-skills/tiktok/upload.md` as things to improve next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframes the SKILL.md post-task ritual into a default “Always contribute back” workflow with explicit cost framing, and scopes the loop to `domain-skills/`. Adds concrete examples, a short schema for durable guidance, and a do-not-write list to avoid brittle tips.

- **Refactors**
  - Made contribution the default; renamed the section to “Always contribute back,” tightened language to emphasize cost (if it cost you steps, the next run shouldn’t pay), and scoped the loop to `domain-skills/` only.
  - Added examples of PR-worthy learnings (private APIs, stable selectors, framework quirks, URL patterns, waits, traps).
  - Added a concise schema for domain skills (capture the durable shape of the site, not task narration).
  - Added a “Do not write” list (ban raw pixel coordinates; exclude run narration and secrets).

<sup>Written for commit 53fe8566ea405f5afb0cb1d9a7c25a36ec6d70a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

