### PR TITLE
Add Microsoft Edge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The simplest, thinnest, **self-healing** harness that gives LLM **complete freedom** to complete any browser task. Built directly on CDP.
 
-The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to Chrome, nothing between.
+The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to Chrome or Edge, nothing between.
 
 ```
   ● agent: wants to upload a file

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The simplest, thinnest, **self-healing** harness that gives LLM **complete freedom** to complete any browser task. Built directly on CDP.
 
-The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to Chrome or Edge, nothing between.
+The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to Chrome, nothing between.
 
 ```
   ● agent: wants to upload a file

--- a/daemon.py
+++ b/daemon.py
@@ -28,10 +28,18 @@ BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
     Path.home() / "Library/Application Support/Microsoft Edge",
+    Path.home() / "Library/Application Support/Microsoft Edge Beta",
+    Path.home() / "Library/Application Support/Microsoft Edge Dev",
+    Path.home() / "Library/Application Support/Microsoft Edge Canary",
     Path.home() / ".config/google-chrome",
     Path.home() / ".config/microsoft-edge",
+    Path.home() / ".config/microsoft-edge-beta",
+    Path.home() / ".config/microsoft-edge-dev",
     Path.home() / "AppData/Local/Google/Chrome/User Data",
     Path.home() / "AppData/Local/Microsoft/Edge/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge Beta/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge Dev/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge SxS/User Data",
 ]
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"

--- a/daemon.py
+++ b/daemon.py
@@ -27,8 +27,11 @@ PID = f"/tmp/bu-{NAME}.pid"
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
+    Path.home() / "Library/Application Support/Microsoft Edge",
     Path.home() / ".config/google-chrome",
+    Path.home() / ".config/microsoft-edge",
     Path.home() / "AppData/Local/Google/Chrome/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge/User Data",
 ]
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"

--- a/install.md
+++ b/install.md
@@ -41,6 +41,8 @@ That makes new Codex or Claude Code sessions in other folders load the runtime b
 
 ## Browser bootstrap
 
+The steps below use Chrome. Microsoft Edge works the same way — the daemon reads `DevToolsActivePort` from Edge's profile dir automatically, and `chrome://inspect/#remote-debugging` resolves inside Edge too. Substitute `Microsoft Edge` for the app name in `open -a` and AppleScript `tell application`; everything else is identical.
+
 1. Run `uv sync`.
    If `browser-harness` is still missing after that, run `command -v browser-harness >/dev/null || uv tool install -e .`.
 2. First try the harness directly. If this works, skip manual browser setup:

--- a/install.md
+++ b/install.md
@@ -41,8 +41,6 @@ That makes new Codex or Claude Code sessions in other folders load the runtime b
 
 ## Browser bootstrap
 
-The steps below use Chrome. Microsoft Edge works the same way — the daemon reads `DevToolsActivePort` from Edge's profile dir automatically, and `chrome://inspect/#remote-debugging` resolves inside Edge too. Substitute `Microsoft Edge` for the app name in `open -a` and AppleScript `tell application`; everything else is identical.
-
 1. Run `uv sync`.
    If `browser-harness` is still missing after that, run `command -v browser-harness >/dev/null || uv tool install -e .`.
 2. First try the harness directly. If this works, skip manual browser setup:
@@ -100,3 +98,4 @@ PY
 - If attach is blocked on macOS, open `chrome://inspect/#remote-debugging` in the current Chrome profile and explicitly tell the user to click `Allow` if Chrome shows it.
 - Chrome may open the profile picker before any real tab exists.
 - On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.
+- Microsoft Edge (including Beta/Dev/Canary) works too — substitute the app name; steps are identical.


### PR DESCRIPTION
Edge is Chromium, so the daemon's CDP bootstrap works unchanged once it knows where Edge's DevToolsActivePort lives. This adds the macOS, Linux, and Windows Edge profile paths to the discovery list, plus a one-line note in install.md clarifying that `chrome://inspect/#remote-debugging` and the rest of the setup flow apply to Edge too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Microsoft Edge support across stable and insider channels. The daemon discovers Edge profiles on macOS, Linux, and Windows and bootstraps CDP via `DevToolsActivePort`; setup is the same as Chrome.

- **New Features**
  - Detects Edge Stable, Beta, Dev, and Canary profile dirs (incl. Windows Edge SxS) to read `DevToolsActivePort`.
  - install.md adds a one-line reminder at the bottom: Edge uses the same flow as Chrome; substitute `Microsoft Edge` in `open -a` and AppleScript.

<sup>Written for commit 261ff52da85f19398860cf91a20a3a20640e5b5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

