### PR TITLE
page_info: surface pending native dialog

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -91,6 +91,7 @@ class Daemon:
         self.cdp = None
         self.session = None
         self.events = deque(maxlen=BUF)
+        self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self):
@@ -133,6 +134,10 @@ class Daemon:
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):
             self.events.append({"method": method, "params": params, "session_id": session_id})
+            if method == "Page.javascriptDialogOpening":
+                self.dialog = params
+            elif method == "Page.javascriptDialogClosed":
+                self.dialog = None
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 
@@ -143,6 +148,7 @@ class Daemon:
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
         if meta == "set_session": self.session = req.get("session_id"); return {"session_id": self.session}
+        if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}
 
         method = req["method"]

--- a/helpers.py
+++ b/helpers.py
@@ -53,7 +53,14 @@ def goto(url):
     return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]} if d.is_dir() else r
 
 def page_info():
-    """{url, title, w, h, sx, sy, pw, ph} — viewport + scroll + page size."""
+    """{url, title, w, h, sx, sy, pw, ph} — viewport + scroll + page size.
+
+    If a native dialog (alert/confirm/prompt/beforeunload) is open, returns
+    {dialog: {type, message, ...}} instead — the page's JS thread is frozen
+    until the dialog is handled (see interaction-skills/dialogs.md)."""
+    dialog = _send({"meta": "pending_dialog"}).get("dialog")
+    if dialog:
+        return {"dialog": dialog}
     r = cdp("Runtime.evaluate",
             expression="JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})",
             returnByValue=True)

--- a/interaction-skills/dialogs.md
+++ b/interaction-skills/dialogs.md
@@ -2,6 +2,10 @@
 
 Browser dialogs (`alert`, `confirm`, `prompt`, `beforeunload`) freeze the JS thread. Two approaches depending on timing.
 
+## Detection
+
+`page_info()` auto-surfaces any open dialog: if one is pending it returns `{"dialog": {"type", "message", ...}}` instead of the usual viewport dict (because the page's JS is frozen anyway). So if you call `page_info()` after an action and see a `dialog` key, handle it before doing anything else.
+
 ## Reactive: dismiss via CDP (preferred)
 
 Works even when JS is frozen. Handles all dialog types including `beforeunload`.


### PR DESCRIPTION
## Summary

- Track the latest unhandled \`Page.javascriptDialogOpening\` in the daemon (cleared on \`Page.javascriptDialogClosed\`).
- When a native dialog is open, \`page_info()\` returns \`{dialog: {type, message, ...}}\` instead of the usual viewport dict — the page's JS thread is frozen anyway, so the viewport numbers would be stale/misleading.
- Update \`interaction-skills/dialogs.md\` to point agents at this signal.

## Why

Agents rarely call \`drain_events()\` or remember the dialogs skill exists, so they don't notice when a site pops an \`alert\`/\`confirm\`/\`prompt\`/\`beforeunload\` and silently wonder why nothing works. Folding detection into \`page_info()\` — which they already call to orient themselves — makes the signal unmissable.

## Test plan

- [ ] Fire \`setTimeout(() => alert('x'), 10)\`, wait, call \`page_info()\`, confirm \`{dialog: {type: "alert", message: "x", ...}}\` comes back.
- [ ] \`cdp("Page.handleJavaScriptDialog", accept=True)\`, then \`page_info()\` returns the normal viewport dict again.
- [ ] Same for \`confirm\`, \`prompt\`, and \`beforeunload\` (navigate away from a form with unsaved changes).
- [ ] \`drain_events()\` still sees the opening event (peek-style semantics — dialog state is tracked independently of the ring buffer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `page_info()` surface pending native browser dialogs so agents see them immediately. If a dialog is open, it returns `{dialog: {type, message, ...}}` instead of viewport data to avoid stale values.

- **New Features**
  - Track the latest unhandled `Page.javascriptDialogOpening` in the daemon; clear on `Page.javascriptDialogClosed`.
  - Expose daemon meta `pending_dialog`, consumed by `page_info()` to return `{dialog: ...}` while blocked.
  - Update `interaction-skills/dialogs.md` to tell agents to handle the dialog before continuing.

<sup>Written for commit 7fc545cc8df11adcb6171f438e826a8bc915fd89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

