### PR TITLE
Add 5s timeout on daemon enable calls

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -170,6 +170,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
   `restart_daemon()`
   `PY`
   before assuming setup is wrong.
+- **If `restart_daemon()` also hangs**, kill Chrome entirely (`pkill -9 -f "Google Chrome"`), clean sockets (`rm -f /tmp/bu-default.sock /tmp/bu-default.pid`), reopen Chrome (`open -a "Google Chrome"`), wait 5s, then reconnect. This resets all CDP state.
 - **Browser Use API is camelCase on the wire.** `cdpUrl`, `proxyCountryCode`, etc.
 - **Remote `cdpUrl` is HTTPS, not ws.** Resolve the websocket URL via `/json/version`.
 - **Stop cloud browsers with `PATCH /browsers/{id}` + `{\"action\":\"stop\"}`.**

--- a/daemon.py
+++ b/daemon.py
@@ -109,7 +109,10 @@ class Daemon:
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
         for d in ("Page", "DOM", "Runtime", "Network"):
             try:
-                await self.cdp.send_raw(f"{d}.enable", session_id=self.session)
+                await asyncio.wait_for(
+                    self.cdp.send_raw(f"{d}.enable", session_id=self.session),
+                    timeout=5
+                )
             except Exception as e:
                 log(f"enable {d}: {e}")
         return pages[0]


### PR DESCRIPTION
## Problem
`Page.enable`, `DOM.enable`, etc. can hang indefinitely on heavy pages (TikTok FYP, complex SPAs), preventing the daemon from reaching its socket listener. All subsequent commands queue and hang.

## Fix
- `daemon.py`: wrap enable calls in `asyncio.wait_for(..., timeout=5)` — daemon starts even if enables fail
- `SKILL.md`: one gotcha for nuclear recovery when `restart_daemon()` also hangs


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 5s timeout to CDP `Page/DOM/Runtime/Network.enable` calls so the daemon doesn’t hang on heavy pages and still starts its socket listener. Also adds a recovery step to `SKILL.md` for when `restart_daemon()` hangs (kill Chrome, clear sockets, relaunch, reconnect).

<sup>Written for commit 30419aa5ecc485053f9e112f8a15cb0b1d05f575. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

