### PR TITLE
Try WS handshake once, not 12 times

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -122,17 +122,10 @@ class Daemon:
         url = get_ws_url()
         log(f"connecting to {url}")
         self.cdp = CDPClient(url)
-        # Chrome shows a native "Allow debugging" dialog on first connect -- user may take a while to click.
-        for attempt in range(12):
-            try:
-                await self.cdp.start()
-                break
-            except Exception as e:
-                log(f"ws handshake attempt {attempt+1} failed: {e} -- retrying")
-                self.cdp = CDPClient(url)
-                await asyncio.sleep(5)
-        else:
-            raise RuntimeError("CDP WS handshake never succeeded -- did you accept Chrome's Allow dialog?")
+        try:
+            await self.cdp.start()
+        except Exception as e:
+            raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):


### PR DESCRIPTION
Each retry created a new CDPClient → new WebSocket → new Chrome Allow dialog. 12 retries = 12 stacked popups.

Now tries once. If it fails, error tells the user to click Allow and retry.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attempt the CDP WebSocket handshake once to prevent spawning 12 Chrome “Allow debugging” popups. If it fails, show a clear error asking the user to click Allow in Chrome and retry.

<sup>Written for commit fc2a22b7d5303147d8f44c7b4d1c466a01767898. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

