### PR TITLE
Fix tab indicator: mark on session switch + page load

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -139,12 +139,16 @@ class Daemon:
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
+        mark_js = "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"
         async def tap(method, params, session_id=None):
             self.events.append({"method": method, "params": params, "session_id": session_id})
             if method == "Page.javascriptDialogOpening":
                 self.dialog = params
             elif method == "Page.javascriptDialogClosed":
                 self.dialog = None
+            elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
+                try: await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session), timeout=2)
+                except Exception: pass
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 
@@ -154,7 +158,13 @@ class Daemon:
             out = list(self.events); self.events.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
-        if meta == "set_session": self.session = req.get("session_id"); return {"session_id": self.session}
+        if meta == "set_session":
+            self.session = req.get("session_id")
+            try:
+                await asyncio.wait_for(self.cdp.send_raw("Page.enable", session_id=self.session), timeout=3)
+                await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"}, session_id=self.session), timeout=2)
+            except Exception: pass
+            return {"session_id": self.session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}
 


### PR DESCRIPTION
The merged tab indicator (#69) only marked on `Page.loadEventFired`, but `Page` events weren't enabled for new sessions created by `switch_tab()`. The 🟢 never appeared on tab switches.

Fix: enable `Page` domain + immediately mark title in the `set_session` handler. Also re-mark on `Page.loadEventFired` so it survives `goto()` navigation.

6/6 tests pass: new_tab, switch_tab, goto, click link, cmd+click, switch back.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing green tab indicator when switching sessions. We now enable page events and mark/re-mark the title so the indicator appears on tab switch and persists through navigation.

- **Bug Fixes**
  - Enable `Page` events for new sessions in `set_session` via `Page.enable`.
  - Immediately set the green dot in the title with `Runtime.evaluate`.
  - Re-apply the mark on `Page.loadEventFired` and `Page.domContentEventFired` so it survives `goto()`.

<sup>Written for commit b68436794d09d7990885fd6ab1a60cfb17df2b9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

