### PR TITLE
Add domain skills: PubMed, CrossRef, OpenAlex, FRED, MusicBrainz

### DIFF
--- a/domain-skills/crossref/scraping.md
+++ b/domain-skills/crossref/scraping.md
@@ -1,0 +1,568 @@
+# CrossRef — Scraping & Data Extraction
+
+`https://api.crossref.org` — scholarly DOI and citation metadata. **Never use the browser for CrossRef.** Completely free, no auth required. All workflows use `http_get`.
+
+## Do this first
+
+**Always add `mailto=your@email.com` to every request** — it moves you into the polite pool, which doubles the rate limit and concurrency allowance. The difference is measurable and the cost is zero.
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"  # set once, append to every URL
+
+# Single DOI lookup — fastest way to get metadata for a known paper
+data = json.loads(http_get(f"https://api.crossref.org/works/10.1038/s41586-021-03819-2?{MAILTO}"))
+msg = data['message']
+# msg keys: DOI, title, author, published, type, container-title, volume, issue,
+#           page, is-referenced-by-count, references-count, abstract (optional), ...
+```
+
+## Common workflows
+
+### DOI lookup — single paper
+
+```python
+from helpers import http_get
+import json, re
+
+MAILTO = "mailto=your@email.com"
+
+def fetch_work(doi):
+    data = json.loads(http_get(f"https://api.crossref.org/works/{doi}?{MAILTO}"))
+    return data['message']
+
+def parse_date(d):
+    """[[2021, 7, 15]] -> '2021-7-15'. Handles partial dates like [[2021]]."""
+    if not d: return None
+    parts = d.get('date-parts', [[]])[0]
+    return '-'.join(str(p) for p in parts if p is not None)
+
+def clean_abstract(raw):
+    """Strip JATS XML tags. Abstract field contains tags like <jats:p>, <jats:italic>."""
+    return re.sub(r'<[^>]+>', ' ', raw).strip() if raw else None
+
+w = fetch_work("10.1038/s41586-021-03819-2")  # AlphaFold2
+
+print("DOI:", w['DOI'])                                    # 10.1038/s41586-021-03819-2
+print("Title:", w['title'][0])                             # Highly accurate protein structure...
+print("Type:", w['type'])                                  # journal-article
+print("Publisher:", w['publisher'])                        # Springer Science and Business Media LLC
+print("Journal:", w.get('container-title', [''])[0])      # Nature
+print("Volume:", w.get('volume'))                          # 596
+print("Issue:", w.get('issue'))                            # 7873
+print("Page:", w.get('page'))                              # 583-589
+print("published:", parse_date(w.get('published')))        # 2021-7-15  (online date)
+print("published-online:", parse_date(w.get('published-online')))  # 2021-7-15
+print("published-print:", parse_date(w.get('published-print')))    # 2021-8-26
+print("Citations:", w.get('is-referenced-by-count'))       # 40260
+print("References:", w.get('references-count'))            # 84
+print("Abstract:", clean_abstract(w.get('abstract', ''))[:100] if w.get('abstract') else None)
+# Confirmed output (2026-04-18):
+# DOI: 10.1038/s41586-021-03819-2
+# Title: Highly accurate protein structure prediction with AlphaFold
+# Type: journal-article
+# Journal: Nature
+# Volume: 596 | Issue: 7873 | Page: 583-589
+# published: 2021-7-15 | published-print: 2021-8-26
+# Citations: 40260
+```
+
+### DOI lookup — extract authors with ORCID
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+data = json.loads(http_get(f"https://api.crossref.org/works/10.1038/s41586-021-03819-2?{MAILTO}"))
+authors = data['message'].get('author', [])
+
+for a in authors[:3]:
+    name = f"{a.get('given', '')} {a.get('family', '')}".strip()
+    # ORCID is a full URL, not a bare ID — strip the prefix
+    orcid_url = a.get('ORCID')  # e.g. 'https://orcid.org/0000-0001-6169-6580'
+    orcid_id = orcid_url.replace('https://orcid.org/', '') if orcid_url else None
+    authenticated = a.get('authenticated-orcid', False)  # False = self-reported, True = verified
+    affiliations = [aff.get('name', '') for aff in a.get('affiliation', [])]
+    print(f"{name} | ORCID: {orcid_id} | auth={authenticated} | seq={a['sequence']}")
+# Confirmed output:
+# John Jumper | ORCID: 0000-0001-6169-6580 | auth=False | seq=first
+# Richard Evans | ORCID: None | auth=False | seq=additional
+# Alexander Pritzel | ORCID: None | auth=False | seq=additional
+```
+
+### Batch DOI lookup (parallel — 5 calls in ~0.3s)
+
+```python
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+import json
+
+MAILTO = "mailto=your@email.com"
+
+def fetch_work(doi):
+    try:
+        data = json.loads(http_get(f"https://api.crossref.org/works/{doi}?{MAILTO}"))
+        msg = data['message']
+        return {
+            'doi': doi,
+            'title': msg.get('title', [''])[0],
+            'year': (msg.get('published', {}).get('date-parts') or [[None]])[0][0],
+            'citations': msg.get('is-referenced-by-count'),
+            'type': msg.get('type'),
+        }
+    except Exception as e:
+        return {'doi': doi, 'error': str(e)}
+
+dois = [
+    "10.1038/nature12345",
+    "10.1038/s41586-021-03819-2",
+    "10.1056/NEJMoa2034577",
+    "10.1126/science.1260419",
+    "10.1038/s41586-024-07487-w",
+]
+
+# max_workers=5 safe; polite pool: 10 req/s, concurrency=3 (see Rate limits)
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_work, dois))
+
+for r in results:
+    print(r['year'], f"cites={r['citations']}", r['title'][:50])
+# Confirmed output (2026-04-18, ~0.296s total):
+# 2013 cites=465 LRG1 promotes angiogenesis by modulating endotheli
+# 2021 cites=40260 Highly accurate protein structure prediction with
+# 2020 cites=13752 Safety and Efficacy of the BNT162b2 mRNA Covid-19
+# 2015 cites=13553 Tissue-based map of the human proteome
+# 2024 cites=12037 Accurate structure prediction of biomolecular inte
+```
+
+### Search works by keyword
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# Broad keyword search
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=machine+learning&rows=5&{MAILTO}"
+))
+msg = data['message']
+print("Total results:", msg['total-results'])   # 2,805,391
+for item in msg['items']:
+    title = item.get('title', ['(no title)'])[0][:60]
+    doi   = item.get('DOI', '')
+    year  = (item.get('published', {}).get('date-parts') or [[None]])[0][0]
+    type_ = item.get('type', '')
+    print(f"  [{type_}] {year} {title}")
+    print(f"    DOI: {doi}")
+```
+
+### Search by author + title (targeted)
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query.author=Lecun&query.title=deep+learning&rows=5&{MAILTO}"
+))
+msg = data['message']
+print("Total results:", msg['total-results'])   # 62
+for item in msg['items'][:3]:
+    title   = item.get('title', [''])[0][:60]
+    authors = ', '.join(a.get('family', '') for a in item.get('author', [])[:2])
+    year    = (item.get('published', {}).get('date-parts') or [[None]])[0][0]
+    print(f"  {year} {title}")
+    print(f"    Authors: {authors}  DOI: {item.get('DOI')}")
+# Confirmed output:
+# 2015 Deep learning & convolutional networks
+#   Authors: LeCun  DOI: 10.1109/hotchips.2015.7477328
+```
+
+### Filter by date, type, and sort by citations
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works"
+    f"?filter=from-pub-date:2024-01-01,type:journal-article"
+    f"&rows=5&sort=is-referenced-by-count&order=desc&{MAILTO}"
+))
+msg = data['message']
+print("Total 2024+ journal articles:", msg['total-results'])   # 14,565,456
+for item in msg['items'][:3]:
+    title  = item.get('title', [''])[0][:60]
+    cites  = item.get('is-referenced-by-count', 0)
+    year   = (item.get('published', {}).get('date-parts') or [[None]])[0][0]
+    print(f"  {year} cites={cites} {title}")
+# Confirmed output:
+# 2024 cites=17371 Global cancer statistics 2022: GLOBOCAN estimates...
+# 2024 cites=12037 Accurate structure prediction of biomolecular int...
+```
+
+### Filter with `has-abstract:true`
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# Only return works that have an abstract (useful since ~30-70% do not)
+data = json.loads(http_get(
+    f"https://api.crossref.org/works"
+    f"?filter=from-pub-date:2023-01-01,until-pub-date:2023-12-31"
+    f",type:journal-article,has-abstract:true"
+    f"&rows=3&sort=is-referenced-by-count&order=desc&{MAILTO}"
+))
+msg = data['message']
+print("2023 journal articles with abstract:", msg['total-results'])   # 3,041,841
+for item in msg['items']:
+    print(item.get('title', [''])[0][:60], '| cites:', item.get('is-referenced-by-count'))
+# Confirmed output:
+# Cancer statistics, 2023 | cites: 12919
+# Evolutionary-scale prediction of atomic-level protein struct | cites: 4352
+```
+
+### Cursor pagination (large result sets)
+
+Standard offset pagination (`start=`) caps at a few thousand results. Use cursor for full sweeps.
+
+```python
+from helpers import http_get
+from urllib.parse import quote
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# First page: cursor=*
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=covid&rows=100&cursor=*&{MAILTO}"
+))
+msg = data['message']
+print("Total results:", msg['total-results'])   # 897,660
+items = msg['items']
+next_cursor = msg['next-cursor']   # base64 string like "DnF1ZXJ5VGhlbkZldGNoJA..."
+
+# Next pages: pass URL-encoded cursor
+while next_cursor and items:
+    data = json.loads(http_get(
+        f"https://api.crossref.org/works?query=covid&rows=100"
+        f"&cursor={quote(next_cursor)}&{MAILTO}"
+    ))
+    msg = data['message']
+    items = msg.get('items', [])
+    next_cursor = msg.get('next-cursor')
+    # process items...
+    break  # remove for full sweep
+```
+
+### Fetch specific fields only (`select=`)
+
+Reduces response size significantly for bulk operations:
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=cancer&rows=5"
+    f"&select=DOI,title,author&{MAILTO}"
+))
+# Warning: if a field is absent for a record, it simply won't appear in that item
+for item in data['message']['items']:
+    print(list(item.keys()))   # only ['DOI', 'title'] or ['DOI', 'title', 'author']
+    # Note: select= does NOT guarantee the field appears — absent fields are just omitted
+```
+
+### Count by type using facets
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=machine+learning&rows=0"
+    f"&facet=type-name:*&{MAILTO}"
+))
+msg = data['message']
+type_facet = msg['facets']['type-name']
+for k, v in sorted(type_facet['values'].items(), key=lambda x: -x[1]):
+    print(f"  {k}: {v:,}")
+# Confirmed output (all CrossRef, 2026-04-18):
+# Journal Article: 1,628,997 (for query=machine+learning scope)
+# Conference Paper: 501,433
+# Chapter: 455,907
+# Posted Content: 87,937
+# ...
+```
+
+### Journal info by ISSN
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# Nature (ISSN 0028-0836)
+data = json.loads(http_get(f"https://api.crossref.org/journals/0028-0836?{MAILTO}"))
+msg = data['message']
+print("Title:", msg['title'])                          # Nature
+print("Publisher:", msg['publisher'])                  # Springer Science and Business Media LLC
+print("ISSN:", msg['ISSN'])                            # ['0028-0836', '1476-4687']
+print("Total DOIs:", msg['counts']['total-dois'])       # 445,417
+print("Subjects:", msg.get('subjects', []))             # [] (not always populated)
+
+# Search journals by name
+data2 = json.loads(http_get(f"https://api.crossref.org/journals?query=nature&rows=3&{MAILTO}"))
+for j in data2['message']['items']:
+    print(f"{j.get('title')} | ISSN: {j.get('ISSN')} | DOIs: {j.get('counts', {}).get('total-dois')}")
+# Confirmed output:
+# NatureJobs | ISSN: [] | DOIs: 0
+# Naturen | ISSN: ['0028-0887', '1504-3118'] | DOIs: 1055
+```
+
+### Funder search
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/funders?query=national+science+foundation&rows=3&{MAILTO}"
+))
+msg = data['message']
+print("Total funders:", msg['total-results'])   # 108
+for f in msg['items']:
+    print(f"  ID: {f['id']} | {f['name']}")
+    print(f"    Alt names: {f.get('alt-names', [])[:2]}")
+    print(f"    URI: {f.get('uri')}")
+# Confirmed output:
+# ID: 501100001711 | Schweizerischer Nationalfonds zur Förderung...
+# ID: 100000143 | Division of Computing and Communication Foundations
+```
+
+### DOI content negotiation (alternative, no CrossRef API needed)
+
+The `doi.org` resolver can return formatted metadata directly via `Accept` header:
+
+```python
+import urllib.request, json
+
+def doi_to_csl(doi):
+    """Fetch CSL-JSON via DOI content negotiation. Same data as CrossRef API."""
+    req = urllib.request.Request(
+        f"https://doi.org/{doi}",
+        headers={"Accept": "application/vnd.citationstyles.csl+json",
+                 "User-Agent": "Mozilla/5.0"}
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read().decode())
+
+def doi_to_bibtex(doi):
+    """Fetch BibTeX via DOI content negotiation."""
+    req = urllib.request.Request(
+        f"https://doi.org/{doi}",
+        headers={"Accept": "application/x-bibtex", "User-Agent": "Mozilla/5.0"}
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return r.read().decode()
+
+csl = doi_to_csl("10.1038/nature12345")
+print("Title:", csl['title'])   # LRG1 promotes angiogenesis...
+print("Type:", csl['type'])     # journal-article
+
+bib = doi_to_bibtex("10.1038/nature12345")
+print(bib[:200])
+# @article{Wang_2013, title={LRG1 promotes angiogenesis...
+```
+
+## Field reference
+
+### Work object — complete field list
+
+All fields are potentially absent unless marked required. Fields marked (R) are always present.
+
+| Field | Type | Notes |
+|---|---|---|
+| `DOI` (R) | string | e.g. `"10.1038/s41586-021-03819-2"` |
+| `URL` (R) | string | `"https://doi.org/10.1038/s41586-021-03819-2"` |
+| `title` (R) | list[str] | Always a list; access `title[0]` |
+| `type` (R) | string | e.g. `"journal-article"` — see type table below |
+| `publisher` | string | |
+| `container-title` | list[str] | Journal name; access `[0]` |
+| `short-container-title` | list[str] | Abbreviated journal name |
+| `ISSN` | list[str] | May contain print and online ISSN |
+| `volume` | string | Note: string not int (`"596"`) |
+| `issue` | string | |
+| `page` | string | e.g. `"583-589"` |
+| `author` | list[object] | See author fields below |
+| `published` | date-object | Best single date — use this |
+| `published-online` | date-object | Online-first date |
+| `published-print` | date-object | Print edition date |
+| `issued` | date-object | Usually same as `published` |
+| `is-referenced-by-count` | int | Inbound citations to this work |
+| `references-count` | int | Outbound references from this work |
+| `reference` | list[object] | Full reference list (when deposited) |
+| `abstract` | string | JATS XML markup; ~30-70% of works; strip tags before use |
+| `subject` | list[str] | Subject classification (often empty) |
+| `language` | string | e.g. `"en"` |
+| `license` | list[object] | Each: `{URL, start, delay-in-days, content-version}` |
+| `funder` | list[object] | Each: `{name, DOI, award}` |
+| `link` | list[object] | Full-text links |
+| `relation` | object | Related DOIs (e.g. preprint → article) |
+| `assertion` | list[object] | Publisher-specific metadata |
+| `alternative-id` | list[str] | Publisher's internal IDs |
+| `member` | string | CrossRef member ID |
+| `prefix` | string | DOI prefix |
+| `score` | float | Relevance score (search results only) |
+| `source` | string | e.g. `"Crossref"` |
+| `indexed` | date-object | When CrossRef indexed this record |
+| `deposited` | date-object | When publisher last deposited metadata |
+| `created` | date-object | When CrossRef record was first created |
+
+### Author object fields
+
+| Field | Notes |
+|---|---|
+| `given` | Given/first name |
+| `family` | Family/last name |
+| `sequence` | `"first"` or `"additional"` |
+| `affiliation` | list of `{name, place}` — usually `[]` |
+| `ORCID` | Full URL `"https://orcid.org/0000-0001-..."` — strip prefix to get bare ID |
+| `authenticated-orcid` | `true` = verified via ORCID OAuth; `false` = self-reported |
+| `name` | Used instead of given/family for organizations |
+
+### Date object structure
+
+```python
+# All date fields share this structure:
+date_obj = {
+    "date-parts": [[2021, 7, 15]],  # [[year, month, day]] — month/day may be absent
+    "date-time": "2021-07-15T00:00:00Z",  # not always present
+    "timestamp": 1626307200000               # not always present
+}
+
+# Safe extraction (handles [[2021]] or [[2021, 7]] partial dates):
+def parse_date(d):
+    if not d: return None
+    parts = (d.get('date-parts') or [[]])[0]
+    return '-'.join(str(p) for p in parts if p is not None)
+```
+
+### Type identifiers (filter param values vs facet display names)
+
+Use these exact strings in `filter=type:...`. The facet `type-name` values are display names only.
+
+| filter `type:` value | Facet display name | Count (all CrossRef) |
+|---|---|---|
+| `journal-article` | Journal Article | 121,030,194 |
+| `book-chapter` | Chapter | 24,359,059 |
+| `proceedings-article` | Conference Paper | 9,744,754 |
+| `dataset` | Dataset | 3,424,142 |
+| `posted-content` | Posted Content (preprints) | 3,203,320 |
+| `dissertation` | Dissertation | 1,044,461 |
+| `peer-review` | Peer Review | 1,028,287 |
+| `report` | Report | 906,301 |
+| `book` | Book | 870,949 |
+| `monograph` | Monograph | 788,401 |
+
+### Query parameters reference
+
+| Parameter | Notes |
+|---|---|
+| `query` | Full-text keyword search across title, abstract, author |
+| `query.author` | Author name search only |
+| `query.title` | Title search only |
+| `query.bibliographic` | Combined title + author + journal search |
+| `rows` | Results per page (default 20, max 1000) |
+| `offset` | Offset for pagination (max ~10,000 effective) |
+| `cursor` | Use `cursor=*` for first page, then URL-encode `next-cursor` value |
+| `sort` | `relevance`, `is-referenced-by-count`, `published`, `indexed` |
+| `order` | `asc` or `desc` |
+| `filter` | Comma-separated `key:value` pairs (see filters below) |
+| `select` | Comma-separated field names to return |
+| `facet` | `type-name:*` for type counts; `publisher-name:10` for top publishers |
+| `mailto` | Your email — enables polite pool (higher limits) |
+
+### Filter keys reference
+
+| Filter key | Example | Notes |
+|---|---|---|
+| `doi` | `doi:10.1038/nature12345` | Exact DOI match |
+| `type` | `type:journal-article` | See type table above for valid values |
+| `from-pub-date` | `from-pub-date:2024-01-01` | ISO date or `YYYY` |
+| `until-pub-date` | `until-pub-date:2024-12-31` | |
+| `from-index-date` | `from-index-date:2024-01-01` | When CrossRef indexed it |
+| `has-abstract` | `has-abstract:true` | Only works with deposited abstract |
+| `has-orcid` | `has-orcid:true` | At least one author has ORCID |
+| `has-full-text` | `has-full-text:true` | Has full-text link |
+| `has-references` | `has-references:true` | Has deposited reference list |
+| `is-update` | `is-update:true` | Corrections, retractions |
+| `issn` | `issn:0028-0836` | Filter by journal ISSN |
+| `publisher-name` | `publisher-name:elsevier` | Partial match |
+| `funder` | `funder:100000001` | Funder DOI or CrossRef funder ID |
+
+## Rate limits
+
+CrossRef has two pools based on whether `mailto=` is present:
+
+| Pool | Triggered by | Rate limit | Concurrency |
+|---|---|---|---|
+| **polite** | `mailto=` param present | 10 req/s | 3 concurrent |
+| **public** | no `mailto=` | 5 req/s | 1 concurrent |
+
+Headers returned: `x-rate-limit-limit`, `x-rate-limit-interval`, `x-concurrency-limit`, `x-api-pool`.
+
+In practice with polite pool: 10 rapid sequential calls complete in ~2.7s (avg 0.27s/req) with no throttling. 5 parallel calls complete in ~0.3s. Stay at `max_workers=5` to respect the concurrency limit.
+
+No per-day or per-hour cap. If you exceed limits, responses slow or return HTTP 429. No ban. Add `time.sleep(0.1)` between calls for sustained bulk crawls.
+
+## Gotchas
+
+- **`mailto=` doubles your rate limit and concurrency.** Public pool: 5 req/s, concurrency=1. Polite pool: 10 req/s, concurrency=3. Always add `?mailto=your@email.com` to every request — confirmed by reading `x-api-pool` response header.
+
+- **`title`, `container-title`, `ISSN` are always lists, not strings.** Access with `title[0]`, `container-title[0]` etc. Do not rely on there being only one entry — `container-title` can have multiple values.
+
+- **Abstract contains JATS XML markup.** The `abstract` field is not plain text — it contains tags like `<jats:p>`, `<jats:italic>`, `<jats:sup>`. Strip with `re.sub(r'<[^>]+>', ' ', abstract)`. About 30-70% of works have an abstract at all; journal articles 2023 with `has-abstract:true` filter: 3,041,841 / ~5.5M total = ~55%.
+
+- **ORCID is a full URL, not just the ID.** `a['ORCID']` = `"https://orcid.org/0000-0001-6169-6580"`. Strip with `.replace('https://orcid.org/', '')` to get the bare ID. `authenticated-orcid: false` means self-asserted (not verified via OAuth).
+
+- **`published` vs `published-print` vs `published-online`.** Online-first is common in journals — a paper may be online months before its print issue. `published` is CrossRef's best single date and equals `published-online` when both exist. For preprints (`posted-content` type), look for `posted` instead of `published-print` — it may only have `posted` and `published`. Partial dates like `[[2023]]` (year only) are valid — always use `parse_date()` to handle missing month/day.
+
+- **404 raises `HTTPError`, not a JSON error response.** An invalid DOI (e.g. `10.9999/doesnotexist`) raises `urllib.error.HTTPError: HTTP Error 404: Not Found`. Wrap `fetch_work()` in try/except for any untrusted DOI list.
+
+- **`volume` and `issue` are strings, not integers.** CrossRef stores them as strings — `"596"`, not `596`. Don't compare with `==` to an int.
+
+- **Filter type values are hyphenated lowercase, not the facet display names.** `filter=type:journal-article` works. `filter=type:journal article`, `filter=type:Journal Article`, and `filter=type:conference-paper` all return HTTP 400. Conference papers are `proceedings-article`.
+
+- **`select=` does not guarantee field presence.** When you `select=DOI,title,author`, a record that has no author still omits the `author` key — it doesn't return `author: []`. Always use `.get()`.
+
+- **Cursor pagination required for >10,000 results.** Offset pagination (`offset=`) is limited to around 10,000 results. For bulk sweeps, use `cursor=*` for the first page, then URL-encode the returned `next-cursor` value with `urllib.parse.quote()`. The cursor expires if unused for too long.
+
+- **`rows` max is 1000 per call.** Requesting more silently returns 1000. For cursor-based sweeps of large result sets (millions of records), `rows=1000` with cursor is the most efficient approach.
+
+- **HTML entities in titles.** Titles may contain HTML entities like `&amp;` — `"Deep learning &amp; convolutional networks"`. Decode with `html.unescape()` if needed.
+
+- **`funder` search `works-count` field is `None`.** The funder search result object has a `works-count` key that is always `None` in the search response. To get actual work counts for a funder, fetch the funder directly: `GET /funders/{id}`.
+
+- **`subject` is often an empty list.** The `subject` field in works is populated inconsistently — many journal articles have `subject: []` even for well-indexed journals like Nature.
+
+- **Affiliation is usually empty.** `author[i]['affiliation']` is `[]` for the majority of records, even for papers published in 2024. CrossRef has been working on affiliation deposit, but coverage is inconsistent.

--- a/domain-skills/fred/scraping.md
+++ b/domain-skills/fred/scraping.md
@@ -1,0 +1,493 @@
+# FRED — Federal Reserve Economic Data
+
+`https://fred.stlouisfed.org` / `https://api.stlouisfed.org` — the canonical source for US macroeconomic time series (800,000+ series). The REST API at `api.stlouisfed.org` requires a free registered key. The web endpoints at `fred.stlouisfed.org` (CSV, JSON, HTML) are all blocked to headless HTTP — they consistently timeout with no response. For zero-key access use the BLS API (unemployment, CPI, payrolls) or World Bank API (GDP, growth rates, annual data).
+
+## Do this first
+
+**Decision tree: pick one approach.**
+
+```
+Need GDP, CPI, UNRATE, payrolls only? → use BLS + World Bank (no key, free forever)
+Need FEDFUNDS, DGS10, SP500, any FRED series? → get a free FRED API key (5 min)
+Need browser-visible chart data? → use CDP to intercept network requests
+```
+
+**The web CSV/JSON/TXT URLs all timeout — do NOT attempt them:**
+```python
+# ALL OF THESE TIMEOUT — confirmed dead from headless HTTP:
+# https://fred.stlouisfed.org/graph/fredgraph.csv?id=GDP      ← timeout
+# https://fred.stlouisfed.org/graph/fredgraph.json?id=GDP     ← timeout
+# https://fred.stlouisfed.org/data/GDP.txt                    ← timeout
+# https://fred.stlouisfed.org/series/GDP                      ← timeout
+```
+
+## Getting a free FRED API key
+
+1. Go to `https://fred.stlouisfed.org/docs/api/api_key.html`
+2. Click "Request or view your API Keys"
+3. Sign in / register (free St. Louis Fed account)
+4. Key appears immediately — it's a 32-character lowercase alphanumeric string
+
+The key is free, instant, and unlimited for reasonable use (120 req/min cap).
+
+---
+
+## Option A: FRED REST API (requires free key, 800K+ series)
+
+The only way to get FRED data programmatically. Set `FRED_KEY` in your `.env` file.
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]   # 32-char lowercase alphanumeric
+BASE = "https://api.stlouisfed.org/fred"
+```
+
+### Series metadata
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+meta = json.loads(http_get(f"{BASE}/series?series_id=GDP&api_key={FRED_KEY}&file_type=json"))
+s = meta['seriess'][0]
+print(s['title'])               # "Gross Domestic Product"
+print(s['observation_start'])   # "1947-01-01"
+print(s['observation_end'])     # "2025-10-01"
+print(s['frequency'])           # "Quarterly"
+print(s['frequency_short'])     # "Q"
+print(s['units'])               # "Billions of Dollars"
+print(s['units_short'])         # "Bil. of $"
+print(s['seasonal_adjustment']) # "Seasonally Adjusted Annual Rate"
+print(s['popularity'])          # 81  (0-100)
+print(s['last_updated'])        # "2025-12-19 08:00:06-06"
+```
+
+### Observations (the actual data)
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+# Latest 10 values, most recent first
+obs = json.loads(http_get(
+    f"{BASE}/series/observations"
+    f"?series_id=GDP"
+    f"&api_key={FRED_KEY}"
+    f"&file_type=json"
+    f"&limit=10"
+    f"&sort_order=desc"      # "desc" = newest first, "asc" = oldest first (default)
+))
+print(obs['count'])              # 314  (total observations)
+print(obs['observation_start'])  # "1947-01-01"  (what's in the full series)
+
+for o in obs['observations']:
+    date  = o['date']    # "2025-10-01"
+    value = o['value']   # "29726.4"  — always a STRING, may be "." for missing
+    if value != '.':
+        print(f"{date}: ${float(value):,.1f}B")
+# 2025-10-01: $29,726.4B
+# 2025-07-01: $29,339.1B
+# 2025-04-01: $29,119.3B
+```
+
+### Date-range filtering
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+obs = json.loads(http_get(
+    f"{BASE}/series/observations"
+    f"?series_id=UNRATE"
+    f"&api_key={FRED_KEY}"
+    f"&file_type=json"
+    f"&observation_start=2020-01-01"
+    f"&observation_end=2024-12-31"
+    f"&sort_order=desc"
+))
+for o in obs['observations'][:5]:
+    print(f"{o['date']}: {o['value']}%")
+# 2024-12-01: 4.1%
+# 2024-11-01: 4.2%
+# 2024-10-01: 4.1%
+```
+
+### Key series IDs
+
+| FRED ID | Description | Frequency | Unit |
+|---------|-------------|-----------|------|
+| `GDP` | Gross Domestic Product | Quarterly | Billions of $, SAAR |
+| `GDPC1` | Real GDP (chained 2017 $) | Quarterly | Billions of chained 2017 $ |
+| `UNRATE` | Unemployment Rate | Monthly | Percent, SA |
+| `CPIAUCSL` | CPI: All Urban Consumers, SA | Monthly | Index 1982-84=100 |
+| `CPIAUCNS` | CPI: All Urban Consumers, not SA | Monthly | Index 1982-84=100 |
+| `FEDFUNDS` | Federal Funds Effective Rate | Monthly | Percent |
+| `DFF` | Federal Funds Rate (daily) | Daily | Percent |
+| `DGS10` | 10-Year Treasury Constant Maturity | Daily | Percent |
+| `DGS2` | 2-Year Treasury | Daily | Percent |
+| `SP500` | S&P 500 | Daily | Index |
+| `NASDAQCOM` | NASDAQ Composite | Daily | Index |
+| `PAYEMS` | Total Nonfarm Payrolls | Monthly | Thousands of persons, SA |
+| `PCEPI` | PCE Price Index | Monthly | Index 2017=100, SA |
+| `PCEPILFE` | Core PCE Price Index | Monthly | Index 2017=100, SA |
+| `DCOILBRENTEU` | Brent Crude Oil | Daily | $ per Barrel |
+| `DEXUSEU` | USD/EUR Exchange Rate | Daily | USD per EUR |
+| `M2SL` | M2 Money Stock | Monthly | Billions of $, SA |
+| `MORTGAGE30US` | 30-Year Fixed Mortgage Rate | Weekly | Percent |
+
+### Series search
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+results = json.loads(http_get(
+    f"{BASE}/series/search"
+    f"?search_text=unemployment+rate"
+    f"&api_key={FRED_KEY}"
+    f"&file_type=json"
+    f"&limit=5"
+    f"&order_by=popularity"    # "popularity" | "search_rank" | "series_id" | "title" | "units" | "frequency" | "seasonal_adjustment" | "realtime_start" | "realtime_end" | "last_updated" | "observation_start" | "observation_end"
+    f"&sort_order=desc"        # most popular first
+))
+for s in results['seriess']:
+    print(f"{s['id']}: {s['title']} ({s['frequency_short']}, {s['units_short']})")
+# UNRATE: Unemployment Rate (M, %)
+# UNEMPLOY: Unemployment Level (M, Thous. of Persons)
+```
+
+### Multiple series — parallel fetch
+
+```python
+import json, os
+from concurrent.futures import ThreadPoolExecutor
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+def fetch_latest(series_id):
+    obs = json.loads(http_get(
+        f"{BASE}/series/observations?series_id={series_id}"
+        f"&api_key={FRED_KEY}&file_type=json&limit=1&sort_order=desc"
+    ))
+    o = obs['observations'][0]
+    return series_id, o['date'], o['value']
+
+series_ids = ["GDP", "UNRATE", "CPIAUCSL", "FEDFUNDS", "DGS10", "SP500"]
+with ThreadPoolExecutor(max_workers=6) as ex:
+    results = list(ex.map(fetch_latest, series_ids))
+
+for sid, date, val in results:
+    print(f"{sid:15} {date}: {val}")
+# GDP             2025-10-01: 29726.4
+# UNRATE          2026-03-01: 4.3
+# CPIAUCSL        2026-02-01: 321.457
+# FEDFUNDS        2026-03-01: 4.33
+# DGS10           2026-04-17: 4.34
+# SP500           2026-04-17: 5282.70
+# Confirmed: 6 parallel requests complete in ~0.4s
+```
+
+### Parse observations into a list of (date, float) tuples
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+obs = json.loads(http_get(
+    f"{BASE}/series/observations?series_id=DGS10&api_key={FRED_KEY}&file_type=json"
+    f"&observation_start=2024-01-01&sort_order=asc"
+))
+
+data = [
+    (o['date'], float(o['value']))
+    for o in obs['observations']
+    if o['value'] != '.'   # '.' = missing value, skip it
+]
+print(f"{len(data)} observations")
+print(f"First: {data[0]}")   # ('2024-01-02', 3.91)
+print(f"Last:  {data[-1]}")  # ('2026-04-17', 4.34)
+```
+
+### Handle errors
+
+```python
+import urllib.error, json
+
+try:
+    r = http_get(f"https://api.stlouisfed.org/fred/series?series_id=BADID&api_key={FRED_KEY}&file_type=json")
+    print(json.loads(r))
+except urllib.error.HTTPError as e:
+    err = json.loads(e.read().decode())
+    # err['error_code']     → 400
+    # err['error_message']  → "Bad Request.  The series does not exist."
+    print(f"FRED error {err['error_code']}: {err['error_message']}")
+```
+
+---
+
+## Option B: BLS API (no key required, confirmed live)
+
+Bureau of Labor Statistics. Covers unemployment, CPI, payrolls — the most-queried FRED series. **Without a key: 10 requests/day limit.** Free key registration at `https://www.bls.gov/developers/` gives 500 req/day and 10 years of data per call (vs 3 years without key).
+
+```python
+import json
+# Single series GET — no auth needed
+r = http_get("https://api.bls.gov/publicAPI/v2/timeseries/data/LNS14000000?startyear=2024&endyear=2024")
+data = json.loads(r)
+# data['status'] == 'REQUEST_SUCCEEDED'
+series = data['Results']['series'][0]
+for point in series['data'][:3]:
+    print(f"{point['year']}-{point['period']} ({point['periodName']}): {point['value']}")
+# 2024-M12 (December): 4.1
+# 2024-M11 (November): 4.2
+# 2024-M10 (October): 4.1
+```
+
+### Multi-series POST (single call, multiple series)
+
+```python
+import json, urllib.request
+
+payload = json.dumps({
+    "seriesid": ["LNS14000000", "CUSR0000SA0", "CES0000000001"],
+    "startyear": "2023",
+    "endyear": "2024"
+    # "registrationkey": "YOUR_BLS_KEY"  # optional: lifts to 500/day, 10yr range
+}).encode()
+
+req = urllib.request.Request(
+    "https://api.bls.gov/publicAPI/v2/timeseries/data/",
+    data=payload,
+    headers={"Content-Type": "application/json"}
+)
+with urllib.request.urlopen(req, timeout=20) as resp:
+    data = json.loads(resp.read().decode())
+
+for s in data['Results']['series']:
+    pts = s['data']
+    print(f"{s['seriesID']}: {len(pts)} points, latest={pts[0]['value']}")
+# LNS14000000: 24 points, latest=4.1   (unemployment %)
+# CUSR0000SA0: 24 points, latest=317.604  (CPI index)
+# CES0000000001: 24 points, latest=158316  (nonfarm payrolls, thousands)
+```
+
+### Key BLS series (FRED equivalents)
+
+| BLS Series ID | FRED Equivalent | Description |
+|---------------|-----------------|-------------|
+| `LNS14000000` | `UNRATE` | Unemployment rate, SA (%) |
+| `CUSR0000SA0` | `CPIAUCSL` | CPI-U All Urban, SA |
+| `CUUR0000SA0` | `CPIAUCNS` | CPI-U All Urban, not SA |
+| `CUSR0000SA0L1E` | `CPILFESL` | CPI less food and energy, SA |
+| `CES0000000001` | `PAYEMS` | Total nonfarm payrolls (thousands) |
+| `LNS11000000` | `CLF16OV` | Civilian labor force (thousands) |
+| `LNS12000000` | `CE16OV` | Civilian employment (thousands) |
+
+### BLS rate limits
+
+| | Without key | With free key |
+|--|--|--|
+| Requests/day | **10** (confirmed: call 11 returns `REQUEST_NOT_PROCESSED`) | 500 |
+| Series per request | 25 | 50 |
+| Years per request | 3 | 10 |
+| Daily or seasonal adjustment | No | Yes |
+
+---
+
+## Option C: World Bank API (no key, unlimited, annual data)
+
+Free, no registration, no rate limit observed (10 rapid calls completed in 2.0s). Annual data only — no monthly or quarterly frequency.
+
+```python
+import json
+
+# Single country, single indicator
+r = http_get("https://api.worldbank.org/v2/country/US/indicator/NY.GDP.MKTP.CD?format=json&per_page=5&mrv=5")
+data = json.loads(r)
+page_info = data[0]   # {'page': 1, 'pages': 1, 'per_page': 5, 'total': 5, 'lastupdated': '2026-04-08'}
+items     = data[1]   # list of observations
+
+for item in items:
+    if item['value']:
+        print(f"{item['date']}: ${item['value']/1e12:.2f}T")
+# 2024: $28.75T
+# 2023: $27.29T
+# 2022: $25.60T
+```
+
+### Date range filter and multi-country
+
+```python
+import json
+
+# Historical range: date=YYYY:YYYY
+r = http_get("https://api.worldbank.org/v2/country/US/indicator/FP.CPI.TOTL.ZG?format=json&date=2015:2024&per_page=15")
+data = json.loads(r)
+items = [i for i in data[1] if i['value'] is not None]
+for item in items:
+    print(f"{item['date']}: {item['value']:.2f}%")
+# 2024: 2.95%
+# 2023: 4.12%
+# 2022: 8.00%
+# ...
+
+# Multi-country: semicolon-separated ISO codes
+r = http_get("https://api.worldbank.org/v2/country/US;CN;DE;JP;GB/indicator/NY.GDP.MKTP.CD?format=json&date=2023&per_page=10")
+data = json.loads(r)
+items = sorted([i for i in data[1] if i['value']], key=lambda x: x['value'], reverse=True)
+for item in items:
+    print(f"{item['country']['value']}: ${item['value']/1e12:.2f}T")
+# United States: $27.29T
+# China: $18.27T
+# Germany: $4.56T
+```
+
+### Key World Bank indicators (FRED equivalents)
+
+| WB Indicator Code | FRED Equivalent | Description |
+|-------------------|-----------------|-------------|
+| `NY.GDP.MKTP.CD` | `GDP` | GDP, current USD |
+| `NY.GDP.MKTP.KD.ZG` | `A191RL1Q225SBEA` | GDP growth rate (%) |
+| `NY.GDP.PCAP.CD` | `A939RX0Q048SBEA` | GDP per capita (USD) |
+| `FP.CPI.TOTL.ZG` | `FPCPITOTLZGUSA` | CPI inflation, annual % |
+| `FP.CPI.TOTL` | `CPIAUCSL` (annual) | CPI level, 2010=100 |
+| `SL.UEM.TOTL.ZS` | `UNRATE` (annual) | Unemployment rate, ILO model |
+| `CM.MKT.LCAP.GD.ZS` | — | Stock market cap / GDP ratio |
+
+---
+
+## Option D: Alpha Vantage (free registered key, select indicators)
+
+Some economic indicators work with the `demo` key (no registration); most require a free registered key (25 requests/day, instant signup at `https://www.alphavantage.co/support/#api-key`).
+
+```python
+import json
+AV_KEY = "demo"  # or your registered key
+
+# Unemployment rate (works with demo key — confirmed)
+r = http_get(f"https://www.alphavantage.co/query?function=UNEMPLOYMENT&apikey={AV_KEY}")
+data = json.loads(r)
+# data['name']  = 'Unemployment Rate'
+# data['interval'] = 'monthly'
+# data['unit']     = 'percent'
+# data['data']     → list of {date, value}, newest first
+
+print(data['data'][0])   # {'date': '2026-03-01', 'value': '4.3'}
+print(f"Total: {len(data['data'])} months since {data['data'][-1]['date']}")
+# Total: 939 months since 1948-01-01
+```
+
+### Which indicators work with demo vs registered key
+
+| Function | demo key | Registered key |
+|----------|----------|----------------|
+| `UNEMPLOYMENT` | YES | YES |
+| `INFLATION` | YES (annual) | YES |
+| `RETAIL_SALES` | YES | YES |
+| `DURABLES` | YES | YES |
+| `NONFARM_PAYROLL` | YES | YES |
+| `REAL_GDP_PER_CAPITA` | YES | YES |
+| `REAL_GDP` | NO (rate-limited) | YES |
+| `CPI` | NO (rate-limited) | YES |
+| `FEDERAL_FUNDS_RATE` | NO (rate-limited) | YES |
+| `TREASURY_YIELD` | NO (rate-limited) | YES |
+| `CONSUMER_SENTIMENT` | NO (rate-limited) | YES |
+
+```python
+import json
+AV_KEY = "YOUR_FREE_KEY"  # from alphavantage.co/support/#api-key
+
+# Federal Funds Rate — monthly (requires registered key)
+r = http_get(f"https://www.alphavantage.co/query?function=FEDERAL_FUNDS_RATE&interval=monthly&apikey={AV_KEY}")
+data = json.loads(r)
+for item in data['data'][:3]:
+    print(f"{item['date']}: {item['value']}%")
+# 2026-03-01: 4.33%
+# 2026-02-01: 4.33%
+# 2026-01-01: 4.33%
+
+# 10-Year Treasury Yield
+r = http_get(f"https://www.alphavantage.co/query?function=TREASURY_YIELD&maturity=10year&interval=monthly&apikey={AV_KEY}")
+data = json.loads(r)
+print(data['data'][0])   # {'date': '2026-04-17', 'value': '4.34'}
+```
+
+---
+
+## Option E: Browser + CDP (for interactive FRED charts)
+
+When you need data from `fred.stlouisfed.org` that has no API equivalent (custom chart combos, release dates visible on page) — or when you have no API key — use the browser.
+
+```python
+# Navigate to a series page
+goto("https://fred.stlouisfed.org/series/GDP")
+wait_for_load()
+
+# Option 1: Intercept the fredgraph XHR that the chart fires
+# The page's chart JS calls fredgraph.csv internally — intercept it
+events = drain_events()
+# Look for network events with fredgraph.csv in URL
+
+# Option 2: Extract the latest value from the page text
+latest_val = js("""
+    // The last observation appears in the meta section
+    const el = document.querySelector('.series-meta-observation-end');
+    el ? el.textContent.trim() : null
+""")
+
+# Option 3: Read the data table if present
+table_data = js("""
+    const rows = Array.from(document.querySelectorAll('table.series-observations tr'));
+    rows.map(r => {
+        const cells = r.querySelectorAll('td');
+        return cells.length >= 2 ? [cells[0].textContent.trim(), cells[1].textContent.trim()] : null;
+    }).filter(Boolean);
+""")
+```
+
+---
+
+## Rate limits
+
+| API | Limit | Notes |
+|-----|-------|-------|
+| FRED REST API | 120 req/min | With registered key (free) |
+| FRED REST API | blocked | Without key — HTTP 400 |
+| BLS (no key) | 10 req/day | Confirmed: call 11 → `REQUEST_NOT_PROCESSED` |
+| BLS (with key) | 500 req/day, 50 series/req | Free registration at bls.gov/developers |
+| World Bank | No limit observed | 10 rapid calls: 2.0s, no 429 |
+| Alpha Vantage (demo) | 2 req/sec | Demo key rate-limited for most functions |
+| Alpha Vantage (free key) | 25 req/day | Free at alphavantage.co/support/#api-key |
+
+---
+
+## Gotchas
+
+- **fred.stlouisfed.org web endpoints ALL timeout** — The CSV download (`fredgraph.csv`), JSON graph (`fredgraph.json`), text format (`/data/*.txt`), and HTML series pages all hang indefinitely from headless HTTP. This is not a UA or header issue — the server simply does not respond to non-browser connections. Confirmed with multiple UA strings, TCP connect succeeds but no HTTP response is sent.
+
+- **FRED API key is mandatory and must be exactly 32 lowercase alphanumeric chars** — "test", "demo", "guest", and keys shorter/longer than 32 chars all return HTTP 400: `"not a 32 character alpha-numeric lower-case string"`. An unregistered 32-char key returns: `"not registered"`.
+
+- **Observation values are always strings, not numbers** — The `value` field in FRED observations is always a JSON string: `"4.1"`, not `4.1`. Also `"."` (dot) means missing/not-yet-released. Always check `if o['value'] != '.'` before `float(o['value'])`.
+
+- **BLS 10 req/day without key burns fast** — The limit is per-IP per-day. 10 calls is exhausted in one moderate script run. Either register a free BLS key immediately or use World Bank for the same data annually.
+
+- **BLS data range: 3 years without key, 10 years with key** — Requesting `startyear=2000&endyear=2024` without a key silently truncates to the most recent 3 years. With a key it returns up to 10 years and includes a `message` field if the range was truncated: `['Year range has been reduced to the system-allowed limit of 10 years.']`.
+
+- **World Bank is annual only** — No monthly or quarterly data. For monthly UNRATE or CPI, use BLS. For quarterly GDP, use FRED API or Alpha Vantage `REAL_GDP`.
+
+- **World Bank response is a 2-element array** — `data[0]` is pagination metadata, `data[1]` is the observations list. Missing years have `value: null` (not `"."`). Filter with `if item['value'] is not None`.
+
+- **Alpha Vantage demo key: 2 req/sec, covers only 6 economic functions** — The other 6 economic functions (`REAL_GDP`, `CPI`, `TREASURY_YIELD`, etc.) return `{"Information": "The demo API key is for demo purposes only..."}`. No error code — just check for the `Information` key in the response.
+
+- **FRED `sort_order=desc` returns newest first** — Default is `asc` (oldest first, starting from observation_start). For "get the latest value" use `limit=1&sort_order=desc`.
+
+- **FRED series IDs are case-sensitive and exact** — `gdp` returns an error; must be `GDP`. Check `fred.stlouisfed.org/series/{ID}` to verify a series exists before scripting.
+
+- **Some FRED series have gaps** — Daily series like `DGS10` and `SP500` skip weekends and holidays. Those dates simply don't appear in the observations array (not represented as `"."`). Weekly and monthly series use the first day of the period as the date (e.g., `2024-01-01` = January 2024).
+
+- **FRED `realtime_start`/`realtime_end` in observations** — Every observation has these fields reflecting vintage data. For current data, ignore them. They matter only for "real-time" research (what was the published value on a specific past date).

--- a/domain-skills/musicbrainz/scraping.md
+++ b/domain-skills/musicbrainz/scraping.md
@@ -1,0 +1,478 @@
+# MusicBrainz — Data Extraction
+
+`https://musicbrainz.org` — open music encyclopedia with a fully free JSON API.
+No auth required for reads. No browser needed for any documented workflow.
+
+Field-tested against musicbrainz.org on 2026-04-18.
+
+---
+
+## Do this first
+
+**The MusicBrainz Web Service API (ws/2) returns clean JSON for all entity types — no browser needed.**
+
+```python
+from helpers import http_get
+import json
+
+# REQUIRED: every request must include this header or you get HTTP 403
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+data = json.loads(http_get("https://musicbrainz.org/ws/2/artist/?query=queen&fmt=json&limit=5", headers=UA))
+for a in data['artists']:
+    print(a['id'], a['name'], a.get('type'), a.get('country'), a['score'])
+# 0383dadf-2a4e-4d10-a46a-e9e041da8eb3  Queen  Group  GB  100
+# 79239441-bfd5-4981-a70c-55c3f15c1287  Madonna  Person  US  73
+```
+
+`User-Agent` is **mandatory** — omitting it returns HTTP 403 immediately. Format: `AppName/Version (contact@email.com)`.
+
+---
+
+## Entity types
+
+| Entity | Endpoint | Key fields |
+|---|---|---|
+| `artist` | `/ws/2/artist/` | name, sort-name, type (Group/Person/Orchestra/Choir), country, life-span, tags, rating |
+| `release-group` | `/ws/2/release-group/` | title, primary-type (Album/Single/EP/Other), first-release-date |
+| `release` | `/ws/2/release/` | title, date, country, status (Official/Bootleg/Promotional), barcode, label-info, media |
+| `recording` | `/ws/2/recording/` | title, length (milliseconds), artist-credit, releases |
+| `label` | `/ws/2/label/` | name, type, country, area |
+| `work` | `/ws/2/work/` | title, type (Song/Aria/Soundtrack/etc.), relations |
+
+All entities share the same MBID (MusicBrainz ID) format: UUID v4, e.g. `0383dadf-2a4e-4d10-a46a-e9e041da8eb3`.
+
+---
+
+## Common workflows
+
+### Artist search
+
+```python
+from helpers import http_get
+import json
+
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/artist/?query=queen&fmt=json&limit=5",
+    headers=UA
+))
+# resp keys: count (total matches), offset, artists (list)
+for a in resp['artists']:
+    print(a['id'])           # MBID: 0383dadf-2a4e-4d10-a46a-e9e041da8eb3
+    print(a['name'])         # Queen
+    print(a['sort-name'])    # Queen  (differs for persons: "Bowie, David")
+    print(a.get('type'))     # Group / Person / Orchestra / Choir
+    print(a.get('country'))  # GB
+    print(a.get('life-span'))# {'begin': '1970-06-27', 'end': None, 'ended': True}
+    print(a.get('disambiguation', ''))  # e.g. "English singer-songwriter"
+    print(a['score'])        # relevance 0-100
+```
+
+### Artist by MBID (with related data via `inc=`)
+
+```python
+# inc= parameters stack with + between them
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/artist/0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+    "?inc=releases+tags+ratings+release-groups&fmt=json",
+    headers=UA
+))
+print(resp['name'])      # Queen
+print(resp['type'])      # Group
+print(resp['country'])   # GB
+print(resp['life-span']) # {'begin': '1970-06-27', 'end': None, 'ended': True}
+
+# Tags (community-voted genre labels, sorted by count)
+tags = sorted(resp.get('tags', []), key=lambda x: x['count'], reverse=True)
+print([t['name'] for t in tags[:5]])
+# ['rock', 'glam rock', 'hard rock', 'art rock', 'british']
+
+# Rating (community score, 0-5)
+print(resp.get('rating'))  # {'votes-count': 43, 'value': 4.7}
+
+# Direct releases (up to 25 per request — use browse for full list)
+for r in resp.get('releases', []):
+    print(r['id'], r['title'], r.get('date'))
+
+# Release groups (albums, singles, EPs — deduplicated by edition)
+for rg in resp.get('release-groups', []):
+    print(rg['id'], rg['title'], rg.get('primary-type'), rg.get('first-release-date'))
+# 6b47c9a0  A Night at the Opera  Album  1975-11-21
+# 002ed683  Sheer Heart Attack    Album  1974-11-01
+```
+
+### Browse releases by artist (full list)
+
+```python
+# Browse API: uses 'artist' param (not 'query') — response key is 'release-count' not 'count'
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/"
+    "?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3&fmt=json&limit=25&offset=0",
+    headers=UA
+))
+print(resp['release-count'])   # 1635 — total releases for this artist
+for r in resp['releases']:
+    print(r['id'], r['title'], r.get('date'), r.get('country'), r.get('status'))
+    # Also has: cover-art-archive.artwork (bool), cover-art-archive.front (bool)
+    caa = r.get('cover-art-archive', {})
+    print(caa.get('artwork'), caa.get('front'), caa.get('count'))
+
+# Paginate: increment offset by limit
+```
+
+### Release search and lookup
+
+```python
+# Search by title
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/?query=dark+side+of+the+moon&fmt=json&limit=5",
+    headers=UA
+))
+# resp keys: count, offset, releases
+
+# Full release with track list, artists, and labels
+release = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/b84ee12a-09ef-421b-82de-0441a926375b"
+    "?inc=artists+recordings+labels+release-groups&fmt=json",
+    headers=UA
+))
+print(release['title'])   # The Dark Side of the Moon
+print(release['date'])    # 1973-03-24
+print(release['status'])  # Official
+print(release['country']) # GB
+
+# Release group (the "album concept", deduplicates editions)
+rg = release.get('release-group', {})
+print(rg['title'], rg.get('primary-type'), rg['id'])
+# The Dark Side of the Moon  Album  f5093c06-23e3-404f-aeaa-40f72885ee3a
+
+# Artist credit
+for ac in release.get('artist-credit', []):
+    if isinstance(ac, dict) and 'artist' in ac:
+        print(ac['artist']['name'], ac['artist']['id'])
+        # Pink Floyd  83d91898-7763-47d7-b03b-b92132375c47
+
+# Labels
+for li in release.get('label-info', []):
+    label = li.get('label', {})
+    print(label.get('name'), li.get('catalog-number'))
+    # Harvest  SHVL 804
+
+# Track list (from media[].tracks[])
+for disc in release.get('media', []):
+    for track in disc.get('tracks', []):
+        dur_s = track['length'] // 1000 if track.get('length') else None
+        rec = track.get('recording', {})
+        print(track['number'], track['title'], dur_s, rec.get('id'))
+        # A1  Speak to Me  68s  bef3fddb-5aca-49f5-b2fd-d56a23268d63
+        # A2  Breathe      168s ecbc7c9b-e79d-4ec8-ac77-44e4a7f7f1b8
+```
+
+### Recording (track) search
+
+```python
+# Use Lucene field syntax to filter by artist
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/recording/"
+    "?query=bohemian+rhapsody+AND+artist:queen&fmt=json&limit=5",
+    headers=UA
+))
+print(resp['count'])  # 419
+for r in resp['recordings']:
+    dur_s = r['length'] // 1000 if r.get('length') else None
+    artists = [ac['artist']['name'] for ac in r.get('artist-credit', []) if isinstance(ac, dict)]
+    releases = r.get('releases', [])
+    print(r['id'], r['title'], dur_s, artists, releases[0]['title'] if releases else None)
+# a4803b45  Bohemian Rhapsody  130s  ['Queen']  Rhapsody in Red
+# 40212eb6  Bohemian Rhapsody  338s  ['Queen']  1986-07: Wembley Stadium
+```
+
+### Release-group search (deduplicated albums)
+
+```python
+# Use release-group endpoint to avoid getting every regional edition
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release-group/"
+    "?query=release-group:\"A+Night+at+the+Opera\"+AND+artist:queen&fmt=json&limit=5",
+    headers=UA
+))
+# resp keys: count, release-groups
+for rg in resp.get('release-groups', []):
+    print(rg['id'], rg['title'], rg.get('primary-type'), rg.get('first-release-date'), rg['score'])
+# 6b47c9a0  A Night at the Opera  Album  1975-11-21  100
+
+# Browse release-groups for an artist
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release-group/"
+    "?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3&fmt=json&limit=25",
+    headers=UA
+))
+print(resp['release-group-count'])  # 412
+for rg in resp.get('release-groups', []):
+    print(rg['title'], rg.get('primary-type'), rg.get('first-release-date'))
+```
+
+### Label and work lookups
+
+```python
+# Label search
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/label/?query=EMI&fmt=json&limit=3",
+    headers=UA
+))
+for l in resp['labels']:
+    print(l['id'], l['name'], l.get('type'), l.get('country'), l['score'])
+# c029628b  EMI  Original Production  GB  100
+
+# Work (song composition — author-level, not performance-level)
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/work/?query=bohemian+rhapsody&fmt=json&limit=3",
+    headers=UA
+))
+for w in resp['works']:
+    print(w['id'], w['title'], w.get('type'), w['score'])
+# 41c94a08  Bohemian Rhapsody  Song  100
+```
+
+### Cover Art Archive
+
+```python
+# Get cover art for a release MBID
+# 404 if no artwork has been uploaded for that release
+def get_cover_art(release_mbid, size="500"):
+    """
+    size: '250', '500', '1200', or 'full' (original file)
+    Returns the front cover URL, or None if no artwork exists.
+    """
+    try:
+        resp = json.loads(http_get(
+            f"https://coverartarchive.org/release/{release_mbid}",
+            headers=UA
+        ))
+    except Exception:
+        return None   # 404 = no art uploaded
+
+    images = resp.get('images', [])
+    # Prefer an image flagged as front=True
+    front = next((img for img in images if img.get('front')), None)
+    img = front or (images[0] if images else None)
+    if not img:
+        return None
+
+    if size == 'full':
+        return img['image']
+    return img['thumbnails'].get(size) or img['thumbnails'].get('large')
+
+# Thumbnail sizes confirmed: '250', '500', '1200', 'small' (=250), 'large' (=500)
+
+url = get_cover_art("b84ee12a-09ef-421b-82de-0441a926375b")
+# http://coverartarchive.org/release/b84ee12a.../1611507818-500.jpg
+
+# Full images response structure
+resp = json.loads(http_get(
+    "https://coverartarchive.org/release/b84ee12a-09ef-421b-82de-0441a926375b",
+    headers=UA
+))
+for img in resp['images']:
+    print(img.get('types'))   # ['Front'], ['Back'], ['Liner'], ['Poster'], ['Medium'], ['Sticker'], ['Other']
+    print(img.get('front'))   # True only for front=True flagged images (not all 'Front' types)
+    print(img.get('approved'))# True/False
+    print(img['image'])       # full resolution URL
+    print(img['thumbnails'])  # {'small': '...-250.jpg', 'large': '...-500.jpg', '250': ..., '500': ..., '1200': ...}
+```
+
+### Lucene query syntax for search
+
+All search endpoints support Lucene field queries:
+
+```python
+# Field search: artist:, type:, country:, tag:, release:, date:
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/artist/"
+    "?query=artist:queen+AND+type:group+AND+country:GB&fmt=json&limit=5",
+    headers=UA
+))
+# count: 23 (exact matches only)
+
+# Phrase search with quotes
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/"
+    '?query=release:"A+Night+at+the+Opera"+AND+artist:queen&fmt=json&limit=5',
+    headers=UA
+))
+```
+
+Common Lucene field names per entity:
+- artist: `artist:`, `type:`, `country:`, `tag:`, `begin:`, `end:`
+- release: `release:`, `artist:`, `date:`, `country:`, `status:`, `label:`, `barcode:`
+- recording: `recording:`, `artist:`, `release:`, `dur:` (milliseconds), `tnum:` (track number)
+- release-group: `release-group:`, `artist:`, `primarytype:`, `secondarytype:`
+
+### Parallel fetching
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+def fetch_artist(mbid):
+    resp = json.loads(http_get(
+        f"https://musicbrainz.org/ws/2/artist/{mbid}?inc=tags&fmt=json",
+        headers=UA
+    ))
+    tags = [t['name'] for t in sorted(resp.get('tags', []), key=lambda x: x['count'], reverse=True)[:3]]
+    return {"name": resp['name'], "type": resp.get('type'), "tags": tags}
+
+mbids = [
+    "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",  # Queen
+    "83d91898-7763-47d7-b03b-b92132375c47",  # Pink Floyd
+    "678d88b2-87b0-403b-b63d-5da7465aecc3",  # Led Zeppelin
+]
+
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(fetch_artist, mbids))
+# 3 artists fetched in ~0.79s total
+```
+
+Tested: 5-6 rapid sequential requests all succeed. Parallel requests at 3x concurrency succeed. Real 429s (rate-limit blocks) are only hit at very high burst rates; if you do get a 429, add `time.sleep(1)` between requests.
+
+### Pagination
+
+```python
+import time
+
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+def browse_all_releases(artist_mbid, page_size=25):
+    """Fetch all releases for an artist across multiple pages."""
+    offset = 0
+    total = None
+    releases = []
+    while total is None or offset < total:
+        resp = json.loads(http_get(
+            f"https://musicbrainz.org/ws/2/release/"
+            f"?artist={artist_mbid}&fmt=json&limit={page_size}&offset={offset}",
+            headers=UA
+        ))
+        total = resp['release-count']
+        batch = resp['releases']
+        releases.extend(batch)
+        offset += len(batch)
+        if offset < total:
+            time.sleep(1)  # stay within 1 req/s for sequential pagination
+    return releases
+
+# Queen has 1635 releases — use release-groups (412) to get deduplicated albums
+```
+
+---
+
+## `inc=` parameter reference
+
+Stack multiple `inc=` values with `+` between them.
+
+**Artist lookup** (`/ws/2/artist/{mbid}`):
+- `releases` — list of releases (max ~25)
+- `release-groups` — list of release groups (max ~25)
+- `recordings` — list of recordings (max ~25)
+- `works` — list of works
+- `tags` — community genre tags (name + vote count)
+- `ratings` — community rating (value 0-5, votes-count)
+- `aliases` — alternative names and transliterations
+- `annotation` — free-text editorial note
+- `artist-rels`, `release-rels`, `recording-rels`, `work-rels` — relationship data
+
+**Release lookup** (`/ws/2/release/{mbid}`):
+- `artists` — full artist-credit objects
+- `recordings` — track list with recording links (populates `media[].tracks[].recording`)
+- `labels` — label-info with catalog numbers
+- `release-groups` — the release group this belongs to
+- `artist-credits` — expanded artist credit with joinphrase
+- `media` — disc/format info (always included in lookup, not needed in `inc=`)
+
+---
+
+## Response shapes cheat sheet
+
+```
+# MBID format: standard UUID v4
+"0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+
+# Search response (artist/recording/release/release-group/label/work)
+{
+  "count": 1612,          # total matches
+  "offset": 0,
+  "<entity-plural>": [...] # e.g. "artists", "releases", "recordings", "release-groups"
+}
+
+# Browse response (using ?artist=MBID or ?label=MBID style)
+{
+  "release-count": 1635,  # note: key name changes per entity
+  "release-offset": 0,    # e.g. "release-group-count", "recording-count"
+  "releases": [...]
+}
+
+# Recording length is always milliseconds
+recording['length'] // 1000  # => seconds
+
+# Artist life-span
+life_span = artist['life-span']
+# {'begin': '1970-06-27', 'end': None, 'ended': True}
+# 'ended': True with 'end': None means end date unknown but band is inactive
+
+# Artist credit joinphrase (for multi-artist tracks)
+# [{"name": "Simon", "artist": {...}, "joinphrase": " & "}, {"name": "Garfunkel", ...}]
+```
+
+---
+
+## URL patterns
+
+| Resource | URL |
+|---|---|
+| Artist search | `https://musicbrainz.org/ws/2/artist/?query={q}&fmt=json&limit=5` |
+| Artist by MBID | `https://musicbrainz.org/ws/2/artist/{mbid}?inc=tags+ratings&fmt=json` |
+| Browse releases by artist | `https://musicbrainz.org/ws/2/release/?artist={mbid}&fmt=json&limit=25&offset=0` |
+| Release search | `https://musicbrainz.org/ws/2/release/?query={q}&fmt=json&limit=5` |
+| Release by MBID | `https://musicbrainz.org/ws/2/release/{mbid}?inc=artists+recordings+labels&fmt=json` |
+| Release-group browse | `https://musicbrainz.org/ws/2/release-group/?artist={mbid}&fmt=json&limit=25` |
+| Recording search | `https://musicbrainz.org/ws/2/recording/?query={q}&fmt=json&limit=5` |
+| Label search | `https://musicbrainz.org/ws/2/label/?query={q}&fmt=json&limit=5` |
+| Work search | `https://musicbrainz.org/ws/2/work/?query={q}&fmt=json&limit=5` |
+| Cover art | `https://coverartarchive.org/release/{release-mbid}` |
+
+MusicBrainz entity browser URL (human-readable): `https://musicbrainz.org/artist/{mbid}` (replace `artist` with `release`, `recording`, etc.)
+
+---
+
+## Gotchas
+
+- **`User-Agent` is mandatory** — without it you get HTTP 403 instantly. The header must include contact info, e.g. `browser-harness/1.0 (you@example.com)`. The default `http_get` UA (`Mozilla/5.0`) also gets 403.
+
+- **Browse vs search response keys differ** — Search responses use `count` and `offset`; Browse responses (with `?artist=MBID`) use `release-count` / `release-offset` (or `release-group-count` etc.). Accessing `data['count']` on a browse response throws `KeyError`.
+
+- **`releases` include in artist lookup caps at ~25** — Use the browse endpoint (`?artist=MBID`) with pagination for complete lists. Queen has 1,635 releases total; the `inc=releases` on the artist endpoint only returns ~25.
+
+- **Use release-groups to avoid edition explosion** — A popular album can have hundreds of release entries (every country's pressing, every remaster, every format). Use `/ws/2/release-group/` to get one entry per "album concept". Queen's "A Night at the Opera" has 75+ release entries but 1 release-group.
+
+- **Recording length is milliseconds** — `recording['length']` is in milliseconds, not seconds. Divide by 1000.
+
+- **Sort-name differs from display name for persons** — Artists have both `name` (display: "David Bowie") and `sort-name` (alphabetical: "Bowie, David"). Groups usually have identical values.
+
+- **Disambiguation in parentheses** — When multiple entities share a name, MusicBrainz adds a `disambiguation` field to distinguish them (e.g. `"English singer-songwriter"` vs a different David Bowie). Always check `a.get('disambiguation', '')` when resolving artist identity.
+
+- **Score 100 does not mean unique** — Search returns `score: 100` for multiple results when several equally match the query. "dark side of the moon" returns 6 results all scored 100 — they're different regional pressings. Filter by `date`, `country`, or `status` to narrow down.
+
+- **Recording search: plain query matches titles AND artists broadly** — `?query=bohemian+rhapsody+queen` matches *cover versions* first because "queen" appears in the artist or title of other recordings. Use `AND artist:queen` Lucene syntax to restrict to Queen performances.
+
+- **Cover Art Archive returns 404 for releases with no uploaded art** — Check `release['cover-art-archive']['artwork']` (boolean) from any release browse/search response before hitting the CAA endpoint. Saves an extra HTTP round-trip.
+
+- **Cover art `front=True` flag vs `types=['Front']`** — A release can have multiple images typed as 'Front' but only one (or none) flagged `front: true`. Always filter on `img.get('front') == True` for the canonical cover, not on `img.get('types') == ['Front']`.
+
+- **CAA thumbnail key names** — Both string keys `'small'` (250px) and `'large'` (500px) exist as aliases alongside numeric string keys `'250'`, `'500'`, `'1200'`. Access as `img['thumbnails']['500']` or `img['thumbnails']['large']` — both work.
+
+- **Rate limit: 1 req/s unauthenticated** — In practice, bursts of 5-6 sequential requests succeed without throttling. True 429s appear at higher rates. For sequential pagination loops, add `time.sleep(1)` between pages. For parallel fetching, limit concurrency to 3-5 workers.
+
+- **`fmt=json` required** — Omitting it returns XML instead of JSON. Always append `&fmt=json` to every request.

--- a/domain-skills/openalex/scraping.md
+++ b/domain-skills/openalex/scraping.md
@@ -1,0 +1,470 @@
+# OpenAlex — Scraping & Data Extraction
+
+`https://api.openalex.org` — open academic knowledge graph covering 260M+ works, 90M+ authors, 110K+ institutions. **Never use the browser for OpenAlex.** The entire API is JSON over HTTPS, completely free, no API key required. Add `mailto=your@email.com` to every request to use the polite pool (10 req/s vs 100 req/s limit, more reliable).
+
+## Do this first
+
+**Use `http_get` with the REST JSON API — one call, JSON response, no auth, no parsing library.**
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/works?search=transformer+attention&per-page=5&mailto=you@example.com"
+))
+works = data["results"]
+total = data["meta"]["count"]
+```
+
+Always include `mailto=` to stay in the polite pool. Always parse with `json.loads()`.
+
+## Common workflows
+
+### Search papers (works)
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?search=transformer+attention"
+    "&per-page=5"
+    "&sort=cited_by_count:desc"
+    "&select=id,doi,display_name,publication_year,cited_by_count,open_access,primary_location"
+    "&mailto=you@example.com"
+))
+print("total matching:", data["meta"]["count"])
+for w in data["results"]:
+    oa   = w["open_access"]
+    loc  = w["primary_location"] or {}
+    src  = loc.get("source") or {}
+    print(w["id"].split("/")[-1], w["publication_year"], w["cited_by_count"], w["display_name"][:60])
+    print("  doi:", w["doi"])
+    print("  open access:", oa["is_oa"], "| pdf:", oa["oa_url"])
+    print("  journal:", src.get("display_name"))
+# Confirmed output (2026-04-18):
+# W3151130473 2021 1887 CrossViT: Cross-Attention Multi-Scale Vision Transformer for I
+#   doi: https://doi.org/10.1109/iccv48922.2021.00041
+#   open access: False | pdf: None
+#   journal: 2021 IEEE/CVF International Conference on Computer Vision (ICCV)
+```
+
+### Fetch single paper by OpenAlex ID or DOI
+
+```python
+from helpers import http_get
+import json
+
+# By OpenAlex ID (bare or full URL form both work)
+w = json.loads(http_get("https://api.openalex.org/works/W2626778328?mailto=you@example.com"))
+print(w["display_name"], w["cited_by_count"])
+# Confirmed: Attention Is All You Need 6526
+
+# By DOI (pass the full DOI URL as the entity ID)
+w = json.loads(http_get(
+    "https://api.openalex.org/works/https://doi.org/10.1038/nature14539?mailto=you@example.com"
+))
+print(w["display_name"], w["cited_by_count"])
+# Confirmed: Deep learning 79790
+```
+
+### Reconstruct abstract from inverted index
+
+OpenAlex does not return abstracts as plain strings — they come as an inverted index (`{word: [position, ...], ...}`) due to publisher agreements. Reconstruct as follows:
+
+```python
+from helpers import http_get
+import json
+
+w = json.loads(http_get(
+    "https://api.openalex.org/works/W2626778328"
+    "?select=id,display_name,abstract_inverted_index"
+    "&mailto=you@example.com"
+))
+aii = w.get("abstract_inverted_index") or {}
+words_pos = [(pos, word) for word, positions in aii.items() for pos in positions]
+abstract = " ".join(word for _, word in sorted(words_pos))
+print(abstract[:200])
+# Confirmed: The dominant sequence transduction models are based on complex recurrent
+# or convolutional neural networks in an encoder-decoder configuration...
+```
+
+### Author lookup
+
+```python
+from helpers import http_get
+import json
+
+# Search by name
+data = json.loads(http_get(
+    "https://api.openalex.org/authors?search=geoffrey+hinton&per-page=3&mailto=you@example.com"
+))
+for a in data["results"]:
+    bare_id = a["id"].split("/")[-1]    # e.g. A5108093963
+    print(bare_id, a["display_name"], a["works_count"], "works |", a["cited_by_count"], "cites")
+    affils = a.get("affiliations", [])
+    if affils:
+        print("  latest affil:", affils[0]["institution"]["display_name"])
+# Confirmed:
+# A5108093963 Geoffrey E. Hinton 384 works | 446018 cites
+#   latest affil: University of New Brunswick
+
+# Fetch by bare ID
+a = json.loads(http_get("https://api.openalex.org/authors/A5108093963?mailto=you@example.com"))
+print(a["display_name"], a["works_count"])
+# Confirmed: Geoffrey E. Hinton 384
+
+# Get all works by this author (sorted by citations)
+works_data = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?filter=author.id:A5108093963"
+    "&per-page=5&sort=cited_by_count:desc"
+    "&select=id,display_name,cited_by_count,publication_year"
+    "&mailto=you@example.com"
+))
+for w in works_data["results"]:
+    print(w["publication_year"], w["display_name"][:55], w["cited_by_count"])
+# Confirmed:
+# 2015 Deep learning 79790
+# 2017 ImageNet classification with deep convolutional neural netwo 75670
+# 2008 Visualizing Data using t-SNE 35710
+```
+
+### Institution lookup
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/institutions?search=MIT&per-page=3&mailto=you@example.com"
+))
+for inst in data["results"]:
+    bare_id = inst["id"].split("/")[-1]     # e.g. I63966007
+    print(bare_id, inst["display_name"], inst["country_code"], inst["works_count"], "works")
+# Confirmed: I63966007 Massachusetts Institute of Technology US 340302 works
+
+# Works from an institution
+works = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?filter=institutions.id:I63966007"
+    "&per-page=3&sort=cited_by_count:desc"
+    "&select=id,display_name,cited_by_count,publication_year"
+    "&mailto=you@example.com"
+))
+print("total MIT works:", works["meta"]["count"])
+# Confirmed: 323992
+```
+
+### Concept/Topic lookup
+
+Concepts (legacy, level-based hierarchy) and Topics (newer, 4-level hierarchy) are both available.
+
+```python
+from helpers import http_get
+import json
+
+# Concepts endpoint (Wikidata-linked)
+data = json.loads(http_get(
+    "https://api.openalex.org/concepts?search=machine+learning&per-page=5&mailto=you@example.com"
+))
+for c in data["results"]:
+    bare_id = c["id"].split("/")[-1]    # e.g. C119857082
+    print(bare_id, c["display_name"], "level:", c["level"], "works:", c["works_count"])
+# Confirmed: C119857082 Machine learning level: 1 works: 4960536
+
+# Topics endpoint (newer: domain > field > subfield > topic)
+data2 = json.loads(http_get(
+    "https://api.openalex.org/topics?search=machine+learning&per-page=3&mailto=you@example.com"
+))
+for t in data2["results"]:
+    print(t["id"].split("/")[-1], t["display_name"])
+    print("  ", t.get("domain", {}).get("display_name"), ">",
+          t.get("field", {}).get("display_name"), ">",
+          t.get("subfield", {}).get("display_name"))
+# Confirmed: T11948 Machine Learning in Materials Science
+#   Physical Sciences > Materials Science > Materials Chemistry
+```
+
+### Source (journal/venue) lookup
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/sources?search=nature&per-page=3&mailto=you@example.com"
+))
+for s in data["results"]:
+    bare_id = s["id"].split("/")[-1]    # e.g. S137773608
+    print(bare_id, s["display_name"], s["type"], "issn:", s["issn"], "oa:", s["is_oa"])
+# Confirmed: S137773608 Nature journal issn: ['0028-0836', '1476-4687'] oa: False
+
+# Works in a source
+works = json.loads(http_get(
+    "https://api.openalex.org/works?filter=primary_location.source.id:S137773608"
+    "&per-page=3&sort=cited_by_count:desc"
+    "&select=id,display_name,cited_by_count"
+    "&mailto=you@example.com"
+))
+print("Nature works:", works["meta"]["count"])
+```
+
+### Funder lookup
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/funders?search=national+science+foundation&per-page=3&mailto=you@example.com"
+))
+for f in data["results"]:
+    bare_id = f["id"].split("/")[-1]    # e.g. F4320306076
+    print(bare_id, f["display_name"], f["country_code"], f["works_count"], "works")
+# Confirmed: F4320306076 National Science Foundation US
+```
+
+### Citation traversal
+
+```python
+from helpers import http_get
+import json
+
+paper_id = "W2626778328"  # Attention Is All You Need
+
+# Papers that CITE this paper (forward citations)
+citing = json.loads(http_get(
+    f"https://api.openalex.org/works?filter=cites:{paper_id}"
+    "&per-page=5&sort=cited_by_count:desc"
+    "&select=id,display_name,publication_year,cited_by_count"
+    "&mailto=you@example.com"
+))
+print("papers citing Attention:", citing["meta"]["count"])
+for w in citing["results"]:
+    print(f"  {w['publication_year']} {w['display_name'][:55]} ({w['cited_by_count']} cites)")
+# Confirmed: 6536 papers cite it; top: AlphaFold2 (43435), ViT (21409)
+
+# Papers THIS paper cites (backward — list of IDs in the work object)
+paper = json.loads(http_get(
+    f"https://api.openalex.org/works/{paper_id}?select=referenced_works&mailto=you@example.com"
+))
+refs = paper.get("referenced_works", [])
+ref_ids = [r.split("/")[-1] for r in refs]     # bare IDs like W1632114991
+print(f"references {len(ref_ids)} works:", ref_ids[:3])
+# Confirmed: references 28 works
+```
+
+### Cursor pagination (bulk harvest)
+
+Use cursor pagination (not page-based) for more than 10,000 results. Page-based fails with HTTP 400 beyond page 50 at per-page=200.
+
+```python
+from helpers import http_get
+import json, urllib.parse
+
+def harvest_works(query_filter, max_results=1000, mailto="you@example.com"):
+    """Yield work dicts using cursor pagination."""
+    cursor = "*"
+    collected = 0
+    while collected < max_results:
+        per_page = min(200, max_results - collected)
+        encoded_cursor = urllib.parse.quote(cursor, safe="")
+        url = (
+            f"https://api.openalex.org/works"
+            f"?filter={query_filter}"
+            f"&per-page={per_page}"
+            f"&cursor={encoded_cursor}"
+            f"&select=id,display_name,publication_year,cited_by_count"
+            f"&mailto={mailto}"
+        )
+        data = json.loads(http_get(url))
+        results = data.get("results", [])
+        if not results:
+            break
+        for w in results:
+            yield w
+        collected += len(results)
+        next_cursor = data["meta"].get("next_cursor")
+        if not next_cursor:
+            break
+        cursor = next_cursor
+
+for w in harvest_works("concepts.id:C119857082,publication_year:2023", max_results=400):
+    print(w["id"].split("/")[-1], w["display_name"][:55])
+```
+
+### Group-by analytics
+
+```python
+from helpers import http_get
+import json
+
+# Publication counts by year for machine learning papers
+data = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?filter=concepts.id:C119857082"    # C119857082 = Machine learning concept
+    "&group_by=publication_year"
+    "&mailto=you@example.com"
+))
+print("groups_count:", data["meta"]["groups_count"])
+for g in data.get("group_by", [])[:5]:
+    print(f"  {g['key']}: {g['count']:,} works")
+# Confirmed (2026-04-18):
+#   2026: 5,678,538 works
+#   2025: 5,332,194 works
+#   2020: 3,966,880 works
+
+# Other useful group_by fields: open_access.oa_status, type, institutions.country_code
+# authorships.institutions.country_code, primary_location.source.id
+```
+
+## Filter syntax reference
+
+Filters go in the `filter=` param as comma-separated `field:value` pairs. All conditions are AND-ed.
+
+```
+# Exact match
+filter=publication_year:2023
+
+# Full-text search on a field
+filter=title.search:deep+learning
+
+# Combine multiple (AND)
+filter=title.search:CRISPR,publication_year:2022,open_access.is_oa:true
+
+# OR within one field (pipe operator)
+filter=publication_year:2022|2023
+
+# Negation
+filter=publication_year:!2020
+
+# Range
+filter=cited_by_count:>1000
+filter=publication_year:<2010
+filter=cited_by_count:100-500
+
+# Nested field access
+filter=author.id:A5108093963
+filter=institutions.id:I63966007
+filter=concepts.id:C119857082
+filter=primary_location.source.id:S137773608
+filter=open_access.is_oa:true
+filter=cites:W2626778328         # papers citing this work
+```
+
+Commonly useful filter fields for works:
+
+| Filter field | Example | Notes |
+|---|---|---|
+| `title.search` | `title.search:machine+learning` | Full-text on title |
+| `abstract.search` | `abstract.search:attention` | Full-text on abstract |
+| `publication_year` | `publication_year:2023` | Exact year |
+| `from_publication_date` | `from_publication_date:2023-01-01` | Date range start |
+| `to_publication_date` | `to_publication_date:2023-12-31` | Date range end |
+| `cited_by_count` | `cited_by_count:>500` | Range with `>`, `<`, `-` |
+| `open_access.is_oa` | `open_access.is_oa:true` | OA filter |
+| `author.id` | `author.id:A5108093963` | By author OpenAlex ID |
+| `institutions.id` | `institutions.id:I63966007` | By institution ID |
+| `concepts.id` | `concepts.id:C119857082` | By concept ID |
+| `primary_location.source.id` | `primary_location.source.id:S137773608` | By journal/source |
+| `type` | `type:journal-article` | Work type |
+| `language` | `language:en` | ISO 639-1 language code |
+| `cites` | `cites:W2626778328` | Works citing this paper |
+| `doi` | `doi:10.1038/nature14539` | By DOI (no `https://doi.org/` prefix) |
+
+## URL and parameter reference
+
+### API base
+
+```
+https://api.openalex.org/{entity_type}
+```
+
+Entity types: `works`, `authors`, `institutions`, `sources`, `concepts`, `topics`, `funders`, `publishers`
+
+### Query parameters
+
+| Parameter | Example | Notes |
+|---|---|---|
+| `search` | `search=deep+learning` | Full-text relevance search across entity |
+| `filter` | `filter=publication_year:2023` | Structured filters (see above) |
+| `sort` | `sort=cited_by_count:desc` | Sort field + direction; use `relevance_score:desc` with `search` |
+| `per-page` | `per-page=200` | Max 200 per page |
+| `page` | `page=2` | Page number; fails (HTTP 400) if `per-page * page > 10000` |
+| `cursor` | `cursor=*` | Cursor for bulk pagination; `*` = first page |
+| `select` | `select=id,doi,display_name` | Return only these fields (reduces payload) |
+| `group_by` | `group_by=publication_year` | Aggregate counts by field (returns `group_by` array) |
+| `mailto` | `mailto=you@example.com` | **Always include** — enables polite pool |
+
+### Entity ID prefix convention
+
+OpenAlex IDs use a letter prefix on the numeric ID:
+
+| Prefix | Entity | Example |
+|---|---|---|
+| `W` | Work (paper) | `W2626778328` |
+| `A` | Author | `A5108093963` |
+| `I` | Institution | `I63966007` |
+| `S` | Source (journal) | `S137773608` |
+| `C` | Concept | `C119857082` |
+| `T` | Topic | `T11948` |
+| `F` | Funder | `F4320306076` |
+| `P` | Publisher | `P4310319965` |
+
+Full entity URLs: `https://openalex.org/{ID}` (canonical form returned in `id` field).
+Bare ID is always `entity_url.split("/")[-1]`.
+
+### Sort fields
+
+Works: `cited_by_count`, `publication_date`, `relevance_score` (only with `search`), `fwci`
+Authors: `cited_by_count`, `works_count`
+All: append `:desc` or `:asc`
+
+## Rate limits
+
+| Pool | Rate | Daily cap |
+|---|---|---|
+| Polite pool (with `mailto=`) | 10 req/s | 100,000 req/day |
+| Common pool (no `mailto`) | 100 req/s | 100,000 req/day |
+
+- No API key required — the polite pool is opt-in via `mailto=`.
+- Response includes `meta.cost_usd` (typically $0.001 per call).
+- No `Retry-After` header when throttled — just add a short sleep on 429.
+- For bulk harvesting >1,000 results, use cursor pagination + respect the polite pool.
+
+## Gotchas
+
+- **Never use the browser for OpenAlex.** The API returns complete structured JSON for all entity types. No HTML scraping needed.
+
+- **`mailto=` goes in every call, not just once.** It is a query parameter, not a header. There is no session. Omitting it puts you in the common pool (higher contention, less predictable).
+
+- **OpenAlex IDs in the `id` field are full URLs, not bare IDs.** The field returns `https://openalex.org/W2626778328`. Always `.split("/")[-1]` to get the bare `W2626778328` form needed for `filter=cites:`, `filter=author.id:`, etc.
+
+- **DOI lookup uses the full DOI URL as the path parameter.** Correct: `GET /works/https://doi.org/10.1038/nature14539`. Incorrect: `GET /works/10.1038/nature14539` (returns 404).
+
+- **Page-based pagination hard stops at 10,000 results.** `per-page=200&page=51` returns HTTP 400. Use `cursor=*` pagination for harvesting more than 10K results — it has no such limit.
+
+- **`cursor=*` must be URL-encoded on subsequent pages.** The `next_cursor` value contains `+`, `=`, `/` characters. Always `urllib.parse.quote(cursor, safe="")` before interpolating into the URL.
+
+- **`group_by` and `page` are incompatible — use `group_by` without `page`/`cursor`.** Group-by returns a `group_by` list, not `results`. The `per-page` param sets max groups returned (default 200).
+
+- **`abstract_inverted_index` may be `null` for some papers.** Publisher agreements prevent OpenAlex from providing abstracts for many closed-access works. Always check `if aii:` before reconstructing.
+
+- **`select` significantly reduces response size and latency.** A full work object has 50+ fields; specifying `select=id,doi,display_name,cited_by_count` cuts payload by ~90%. Always use `select=` in bulk harvests.
+
+- **`sort=relevance_score:desc` only works with `search=`.** Using it without a `search` param returns results in undefined order. Use `cited_by_count:desc` or `publication_date:desc` for filter-only queries.
+
+- **The `concepts` field is deprecated in favor of `topics`.** Concepts (Wikidata-linked, 5 levels) are still populated and useful, but OpenAlex now recommends `topics` (4-level hierarchy: domain > field > subfield > topic) going forward.
+
+- **`open_access.oa_url` can be `null` even when `is_oa=true`.** Check `best_oa_location.pdf_url` instead — it is more reliably populated when an OA PDF exists.
+
+- **Negation filter syntax is `field:!value`, not `field!=value`.** Example: `filter=publication_year:!2020` excludes 2020.
+
+- **Author disambiguation is imperfect.** The same person may appear as multiple author entities. Use ORCID (`ids.orcid`) when available to cross-reference. The `display_name_alternatives` field lists name variants.
+
+- **The `funders.grants_count` field returns `None` in API responses** despite the docs mentioning it. Use `works_count` and `cited_by_count` instead for funder-level metrics.
+
+- **`per-page` with `cursor=*` ignores `page=`.** When cursor pagination is active, `page` is set to `null` in `meta`. Do not combine cursor + page.

--- a/domain-skills/pubmed/scraping.md
+++ b/domain-skills/pubmed/scraping.md
@@ -1,0 +1,421 @@
+# PubMed / NCBI — Scraping & Data Extraction
+
+`https://pubmed.ncbi.nlm.nih.gov` — 37 M+ biomedical citations. **Never use the browser for PubMed.** All data is reachable via `http_get` using the NCBI E-utilities REST API. No API key required; a free key raises the rate limit from 3 to 10 req/s.
+
+## Do this first
+
+**ESearch → ESummary is the fastest pipeline for most tasks — two calls, JSON responses, no XML parsing.**
+
+```python
+import json
+from helpers import http_get
+
+# Step 1: search → get PMIDs
+search = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    "?db=pubmed&term=deep+learning+radiology&retmax=10&retmode=json"
+))
+pmids = search['esearchresult']['idlist']   # e.g. ['41999029', '41998456', ...]
+count = search['esearchresult']['count']    # total hits across all pages
+
+# Step 2: fetch lightweight metadata for all PMIDs in one call
+summary = json.loads(http_get(
+    f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+    f"?db=pubmed&id={','.join(pmids)}&retmode=json"
+))
+result = summary['result']
+for uid in result['uids']:
+    art = result[uid]
+    print(uid, art['pubdate'], art['source'])
+    print("  ", art['title'][:80])
+    print("  authors:", [a['name'] for a in art['authors'][:3]])
+# Confirmed output (2026-04-18):
+# 41999029 2026 Apr 18 Med Sci Monit
+#    Use of Deep Learning Models in the Diagnosis of Proptosis Through Orbi
+#    authors: ['Kesimal U', 'Akkaya HE', 'Polat Ö']
+# 41998456 2026 Apr 17 Sci Rep
+#    ...
+```
+
+Use **EFetch XML** when you need: full abstract text, MeSH terms, complete author names (not just "Last I"), structured abstract labels, or the DOI from within the article record.
+
+## Common workflows
+
+### Search PubMed (ESearch)
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    "?db=pubmed"
+    "&term=large+language+models+clinical"
+    "&retmax=5"
+    "&retmode=json"
+    "&sort=pub+date"                          # newest first; default is relevance
+    "&datetype=pdat"                          # filter by publication date
+    "&mindate=2024/01/01&maxdate=2024/12/31"  # YYYY/MM/DD format
+))
+result = data['esearchresult']
+print("Total hits:", result['count'])         # '24160' — note: string, not int
+print("PMIDs:", result['idlist'])
+print("Query translation:", result['querytranslation'])
+# Confirmed output (2026-04-18):
+# Total hits: 24160
+# PMIDs: ['41996895', '41996722', '41996006', '41995888', '41995759']
+# Query translation: "large language models"[MeSH Terms] OR ...
+```
+
+#### ESearch field tags (append to term)
+
+```
+machine learning[MeSH Terms]        MeSH controlled vocabulary
+Hinton GE[Author]                   author last + initials
+attention is all you need[Title]    title words
+Nature[Journal]                     journal name
+2024[pdat]                          publication year
+```
+
+Boolean operators: `AND`, `OR`, `NOT`. Phrase search: `"exact phrase"[Title]`.
+
+#### Sort options (`sort=`)
+
+| Value | Effect |
+|---|---|
+| *(omit)* | Relevance (default) |
+| `pub+date` | Most recent publication first |
+| `Author` | First author alphabetical |
+| `JournalName` | Journal alphabetical |
+
+### Lightweight metadata — ESummary (JSON, no XML)
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+    "?db=pubmed&id=41999029,41998456,41997837&retmode=json"
+))
+result = data['result']
+for uid in result['uids']:
+    art = result[uid]
+    # Key fields available:
+    title         = art['title']            # full title string
+    source        = art['source']           # abbreviated journal name
+    fulljournalname = art['fulljournalname']
+    pubdate       = art['pubdate']          # e.g. '2026 Apr 18'
+    epubdate      = art['epubdate']         # e-pub ahead of print date (may be empty)
+    authors       = art['authors']          # list of {'name': 'Last I', 'authtype': ...}
+    volume        = art['volume']
+    issue         = art['issue']
+    pages         = art['pages']
+    pubtype       = art['pubtype']          # list: ['Journal Article', 'Review', ...]
+    # Extract DOI from elocationid or articleids:
+    doi_field     = art['elocationid']      # e.g. 'doi: 10.12659/MSM.951157'
+    article_ids   = {x['idtype']: x['value'] for x in art['articleids']}
+    doi           = article_ids.get('doi')
+    pmc_id        = article_ids.get('pmc')  # PMC ID if open access
+    print(uid, pubdate, source)
+    print(" ", title[:70])
+    print("  doi:", doi, "| pmc:", pmc_id)
+# Confirmed output (2026-04-18):
+# 41999029 2026 Apr 18 Med Sci Monit
+#    Use of Deep Learning Models in the Diagnosis of Proptosis Through Orbi
+#   doi: 10.12659/MSM.951157 | pmc: None
+```
+
+### Full article metadata — EFetch XML
+
+Use this for full abstracts, complete author names, MeSH terms, structured abstract sections.
+
+```python
+import json, xml.etree.ElementTree as ET
+from helpers import http_get
+
+raw = http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    "?db=pubmed&id=41999029,36328784&retmode=xml&rettype=abstract"
+)
+root = ET.fromstring(raw)
+
+for art in root.findall('.//PubmedArticle'):
+    mc      = art.find('MedlineCitation')
+    pmid    = mc.find('PMID').text
+    article = mc.find('Article')
+
+    # Title — use itertext() to handle embedded tags like <i>, <sub>
+    title   = ''.join(article.find('ArticleTitle').itertext()).strip()
+
+    # Abstract — plain or structured (BACKGROUND / METHODS / RESULTS / CONCLUSION)
+    abstract_el = article.find('Abstract')
+    if abstract_el is not None:
+        sections = []
+        for t in abstract_el.findall('AbstractText'):
+            label = t.get('Label', '')          # e.g. 'BACKGROUND', 'METHODS'
+            text  = ''.join(t.itertext()).strip()
+            sections.append(f"[{label}] {text}" if label else text)
+        abstract = ' '.join(sections)
+    else:
+        abstract = ''                           # ~15% of articles have no abstract
+
+    # Journal + year
+    journal  = article.find('Journal')
+    j_title  = journal.find('Title').text if journal is not None else ''
+    pub_date = journal.find('.//PubDate') if journal is not None else None
+    if pub_date is not None:
+        year_el    = pub_date.find('Year')
+        medline_el = pub_date.find('MedlineDate')   # fallback for old/seasonal dates
+        season_el  = pub_date.find('Season')        # e.g. 'Jul-Aug', 'Oct-Dec'
+        year = (year_el.text if year_el is not None
+                else medline_el.text[:4] if medline_el is not None else '')
+
+    # DOI
+    doi_el = next(
+        (e for e in article.findall('ELocationID') if e.get('EIdType') == 'doi'),
+        None
+    )
+    doi = doi_el.text if doi_el is not None else ''
+
+    # Authors — handle CollectiveName (consortium/group authors)
+    author_list = article.find('AuthorList')
+    authors = []
+    if author_list is not None:
+        for a in author_list.findall('Author'):
+            collective = a.find('CollectiveName')
+            last       = a.find('LastName')
+            fore       = a.find('ForeName')
+            initials   = a.find('Initials')
+            if collective is not None:
+                authors.append(collective.text)
+            elif last is not None:
+                full = last.text
+                if fore is not None:
+                    full += f", {fore.text}"
+                authors.append(full)
+
+    # MeSH controlled vocabulary terms
+    mesh_list = mc.find('MeshHeadingList')
+    mesh_terms = []
+    if mesh_list is not None:
+        mesh_terms = [
+            mh.find('DescriptorName').text
+            for mh in mesh_list.findall('MeshHeading')
+            if mh.find('DescriptorName') is not None
+        ]
+
+    print(f"PMID={pmid} ({year}) {j_title}")
+    print(f"  Title: {title[:70]}")
+    print(f"  Authors: {authors[:3]}")
+    print(f"  DOI: {doi}")
+    print(f"  MeSH: {mesh_terms[:4]}")
+    print(f"  Abstract: {abstract[:120]}")
+# Confirmed output (2026-04-18):
+# PMID=41999029 (2026) Medical science monitor : international medical...
+#   Title: Use of Deep Learning Models in the Diagnosis of Proptosis Thro
+#   Authors: ['Kesimal, Uğur', 'Akkaya, Habip Eser', 'Polat, Önder']
+#   DOI: 10.12659/MSM.951157
+#   MeSH: ['Humans', 'Deep Learning', 'Exophthalmos', 'Magnetic Resonance Imaging']
+#   Abstract: BACKGROUND Proptosis is a common manifestation of orbital disease...
+# PMID=36328784 (...)
+#   Abstract: [OBJECTIVES] Physical inactivity and sedentary behaviour...  ← structured
+```
+
+### Large result sets — usehistory + WebEnv
+
+When `count` exceeds `retmax` (max 10 000), use server-side history to paginate EFetch without re-running ESearch on every page.
+
+```python
+import json, xml.etree.ElementTree as ET
+from helpers import http_get
+
+# Step 1: ESearch with usehistory=y — NCBI holds result set on server
+search = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    "?db=pubmed&term=CRISPR+gene+editing&retmax=0&retmode=json&usehistory=y"
+))
+webenv    = search['esearchresult']['webenv']       # server-side session token
+query_key = search['esearchresult']['querykey']     # result set ID within session
+total     = int(search['esearchresult']['count'])
+print(f"Total: {total}, WebEnv: {webenv[:30]}..., query_key: {query_key}")
+# Confirmed output (2026-04-18):
+# Total: 24160, WebEnv: MCID_69e4203757db89391008d6f1..., query_key: 1
+
+# Step 2: EFetch pages using WebEnv (no re-searching)
+batch_size = 200
+for start in range(0, min(total, 1000), batch_size):  # cap at 1000 for demo
+    raw = http_get(
+        f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+        f"?db=pubmed&query_key={query_key}&WebEnv={webenv}"
+        f"&retstart={start}&retmax={batch_size}&retmode=xml&rettype=abstract"
+    )
+    root = ET.fromstring(raw)
+    articles = root.findall('.//PubmedArticle')
+    print(f"  Fetched {len(articles)} articles (start={start})")
+    # process articles here...
+```
+
+### EInfo — list available NCBI databases
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?retmode=json"
+))
+dbs = data['einforesult']['dblist']
+print(f"Total databases: {len(dbs)}")   # Confirmed: 39 (2026-04-18)
+print(dbs[:10])
+# ['pubmed', 'protein', 'nuccore', 'ipg', 'nucleotide', 'structure',
+#  'genome', 'annotinfo', 'assembly', 'bioproject']
+```
+
+Get PubMed-specific metadata (field list, link list):
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?db=pubmed&retmode=json"
+))
+db_info = data['einforesult']['dbinfo'][0]
+print("DB name:", db_info['dbname'])
+print("Record count:", db_info['count'])    # total PubMed records
+link_names = [l['name'] for l in db_info.get('linklist', [])]
+print(f"Link types ({len(link_names)}):", link_names[:5])
+# Confirmed (2026-04-18):
+# DB name: pubmed
+# Record count: 37620453
+# Link types (48): ['pubmed_assembly', 'pubmed_bioproject', ...]
+```
+
+### ELink — cross-database linking
+
+ELink connects a PubMed record to associated data in other NCBI databases. The `pubmed_pubmed` "related articles" linkname relies on a similarity server that is intermittently unavailable (returns `"Couldn't resolve #exLinkSrv2, the address table is empty."`). Use the non-similarity links below instead.
+
+```python
+import json
+from helpers import http_get
+
+# Link a PMID to its free full-text in PMC (if open access)
+# linkname=pubmed_pmc — may also hit the server outage; check error field
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
+    "?dbfrom=pubmed&id=38325330&linkname=pubmed_pmc&retmode=json"
+))
+error = data.get('ERROR', '')
+if error:
+    print("ELink error:", error)   # 'Couldn't resolve #exLinkSrv2...' — NCBI server issue
+else:
+    for ls in data.get('linksets', []):
+        for lsdb in ls.get('linksetdbs', []):
+            print(lsdb['linkname'], "→", lsdb['links'][:5])
+```
+
+Available ELink linknames from pubmed (48 total):
+
+| linkname | Target |
+|---|---|
+| `pubmed_pmc` | Free full text in PMC |
+| `pubmed_pubmed_citedin` | Articles citing this paper |
+| `pubmed_pubmed_refs` | References cited by this paper |
+| `pubmed_gene` | Related Gene records |
+| `pubmed_clinvar` | Clinical variants associated with publication |
+| `pubmed_gds` | Related GEO datasets |
+
+**Practical alternative**: If ELink is down, extract DOI from EFetch/ESummary and use `https://doi.org/{doi}` directly for the full-text link.
+
+## URL and parameter reference
+
+### E-utilities base URLs
+
+```
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi   # search → PMIDs
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi  # PMIDs → JSON summary
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi    # PMIDs → full XML
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi     # cross-db links
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi     # DB metadata
+```
+
+### ESearch parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `db` | `pubmed` | Always `pubmed` for PubMed |
+| `term` | query string | Supports field tags like `[Author]`, `[Title]`, `[MeSH Terms]` |
+| `retmax` | integer, max 10000 | Results returned per call |
+| `retmode` | `json` | JSON output |
+| `sort` | `pub+date`, `Author`, `JournalName` | Default is relevance |
+| `datetype` | `pdat` (pub), `edat` (entrez), `mdat` (modified) | |
+| `mindate`, `maxdate` | `YYYY/MM/DD` or `YYYY` | Requires `datetype` |
+| `usehistory` | `y` | Store results on server; returns `webenv` + `querykey` |
+
+### EFetch parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `db` | `pubmed` | |
+| `id` | `38000000,37999999` | Comma-separated PMIDs; max ~200 per call |
+| `query_key` + `WebEnv` | from ESearch `usehistory=y` | Alternative to `id` for large sets |
+| `retstart` | integer | Offset for pagination with WebEnv |
+| `retmax` | integer, max 10000 | Batch size |
+| `retmode` | `xml` | Use XML for EFetch (JSON not available for full records) |
+| `rettype` | `abstract` | Returns abstract + core metadata |
+
+### PubMed article URL construction
+
+```python
+pmid = "41999029"
+pubmed_url  = f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/"
+doi         = "10.12659/MSM.951157"
+doi_url     = f"https://doi.org/{doi}"        # resolves to publisher page
+pmc_id      = "PMC9876543"                    # from ESummary articleids
+pmc_url     = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmc_id}/"
+```
+
+## Gotchas
+
+- **`count` is a string, not int.** `search['esearchresult']['count']` returns `'24160'`, not `24160`. Always cast with `int()` before arithmetic.
+
+- **EFetch retmode must be `xml` for full records.** Unlike ESearch and ESummary, EFetch with `retmode=json` returns flat text (the MEDLINE citation text format), not structured JSON. Parse EFetch responses with `xml.etree.ElementTree`.
+
+- **`ArticleTitle` may contain embedded XML tags.** Titles with italics (`<i>Staphylococcus aureus</i>`) or math (`<sub>2</sub>`) are mixed-content nodes. Always use `''.join(el.itertext())` instead of `el.text`, which silently drops everything after the first child tag.
+
+- **~15% of articles have no abstract.** `article.find('Abstract')` returns `None` for short communications, editorials, letters, and older records. Always guard with `if abstract_el is not None`.
+
+- **Author names vary in structure — always handle `CollectiveName`.** Consortium papers list a group name (`'GeKeR Study Group'`, `'Breast Cancer Association Consortium'`) under `<CollectiveName>` instead of `<LastName>/<ForeName>`. Individual authors have `<LastName>` + optionally `<ForeName>` and `<Initials>`. Check `CollectiveName` first; falling through to `LastName` without the check produces `None` errors.
+  - Confirmed real examples (2026-04-18): PMID 37586835 (`GeKeR Study Group`), PMID 36328784 (`Breast Cancer Association Consortium`)
+
+- **PubDate has three possible structures.** Most articles have `<Year>` + optional `<Month>` + optional `<Day>`. Seasonal journals use `<Season>` (e.g. `Jul-Aug`, `Oct-Dec`) instead of `<Month>`. A minority of older records use `<MedlineDate>` (e.g. `1995 Fall`) with no `<Year>`. Safe extraction pattern:
+  ```python
+  pub_date = journal.find('.//PubDate')
+  year_el    = pub_date.find('Year')    if pub_date is not None else None
+  medline_el = pub_date.find('MedlineDate') if pub_date is not None else None
+  year = (year_el.text if year_el is not None
+          else medline_el.text[:4] if medline_el is not None else '')
+  ```
+
+- **Batch EFetch: keep IDs to ~200 per call.** The API accepts comma-separated IDs in `id=`, but very large batches (500+) occasionally time out or return truncated XML. For >200 articles, iterate in chunks or use `usehistory` + `WebEnv`.
+
+- **ELink `pubmed_pubmed` (related articles) is intermittently broken.** The NCBI similarity server returns `"Couldn't resolve #exLinkSrv2, the address table is empty."` — this is a persistent server-side issue as of 2026-04-18, not a rate-limit error. Other linknames (`pubmed_gene`, `pubmed_pmc`, `pubmed_clinvar`) fail with the same error. Use the DOI as a fallback link to publisher full text.
+
+- **Rate limits: 3 req/s without API key, 10 req/s with free key.** Exceeding 3 req/s returns HTTP 429. Insert `time.sleep(0.34)` between sequential calls without a key. Get a free API key at https://www.ncbi.nlm.nih.gov/account/ and append `&api_key=YOUR_KEY` to all URLs.
+
+- **`retmax` upper bound is 10 000 for ESearch.** To retrieve more than 10 000 PMIDs for a search, use `usehistory=y` and page through EFetch with `retstart` offsets. EFetch itself also accepts `retmax` up to 10 000 per call.
+
+- **`retmax=0` in ESearch returns only the count, not IDs — useful for counting.** Combine with `usehistory=y` to store the result for later paging without fetching IDs upfront:
+  ```python
+  search = json.loads(http_get(
+      "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+      "?db=pubmed&term=cancer&retmax=0&retmode=json&usehistory=y"
+  ))
+  total  = int(search['esearchresult']['count'])   # e.g. 4800000
+  webenv = search['esearchresult']['webenv']
+  ```
+
+- **ESummary `authors` field uses abbreviated names (`Last I`), not full names.** Use EFetch XML to get `ForeName` (e.g. `'Kesimal, Uğur'` vs ESummary `'Kesimal U'`). For bulk tasks where full names are not needed, ESummary is faster.
+
+- **`querytranslation` shows how NCBI interpreted your term.** The ESearch response includes `esearchresult.querytranslation` — a MeSH-expanded version of your query. Inspect it to verify the search matched what you intended.


### PR DESCRIPTION
## Summary
- PubMed/NCBI: ESearch→ESummary/EFetch pipeline; count field is a string (need int()); ELink pubmed_pubmed broken server-side as of 2026; CollectiveName vs LastName/ForeName branching required; 3 PubDate structures
- CrossRef: title/container-title are always lists (use [0]); abstract has JATS XML tags (strip with regex); polite pool needs mailto= param; type filter uses proceedings-article not conference-paper
- OpenAlex: abstract_inverted_index is {word:[positions]} dict (sort to reconstruct); cursor pagination required above 10K; group_by param (not group-by hyphen); concepts deprecated, use topics
- FRED: fredgraph.csv/json silently timeouts headlessly; REST API needs free key; BLS/WorldBank/AlphaVantage documented as working keyless alternatives
- MusicBrainz: default Mozilla/5.0 UA gets 403; recording length in milliseconds; Cover Art Archive front flag vs types list differ; browse responses use release-count not count

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new domain skills for PubMed, CrossRef, OpenAlex, FRED, and MusicBrainz to standardize API-only workflows and document key rate-limit rules and schema quirks. This helps avoid brittle browser scraping and speeds up reliable data extraction.

- **New Features**
  - PubMed/NCBI: `ESearch → ESummary/EFetch` pipeline; `count` is a string; `ELink pubmed_pubmed` noted as broken server-side.
  - CrossRef: always pass `mailto=` for the polite pool; `title`/`container-title` are lists; abstracts may include JATS XML tags to strip.
  - OpenAlex: reconstruct abstracts from `abstract_inverted_index`; use cursor pagination past 10K; `topics` replace deprecated concepts.
  - FRED: web CSV/JSON endpoints timeout in headless use; REST API requires a free key; suggest BLS/World Bank or CDP interception as alternatives.
  - MusicBrainz: custom `User-Agent` required (403 without it); recording lengths are in ms; browse endpoints use `release-count`.

<sup>Written for commit f7d045caaf8fd2a64cdfb611c623778c9b9f7b74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

