### PR TITLE
install: error-driven decision tree, drop unconditional chrome://inspect

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ Easiest and most powerful way to interact with the browser.
 Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `install.md` first. For normal use, stay in this file.
 
 ```bash
-uv run bh <<'PY'
+uv run browser-harness <<'PY'
 goto("https://browser-use.com")
 wait_for_load()
 print(page_info())
@@ -156,7 +156,8 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 ## Gotchas (field-tested)
 
 - **Chrome 144+ `chrome://inspect/#remote-debugging` does NOT serve `/json/version`.** Read `DevToolsActivePort` instead.
-- **Try attaching before asking for setup.** If `uv run browser-harness` already works, skip the remote-debugging instructions entirely.
+- **Try attaching before asking for setup.** If `uv run browser-harness` already works, skip the remote-debugging instructions entirely. Decide what to escalate from the harness's error message, not from whether Chrome is visibly running.
+- **The remote-debugging checkbox is per-profile sticky in Chrome.** Once ticked on a profile, every future Chrome launch auto-enables CDP — only navigate to `chrome://inspect/#remote-debugging` when `DevToolsActivePort` is genuinely missing on a fresh profile.
 - **The first connect may block on Chrome's Allow dialog.** If setup hangs, explicitly tell the user to click `Allow` in Chrome if it appears, then keep polling for up to 30 seconds instead of treating follow-on errors as a new failure.
 - **`DevToolsActivePort` can exist before the port is actually listening.** Treat connection refused as "still enabling" and keep polling for up to 30 seconds.
 - **Chrome may open the profile picker before any real tab exists.** If Chrome opens both a profile picker and the remote-debugging page, tell the user to choose their normal profile first, then tick the checkbox and click `Allow` if shown.

--- a/install.md
+++ b/install.md
@@ -71,7 +71,7 @@ osascript -e 'tell application "Google Chrome" to activate' \
    If Chrome shows the profile picker first, tell the user to choose their normal profile, *then* (only if `DevToolsActivePort` is still missing) open the inspect page in that profile. Keep polling instead of waiting for the user to type a follow-up.
 4. Be explicit with the user about the two possible Chrome actions: choose their normal profile if the profile picker is open, and in the remote-debugging tab tick the checkbox and click `Allow` once if Chrome shows it.
 5. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the Chrome profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. After asking, keep retrying for at least 30 seconds even if you see connection-refused, stale websocket, or other weird transient attach errors.
-6. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation. As soon as attach succeeds, continue immediately with the verification task without asking again.
+6. If setup still lands on the profile picker, have the user choose their normal profile, then (only if `DevToolsActivePort` is still missing) open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation. As soon as attach succeeds, continue immediately with the verification task without asking again.
 7. Verify with:
 
 ```bash

--- a/install.md
+++ b/install.md
@@ -53,22 +53,26 @@ PY
 
    Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session.
 
-3. If that fails and Chrome is already running, open `chrome://inspect/#remote-debugging` in the existing Chrome profile instead of launching a fresh Chrome process.
-   On macOS:
+3. If it failed, **read the error and escalate from there — do not assume you need `chrome://inspect`**. The remote-debugging checkbox is per-profile sticky in Chrome, so any profile that has had it toggled on once will auto-enable CDP on every future launch; the inspect page is only needed the first time per profile.
+
+   - **No Chrome process running** → just start Chrome and re-run the harness. On macOS: `open -a "Google Chrome"`. Do *not* navigate to `chrome://inspect` yet — if the user has ever ticked the checkbox on this profile, the harness will attach on its own.
+   - **`DevToolsActivePort` missing or empty after Chrome is up** → remote-debugging has never been enabled on this profile. *This* is when you open `chrome://inspect/#remote-debugging` and ask the user to tick the checkbox and click `Allow`. Once ticked, the setting sticks.
+   - **Port present but `connection refused` / `DevTools not live yet` / `/json/version` 404** → Chrome is mid-startup. Just keep polling for up to 30 seconds; do not restart Chrome and do not open the inspect page.
+   - **`no close frame received or sent` / stale websocket** → the daemon (not Chrome) is the problem. Run `restart_daemon()` once and retry — see step 8 below.
+
+   When you do need to open the inspect page on macOS and Chrome is already running, prefer AppleScript so it reuses the current profile instead of going through the picker:
 
 ```bash
 osascript -e 'tell application "Google Chrome" to activate' \
           -e 'tell application "Google Chrome" to open location "chrome://inspect/#remote-debugging"'
 ```
 
-   On Linux: use the already-running Chrome window and open that URL manually.
-   If the attach looks blocked or Chrome's remote-debugging page is open but DevTools is not live yet, tell the user: "Chrome is waiting on you. In the Chrome windows I opened, choose your normal profile first if Chrome is showing the profile picker, then tick the remote-debugging checkbox and click `Allow` if Chrome shows it." Then keep polling instead of waiting for the user to type a follow-up.
-4. If Chrome is not running, start Chrome first and let the user choose their normal profile if Chrome opens the profile picker. Only after that, open `chrome://inspect/#remote-debugging`.
-   On macOS: `open -a "Google Chrome"`
-5. Be explicit with the user about the two possible Chrome actions: choose their normal profile if the profile picker is open, and in the remote-debugging tab tick the checkbox and click `Allow` once if Chrome shows it.
-6. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the Chrome profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. After asking, keep retrying for at least 30 seconds even if you see connection-refused, stale websocket, or other weird transient attach errors.
-7. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation. As soon as attach succeeds, continue immediately with the verification task without asking again.
-8. Verify with:
+   On Linux: open that URL manually in the existing Chrome window.
+   If Chrome shows the profile picker first, tell the user to choose their normal profile, *then* (only if `DevToolsActivePort` is still missing) open the inspect page in that profile. Keep polling instead of waiting for the user to type a follow-up.
+4. Be explicit with the user about the two possible Chrome actions: choose their normal profile if the profile picker is open, and in the remote-debugging tab tick the checkbox and click `Allow` once if Chrome shows it.
+5. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the Chrome profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. After asking, keep retrying for at least 30 seconds even if you see connection-refused, stale websocket, or other weird transient attach errors.
+6. If setup still lands on the profile picker, have the user choose their normal profile, then open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation. As soon as attach succeeds, continue immediately with the verification task without asking again.
+7. Verify with:
 
 ```bash
 uv run browser-harness <<'PY'
@@ -87,15 +91,15 @@ restart_daemon()
 PY
 ```
 
-9. After install and browser bootstrap succeed, use the repository page as a small interaction check. If the user is logged in to GitHub, try to star `https://github.com/browser-use/browser-harness` to verify the interaction works. Then ask the user what you should do next.
+8. After install and browser bootstrap succeed, use the repository page as a small interaction check. If the user is logged in to GitHub, try to star `https://github.com/browser-use/browser-harness` to verify the interaction works. Then ask the user what you should do next.
 
 ## Cold-start reminders
 
-- Try attaching before asking the user to change anything.
+- Try attaching before asking the user to change anything. Decide what to escalate based on the harness's error message, not on whether Chrome is visibly running.
+- The remote-debugging checkbox is per-profile sticky in Chrome. If it has ever been ticked on a profile, just launching Chrome is enough — only navigate to `chrome://inspect/#remote-debugging` when `DevToolsActivePort` is genuinely missing.
 - The first connect may block on Chrome's `Allow` dialog, and Chrome may also stop first on the profile picker.
 - `DevToolsActivePort` can exist before the port is actually listening. Treat connection refused as "still enabling" and keep polling briefly.
 - If the port is listening but `/json/version` returns `404`, treat that as expected on newer Chrome builds and retry `browser-harness`.
-- If attach is blocked on macOS, open `chrome://inspect/#remote-debugging` in the current Chrome profile and explicitly tell the user to click `Allow` if Chrome shows it.
 - Chrome may open the profile picker before any real tab exists.
 - On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.
 - Microsoft Edge (including Beta/Dev/Canary) works too — substitute the app name; steps are identical.

--- a/install.md
+++ b/install.md
@@ -58,7 +58,7 @@ PY
    - **No Chrome process running** → just start Chrome and re-run the harness. On macOS: `open -a "Google Chrome"`. Do *not* navigate to `chrome://inspect` yet — if the user has ever ticked the checkbox on this profile, the harness will attach on its own.
    - **`DevToolsActivePort` missing or empty after Chrome is up** → remote-debugging has never been enabled on this profile. *This* is when you open `chrome://inspect/#remote-debugging` and ask the user to tick the checkbox and click `Allow`. Once ticked, the setting sticks.
    - **Port present but `connection refused` / `DevTools not live yet` / `/json/version` 404** → Chrome is mid-startup. Just keep polling for up to 30 seconds; do not restart Chrome and do not open the inspect page.
-   - **`no close frame received or sent` / stale websocket** → the daemon (not Chrome) is the problem. Run `restart_daemon()` once and retry — see step 8 below.
+   - **`no close frame received or sent` / stale websocket** → the daemon (not Chrome) is the problem. Run `restart_daemon()` once and retry — see step 7 below.
 
    When you do need to open the inspect page on macOS and Chrome is already running, prefer AppleScript so it reuses the current profile instead of going through the picker:
 


### PR DESCRIPTION
## Summary
- Bootstrap previously implied that every attach failure needed a `chrome://inspect/#remote-debugging` navigation. In practice the checkbox is **per-profile sticky** in Chrome — once ticked, every future Chrome launch auto-enables CDP. The inspect page is only needed the first time per profile, when `DevToolsActivePort` is genuinely missing.
- Restructure step 3 of `install.md` as an explicit decision tree keyed off the harness's error message: no Chrome process / `DevToolsActivePort` missing / port not live yet / stale websocket. Cuts an unnecessary user-visible step in the common case (Chrome simply not running).
- Mirror the rule in `SKILL.md` "Gotchas" so it's available without reading `install.md`. Also fix a stale `uv run bh` snippet — the entrypoint registered in `pyproject.toml` is `browser-harness`.

## Motivation
Hit this in a real session today: agent saw Chrome wasn't running and immediately scripted `open -a "Google Chrome"` + AppleScript-to-`chrome://inspect`, when `open -a "Google Chrome"` alone would have been enough since the profile's checkbox was already ticked.

## Test plan
- [ ] Read the new step 3 of `install.md` end to end and confirm each error case maps to one action
- [ ] Confirm `SKILL.md` Fast start example runs (`uv run browser-harness <<<'PY ...'`)
- [ ] On a fresh Chrome profile, confirm the `DevToolsActivePort missing` branch correctly routes to `chrome://inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shifted install flow to an error-driven decision tree that avoids opening `chrome://inspect` by default and prefers launching Chrome and polling when CDP is already enabled. Tightened guidance in `install.md` and `SKILL.md`, added the per‑profile sticky rule, and fixed the `uv run browser-harness` command.

- **Refactors**
  - Expanded step 3 into explicit error-based branches: no Chrome → start Chrome; `DevToolsActivePort` missing → open `chrome://inspect/#remote-debugging`; port present but refused/`/json/version` 404 → poll up to 30s; stale websocket → `restart_daemon()`.
  - Emphasized the remote‑debugging checkbox is per‑profile sticky; only use `chrome://inspect` when `DevToolsActivePort` is genuinely missing on a fresh profile.
  - On macOS, prefer AppleScript to reuse the current profile; on Linux, open the URL in the existing window; clarified profile‑picker flow.
  - Rewrote cold‑start reminders to escalate based on harness errors and removed the prior unconditional macOS `chrome://inspect` note.
  - Updated `SKILL.md` gotchas to mirror the rule and corrected `uv run bh` to `uv run browser-harness`.

<sup>Written for commit 16a57140b9cd8d250dbb776309948d0fc568e1d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

