### PR TITLE
fix(helpers): new_tab(url) actually lands on url

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -134,8 +134,13 @@ def switch_tab(target_id):
     return sid
 
 def new_tab(url="about:blank"):
-    tid = cdp("Target.createTarget", url=url)["targetId"]
+    # Always create blank, then goto: passing url to createTarget races with
+    # attach, so the brief about:blank is "complete" by the time the caller
+    # polls and wait_for_load() returns before navigation actually starts.
+    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
     switch_tab(tid)
+    if url != "about:blank":
+        goto(url)
     return tid
 
 def ensure_real_tab():


### PR DESCRIPTION
## Summary
- `new_tab("https://x")` was returning before navigation actually started, so a subsequent `wait_for_load()` saw `document.readyState == "complete"` on the brief about:blank and returned instantly. `page_info()` then read about:blank state.
- Root cause: `Target.createTarget(url=...)` returns a targetId immediately; by the time `switch_tab` attaches and `_mark_tab` runs, the about:blank phase is already "complete". The real navigation hasn't started in the renderer yet.
- Fix: always create the tab on about:blank, attach, then route real URLs through the existing `goto()`. Same contract as `goto(url)` (caller still calls `wait_for_load()`) — consistent with the rest of the API and adds no new event-handling code.

## Repro (before)
```python
new_tab("https://www.google.com/")
wait_for_load()
print(page_info())
# {'url': 'about:blank', 'title': '🟢', ...}   ← wrong
```

## After
```python
new_tab("https://example.com/")
wait_for_load()
print(page_info())
# {'url': 'https://example.com/', 'title': '🟢 Example Domain', ...}   ← right
```

## Alternatives considered
- **Wait for load inside `new_tab`** — inconsistent with `goto()`, surprising for callers that want to overlap work.
- **Add `new_tab_and_load(url)`** — extra API surface, against the "helpers stay short" design constraint.
- **Just document the gotcha** — punts the problem to every caller.

## Test plan
- [x] `new_tab("https://example.com/"); wait_for_load(); print(page_info())` lands on example.com (verified locally)
- [ ] `new_tab()` (default about:blank) still no-ops the navigation
- [ ] `new_tab` from inside an iframe-heavy page doesn't regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `new_tab(url)` that could cause `wait_for_load()` to return early and `page_info()` to report `about:blank`. New tabs now open on `about:blank`, attach, then navigate via `goto(url)` so they land on the intended URL.

- **Bug Fixes**
  - Create tab with `Target.createTarget(url="about:blank")`, attach via `switch_tab`, then call `goto(url)` when provided.
  - Keeps the `goto(url)` contract: callers still use `wait_for_load()`.

<sup>Written for commit 0642262de0232ecdd8d02a63a47e936fe8c9fb00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

