### PR TITLE
Add domain skills: OpenFDA, USGS Earthquakes, Wikidata, TheSportsDB, Mastodon

### DIFF
--- a/domain-skills/crossref/scraping.md
+++ b/domain-skills/crossref/scraping.md
@@ -1,0 +1,568 @@
+# CrossRef — Scraping & Data Extraction
+
+`https://api.crossref.org` — scholarly DOI and citation metadata. **Never use the browser for CrossRef.** Completely free, no auth required. All workflows use `http_get`.
+
+## Do this first
+
+**Always add `mailto=your@email.com` to every request** — it moves you into the polite pool, which doubles the rate limit and concurrency allowance. The difference is measurable and the cost is zero.
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"  # set once, append to every URL
+
+# Single DOI lookup — fastest way to get metadata for a known paper
+data = json.loads(http_get(f"https://api.crossref.org/works/10.1038/s41586-021-03819-2?{MAILTO}"))
+msg = data['message']
+# msg keys: DOI, title, author, published, type, container-title, volume, issue,
+#           page, is-referenced-by-count, references-count, abstract (optional), ...
+```
+
+## Common workflows
+
+### DOI lookup — single paper
+
+```python
+from helpers import http_get
+import json, re
+
+MAILTO = "mailto=your@email.com"
+
+def fetch_work(doi):
+    data = json.loads(http_get(f"https://api.crossref.org/works/{doi}?{MAILTO}"))
+    return data['message']
+
+def parse_date(d):
+    """[[2021, 7, 15]] -> '2021-7-15'. Handles partial dates like [[2021]]."""
+    if not d: return None
+    parts = d.get('date-parts', [[]])[0]
+    return '-'.join(str(p) for p in parts if p is not None)
+
+def clean_abstract(raw):
+    """Strip JATS XML tags. Abstract field contains tags like <jats:p>, <jats:italic>."""
+    return re.sub(r'<[^>]+>', ' ', raw).strip() if raw else None
+
+w = fetch_work("10.1038/s41586-021-03819-2")  # AlphaFold2
+
+print("DOI:", w['DOI'])                                    # 10.1038/s41586-021-03819-2
+print("Title:", w['title'][0])                             # Highly accurate protein structure...
+print("Type:", w['type'])                                  # journal-article
+print("Publisher:", w['publisher'])                        # Springer Science and Business Media LLC
+print("Journal:", w.get('container-title', [''])[0])      # Nature
+print("Volume:", w.get('volume'))                          # 596
+print("Issue:", w.get('issue'))                            # 7873
+print("Page:", w.get('page'))                              # 583-589
+print("published:", parse_date(w.get('published')))        # 2021-7-15  (online date)
+print("published-online:", parse_date(w.get('published-online')))  # 2021-7-15
+print("published-print:", parse_date(w.get('published-print')))    # 2021-8-26
+print("Citations:", w.get('is-referenced-by-count'))       # 40260
+print("References:", w.get('references-count'))            # 84
+print("Abstract:", clean_abstract(w.get('abstract', ''))[:100] if w.get('abstract') else None)
+# Confirmed output (2026-04-18):
+# DOI: 10.1038/s41586-021-03819-2
+# Title: Highly accurate protein structure prediction with AlphaFold
+# Type: journal-article
+# Journal: Nature
+# Volume: 596 | Issue: 7873 | Page: 583-589
+# published: 2021-7-15 | published-print: 2021-8-26
+# Citations: 40260
+```
+
+### DOI lookup — extract authors with ORCID
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+data = json.loads(http_get(f"https://api.crossref.org/works/10.1038/s41586-021-03819-2?{MAILTO}"))
+authors = data['message'].get('author', [])
+
+for a in authors[:3]:
+    name = f"{a.get('given', '')} {a.get('family', '')}".strip()
+    # ORCID is a full URL, not a bare ID — strip the prefix
+    orcid_url = a.get('ORCID')  # e.g. 'https://orcid.org/0000-0001-6169-6580'
+    orcid_id = orcid_url.replace('https://orcid.org/', '') if orcid_url else None
+    authenticated = a.get('authenticated-orcid', False)  # False = self-reported, True = verified
+    affiliations = [aff.get('name', '') for aff in a.get('affiliation', [])]
+    print(f"{name} | ORCID: {orcid_id} | auth={authenticated} | seq={a['sequence']}")
+# Confirmed output:
+# John Jumper | ORCID: 0000-0001-6169-6580 | auth=False | seq=first
+# Richard Evans | ORCID: None | auth=False | seq=additional
+# Alexander Pritzel | ORCID: None | auth=False | seq=additional
+```
+
+### Batch DOI lookup (parallel — 5 calls in ~0.3s)
+
+```python
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+import json
+
+MAILTO = "mailto=your@email.com"
+
+def fetch_work(doi):
+    try:
+        data = json.loads(http_get(f"https://api.crossref.org/works/{doi}?{MAILTO}"))
+        msg = data['message']
+        return {
+            'doi': doi,
+            'title': msg.get('title', [''])[0],
+            'year': (msg.get('published', {}).get('date-parts') or [[None]])[0][0],
+            'citations': msg.get('is-referenced-by-count'),
+            'type': msg.get('type'),
+        }
+    except Exception as e:
+        return {'doi': doi, 'error': str(e)}
+
+dois = [
+    "10.1038/nature12345",
+    "10.1038/s41586-021-03819-2",
+    "10.1056/NEJMoa2034577",
+    "10.1126/science.1260419",
+    "10.1038/s41586-024-07487-w",
+]
+
+# max_workers=5 safe; polite pool: 10 req/s, concurrency=3 (see Rate limits)
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_work, dois))
+
+for r in results:
+    print(r['year'], f"cites={r['citations']}", r['title'][:50])
+# Confirmed output (2026-04-18, ~0.296s total):
+# 2013 cites=465 LRG1 promotes angiogenesis by modulating endotheli
+# 2021 cites=40260 Highly accurate protein structure prediction with
+# 2020 cites=13752 Safety and Efficacy of the BNT162b2 mRNA Covid-19
+# 2015 cites=13553 Tissue-based map of the human proteome
+# 2024 cites=12037 Accurate structure prediction of biomolecular inte
+```
+
+### Search works by keyword
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# Broad keyword search
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=machine+learning&rows=5&{MAILTO}"
+))
+msg = data['message']
+print("Total results:", msg['total-results'])   # 2,805,391
+for item in msg['items']:
+    title = item.get('title', ['(no title)'])[0][:60]
+    doi   = item.get('DOI', '')
+    year  = (item.get('published', {}).get('date-parts') or [[None]])[0][0]
+    type_ = item.get('type', '')
+    print(f"  [{type_}] {year} {title}")
+    print(f"    DOI: {doi}")
+```
+
+### Search by author + title (targeted)
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query.author=Lecun&query.title=deep+learning&rows=5&{MAILTO}"
+))
+msg = data['message']
+print("Total results:", msg['total-results'])   # 62
+for item in msg['items'][:3]:
+    title   = item.get('title', [''])[0][:60]
+    authors = ', '.join(a.get('family', '') for a in item.get('author', [])[:2])
+    year    = (item.get('published', {}).get('date-parts') or [[None]])[0][0]
+    print(f"  {year} {title}")
+    print(f"    Authors: {authors}  DOI: {item.get('DOI')}")
+# Confirmed output:
+# 2015 Deep learning & convolutional networks
+#   Authors: LeCun  DOI: 10.1109/hotchips.2015.7477328
+```
+
+### Filter by date, type, and sort by citations
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works"
+    f"?filter=from-pub-date:2024-01-01,type:journal-article"
+    f"&rows=5&sort=is-referenced-by-count&order=desc&{MAILTO}"
+))
+msg = data['message']
+print("Total 2024+ journal articles:", msg['total-results'])   # 14,565,456
+for item in msg['items'][:3]:
+    title  = item.get('title', [''])[0][:60]
+    cites  = item.get('is-referenced-by-count', 0)
+    year   = (item.get('published', {}).get('date-parts') or [[None]])[0][0]
+    print(f"  {year} cites={cites} {title}")
+# Confirmed output:
+# 2024 cites=17371 Global cancer statistics 2022: GLOBOCAN estimates...
+# 2024 cites=12037 Accurate structure prediction of biomolecular int...
+```
+
+### Filter with `has-abstract:true`
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# Only return works that have an abstract (useful since ~30-70% do not)
+data = json.loads(http_get(
+    f"https://api.crossref.org/works"
+    f"?filter=from-pub-date:2023-01-01,until-pub-date:2023-12-31"
+    f",type:journal-article,has-abstract:true"
+    f"&rows=3&sort=is-referenced-by-count&order=desc&{MAILTO}"
+))
+msg = data['message']
+print("2023 journal articles with abstract:", msg['total-results'])   # 3,041,841
+for item in msg['items']:
+    print(item.get('title', [''])[0][:60], '| cites:', item.get('is-referenced-by-count'))
+# Confirmed output:
+# Cancer statistics, 2023 | cites: 12919
+# Evolutionary-scale prediction of atomic-level protein struct | cites: 4352
+```
+
+### Cursor pagination (large result sets)
+
+Standard offset pagination (`start=`) caps at a few thousand results. Use cursor for full sweeps.
+
+```python
+from helpers import http_get
+from urllib.parse import quote
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# First page: cursor=*
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=covid&rows=100&cursor=*&{MAILTO}"
+))
+msg = data['message']
+print("Total results:", msg['total-results'])   # 897,660
+items = msg['items']
+next_cursor = msg['next-cursor']   # base64 string like "DnF1ZXJ5VGhlbkZldGNoJA..."
+
+# Next pages: pass URL-encoded cursor
+while next_cursor and items:
+    data = json.loads(http_get(
+        f"https://api.crossref.org/works?query=covid&rows=100"
+        f"&cursor={quote(next_cursor)}&{MAILTO}"
+    ))
+    msg = data['message']
+    items = msg.get('items', [])
+    next_cursor = msg.get('next-cursor')
+    # process items...
+    break  # remove for full sweep
+```
+
+### Fetch specific fields only (`select=`)
+
+Reduces response size significantly for bulk operations:
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=cancer&rows=5"
+    f"&select=DOI,title,author&{MAILTO}"
+))
+# Warning: if a field is absent for a record, it simply won't appear in that item
+for item in data['message']['items']:
+    print(list(item.keys()))   # only ['DOI', 'title'] or ['DOI', 'title', 'author']
+    # Note: select= does NOT guarantee the field appears — absent fields are just omitted
+```
+
+### Count by type using facets
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/works?query=machine+learning&rows=0"
+    f"&facet=type-name:*&{MAILTO}"
+))
+msg = data['message']
+type_facet = msg['facets']['type-name']
+for k, v in sorted(type_facet['values'].items(), key=lambda x: -x[1]):
+    print(f"  {k}: {v:,}")
+# Confirmed output (all CrossRef, 2026-04-18):
+# Journal Article: 1,628,997 (for query=machine+learning scope)
+# Conference Paper: 501,433
+# Chapter: 455,907
+# Posted Content: 87,937
+# ...
+```
+
+### Journal info by ISSN
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+# Nature (ISSN 0028-0836)
+data = json.loads(http_get(f"https://api.crossref.org/journals/0028-0836?{MAILTO}"))
+msg = data['message']
+print("Title:", msg['title'])                          # Nature
+print("Publisher:", msg['publisher'])                  # Springer Science and Business Media LLC
+print("ISSN:", msg['ISSN'])                            # ['0028-0836', '1476-4687']
+print("Total DOIs:", msg['counts']['total-dois'])       # 445,417
+print("Subjects:", msg.get('subjects', []))             # [] (not always populated)
+
+# Search journals by name
+data2 = json.loads(http_get(f"https://api.crossref.org/journals?query=nature&rows=3&{MAILTO}"))
+for j in data2['message']['items']:
+    print(f"{j.get('title')} | ISSN: {j.get('ISSN')} | DOIs: {j.get('counts', {}).get('total-dois')}")
+# Confirmed output:
+# NatureJobs | ISSN: [] | DOIs: 0
+# Naturen | ISSN: ['0028-0887', '1504-3118'] | DOIs: 1055
+```
+
+### Funder search
+
+```python
+from helpers import http_get
+import json
+
+MAILTO = "mailto=your@email.com"
+
+data = json.loads(http_get(
+    f"https://api.crossref.org/funders?query=national+science+foundation&rows=3&{MAILTO}"
+))
+msg = data['message']
+print("Total funders:", msg['total-results'])   # 108
+for f in msg['items']:
+    print(f"  ID: {f['id']} | {f['name']}")
+    print(f"    Alt names: {f.get('alt-names', [])[:2]}")
+    print(f"    URI: {f.get('uri')}")
+# Confirmed output:
+# ID: 501100001711 | Schweizerischer Nationalfonds zur Förderung...
+# ID: 100000143 | Division of Computing and Communication Foundations
+```
+
+### DOI content negotiation (alternative, no CrossRef API needed)
+
+The `doi.org` resolver can return formatted metadata directly via `Accept` header:
+
+```python
+import urllib.request, json
+
+def doi_to_csl(doi):
+    """Fetch CSL-JSON via DOI content negotiation. Same data as CrossRef API."""
+    req = urllib.request.Request(
+        f"https://doi.org/{doi}",
+        headers={"Accept": "application/vnd.citationstyles.csl+json",
+                 "User-Agent": "Mozilla/5.0"}
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read().decode())
+
+def doi_to_bibtex(doi):
+    """Fetch BibTeX via DOI content negotiation."""
+    req = urllib.request.Request(
+        f"https://doi.org/{doi}",
+        headers={"Accept": "application/x-bibtex", "User-Agent": "Mozilla/5.0"}
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return r.read().decode()
+
+csl = doi_to_csl("10.1038/nature12345")
+print("Title:", csl['title'])   # LRG1 promotes angiogenesis...
+print("Type:", csl['type'])     # journal-article
+
+bib = doi_to_bibtex("10.1038/nature12345")
+print(bib[:200])
+# @article{Wang_2013, title={LRG1 promotes angiogenesis...
+```
+
+## Field reference
+
+### Work object — complete field list
+
+All fields are potentially absent unless marked required. Fields marked (R) are always present.
+
+| Field | Type | Notes |
+|---|---|---|
+| `DOI` (R) | string | e.g. `"10.1038/s41586-021-03819-2"` |
+| `URL` (R) | string | `"https://doi.org/10.1038/s41586-021-03819-2"` |
+| `title` (R) | list[str] | Always a list; access `title[0]` |
+| `type` (R) | string | e.g. `"journal-article"` — see type table below |
+| `publisher` | string | |
+| `container-title` | list[str] | Journal name; access `[0]` |
+| `short-container-title` | list[str] | Abbreviated journal name |
+| `ISSN` | list[str] | May contain print and online ISSN |
+| `volume` | string | Note: string not int (`"596"`) |
+| `issue` | string | |
+| `page` | string | e.g. `"583-589"` |
+| `author` | list[object] | See author fields below |
+| `published` | date-object | Best single date — use this |
+| `published-online` | date-object | Online-first date |
+| `published-print` | date-object | Print edition date |
+| `issued` | date-object | Usually same as `published` |
+| `is-referenced-by-count` | int | Inbound citations to this work |
+| `references-count` | int | Outbound references from this work |
+| `reference` | list[object] | Full reference list (when deposited) |
+| `abstract` | string | JATS XML markup; ~30-70% of works; strip tags before use |
+| `subject` | list[str] | Subject classification (often empty) |
+| `language` | string | e.g. `"en"` |
+| `license` | list[object] | Each: `{URL, start, delay-in-days, content-version}` |
+| `funder` | list[object] | Each: `{name, DOI, award}` |
+| `link` | list[object] | Full-text links |
+| `relation` | object | Related DOIs (e.g. preprint → article) |
+| `assertion` | list[object] | Publisher-specific metadata |
+| `alternative-id` | list[str] | Publisher's internal IDs |
+| `member` | string | CrossRef member ID |
+| `prefix` | string | DOI prefix |
+| `score` | float | Relevance score (search results only) |
+| `source` | string | e.g. `"Crossref"` |
+| `indexed` | date-object | When CrossRef indexed this record |
+| `deposited` | date-object | When publisher last deposited metadata |
+| `created` | date-object | When CrossRef record was first created |
+
+### Author object fields
+
+| Field | Notes |
+|---|---|
+| `given` | Given/first name |
+| `family` | Family/last name |
+| `sequence` | `"first"` or `"additional"` |
+| `affiliation` | list of `{name, place}` — usually `[]` |
+| `ORCID` | Full URL `"https://orcid.org/0000-0001-..."` — strip prefix to get bare ID |
+| `authenticated-orcid` | `true` = verified via ORCID OAuth; `false` = self-reported |
+| `name` | Used instead of given/family for organizations |
+
+### Date object structure
+
+```python
+# All date fields share this structure:
+date_obj = {
+    "date-parts": [[2021, 7, 15]],  # [[year, month, day]] — month/day may be absent
+    "date-time": "2021-07-15T00:00:00Z",  # not always present
+    "timestamp": 1626307200000               # not always present
+}
+
+# Safe extraction (handles [[2021]] or [[2021, 7]] partial dates):
+def parse_date(d):
+    if not d: return None
+    parts = (d.get('date-parts') or [[]])[0]
+    return '-'.join(str(p) for p in parts if p is not None)
+```
+
+### Type identifiers (filter param values vs facet display names)
+
+Use these exact strings in `filter=type:...`. The facet `type-name` values are display names only.
+
+| filter `type:` value | Facet display name | Count (all CrossRef) |
+|---|---|---|
+| `journal-article` | Journal Article | 121,030,194 |
+| `book-chapter` | Chapter | 24,359,059 |
+| `proceedings-article` | Conference Paper | 9,744,754 |
+| `dataset` | Dataset | 3,424,142 |
+| `posted-content` | Posted Content (preprints) | 3,203,320 |
+| `dissertation` | Dissertation | 1,044,461 |
+| `peer-review` | Peer Review | 1,028,287 |
+| `report` | Report | 906,301 |
+| `book` | Book | 870,949 |
+| `monograph` | Monograph | 788,401 |
+
+### Query parameters reference
+
+| Parameter | Notes |
+|---|---|
+| `query` | Full-text keyword search across title, abstract, author |
+| `query.author` | Author name search only |
+| `query.title` | Title search only |
+| `query.bibliographic` | Combined title + author + journal search |
+| `rows` | Results per page (default 20, max 1000) |
+| `offset` | Offset for pagination (max ~10,000 effective) |
+| `cursor` | Use `cursor=*` for first page, then URL-encode `next-cursor` value |
+| `sort` | `relevance`, `is-referenced-by-count`, `published`, `indexed` |
+| `order` | `asc` or `desc` |
+| `filter` | Comma-separated `key:value` pairs (see filters below) |
+| `select` | Comma-separated field names to return |
+| `facet` | `type-name:*` for type counts; `publisher-name:10` for top publishers |
+| `mailto` | Your email — enables polite pool (higher limits) |
+
+### Filter keys reference
+
+| Filter key | Example | Notes |
+|---|---|---|
+| `doi` | `doi:10.1038/nature12345` | Exact DOI match |
+| `type` | `type:journal-article` | See type table above for valid values |
+| `from-pub-date` | `from-pub-date:2024-01-01` | ISO date or `YYYY` |
+| `until-pub-date` | `until-pub-date:2024-12-31` | |
+| `from-index-date` | `from-index-date:2024-01-01` | When CrossRef indexed it |
+| `has-abstract` | `has-abstract:true` | Only works with deposited abstract |
+| `has-orcid` | `has-orcid:true` | At least one author has ORCID |
+| `has-full-text` | `has-full-text:true` | Has full-text link |
+| `has-references` | `has-references:true` | Has deposited reference list |
+| `is-update` | `is-update:true` | Corrections, retractions |
+| `issn` | `issn:0028-0836` | Filter by journal ISSN |
+| `publisher-name` | `publisher-name:elsevier` | Partial match |
+| `funder` | `funder:100000001` | Funder DOI or CrossRef funder ID |
+
+## Rate limits
+
+CrossRef has two pools based on whether `mailto=` is present:
+
+| Pool | Triggered by | Rate limit | Concurrency |
+|---|---|---|---|
+| **polite** | `mailto=` param present | 10 req/s | 3 concurrent |
+| **public** | no `mailto=` | 5 req/s | 1 concurrent |
+
+Headers returned: `x-rate-limit-limit`, `x-rate-limit-interval`, `x-concurrency-limit`, `x-api-pool`.
+
+In practice with polite pool: 10 rapid sequential calls complete in ~2.7s (avg 0.27s/req) with no throttling. 5 parallel calls complete in ~0.3s. Stay at `max_workers=5` to respect the concurrency limit.
+
+No per-day or per-hour cap. If you exceed limits, responses slow or return HTTP 429. No ban. Add `time.sleep(0.1)` between calls for sustained bulk crawls.
+
+## Gotchas
+
+- **`mailto=` doubles your rate limit and concurrency.** Public pool: 5 req/s, concurrency=1. Polite pool: 10 req/s, concurrency=3. Always add `?mailto=your@email.com` to every request — confirmed by reading `x-api-pool` response header.
+
+- **`title`, `container-title`, `ISSN` are always lists, not strings.** Access with `title[0]`, `container-title[0]` etc. Do not rely on there being only one entry — `container-title` can have multiple values.
+
+- **Abstract contains JATS XML markup.** The `abstract` field is not plain text — it contains tags like `<jats:p>`, `<jats:italic>`, `<jats:sup>`. Strip with `re.sub(r'<[^>]+>', ' ', abstract)`. About 30-70% of works have an abstract at all; journal articles 2023 with `has-abstract:true` filter: 3,041,841 / ~5.5M total = ~55%.
+
+- **ORCID is a full URL, not just the ID.** `a['ORCID']` = `"https://orcid.org/0000-0001-6169-6580"`. Strip with `.replace('https://orcid.org/', '')` to get the bare ID. `authenticated-orcid: false` means self-asserted (not verified via OAuth).
+
+- **`published` vs `published-print` vs `published-online`.** Online-first is common in journals — a paper may be online months before its print issue. `published` is CrossRef's best single date and equals `published-online` when both exist. For preprints (`posted-content` type), look for `posted` instead of `published-print` — it may only have `posted` and `published`. Partial dates like `[[2023]]` (year only) are valid — always use `parse_date()` to handle missing month/day.
+
+- **404 raises `HTTPError`, not a JSON error response.** An invalid DOI (e.g. `10.9999/doesnotexist`) raises `urllib.error.HTTPError: HTTP Error 404: Not Found`. Wrap `fetch_work()` in try/except for any untrusted DOI list.
+
+- **`volume` and `issue` are strings, not integers.** CrossRef stores them as strings — `"596"`, not `596`. Don't compare with `==` to an int.
+
+- **Filter type values are hyphenated lowercase, not the facet display names.** `filter=type:journal-article` works. `filter=type:journal article`, `filter=type:Journal Article`, and `filter=type:conference-paper` all return HTTP 400. Conference papers are `proceedings-article`.
+
+- **`select=` does not guarantee field presence.** When you `select=DOI,title,author`, a record that has no author still omits the `author` key — it doesn't return `author: []`. Always use `.get()`.
+
+- **Cursor pagination required for >10,000 results.** Offset pagination (`offset=`) is limited to around 10,000 results. For bulk sweeps, use `cursor=*` for the first page, then URL-encode the returned `next-cursor` value with `urllib.parse.quote()`. The cursor expires if unused for too long.
+
+- **`rows` max is 1000 per call.** Requesting more silently returns 1000. For cursor-based sweeps of large result sets (millions of records), `rows=1000` with cursor is the most efficient approach.
+
+- **HTML entities in titles.** Titles may contain HTML entities like `&amp;` — `"Deep learning &amp; convolutional networks"`. Decode with `html.unescape()` if needed.
+
+- **`funder` search `works-count` field is `None`.** The funder search result object has a `works-count` key that is always `None` in the search response. To get actual work counts for a funder, fetch the funder directly: `GET /funders/{id}`.
+
+- **`subject` is often an empty list.** The `subject` field in works is populated inconsistently — many journal articles have `subject: []` even for well-indexed journals like Nature.
+
+- **Affiliation is usually empty.** `author[i]['affiliation']` is `[]` for the majority of records, even for papers published in 2024. CrossRef has been working on affiliation deposit, but coverage is inconsistent.

--- a/domain-skills/fred/scraping.md
+++ b/domain-skills/fred/scraping.md
@@ -1,0 +1,493 @@
+# FRED — Federal Reserve Economic Data
+
+`https://fred.stlouisfed.org` / `https://api.stlouisfed.org` — the canonical source for US macroeconomic time series (800,000+ series). The REST API at `api.stlouisfed.org` requires a free registered key. The web endpoints at `fred.stlouisfed.org` (CSV, JSON, HTML) are all blocked to headless HTTP — they consistently timeout with no response. For zero-key access use the BLS API (unemployment, CPI, payrolls) or World Bank API (GDP, growth rates, annual data).
+
+## Do this first
+
+**Decision tree: pick one approach.**
+
+```
+Need GDP, CPI, UNRATE, payrolls only? → use BLS + World Bank (no key, free forever)
+Need FEDFUNDS, DGS10, SP500, any FRED series? → get a free FRED API key (5 min)
+Need browser-visible chart data? → use CDP to intercept network requests
+```
+
+**The web CSV/JSON/TXT URLs all timeout — do NOT attempt them:**
+```python
+# ALL OF THESE TIMEOUT — confirmed dead from headless HTTP:
+# https://fred.stlouisfed.org/graph/fredgraph.csv?id=GDP      ← timeout
+# https://fred.stlouisfed.org/graph/fredgraph.json?id=GDP     ← timeout
+# https://fred.stlouisfed.org/data/GDP.txt                    ← timeout
+# https://fred.stlouisfed.org/series/GDP                      ← timeout
+```
+
+## Getting a free FRED API key
+
+1. Go to `https://fred.stlouisfed.org/docs/api/api_key.html`
+2. Click "Request or view your API Keys"
+3. Sign in / register (free St. Louis Fed account)
+4. Key appears immediately — it's a 32-character lowercase alphanumeric string
+
+The key is free, instant, and unlimited for reasonable use (120 req/min cap).
+
+---
+
+## Option A: FRED REST API (requires free key, 800K+ series)
+
+The only way to get FRED data programmatically. Set `FRED_KEY` in your `.env` file.
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]   # 32-char lowercase alphanumeric
+BASE = "https://api.stlouisfed.org/fred"
+```
+
+### Series metadata
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+meta = json.loads(http_get(f"{BASE}/series?series_id=GDP&api_key={FRED_KEY}&file_type=json"))
+s = meta['seriess'][0]
+print(s['title'])               # "Gross Domestic Product"
+print(s['observation_start'])   # "1947-01-01"
+print(s['observation_end'])     # "2025-10-01"
+print(s['frequency'])           # "Quarterly"
+print(s['frequency_short'])     # "Q"
+print(s['units'])               # "Billions of Dollars"
+print(s['units_short'])         # "Bil. of $"
+print(s['seasonal_adjustment']) # "Seasonally Adjusted Annual Rate"
+print(s['popularity'])          # 81  (0-100)
+print(s['last_updated'])        # "2025-12-19 08:00:06-06"
+```
+
+### Observations (the actual data)
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+# Latest 10 values, most recent first
+obs = json.loads(http_get(
+    f"{BASE}/series/observations"
+    f"?series_id=GDP"
+    f"&api_key={FRED_KEY}"
+    f"&file_type=json"
+    f"&limit=10"
+    f"&sort_order=desc"      # "desc" = newest first, "asc" = oldest first (default)
+))
+print(obs['count'])              # 314  (total observations)
+print(obs['observation_start'])  # "1947-01-01"  (what's in the full series)
+
+for o in obs['observations']:
+    date  = o['date']    # "2025-10-01"
+    value = o['value']   # "29726.4"  — always a STRING, may be "." for missing
+    if value != '.':
+        print(f"{date}: ${float(value):,.1f}B")
+# 2025-10-01: $29,726.4B
+# 2025-07-01: $29,339.1B
+# 2025-04-01: $29,119.3B
+```
+
+### Date-range filtering
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+obs = json.loads(http_get(
+    f"{BASE}/series/observations"
+    f"?series_id=UNRATE"
+    f"&api_key={FRED_KEY}"
+    f"&file_type=json"
+    f"&observation_start=2020-01-01"
+    f"&observation_end=2024-12-31"
+    f"&sort_order=desc"
+))
+for o in obs['observations'][:5]:
+    print(f"{o['date']}: {o['value']}%")
+# 2024-12-01: 4.1%
+# 2024-11-01: 4.2%
+# 2024-10-01: 4.1%
+```
+
+### Key series IDs
+
+| FRED ID | Description | Frequency | Unit |
+|---------|-------------|-----------|------|
+| `GDP` | Gross Domestic Product | Quarterly | Billions of $, SAAR |
+| `GDPC1` | Real GDP (chained 2017 $) | Quarterly | Billions of chained 2017 $ |
+| `UNRATE` | Unemployment Rate | Monthly | Percent, SA |
+| `CPIAUCSL` | CPI: All Urban Consumers, SA | Monthly | Index 1982-84=100 |
+| `CPIAUCNS` | CPI: All Urban Consumers, not SA | Monthly | Index 1982-84=100 |
+| `FEDFUNDS` | Federal Funds Effective Rate | Monthly | Percent |
+| `DFF` | Federal Funds Rate (daily) | Daily | Percent |
+| `DGS10` | 10-Year Treasury Constant Maturity | Daily | Percent |
+| `DGS2` | 2-Year Treasury | Daily | Percent |
+| `SP500` | S&P 500 | Daily | Index |
+| `NASDAQCOM` | NASDAQ Composite | Daily | Index |
+| `PAYEMS` | Total Nonfarm Payrolls | Monthly | Thousands of persons, SA |
+| `PCEPI` | PCE Price Index | Monthly | Index 2017=100, SA |
+| `PCEPILFE` | Core PCE Price Index | Monthly | Index 2017=100, SA |
+| `DCOILBRENTEU` | Brent Crude Oil | Daily | $ per Barrel |
+| `DEXUSEU` | USD/EUR Exchange Rate | Daily | USD per EUR |
+| `M2SL` | M2 Money Stock | Monthly | Billions of $, SA |
+| `MORTGAGE30US` | 30-Year Fixed Mortgage Rate | Weekly | Percent |
+
+### Series search
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+results = json.loads(http_get(
+    f"{BASE}/series/search"
+    f"?search_text=unemployment+rate"
+    f"&api_key={FRED_KEY}"
+    f"&file_type=json"
+    f"&limit=5"
+    f"&order_by=popularity"    # "popularity" | "search_rank" | "series_id" | "title" | "units" | "frequency" | "seasonal_adjustment" | "realtime_start" | "realtime_end" | "last_updated" | "observation_start" | "observation_end"
+    f"&sort_order=desc"        # most popular first
+))
+for s in results['seriess']:
+    print(f"{s['id']}: {s['title']} ({s['frequency_short']}, {s['units_short']})")
+# UNRATE: Unemployment Rate (M, %)
+# UNEMPLOY: Unemployment Level (M, Thous. of Persons)
+```
+
+### Multiple series — parallel fetch
+
+```python
+import json, os
+from concurrent.futures import ThreadPoolExecutor
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+def fetch_latest(series_id):
+    obs = json.loads(http_get(
+        f"{BASE}/series/observations?series_id={series_id}"
+        f"&api_key={FRED_KEY}&file_type=json&limit=1&sort_order=desc"
+    ))
+    o = obs['observations'][0]
+    return series_id, o['date'], o['value']
+
+series_ids = ["GDP", "UNRATE", "CPIAUCSL", "FEDFUNDS", "DGS10", "SP500"]
+with ThreadPoolExecutor(max_workers=6) as ex:
+    results = list(ex.map(fetch_latest, series_ids))
+
+for sid, date, val in results:
+    print(f"{sid:15} {date}: {val}")
+# GDP             2025-10-01: 29726.4
+# UNRATE          2026-03-01: 4.3
+# CPIAUCSL        2026-02-01: 321.457
+# FEDFUNDS        2026-03-01: 4.33
+# DGS10           2026-04-17: 4.34
+# SP500           2026-04-17: 5282.70
+# Confirmed: 6 parallel requests complete in ~0.4s
+```
+
+### Parse observations into a list of (date, float) tuples
+
+```python
+import json, os
+FRED_KEY = os.environ["FRED_KEY"]
+BASE = "https://api.stlouisfed.org/fred"
+
+obs = json.loads(http_get(
+    f"{BASE}/series/observations?series_id=DGS10&api_key={FRED_KEY}&file_type=json"
+    f"&observation_start=2024-01-01&sort_order=asc"
+))
+
+data = [
+    (o['date'], float(o['value']))
+    for o in obs['observations']
+    if o['value'] != '.'   # '.' = missing value, skip it
+]
+print(f"{len(data)} observations")
+print(f"First: {data[0]}")   # ('2024-01-02', 3.91)
+print(f"Last:  {data[-1]}")  # ('2026-04-17', 4.34)
+```
+
+### Handle errors
+
+```python
+import urllib.error, json
+
+try:
+    r = http_get(f"https://api.stlouisfed.org/fred/series?series_id=BADID&api_key={FRED_KEY}&file_type=json")
+    print(json.loads(r))
+except urllib.error.HTTPError as e:
+    err = json.loads(e.read().decode())
+    # err['error_code']     → 400
+    # err['error_message']  → "Bad Request.  The series does not exist."
+    print(f"FRED error {err['error_code']}: {err['error_message']}")
+```
+
+---
+
+## Option B: BLS API (no key required, confirmed live)
+
+Bureau of Labor Statistics. Covers unemployment, CPI, payrolls — the most-queried FRED series. **Without a key: 10 requests/day limit.** Free key registration at `https://www.bls.gov/developers/` gives 500 req/day and 10 years of data per call (vs 3 years without key).
+
+```python
+import json
+# Single series GET — no auth needed
+r = http_get("https://api.bls.gov/publicAPI/v2/timeseries/data/LNS14000000?startyear=2024&endyear=2024")
+data = json.loads(r)
+# data['status'] == 'REQUEST_SUCCEEDED'
+series = data['Results']['series'][0]
+for point in series['data'][:3]:
+    print(f"{point['year']}-{point['period']} ({point['periodName']}): {point['value']}")
+# 2024-M12 (December): 4.1
+# 2024-M11 (November): 4.2
+# 2024-M10 (October): 4.1
+```
+
+### Multi-series POST (single call, multiple series)
+
+```python
+import json, urllib.request
+
+payload = json.dumps({
+    "seriesid": ["LNS14000000", "CUSR0000SA0", "CES0000000001"],
+    "startyear": "2023",
+    "endyear": "2024"
+    # "registrationkey": "YOUR_BLS_KEY"  # optional: lifts to 500/day, 10yr range
+}).encode()
+
+req = urllib.request.Request(
+    "https://api.bls.gov/publicAPI/v2/timeseries/data/",
+    data=payload,
+    headers={"Content-Type": "application/json"}
+)
+with urllib.request.urlopen(req, timeout=20) as resp:
+    data = json.loads(resp.read().decode())
+
+for s in data['Results']['series']:
+    pts = s['data']
+    print(f"{s['seriesID']}: {len(pts)} points, latest={pts[0]['value']}")
+# LNS14000000: 24 points, latest=4.1   (unemployment %)
+# CUSR0000SA0: 24 points, latest=317.604  (CPI index)
+# CES0000000001: 24 points, latest=158316  (nonfarm payrolls, thousands)
+```
+
+### Key BLS series (FRED equivalents)
+
+| BLS Series ID | FRED Equivalent | Description |
+|---------------|-----------------|-------------|
+| `LNS14000000` | `UNRATE` | Unemployment rate, SA (%) |
+| `CUSR0000SA0` | `CPIAUCSL` | CPI-U All Urban, SA |
+| `CUUR0000SA0` | `CPIAUCNS` | CPI-U All Urban, not SA |
+| `CUSR0000SA0L1E` | `CPILFESL` | CPI less food and energy, SA |
+| `CES0000000001` | `PAYEMS` | Total nonfarm payrolls (thousands) |
+| `LNS11000000` | `CLF16OV` | Civilian labor force (thousands) |
+| `LNS12000000` | `CE16OV` | Civilian employment (thousands) |
+
+### BLS rate limits
+
+| | Without key | With free key |
+|--|--|--|
+| Requests/day | **10** (confirmed: call 11 returns `REQUEST_NOT_PROCESSED`) | 500 |
+| Series per request | 25 | 50 |
+| Years per request | 3 | 10 |
+| Daily or seasonal adjustment | No | Yes |
+
+---
+
+## Option C: World Bank API (no key, unlimited, annual data)
+
+Free, no registration, no rate limit observed (10 rapid calls completed in 2.0s). Annual data only — no monthly or quarterly frequency.
+
+```python
+import json
+
+# Single country, single indicator
+r = http_get("https://api.worldbank.org/v2/country/US/indicator/NY.GDP.MKTP.CD?format=json&per_page=5&mrv=5")
+data = json.loads(r)
+page_info = data[0]   # {'page': 1, 'pages': 1, 'per_page': 5, 'total': 5, 'lastupdated': '2026-04-08'}
+items     = data[1]   # list of observations
+
+for item in items:
+    if item['value']:
+        print(f"{item['date']}: ${item['value']/1e12:.2f}T")
+# 2024: $28.75T
+# 2023: $27.29T
+# 2022: $25.60T
+```
+
+### Date range filter and multi-country
+
+```python
+import json
+
+# Historical range: date=YYYY:YYYY
+r = http_get("https://api.worldbank.org/v2/country/US/indicator/FP.CPI.TOTL.ZG?format=json&date=2015:2024&per_page=15")
+data = json.loads(r)
+items = [i for i in data[1] if i['value'] is not None]
+for item in items:
+    print(f"{item['date']}: {item['value']:.2f}%")
+# 2024: 2.95%
+# 2023: 4.12%
+# 2022: 8.00%
+# ...
+
+# Multi-country: semicolon-separated ISO codes
+r = http_get("https://api.worldbank.org/v2/country/US;CN;DE;JP;GB/indicator/NY.GDP.MKTP.CD?format=json&date=2023&per_page=10")
+data = json.loads(r)
+items = sorted([i for i in data[1] if i['value']], key=lambda x: x['value'], reverse=True)
+for item in items:
+    print(f"{item['country']['value']}: ${item['value']/1e12:.2f}T")
+# United States: $27.29T
+# China: $18.27T
+# Germany: $4.56T
+```
+
+### Key World Bank indicators (FRED equivalents)
+
+| WB Indicator Code | FRED Equivalent | Description |
+|-------------------|-----------------|-------------|
+| `NY.GDP.MKTP.CD` | `GDP` | GDP, current USD |
+| `NY.GDP.MKTP.KD.ZG` | `A191RL1Q225SBEA` | GDP growth rate (%) |
+| `NY.GDP.PCAP.CD` | `A939RX0Q048SBEA` | GDP per capita (USD) |
+| `FP.CPI.TOTL.ZG` | `FPCPITOTLZGUSA` | CPI inflation, annual % |
+| `FP.CPI.TOTL` | `CPIAUCSL` (annual) | CPI level, 2010=100 |
+| `SL.UEM.TOTL.ZS` | `UNRATE` (annual) | Unemployment rate, ILO model |
+| `CM.MKT.LCAP.GD.ZS` | — | Stock market cap / GDP ratio |
+
+---
+
+## Option D: Alpha Vantage (free registered key, select indicators)
+
+Some economic indicators work with the `demo` key (no registration); most require a free registered key (25 requests/day, instant signup at `https://www.alphavantage.co/support/#api-key`).
+
+```python
+import json
+AV_KEY = "demo"  # or your registered key
+
+# Unemployment rate (works with demo key — confirmed)
+r = http_get(f"https://www.alphavantage.co/query?function=UNEMPLOYMENT&apikey={AV_KEY}")
+data = json.loads(r)
+# data['name']  = 'Unemployment Rate'
+# data['interval'] = 'monthly'
+# data['unit']     = 'percent'
+# data['data']     → list of {date, value}, newest first
+
+print(data['data'][0])   # {'date': '2026-03-01', 'value': '4.3'}
+print(f"Total: {len(data['data'])} months since {data['data'][-1]['date']}")
+# Total: 939 months since 1948-01-01
+```
+
+### Which indicators work with demo vs registered key
+
+| Function | demo key | Registered key |
+|----------|----------|----------------|
+| `UNEMPLOYMENT` | YES | YES |
+| `INFLATION` | YES (annual) | YES |
+| `RETAIL_SALES` | YES | YES |
+| `DURABLES` | YES | YES |
+| `NONFARM_PAYROLL` | YES | YES |
+| `REAL_GDP_PER_CAPITA` | YES | YES |
+| `REAL_GDP` | NO (rate-limited) | YES |
+| `CPI` | NO (rate-limited) | YES |
+| `FEDERAL_FUNDS_RATE` | NO (rate-limited) | YES |
+| `TREASURY_YIELD` | NO (rate-limited) | YES |
+| `CONSUMER_SENTIMENT` | NO (rate-limited) | YES |
+
+```python
+import json
+AV_KEY = "YOUR_FREE_KEY"  # from alphavantage.co/support/#api-key
+
+# Federal Funds Rate — monthly (requires registered key)
+r = http_get(f"https://www.alphavantage.co/query?function=FEDERAL_FUNDS_RATE&interval=monthly&apikey={AV_KEY}")
+data = json.loads(r)
+for item in data['data'][:3]:
+    print(f"{item['date']}: {item['value']}%")
+# 2026-03-01: 4.33%
+# 2026-02-01: 4.33%
+# 2026-01-01: 4.33%
+
+# 10-Year Treasury Yield
+r = http_get(f"https://www.alphavantage.co/query?function=TREASURY_YIELD&maturity=10year&interval=monthly&apikey={AV_KEY}")
+data = json.loads(r)
+print(data['data'][0])   # {'date': '2026-04-17', 'value': '4.34'}
+```
+
+---
+
+## Option E: Browser + CDP (for interactive FRED charts)
+
+When you need data from `fred.stlouisfed.org` that has no API equivalent (custom chart combos, release dates visible on page) — or when you have no API key — use the browser.
+
+```python
+# Navigate to a series page
+goto("https://fred.stlouisfed.org/series/GDP")
+wait_for_load()
+
+# Option 1: Intercept the fredgraph XHR that the chart fires
+# The page's chart JS calls fredgraph.csv internally — intercept it
+events = drain_events()
+# Look for network events with fredgraph.csv in URL
+
+# Option 2: Extract the latest value from the page text
+latest_val = js("""
+    // The last observation appears in the meta section
+    const el = document.querySelector('.series-meta-observation-end');
+    el ? el.textContent.trim() : null
+""")
+
+# Option 3: Read the data table if present
+table_data = js("""
+    const rows = Array.from(document.querySelectorAll('table.series-observations tr'));
+    rows.map(r => {
+        const cells = r.querySelectorAll('td');
+        return cells.length >= 2 ? [cells[0].textContent.trim(), cells[1].textContent.trim()] : null;
+    }).filter(Boolean);
+""")
+```
+
+---
+
+## Rate limits
+
+| API | Limit | Notes |
+|-----|-------|-------|
+| FRED REST API | 120 req/min | With registered key (free) |
+| FRED REST API | blocked | Without key — HTTP 400 |
+| BLS (no key) | 10 req/day | Confirmed: call 11 → `REQUEST_NOT_PROCESSED` |
+| BLS (with key) | 500 req/day, 50 series/req | Free registration at bls.gov/developers |
+| World Bank | No limit observed | 10 rapid calls: 2.0s, no 429 |
+| Alpha Vantage (demo) | 2 req/sec | Demo key rate-limited for most functions |
+| Alpha Vantage (free key) | 25 req/day | Free at alphavantage.co/support/#api-key |
+
+---
+
+## Gotchas
+
+- **fred.stlouisfed.org web endpoints ALL timeout** — The CSV download (`fredgraph.csv`), JSON graph (`fredgraph.json`), text format (`/data/*.txt`), and HTML series pages all hang indefinitely from headless HTTP. This is not a UA or header issue — the server simply does not respond to non-browser connections. Confirmed with multiple UA strings, TCP connect succeeds but no HTTP response is sent.
+
+- **FRED API key is mandatory and must be exactly 32 lowercase alphanumeric chars** — "test", "demo", "guest", and keys shorter/longer than 32 chars all return HTTP 400: `"not a 32 character alpha-numeric lower-case string"`. An unregistered 32-char key returns: `"not registered"`.
+
+- **Observation values are always strings, not numbers** — The `value` field in FRED observations is always a JSON string: `"4.1"`, not `4.1`. Also `"."` (dot) means missing/not-yet-released. Always check `if o['value'] != '.'` before `float(o['value'])`.
+
+- **BLS 10 req/day without key burns fast** — The limit is per-IP per-day. 10 calls is exhausted in one moderate script run. Either register a free BLS key immediately or use World Bank for the same data annually.
+
+- **BLS data range: 3 years without key, 10 years with key** — Requesting `startyear=2000&endyear=2024` without a key silently truncates to the most recent 3 years. With a key it returns up to 10 years and includes a `message` field if the range was truncated: `['Year range has been reduced to the system-allowed limit of 10 years.']`.
+
+- **World Bank is annual only** — No monthly or quarterly data. For monthly UNRATE or CPI, use BLS. For quarterly GDP, use FRED API or Alpha Vantage `REAL_GDP`.
+
+- **World Bank response is a 2-element array** — `data[0]` is pagination metadata, `data[1]` is the observations list. Missing years have `value: null` (not `"."`). Filter with `if item['value'] is not None`.
+
+- **Alpha Vantage demo key: 2 req/sec, covers only 6 economic functions** — The other 6 economic functions (`REAL_GDP`, `CPI`, `TREASURY_YIELD`, etc.) return `{"Information": "The demo API key is for demo purposes only..."}`. No error code — just check for the `Information` key in the response.
+
+- **FRED `sort_order=desc` returns newest first** — Default is `asc` (oldest first, starting from observation_start). For "get the latest value" use `limit=1&sort_order=desc`.
+
+- **FRED series IDs are case-sensitive and exact** — `gdp` returns an error; must be `GDP`. Check `fred.stlouisfed.org/series/{ID}` to verify a series exists before scripting.
+
+- **Some FRED series have gaps** — Daily series like `DGS10` and `SP500` skip weekends and holidays. Those dates simply don't appear in the observations array (not represented as `"."`). Weekly and monthly series use the first day of the period as the date (e.g., `2024-01-01` = January 2024).
+
+- **FRED `realtime_start`/`realtime_end` in observations** — Every observation has these fields reflecting vintage data. For current data, ignore them. They matter only for "real-time" research (what was the published value on a specific past date).

--- a/domain-skills/mastodon/scraping.md
+++ b/domain-skills/mastodon/scraping.md
@@ -1,0 +1,355 @@
+# Mastodon — Scraping & Data Extraction
+
+`https://mastodon.social` / `https://fosstodon.org` — decentralized social network (ActivityPub).
+Most read endpoints work without auth. No browser needed for any data task covered here.
+
+## Do this first
+
+**Use the REST API — it returns clean JSON, no browser, no auth for most endpoints.**
+
+```python
+import json
+from helpers import http_get
+
+# Public trending posts (no auth, works on mastodon.social)
+toots = json.loads(http_get("https://mastodon.social/api/v1/trends/statuses?limit=5"))
+
+# Account lookup by username
+acct = json.loads(http_get("https://mastodon.social/api/v1/accounts/lookup?acct=Mastodon"))
+print(acct['id'], acct['followers_count'])   # 13179  869022
+
+# Hashtag timeline
+posts = json.loads(http_get("https://mastodon.social/api/v1/timelines/tag/python?limit=10"))
+```
+
+**Important instance note:** `mastodon.social` has disabled its public live-feed timeline
+(`/timelines/public`) — it returns HTTP 422 with `"This method requires an authenticated user"`.
+Use `fosstodon.org` for unauthenticated public/local timelines, or use the hashtag timeline on
+either instance (hashtag feeds are always public).
+
+## What works without auth
+
+| Endpoint | mastodon.social | fosstodon.org |
+|---|---|---|
+| `GET /api/v1/timelines/public` | **NO** (422) | YES |
+| `GET /api/v1/timelines/public?local=true` | **NO** (422) | YES |
+| `GET /api/v1/timelines/tag/{hashtag}` | YES | YES |
+| `GET /api/v1/trends/statuses` | YES | YES |
+| `GET /api/v1/trends/tags` | YES | YES |
+| `GET /api/v1/trends/links` | YES | YES |
+| `GET /api/v1/accounts/lookup` | YES | YES |
+| `GET /api/v1/accounts/{id}/statuses` | YES | YES |
+| `GET /api/v1/statuses/{id}` | YES | YES |
+| `GET /api/v1/statuses/{id}/context` | YES | YES |
+| `GET /api/v2/search` (accounts + hashtags) | YES | YES |
+| `GET /api/v2/search` (statuses) | **NO** (empty) | NO |
+| `GET /api/v1/instance` | YES | YES |
+| `GET /api/v2/instance` | YES | YES |
+| `GET /api/v1/instance/peers` | YES | YES |
+| `GET /api/v1/directory` | YES | YES |
+
+## Common workflows
+
+### Trending posts
+
+```python
+import json, re
+from helpers import http_get
+
+def strip_html(html):
+    text = re.sub(r'<[^>]+>', '', html)
+    for ent, ch in [('&amp;','&'),('&lt;','<'),('&gt;','>'),('&quot;','"'),('&#39;',"'"),('&nbsp;',' ')]:
+        text = text.replace(ent, ch)
+    return text.strip()
+
+toots = json.loads(http_get("https://mastodon.social/api/v1/trends/statuses?limit=5"))
+for t in toots:
+    print(t['id'], t['created_at'])
+    print(t['account']['acct'], t['account']['followers_count'])
+    print("favs:", t['favourites_count'], "reblogs:", t['reblogs_count'])
+    print(strip_html(t['content'])[:200])
+    print()
+```
+
+### Trending hashtags
+
+```python
+import json
+from helpers import http_get
+
+tags = json.loads(http_get("https://mastodon.social/api/v1/trends/tags?limit=10"))
+for tag in tags:
+    day0 = tag['history'][0]   # most recent day
+    print(f"#{tag['name']}: {day0['uses']} uses by {day0['accounts']} accounts today")
+# history is a list of dicts: {day (unix timestamp str), uses (str), accounts (str)}
+# day[0] = most recent, day[1] = yesterday, etc. Values are strings — cast with int()
+```
+
+### Hashtag timeline (confirmed on both instances)
+
+```python
+import json
+from helpers import http_get
+
+posts = json.loads(http_get("https://mastodon.social/api/v1/timelines/tag/python?limit=10"))
+for p in posts:
+    # Skip reblogs if you want only originals
+    if p['reblog']:
+        continue
+    print(p['id'], p['account']['acct'])
+    print(strip_html(p['content'])[:200])
+```
+
+### Public / local timeline (use fosstodon.org)
+
+```python
+import json
+from helpers import http_get
+
+# Federated (all instances)
+federated = json.loads(http_get("https://fosstodon.org/api/v1/timelines/public?limit=20"))
+
+# Local only (fosstodon.org users)
+local = json.loads(http_get("https://fosstodon.org/api/v1/timelines/public?local=true&limit=20"))
+```
+
+### Account lookup and their posts
+
+```python
+import json
+from helpers import http_get
+
+# Lookup by username (cross-instance: use full acct@domain)
+acct = json.loads(http_get("https://mastodon.social/api/v1/accounts/lookup?acct=Mastodon"))
+# acct@domain format for remote users: ?acct=fosstodon@fosstodon.org
+uid = acct['id']  # '13179'
+
+# Fetch their posts
+posts = json.loads(http_get(
+    f"https://mastodon.social/api/v1/accounts/{uid}/statuses?limit=10&exclude_reblogs=true"
+))
+# Optional params: exclude_reblogs=true, exclude_replies=true, only_media=true, pinned=true
+```
+
+Account fields:
+- `id`, `acct` (username or username@domain), `display_name`, `username`
+- `followers_count`, `following_count`, `statuses_count`
+- `note` (bio — HTML, strip it), `fields` (profile metadata — also HTML)
+- `created_at`, `last_status_at`, `bot`, `group`, `locked`
+- `avatar`, `header` (image URLs)
+
+### Single status + thread context
+
+```python
+import json
+from helpers import http_get
+
+status = json.loads(http_get("https://mastodon.social/api/v1/statuses/116402716327956884"))
+print(status['reblogs_count'], status['favourites_count'], status['replies_count'])
+
+# Get full thread (ancestors + descendants)
+ctx = json.loads(http_get("https://mastodon.social/api/v1/statuses/116402716327956884/context"))
+print(len(ctx['ancestors']), "parents,", len(ctx['descendants']), "replies")
+```
+
+### Search (accounts and hashtags — no auth required; statuses require auth)
+
+```python
+import json
+from helpers import http_get
+
+results = json.loads(http_get(
+    "https://mastodon.social/api/v2/search?q=python&type=accounts&limit=5"
+))
+for a in results['accounts']:
+    print(a['acct'], a['followers_count'])
+
+# Hashtag search
+results = json.loads(http_get(
+    "https://mastodon.social/api/v2/search?q=python&type=hashtags&limit=5"
+))
+for h in results['hashtags']:
+    print(h['name'], h['url'])
+
+# type=statuses returns empty list without auth — don't bother without a token
+```
+
+### Instance metadata
+
+```python
+import json
+from helpers import http_get
+
+# v1 — stats, rules, version
+info = json.loads(http_get("https://mastodon.social/api/v1/instance"))
+print(info['stats'])      # {'user_count': 3237063, 'status_count': 171295328, 'domain_count': 114640}
+print(info['version'])    # '4.6.0-nightly.2026-04-17'
+print(info['rules'])      # list of {id, text}
+
+# v2 — monthly active users, character limit, config
+info2 = json.loads(http_get("https://mastodon.social/api/v2/instance"))
+print(info2['usage']['users']['active_month'])   # 286734
+print(info2['configuration']['statuses']['max_characters'])  # 500
+
+# Federated instance list (warning: huge — 114,230 entries on mastodon.social)
+peers = json.loads(http_get("https://mastodon.social/api/v1/instance/peers"))
+print(len(peers))  # 114230
+
+# Public account directory
+directory = json.loads(http_get("https://mastodon.social/api/v1/directory?limit=10&order=active"))
+# order=active (recently posted) or order=new (recently joined)
+```
+
+### Pagination (Link header, not offset)
+
+Mastodon uses cursor-based pagination via the `Link` response header — there is no `page=` or
+`offset=` parameter. The response contains `rel="next"` (older) and `rel="prev"` (newer) URLs.
+
+```python
+import json, re, gzip, urllib.request
+from helpers import http_get
+
+def http_get_with_link(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        link = r.headers.get("Link", "")
+        return json.loads(data.decode()), link
+
+def parse_link(link_header):
+    next_m = re.search(r'<([^>]+)>; rel="next"', link_header)
+    prev_m = re.search(r'<([^>]+)>; rel="prev"', link_header)
+    return next_m.group(1) if next_m else None, prev_m.group(1) if prev_m else None
+
+# Crawl older posts page by page
+url = "https://fosstodon.org/api/v1/timelines/public?local=true&limit=20"
+all_posts = []
+for _ in range(3):   # 3 pages = 60 posts
+    data, link = http_get_with_link(url)
+    all_posts.extend(data)
+    next_url, _ = parse_link(link)
+    if not next_url:
+        break
+    url = next_url
+print(f"Collected {len(all_posts)} posts")
+
+# Or manually: append max_id=<oldest_id_seen> to get posts older than that
+oldest_id = data[-1]['id']
+older = json.loads(http_get(
+    f"https://fosstodon.org/api/v1/timelines/public?local=true&limit=20&max_id={oldest_id}"
+))
+# For newer posts (since last check), use min_id=<newest_id_seen>
+```
+
+### Parallel account fetching
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+def fetch_account(acct_name):
+    try:
+        data = json.loads(http_get(f"https://mastodon.social/api/v1/accounts/lookup?acct={acct_name}"))
+        return {"acct": data['acct'], "followers": data['followers_count'], "id": data['id']}
+    except Exception as e:
+        return {"acct": acct_name, "error": str(e)}
+
+accounts = ["Mastodon", "fosstodon@fosstodon.org", "kuketzblog@social.tchncs.de"]
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_account, accounts))
+# Verified: 3 concurrent calls complete without rate limiting
+```
+
+## Status (toot) fields
+
+Every status object returned by all list and single-fetch endpoints:
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Snowflake ID (numeric string); sortable as integer — larger = newer |
+| `created_at` | string | ISO 8601 UTC, e.g. `"2026-04-19T00:26:54.248Z"` |
+| `content` | string | **HTML** — always strip tags before displaying (see `strip_html` above) |
+| `reblog` | object or null | If non-null, this is a boost; the original toot is in `reblog` |
+| `reblogs_count` | int | Number of boosts |
+| `favourites_count` | int | Number of favourites (likes) |
+| `replies_count` | int | Number of replies |
+| `sensitive` | bool | True = media is hidden behind a click-through |
+| `spoiler_text` | string | Content warning text (empty string `""` when none) |
+| `visibility` | string | `"public"`, `"unlisted"`, `"private"`, `"direct"` |
+| `language` | string | BCP 47 code, e.g. `"en"`, or null |
+| `url` | string | Canonical URL of the toot, e.g. `"https://mastodon.social/@Mastodon/116402..."` |
+| `uri` | string | ActivityPub URI |
+| `account` | object | Author — see account fields above |
+| `media_attachments` | list | Images/video — each has `type`, `url`, `preview_url`, `description` |
+| `tags` | list | `[{name, url}]` — hashtags in the toot |
+| `mentions` | list | `[{id, username, acct, url}]` — @-mentioned users |
+| `card` | object or null | Link preview card with `url`, `title`, `description`, `image` |
+| `poll` | object or null | Poll with `options`, `votes_count`, `expires_at` |
+| `in_reply_to_id` | string or null | ID of parent toot if this is a reply |
+| `edited_at` | string or null | ISO 8601 if toot was edited |
+
+## Rate limits
+
+- **300 requests per 5 minutes** per IP without authentication
+- Header: `X-RateLimit-Limit: 300`, `X-RateLimit-Remaining: N`, `X-RateLimit-Reset: <ISO timestamp>`
+- Reset is a rolling 5-minute window aligned to clock minutes (confirmed from response headers)
+- With auth (user token): higher limits, but documented per-endpoint in Mastodon docs
+- The `/api/v1/instance/peers` response is ~1.6 MB — counts as 1 request but is slow
+
+## Gotchas
+
+- **mastodon.social disabled public timeline** — `/api/v1/timelines/public` returns HTTP 422
+  `"This method requires an authenticated user"`. This is an instance policy, not an API design.
+  Check `GET /api/v2/instance` → `configuration.timelines_access.live_feeds` to see a server's
+  policy before calling. Use `fosstodon.org` or any instance that hasn't restricted it. Hashtag
+  and trending endpoints are always public.
+
+- **Content is HTML, not plain text** — `content` always comes back as `<p>text with <a href>links</a></p>`.
+  Strip with `re.sub(r'<[^>]+>', '', html)`, then decode HTML entities. Whitespace collapses
+  across paragraph boundaries — add a space or newline between `</p><p>` segments if needed.
+
+- **Reblog vs original** — When `status['reblog']` is not null, the top-level `content` is `''`
+  (empty string). The actual content, author, and counts are in `status['reblog']`. Always check:
+  ```python
+  actual = s['reblog'] if s['reblog'] else s
+  text = strip_html(actual['content'])
+  author = actual['account']['acct']
+  ```
+
+- **Snowflake IDs are strings** — `id` is a numeric string like `"116428532236221371"`. Compare
+  and sort as integers: `int(s['id'])`. Larger integer = more recent.
+
+- **Pagination is cursor-based, not offset** — There is no `page=N` or `offset=N` param.
+  Use `max_id=<id>` to get posts older than that ID, `min_id=<id>` for posts newer. The `Link`
+  header in each response gives you pre-built next/prev URLs. Do not parse and reconstruct manually
+  — just follow the `rel="next"` URL verbatim.
+
+- **IDs are not globally unique across instances** — A status ID from fosstodon.org is not
+  valid on mastodon.social. Always query the instance that hosts the content.
+
+- **`spoiler_text` is `""` not null when absent** — Check `s['spoiler_text'] != ''`, not
+  `s['spoiler_text'] is not None`. Same for `edited_at` — it is `null` when unedited, but
+  `spoiler_text` is always a string.
+
+- **`sensitive=True` doesn't always mean NSFW** — Any media can be marked sensitive by the
+  author (e.g. for flashing images, food photos on #MH-related accounts). The `spoiler_text`
+  field is the actual content warning text; `sensitive=True` just hides media behind a click.
+
+- **Account `note` and `fields` are also HTML** — The bio (`note`) and profile metadata (`fields`
+  values) are HTML, not plain text. Strip them the same way as toot content.
+
+- **Search statuses require auth** — `GET /api/v2/search?type=statuses` returns 0 results without
+  a user token. Account and hashtag search work fine unauthenticated.
+
+- **Cross-instance account lookup** — Use full `acct@domain` format to look up remote users:
+  `?acct=fosstodon@fosstodon.org`. Single username resolves to local users only.
+
+- **`/api/v1/instance/peers` is huge** — Returns all 114k+ federated instance hostnames as a
+  flat JSON array (~1.6 MB). Only fetch when you specifically need federation data.
+
+- **Trending history values are strings** — `tag['history'][0]['uses']` and `['accounts']` are
+  strings (`"9"`, `"540"`), not integers. Cast with `int()` before sorting or comparing.
+  `history[0]` is the most recent day; `history[0]['day']` is a Unix timestamp string.

--- a/domain-skills/musicbrainz/scraping.md
+++ b/domain-skills/musicbrainz/scraping.md
@@ -1,0 +1,478 @@
+# MusicBrainz — Data Extraction
+
+`https://musicbrainz.org` — open music encyclopedia with a fully free JSON API.
+No auth required for reads. No browser needed for any documented workflow.
+
+Field-tested against musicbrainz.org on 2026-04-18.
+
+---
+
+## Do this first
+
+**The MusicBrainz Web Service API (ws/2) returns clean JSON for all entity types — no browser needed.**
+
+```python
+from helpers import http_get
+import json
+
+# REQUIRED: every request must include this header or you get HTTP 403
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+data = json.loads(http_get("https://musicbrainz.org/ws/2/artist/?query=queen&fmt=json&limit=5", headers=UA))
+for a in data['artists']:
+    print(a['id'], a['name'], a.get('type'), a.get('country'), a['score'])
+# 0383dadf-2a4e-4d10-a46a-e9e041da8eb3  Queen  Group  GB  100
+# 79239441-bfd5-4981-a70c-55c3f15c1287  Madonna  Person  US  73
+```
+
+`User-Agent` is **mandatory** — omitting it returns HTTP 403 immediately. Format: `AppName/Version (contact@email.com)`.
+
+---
+
+## Entity types
+
+| Entity | Endpoint | Key fields |
+|---|---|---|
+| `artist` | `/ws/2/artist/` | name, sort-name, type (Group/Person/Orchestra/Choir), country, life-span, tags, rating |
+| `release-group` | `/ws/2/release-group/` | title, primary-type (Album/Single/EP/Other), first-release-date |
+| `release` | `/ws/2/release/` | title, date, country, status (Official/Bootleg/Promotional), barcode, label-info, media |
+| `recording` | `/ws/2/recording/` | title, length (milliseconds), artist-credit, releases |
+| `label` | `/ws/2/label/` | name, type, country, area |
+| `work` | `/ws/2/work/` | title, type (Song/Aria/Soundtrack/etc.), relations |
+
+All entities share the same MBID (MusicBrainz ID) format: UUID v4, e.g. `0383dadf-2a4e-4d10-a46a-e9e041da8eb3`.
+
+---
+
+## Common workflows
+
+### Artist search
+
+```python
+from helpers import http_get
+import json
+
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/artist/?query=queen&fmt=json&limit=5",
+    headers=UA
+))
+# resp keys: count (total matches), offset, artists (list)
+for a in resp['artists']:
+    print(a['id'])           # MBID: 0383dadf-2a4e-4d10-a46a-e9e041da8eb3
+    print(a['name'])         # Queen
+    print(a['sort-name'])    # Queen  (differs for persons: "Bowie, David")
+    print(a.get('type'))     # Group / Person / Orchestra / Choir
+    print(a.get('country'))  # GB
+    print(a.get('life-span'))# {'begin': '1970-06-27', 'end': None, 'ended': True}
+    print(a.get('disambiguation', ''))  # e.g. "English singer-songwriter"
+    print(a['score'])        # relevance 0-100
+```
+
+### Artist by MBID (with related data via `inc=`)
+
+```python
+# inc= parameters stack with + between them
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/artist/0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+    "?inc=releases+tags+ratings+release-groups&fmt=json",
+    headers=UA
+))
+print(resp['name'])      # Queen
+print(resp['type'])      # Group
+print(resp['country'])   # GB
+print(resp['life-span']) # {'begin': '1970-06-27', 'end': None, 'ended': True}
+
+# Tags (community-voted genre labels, sorted by count)
+tags = sorted(resp.get('tags', []), key=lambda x: x['count'], reverse=True)
+print([t['name'] for t in tags[:5]])
+# ['rock', 'glam rock', 'hard rock', 'art rock', 'british']
+
+# Rating (community score, 0-5)
+print(resp.get('rating'))  # {'votes-count': 43, 'value': 4.7}
+
+# Direct releases (up to 25 per request — use browse for full list)
+for r in resp.get('releases', []):
+    print(r['id'], r['title'], r.get('date'))
+
+# Release groups (albums, singles, EPs — deduplicated by edition)
+for rg in resp.get('release-groups', []):
+    print(rg['id'], rg['title'], rg.get('primary-type'), rg.get('first-release-date'))
+# 6b47c9a0  A Night at the Opera  Album  1975-11-21
+# 002ed683  Sheer Heart Attack    Album  1974-11-01
+```
+
+### Browse releases by artist (full list)
+
+```python
+# Browse API: uses 'artist' param (not 'query') — response key is 'release-count' not 'count'
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/"
+    "?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3&fmt=json&limit=25&offset=0",
+    headers=UA
+))
+print(resp['release-count'])   # 1635 — total releases for this artist
+for r in resp['releases']:
+    print(r['id'], r['title'], r.get('date'), r.get('country'), r.get('status'))
+    # Also has: cover-art-archive.artwork (bool), cover-art-archive.front (bool)
+    caa = r.get('cover-art-archive', {})
+    print(caa.get('artwork'), caa.get('front'), caa.get('count'))
+
+# Paginate: increment offset by limit
+```
+
+### Release search and lookup
+
+```python
+# Search by title
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/?query=dark+side+of+the+moon&fmt=json&limit=5",
+    headers=UA
+))
+# resp keys: count, offset, releases
+
+# Full release with track list, artists, and labels
+release = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/b84ee12a-09ef-421b-82de-0441a926375b"
+    "?inc=artists+recordings+labels+release-groups&fmt=json",
+    headers=UA
+))
+print(release['title'])   # The Dark Side of the Moon
+print(release['date'])    # 1973-03-24
+print(release['status'])  # Official
+print(release['country']) # GB
+
+# Release group (the "album concept", deduplicates editions)
+rg = release.get('release-group', {})
+print(rg['title'], rg.get('primary-type'), rg['id'])
+# The Dark Side of the Moon  Album  f5093c06-23e3-404f-aeaa-40f72885ee3a
+
+# Artist credit
+for ac in release.get('artist-credit', []):
+    if isinstance(ac, dict) and 'artist' in ac:
+        print(ac['artist']['name'], ac['artist']['id'])
+        # Pink Floyd  83d91898-7763-47d7-b03b-b92132375c47
+
+# Labels
+for li in release.get('label-info', []):
+    label = li.get('label', {})
+    print(label.get('name'), li.get('catalog-number'))
+    # Harvest  SHVL 804
+
+# Track list (from media[].tracks[])
+for disc in release.get('media', []):
+    for track in disc.get('tracks', []):
+        dur_s = track['length'] // 1000 if track.get('length') else None
+        rec = track.get('recording', {})
+        print(track['number'], track['title'], dur_s, rec.get('id'))
+        # A1  Speak to Me  68s  bef3fddb-5aca-49f5-b2fd-d56a23268d63
+        # A2  Breathe      168s ecbc7c9b-e79d-4ec8-ac77-44e4a7f7f1b8
+```
+
+### Recording (track) search
+
+```python
+# Use Lucene field syntax to filter by artist
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/recording/"
+    "?query=bohemian+rhapsody+AND+artist:queen&fmt=json&limit=5",
+    headers=UA
+))
+print(resp['count'])  # 419
+for r in resp['recordings']:
+    dur_s = r['length'] // 1000 if r.get('length') else None
+    artists = [ac['artist']['name'] for ac in r.get('artist-credit', []) if isinstance(ac, dict)]
+    releases = r.get('releases', [])
+    print(r['id'], r['title'], dur_s, artists, releases[0]['title'] if releases else None)
+# a4803b45  Bohemian Rhapsody  130s  ['Queen']  Rhapsody in Red
+# 40212eb6  Bohemian Rhapsody  338s  ['Queen']  1986-07: Wembley Stadium
+```
+
+### Release-group search (deduplicated albums)
+
+```python
+# Use release-group endpoint to avoid getting every regional edition
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release-group/"
+    "?query=release-group:\"A+Night+at+the+Opera\"+AND+artist:queen&fmt=json&limit=5",
+    headers=UA
+))
+# resp keys: count, release-groups
+for rg in resp.get('release-groups', []):
+    print(rg['id'], rg['title'], rg.get('primary-type'), rg.get('first-release-date'), rg['score'])
+# 6b47c9a0  A Night at the Opera  Album  1975-11-21  100
+
+# Browse release-groups for an artist
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release-group/"
+    "?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3&fmt=json&limit=25",
+    headers=UA
+))
+print(resp['release-group-count'])  # 412
+for rg in resp.get('release-groups', []):
+    print(rg['title'], rg.get('primary-type'), rg.get('first-release-date'))
+```
+
+### Label and work lookups
+
+```python
+# Label search
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/label/?query=EMI&fmt=json&limit=3",
+    headers=UA
+))
+for l in resp['labels']:
+    print(l['id'], l['name'], l.get('type'), l.get('country'), l['score'])
+# c029628b  EMI  Original Production  GB  100
+
+# Work (song composition — author-level, not performance-level)
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/work/?query=bohemian+rhapsody&fmt=json&limit=3",
+    headers=UA
+))
+for w in resp['works']:
+    print(w['id'], w['title'], w.get('type'), w['score'])
+# 41c94a08  Bohemian Rhapsody  Song  100
+```
+
+### Cover Art Archive
+
+```python
+# Get cover art for a release MBID
+# 404 if no artwork has been uploaded for that release
+def get_cover_art(release_mbid, size="500"):
+    """
+    size: '250', '500', '1200', or 'full' (original file)
+    Returns the front cover URL, or None if no artwork exists.
+    """
+    try:
+        resp = json.loads(http_get(
+            f"https://coverartarchive.org/release/{release_mbid}",
+            headers=UA
+        ))
+    except Exception:
+        return None   # 404 = no art uploaded
+
+    images = resp.get('images', [])
+    # Prefer an image flagged as front=True
+    front = next((img for img in images if img.get('front')), None)
+    img = front or (images[0] if images else None)
+    if not img:
+        return None
+
+    if size == 'full':
+        return img['image']
+    return img['thumbnails'].get(size) or img['thumbnails'].get('large')
+
+# Thumbnail sizes confirmed: '250', '500', '1200', 'small' (=250), 'large' (=500)
+
+url = get_cover_art("b84ee12a-09ef-421b-82de-0441a926375b")
+# http://coverartarchive.org/release/b84ee12a.../1611507818-500.jpg
+
+# Full images response structure
+resp = json.loads(http_get(
+    "https://coverartarchive.org/release/b84ee12a-09ef-421b-82de-0441a926375b",
+    headers=UA
+))
+for img in resp['images']:
+    print(img.get('types'))   # ['Front'], ['Back'], ['Liner'], ['Poster'], ['Medium'], ['Sticker'], ['Other']
+    print(img.get('front'))   # True only for front=True flagged images (not all 'Front' types)
+    print(img.get('approved'))# True/False
+    print(img['image'])       # full resolution URL
+    print(img['thumbnails'])  # {'small': '...-250.jpg', 'large': '...-500.jpg', '250': ..., '500': ..., '1200': ...}
+```
+
+### Lucene query syntax for search
+
+All search endpoints support Lucene field queries:
+
+```python
+# Field search: artist:, type:, country:, tag:, release:, date:
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/artist/"
+    "?query=artist:queen+AND+type:group+AND+country:GB&fmt=json&limit=5",
+    headers=UA
+))
+# count: 23 (exact matches only)
+
+# Phrase search with quotes
+resp = json.loads(http_get(
+    "https://musicbrainz.org/ws/2/release/"
+    '?query=release:"A+Night+at+the+Opera"+AND+artist:queen&fmt=json&limit=5',
+    headers=UA
+))
+```
+
+Common Lucene field names per entity:
+- artist: `artist:`, `type:`, `country:`, `tag:`, `begin:`, `end:`
+- release: `release:`, `artist:`, `date:`, `country:`, `status:`, `label:`, `barcode:`
+- recording: `recording:`, `artist:`, `release:`, `dur:` (milliseconds), `tnum:` (track number)
+- release-group: `release-group:`, `artist:`, `primarytype:`, `secondarytype:`
+
+### Parallel fetching
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+def fetch_artist(mbid):
+    resp = json.loads(http_get(
+        f"https://musicbrainz.org/ws/2/artist/{mbid}?inc=tags&fmt=json",
+        headers=UA
+    ))
+    tags = [t['name'] for t in sorted(resp.get('tags', []), key=lambda x: x['count'], reverse=True)[:3]]
+    return {"name": resp['name'], "type": resp.get('type'), "tags": tags}
+
+mbids = [
+    "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",  # Queen
+    "83d91898-7763-47d7-b03b-b92132375c47",  # Pink Floyd
+    "678d88b2-87b0-403b-b63d-5da7465aecc3",  # Led Zeppelin
+]
+
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(fetch_artist, mbids))
+# 3 artists fetched in ~0.79s total
+```
+
+Tested: 5-6 rapid sequential requests all succeed. Parallel requests at 3x concurrency succeed. Real 429s (rate-limit blocks) are only hit at very high burst rates; if you do get a 429, add `time.sleep(1)` between requests.
+
+### Pagination
+
+```python
+import time
+
+UA = {"User-Agent": "browser-harness/1.0 (your@email.com)"}
+
+def browse_all_releases(artist_mbid, page_size=25):
+    """Fetch all releases for an artist across multiple pages."""
+    offset = 0
+    total = None
+    releases = []
+    while total is None or offset < total:
+        resp = json.loads(http_get(
+            f"https://musicbrainz.org/ws/2/release/"
+            f"?artist={artist_mbid}&fmt=json&limit={page_size}&offset={offset}",
+            headers=UA
+        ))
+        total = resp['release-count']
+        batch = resp['releases']
+        releases.extend(batch)
+        offset += len(batch)
+        if offset < total:
+            time.sleep(1)  # stay within 1 req/s for sequential pagination
+    return releases
+
+# Queen has 1635 releases — use release-groups (412) to get deduplicated albums
+```
+
+---
+
+## `inc=` parameter reference
+
+Stack multiple `inc=` values with `+` between them.
+
+**Artist lookup** (`/ws/2/artist/{mbid}`):
+- `releases` — list of releases (max ~25)
+- `release-groups` — list of release groups (max ~25)
+- `recordings` — list of recordings (max ~25)
+- `works` — list of works
+- `tags` — community genre tags (name + vote count)
+- `ratings` — community rating (value 0-5, votes-count)
+- `aliases` — alternative names and transliterations
+- `annotation` — free-text editorial note
+- `artist-rels`, `release-rels`, `recording-rels`, `work-rels` — relationship data
+
+**Release lookup** (`/ws/2/release/{mbid}`):
+- `artists` — full artist-credit objects
+- `recordings` — track list with recording links (populates `media[].tracks[].recording`)
+- `labels` — label-info with catalog numbers
+- `release-groups` — the release group this belongs to
+- `artist-credits` — expanded artist credit with joinphrase
+- `media` — disc/format info (always included in lookup, not needed in `inc=`)
+
+---
+
+## Response shapes cheat sheet
+
+```
+# MBID format: standard UUID v4
+"0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+
+# Search response (artist/recording/release/release-group/label/work)
+{
+  "count": 1612,          # total matches
+  "offset": 0,
+  "<entity-plural>": [...] # e.g. "artists", "releases", "recordings", "release-groups"
+}
+
+# Browse response (using ?artist=MBID or ?label=MBID style)
+{
+  "release-count": 1635,  # note: key name changes per entity
+  "release-offset": 0,    # e.g. "release-group-count", "recording-count"
+  "releases": [...]
+}
+
+# Recording length is always milliseconds
+recording['length'] // 1000  # => seconds
+
+# Artist life-span
+life_span = artist['life-span']
+# {'begin': '1970-06-27', 'end': None, 'ended': True}
+# 'ended': True with 'end': None means end date unknown but band is inactive
+
+# Artist credit joinphrase (for multi-artist tracks)
+# [{"name": "Simon", "artist": {...}, "joinphrase": " & "}, {"name": "Garfunkel", ...}]
+```
+
+---
+
+## URL patterns
+
+| Resource | URL |
+|---|---|
+| Artist search | `https://musicbrainz.org/ws/2/artist/?query={q}&fmt=json&limit=5` |
+| Artist by MBID | `https://musicbrainz.org/ws/2/artist/{mbid}?inc=tags+ratings&fmt=json` |
+| Browse releases by artist | `https://musicbrainz.org/ws/2/release/?artist={mbid}&fmt=json&limit=25&offset=0` |
+| Release search | `https://musicbrainz.org/ws/2/release/?query={q}&fmt=json&limit=5` |
+| Release by MBID | `https://musicbrainz.org/ws/2/release/{mbid}?inc=artists+recordings+labels&fmt=json` |
+| Release-group browse | `https://musicbrainz.org/ws/2/release-group/?artist={mbid}&fmt=json&limit=25` |
+| Recording search | `https://musicbrainz.org/ws/2/recording/?query={q}&fmt=json&limit=5` |
+| Label search | `https://musicbrainz.org/ws/2/label/?query={q}&fmt=json&limit=5` |
+| Work search | `https://musicbrainz.org/ws/2/work/?query={q}&fmt=json&limit=5` |
+| Cover art | `https://coverartarchive.org/release/{release-mbid}` |
+
+MusicBrainz entity browser URL (human-readable): `https://musicbrainz.org/artist/{mbid}` (replace `artist` with `release`, `recording`, etc.)
+
+---
+
+## Gotchas
+
+- **`User-Agent` is mandatory** — without it you get HTTP 403 instantly. The header must include contact info, e.g. `browser-harness/1.0 (you@example.com)`. The default `http_get` UA (`Mozilla/5.0`) also gets 403.
+
+- **Browse vs search response keys differ** — Search responses use `count` and `offset`; Browse responses (with `?artist=MBID`) use `release-count` / `release-offset` (or `release-group-count` etc.). Accessing `data['count']` on a browse response throws `KeyError`.
+
+- **`releases` include in artist lookup caps at ~25** — Use the browse endpoint (`?artist=MBID`) with pagination for complete lists. Queen has 1,635 releases total; the `inc=releases` on the artist endpoint only returns ~25.
+
+- **Use release-groups to avoid edition explosion** — A popular album can have hundreds of release entries (every country's pressing, every remaster, every format). Use `/ws/2/release-group/` to get one entry per "album concept". Queen's "A Night at the Opera" has 75+ release entries but 1 release-group.
+
+- **Recording length is milliseconds** — `recording['length']` is in milliseconds, not seconds. Divide by 1000.
+
+- **Sort-name differs from display name for persons** — Artists have both `name` (display: "David Bowie") and `sort-name` (alphabetical: "Bowie, David"). Groups usually have identical values.
+
+- **Disambiguation in parentheses** — When multiple entities share a name, MusicBrainz adds a `disambiguation` field to distinguish them (e.g. `"English singer-songwriter"` vs a different David Bowie). Always check `a.get('disambiguation', '')` when resolving artist identity.
+
+- **Score 100 does not mean unique** — Search returns `score: 100` for multiple results when several equally match the query. "dark side of the moon" returns 6 results all scored 100 — they're different regional pressings. Filter by `date`, `country`, or `status` to narrow down.
+
+- **Recording search: plain query matches titles AND artists broadly** — `?query=bohemian+rhapsody+queen` matches *cover versions* first because "queen" appears in the artist or title of other recordings. Use `AND artist:queen` Lucene syntax to restrict to Queen performances.
+
+- **Cover Art Archive returns 404 for releases with no uploaded art** — Check `release['cover-art-archive']['artwork']` (boolean) from any release browse/search response before hitting the CAA endpoint. Saves an extra HTTP round-trip.
+
+- **Cover art `front=True` flag vs `types=['Front']`** — A release can have multiple images typed as 'Front' but only one (or none) flagged `front: true`. Always filter on `img.get('front') == True` for the canonical cover, not on `img.get('types') == ['Front']`.
+
+- **CAA thumbnail key names** — Both string keys `'small'` (250px) and `'large'` (500px) exist as aliases alongside numeric string keys `'250'`, `'500'`, `'1200'`. Access as `img['thumbnails']['500']` or `img['thumbnails']['large']` — both work.
+
+- **Rate limit: 1 req/s unauthenticated** — In practice, bursts of 5-6 sequential requests succeed without throttling. True 429s appear at higher rates. For sequential pagination loops, add `time.sleep(1)` between pages. For parallel fetching, limit concurrency to 3-5 workers.
+
+- **`fmt=json` required** — Omitting it returns XML instead of JSON. Always append `&fmt=json` to every request.

--- a/domain-skills/openalex/scraping.md
+++ b/domain-skills/openalex/scraping.md
@@ -1,0 +1,470 @@
+# OpenAlex — Scraping & Data Extraction
+
+`https://api.openalex.org` — open academic knowledge graph covering 260M+ works, 90M+ authors, 110K+ institutions. **Never use the browser for OpenAlex.** The entire API is JSON over HTTPS, completely free, no API key required. Add `mailto=your@email.com` to every request to use the polite pool (10 req/s vs 100 req/s limit, more reliable).
+
+## Do this first
+
+**Use `http_get` with the REST JSON API — one call, JSON response, no auth, no parsing library.**
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/works?search=transformer+attention&per-page=5&mailto=you@example.com"
+))
+works = data["results"]
+total = data["meta"]["count"]
+```
+
+Always include `mailto=` to stay in the polite pool. Always parse with `json.loads()`.
+
+## Common workflows
+
+### Search papers (works)
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?search=transformer+attention"
+    "&per-page=5"
+    "&sort=cited_by_count:desc"
+    "&select=id,doi,display_name,publication_year,cited_by_count,open_access,primary_location"
+    "&mailto=you@example.com"
+))
+print("total matching:", data["meta"]["count"])
+for w in data["results"]:
+    oa   = w["open_access"]
+    loc  = w["primary_location"] or {}
+    src  = loc.get("source") or {}
+    print(w["id"].split("/")[-1], w["publication_year"], w["cited_by_count"], w["display_name"][:60])
+    print("  doi:", w["doi"])
+    print("  open access:", oa["is_oa"], "| pdf:", oa["oa_url"])
+    print("  journal:", src.get("display_name"))
+# Confirmed output (2026-04-18):
+# W3151130473 2021 1887 CrossViT: Cross-Attention Multi-Scale Vision Transformer for I
+#   doi: https://doi.org/10.1109/iccv48922.2021.00041
+#   open access: False | pdf: None
+#   journal: 2021 IEEE/CVF International Conference on Computer Vision (ICCV)
+```
+
+### Fetch single paper by OpenAlex ID or DOI
+
+```python
+from helpers import http_get
+import json
+
+# By OpenAlex ID (bare or full URL form both work)
+w = json.loads(http_get("https://api.openalex.org/works/W2626778328?mailto=you@example.com"))
+print(w["display_name"], w["cited_by_count"])
+# Confirmed: Attention Is All You Need 6526
+
+# By DOI (pass the full DOI URL as the entity ID)
+w = json.loads(http_get(
+    "https://api.openalex.org/works/https://doi.org/10.1038/nature14539?mailto=you@example.com"
+))
+print(w["display_name"], w["cited_by_count"])
+# Confirmed: Deep learning 79790
+```
+
+### Reconstruct abstract from inverted index
+
+OpenAlex does not return abstracts as plain strings — they come as an inverted index (`{word: [position, ...], ...}`) due to publisher agreements. Reconstruct as follows:
+
+```python
+from helpers import http_get
+import json
+
+w = json.loads(http_get(
+    "https://api.openalex.org/works/W2626778328"
+    "?select=id,display_name,abstract_inverted_index"
+    "&mailto=you@example.com"
+))
+aii = w.get("abstract_inverted_index") or {}
+words_pos = [(pos, word) for word, positions in aii.items() for pos in positions]
+abstract = " ".join(word for _, word in sorted(words_pos))
+print(abstract[:200])
+# Confirmed: The dominant sequence transduction models are based on complex recurrent
+# or convolutional neural networks in an encoder-decoder configuration...
+```
+
+### Author lookup
+
+```python
+from helpers import http_get
+import json
+
+# Search by name
+data = json.loads(http_get(
+    "https://api.openalex.org/authors?search=geoffrey+hinton&per-page=3&mailto=you@example.com"
+))
+for a in data["results"]:
+    bare_id = a["id"].split("/")[-1]    # e.g. A5108093963
+    print(bare_id, a["display_name"], a["works_count"], "works |", a["cited_by_count"], "cites")
+    affils = a.get("affiliations", [])
+    if affils:
+        print("  latest affil:", affils[0]["institution"]["display_name"])
+# Confirmed:
+# A5108093963 Geoffrey E. Hinton 384 works | 446018 cites
+#   latest affil: University of New Brunswick
+
+# Fetch by bare ID
+a = json.loads(http_get("https://api.openalex.org/authors/A5108093963?mailto=you@example.com"))
+print(a["display_name"], a["works_count"])
+# Confirmed: Geoffrey E. Hinton 384
+
+# Get all works by this author (sorted by citations)
+works_data = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?filter=author.id:A5108093963"
+    "&per-page=5&sort=cited_by_count:desc"
+    "&select=id,display_name,cited_by_count,publication_year"
+    "&mailto=you@example.com"
+))
+for w in works_data["results"]:
+    print(w["publication_year"], w["display_name"][:55], w["cited_by_count"])
+# Confirmed:
+# 2015 Deep learning 79790
+# 2017 ImageNet classification with deep convolutional neural netwo 75670
+# 2008 Visualizing Data using t-SNE 35710
+```
+
+### Institution lookup
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/institutions?search=MIT&per-page=3&mailto=you@example.com"
+))
+for inst in data["results"]:
+    bare_id = inst["id"].split("/")[-1]     # e.g. I63966007
+    print(bare_id, inst["display_name"], inst["country_code"], inst["works_count"], "works")
+# Confirmed: I63966007 Massachusetts Institute of Technology US 340302 works
+
+# Works from an institution
+works = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?filter=institutions.id:I63966007"
+    "&per-page=3&sort=cited_by_count:desc"
+    "&select=id,display_name,cited_by_count,publication_year"
+    "&mailto=you@example.com"
+))
+print("total MIT works:", works["meta"]["count"])
+# Confirmed: 323992
+```
+
+### Concept/Topic lookup
+
+Concepts (legacy, level-based hierarchy) and Topics (newer, 4-level hierarchy) are both available.
+
+```python
+from helpers import http_get
+import json
+
+# Concepts endpoint (Wikidata-linked)
+data = json.loads(http_get(
+    "https://api.openalex.org/concepts?search=machine+learning&per-page=5&mailto=you@example.com"
+))
+for c in data["results"]:
+    bare_id = c["id"].split("/")[-1]    # e.g. C119857082
+    print(bare_id, c["display_name"], "level:", c["level"], "works:", c["works_count"])
+# Confirmed: C119857082 Machine learning level: 1 works: 4960536
+
+# Topics endpoint (newer: domain > field > subfield > topic)
+data2 = json.loads(http_get(
+    "https://api.openalex.org/topics?search=machine+learning&per-page=3&mailto=you@example.com"
+))
+for t in data2["results"]:
+    print(t["id"].split("/")[-1], t["display_name"])
+    print("  ", t.get("domain", {}).get("display_name"), ">",
+          t.get("field", {}).get("display_name"), ">",
+          t.get("subfield", {}).get("display_name"))
+# Confirmed: T11948 Machine Learning in Materials Science
+#   Physical Sciences > Materials Science > Materials Chemistry
+```
+
+### Source (journal/venue) lookup
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/sources?search=nature&per-page=3&mailto=you@example.com"
+))
+for s in data["results"]:
+    bare_id = s["id"].split("/")[-1]    # e.g. S137773608
+    print(bare_id, s["display_name"], s["type"], "issn:", s["issn"], "oa:", s["is_oa"])
+# Confirmed: S137773608 Nature journal issn: ['0028-0836', '1476-4687'] oa: False
+
+# Works in a source
+works = json.loads(http_get(
+    "https://api.openalex.org/works?filter=primary_location.source.id:S137773608"
+    "&per-page=3&sort=cited_by_count:desc"
+    "&select=id,display_name,cited_by_count"
+    "&mailto=you@example.com"
+))
+print("Nature works:", works["meta"]["count"])
+```
+
+### Funder lookup
+
+```python
+from helpers import http_get
+import json
+
+data = json.loads(http_get(
+    "https://api.openalex.org/funders?search=national+science+foundation&per-page=3&mailto=you@example.com"
+))
+for f in data["results"]:
+    bare_id = f["id"].split("/")[-1]    # e.g. F4320306076
+    print(bare_id, f["display_name"], f["country_code"], f["works_count"], "works")
+# Confirmed: F4320306076 National Science Foundation US
+```
+
+### Citation traversal
+
+```python
+from helpers import http_get
+import json
+
+paper_id = "W2626778328"  # Attention Is All You Need
+
+# Papers that CITE this paper (forward citations)
+citing = json.loads(http_get(
+    f"https://api.openalex.org/works?filter=cites:{paper_id}"
+    "&per-page=5&sort=cited_by_count:desc"
+    "&select=id,display_name,publication_year,cited_by_count"
+    "&mailto=you@example.com"
+))
+print("papers citing Attention:", citing["meta"]["count"])
+for w in citing["results"]:
+    print(f"  {w['publication_year']} {w['display_name'][:55]} ({w['cited_by_count']} cites)")
+# Confirmed: 6536 papers cite it; top: AlphaFold2 (43435), ViT (21409)
+
+# Papers THIS paper cites (backward — list of IDs in the work object)
+paper = json.loads(http_get(
+    f"https://api.openalex.org/works/{paper_id}?select=referenced_works&mailto=you@example.com"
+))
+refs = paper.get("referenced_works", [])
+ref_ids = [r.split("/")[-1] for r in refs]     # bare IDs like W1632114991
+print(f"references {len(ref_ids)} works:", ref_ids[:3])
+# Confirmed: references 28 works
+```
+
+### Cursor pagination (bulk harvest)
+
+Use cursor pagination (not page-based) for more than 10,000 results. Page-based fails with HTTP 400 beyond page 50 at per-page=200.
+
+```python
+from helpers import http_get
+import json, urllib.parse
+
+def harvest_works(query_filter, max_results=1000, mailto="you@example.com"):
+    """Yield work dicts using cursor pagination."""
+    cursor = "*"
+    collected = 0
+    while collected < max_results:
+        per_page = min(200, max_results - collected)
+        encoded_cursor = urllib.parse.quote(cursor, safe="")
+        url = (
+            f"https://api.openalex.org/works"
+            f"?filter={query_filter}"
+            f"&per-page={per_page}"
+            f"&cursor={encoded_cursor}"
+            f"&select=id,display_name,publication_year,cited_by_count"
+            f"&mailto={mailto}"
+        )
+        data = json.loads(http_get(url))
+        results = data.get("results", [])
+        if not results:
+            break
+        for w in results:
+            yield w
+        collected += len(results)
+        next_cursor = data["meta"].get("next_cursor")
+        if not next_cursor:
+            break
+        cursor = next_cursor
+
+for w in harvest_works("concepts.id:C119857082,publication_year:2023", max_results=400):
+    print(w["id"].split("/")[-1], w["display_name"][:55])
+```
+
+### Group-by analytics
+
+```python
+from helpers import http_get
+import json
+
+# Publication counts by year for machine learning papers
+data = json.loads(http_get(
+    "https://api.openalex.org/works"
+    "?filter=concepts.id:C119857082"    # C119857082 = Machine learning concept
+    "&group_by=publication_year"
+    "&mailto=you@example.com"
+))
+print("groups_count:", data["meta"]["groups_count"])
+for g in data.get("group_by", [])[:5]:
+    print(f"  {g['key']}: {g['count']:,} works")
+# Confirmed (2026-04-18):
+#   2026: 5,678,538 works
+#   2025: 5,332,194 works
+#   2020: 3,966,880 works
+
+# Other useful group_by fields: open_access.oa_status, type, institutions.country_code
+# authorships.institutions.country_code, primary_location.source.id
+```
+
+## Filter syntax reference
+
+Filters go in the `filter=` param as comma-separated `field:value` pairs. All conditions are AND-ed.
+
+```
+# Exact match
+filter=publication_year:2023
+
+# Full-text search on a field
+filter=title.search:deep+learning
+
+# Combine multiple (AND)
+filter=title.search:CRISPR,publication_year:2022,open_access.is_oa:true
+
+# OR within one field (pipe operator)
+filter=publication_year:2022|2023
+
+# Negation
+filter=publication_year:!2020
+
+# Range
+filter=cited_by_count:>1000
+filter=publication_year:<2010
+filter=cited_by_count:100-500
+
+# Nested field access
+filter=author.id:A5108093963
+filter=institutions.id:I63966007
+filter=concepts.id:C119857082
+filter=primary_location.source.id:S137773608
+filter=open_access.is_oa:true
+filter=cites:W2626778328         # papers citing this work
+```
+
+Commonly useful filter fields for works:
+
+| Filter field | Example | Notes |
+|---|---|---|
+| `title.search` | `title.search:machine+learning` | Full-text on title |
+| `abstract.search` | `abstract.search:attention` | Full-text on abstract |
+| `publication_year` | `publication_year:2023` | Exact year |
+| `from_publication_date` | `from_publication_date:2023-01-01` | Date range start |
+| `to_publication_date` | `to_publication_date:2023-12-31` | Date range end |
+| `cited_by_count` | `cited_by_count:>500` | Range with `>`, `<`, `-` |
+| `open_access.is_oa` | `open_access.is_oa:true` | OA filter |
+| `author.id` | `author.id:A5108093963` | By author OpenAlex ID |
+| `institutions.id` | `institutions.id:I63966007` | By institution ID |
+| `concepts.id` | `concepts.id:C119857082` | By concept ID |
+| `primary_location.source.id` | `primary_location.source.id:S137773608` | By journal/source |
+| `type` | `type:journal-article` | Work type |
+| `language` | `language:en` | ISO 639-1 language code |
+| `cites` | `cites:W2626778328` | Works citing this paper |
+| `doi` | `doi:10.1038/nature14539` | By DOI (no `https://doi.org/` prefix) |
+
+## URL and parameter reference
+
+### API base
+
+```
+https://api.openalex.org/{entity_type}
+```
+
+Entity types: `works`, `authors`, `institutions`, `sources`, `concepts`, `topics`, `funders`, `publishers`
+
+### Query parameters
+
+| Parameter | Example | Notes |
+|---|---|---|
+| `search` | `search=deep+learning` | Full-text relevance search across entity |
+| `filter` | `filter=publication_year:2023` | Structured filters (see above) |
+| `sort` | `sort=cited_by_count:desc` | Sort field + direction; use `relevance_score:desc` with `search` |
+| `per-page` | `per-page=200` | Max 200 per page |
+| `page` | `page=2` | Page number; fails (HTTP 400) if `per-page * page > 10000` |
+| `cursor` | `cursor=*` | Cursor for bulk pagination; `*` = first page |
+| `select` | `select=id,doi,display_name` | Return only these fields (reduces payload) |
+| `group_by` | `group_by=publication_year` | Aggregate counts by field (returns `group_by` array) |
+| `mailto` | `mailto=you@example.com` | **Always include** — enables polite pool |
+
+### Entity ID prefix convention
+
+OpenAlex IDs use a letter prefix on the numeric ID:
+
+| Prefix | Entity | Example |
+|---|---|---|
+| `W` | Work (paper) | `W2626778328` |
+| `A` | Author | `A5108093963` |
+| `I` | Institution | `I63966007` |
+| `S` | Source (journal) | `S137773608` |
+| `C` | Concept | `C119857082` |
+| `T` | Topic | `T11948` |
+| `F` | Funder | `F4320306076` |
+| `P` | Publisher | `P4310319965` |
+
+Full entity URLs: `https://openalex.org/{ID}` (canonical form returned in `id` field).
+Bare ID is always `entity_url.split("/")[-1]`.
+
+### Sort fields
+
+Works: `cited_by_count`, `publication_date`, `relevance_score` (only with `search`), `fwci`
+Authors: `cited_by_count`, `works_count`
+All: append `:desc` or `:asc`
+
+## Rate limits
+
+| Pool | Rate | Daily cap |
+|---|---|---|
+| Polite pool (with `mailto=`) | 10 req/s | 100,000 req/day |
+| Common pool (no `mailto`) | 100 req/s | 100,000 req/day |
+
+- No API key required — the polite pool is opt-in via `mailto=`.
+- Response includes `meta.cost_usd` (typically $0.001 per call).
+- No `Retry-After` header when throttled — just add a short sleep on 429.
+- For bulk harvesting >1,000 results, use cursor pagination + respect the polite pool.
+
+## Gotchas
+
+- **Never use the browser for OpenAlex.** The API returns complete structured JSON for all entity types. No HTML scraping needed.
+
+- **`mailto=` goes in every call, not just once.** It is a query parameter, not a header. There is no session. Omitting it puts you in the common pool (higher contention, less predictable).
+
+- **OpenAlex IDs in the `id` field are full URLs, not bare IDs.** The field returns `https://openalex.org/W2626778328`. Always `.split("/")[-1]` to get the bare `W2626778328` form needed for `filter=cites:`, `filter=author.id:`, etc.
+
+- **DOI lookup uses the full DOI URL as the path parameter.** Correct: `GET /works/https://doi.org/10.1038/nature14539`. Incorrect: `GET /works/10.1038/nature14539` (returns 404).
+
+- **Page-based pagination hard stops at 10,000 results.** `per-page=200&page=51` returns HTTP 400. Use `cursor=*` pagination for harvesting more than 10K results — it has no such limit.
+
+- **`cursor=*` must be URL-encoded on subsequent pages.** The `next_cursor` value contains `+`, `=`, `/` characters. Always `urllib.parse.quote(cursor, safe="")` before interpolating into the URL.
+
+- **`group_by` and `page` are incompatible — use `group_by` without `page`/`cursor`.** Group-by returns a `group_by` list, not `results`. The `per-page` param sets max groups returned (default 200).
+
+- **`abstract_inverted_index` may be `null` for some papers.** Publisher agreements prevent OpenAlex from providing abstracts for many closed-access works. Always check `if aii:` before reconstructing.
+
+- **`select` significantly reduces response size and latency.** A full work object has 50+ fields; specifying `select=id,doi,display_name,cited_by_count` cuts payload by ~90%. Always use `select=` in bulk harvests.
+
+- **`sort=relevance_score:desc` only works with `search=`.** Using it without a `search` param returns results in undefined order. Use `cited_by_count:desc` or `publication_date:desc` for filter-only queries.
+
+- **The `concepts` field is deprecated in favor of `topics`.** Concepts (Wikidata-linked, 5 levels) are still populated and useful, but OpenAlex now recommends `topics` (4-level hierarchy: domain > field > subfield > topic) going forward.
+
+- **`open_access.oa_url` can be `null` even when `is_oa=true`.** Check `best_oa_location.pdf_url` instead — it is more reliably populated when an OA PDF exists.
+
+- **Negation filter syntax is `field:!value`, not `field!=value`.** Example: `filter=publication_year:!2020` excludes 2020.
+
+- **Author disambiguation is imperfect.** The same person may appear as multiple author entities. Use ORCID (`ids.orcid`) when available to cross-reference. The `display_name_alternatives` field lists name variants.
+
+- **The `funders.grants_count` field returns `None` in API responses** despite the docs mentioning it. Use `works_count` and `cited_by_count` instead for funder-level metrics.
+
+- **`per-page` with `cursor=*` ignores `page=`.** When cursor pagination is active, `page` is set to `null` in `meta`. Do not combine cursor + page.

--- a/domain-skills/openfda/scraping.md
+++ b/domain-skills/openfda/scraping.md
@@ -1,0 +1,643 @@
+# OpenFDA — Scraping & Data Extraction
+
+`https://api.fda.gov` — FDA open data API covering drug adverse events, drug labels, recalls, device events, and more. **Never use the browser for OpenFDA.** Everything is reachable via `http_get`. No auth required for basic use (up to 500 results/call, 40 req/min); free API key lifts limit to 1,000 results/call and 240 req/min.
+
+## Do this first
+
+**Use `http_get` directly against the JSON REST API — one call returns structured JSON with full pagination metadata.**
+
+```python
+import json
+from helpers import http_get
+
+# Drug adverse events (20M+ records)
+r = json.loads(http_get("https://api.fda.gov/drug/event.json?limit=5"))
+total = r['meta']['results']['total']   # 20,006,989
+events = r['results']                   # list of report dicts
+```
+
+All endpoints return the same envelope:
+
+```python
+{
+    "meta": {
+        "results": {"skip": 0, "limit": 5, "total": 20006989},
+        "last_updated": "2026-01-27"
+    },
+    "results": [...]
+}
+```
+
+## URL structure
+
+```
+https://api.fda.gov/{type}/{dataset}.json?search=&count=&limit=&skip=&sort=&api_key=
+```
+
+| Segment | Examples |
+|---------|---------|
+| `type` | `drug`, `food`, `device`, `other`, `tobacco` |
+| `dataset` | `event`, `label`, `ndc`, `drugsfda`, `enforcement`, `recall`, `510k`, `pma`, `registrationlisting` |
+
+### All confirmed live endpoints (2026-04-18)
+
+| Endpoint | Total records |
+|----------|--------------|
+| `drug/event` | 20,006,989 |
+| `drug/label` | 257,050 |
+| `drug/ndc` | 134,294 |
+| `drug/drugsfda` | 29,009 |
+| `food/enforcement` | 28,759 |
+| `food/event` | 148,459 |
+| `device/event` | 24,443,693 |
+| `device/recall` | 57,846 |
+| `device/enforcement` | 38,612 |
+| `device/510k` | 174,612 |
+| `device/pma` | 56,116 |
+| `device/registrationlisting` | 322,943 |
+| `other/historicaldocument` | 8,858 |
+| `tobacco/problem` | 1,337 |
+
+## Common workflows
+
+### Drug adverse events
+
+```python
+import json
+from helpers import http_get
+
+# Fetch 5 recent adverse event reports
+r = json.loads(http_get("https://api.fda.gov/drug/event.json?limit=5"))
+for ev in r['results']:
+    report_id  = ev['safetyreportid']              # '5801206-7'
+    received   = ev['receivedate']                 # '20240101' (YYYYMMDD string)
+    serious    = ev.get('serious')                 # '1' = serious, '2' = not serious
+    patient    = ev['patient']
+    age        = patient.get('patientonsetage')    # '26' (years, as string)
+    sex        = patient.get('patientsex')         # '1'=male, '2'=female, '0'=unknown
+    reactions  = [rx['reactionmeddrapt'] for rx in patient.get('reaction', [])]
+    drugs      = [d['medicinalproduct'] for d in patient.get('drug', [])]
+    print(report_id, received, reactions[:2], drugs[:2])
+# 5801206-7 20240101 ['DRUG ADMINISTRATION ERROR', 'OVERDOSE'] ['DURAGESIC-100']
+```
+
+### Search adverse events by reaction
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get(
+    'https://api.fda.gov/drug/event.json'
+    '?search=patient.reaction.reactionmeddrapt:"headache"'
+    '&limit=5'
+))
+print(r['meta']['results']['total'])   # 611,037
+for ev in r['results']:
+    drugs = [d['medicinalproduct'] for d in ev['patient'].get('drug', [])]
+    reactions = [rx['reactionmeddrapt'] for rx in ev['patient'].get('reaction', [])]
+    print(drugs[:2], "->", reactions[:3])
+```
+
+### Search with AND / date range
+
+```python
+import json
+from helpers import http_get
+
+# AND two search terms
+r = json.loads(http_get(
+    'https://api.fda.gov/drug/event.json'
+    '?search=patient.reaction.reactionmeddrapt:"nausea"'
+    '+AND+patient.drug.medicinalproduct:"aspirin"'
+    '&limit=5'
+))
+print(r['meta']['results']['total'])   # 31,055
+
+# Date range: receivedate field is YYYYMMDD, range syntax [X+TO+Y]
+r = json.loads(http_get(
+    "https://api.fda.gov/drug/event.json"
+    "?search=receivedate:[20240101+TO+20240131]"
+    "&limit=5"
+))
+print(r['meta']['results']['total'])   # 106,399 in Jan 2024
+for ev in r['results']:
+    print(ev['receivedate'])           # '20240101'
+```
+
+### Drug labels (FDA-approved prescribing information)
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get(
+    'https://api.fda.gov/drug/label.json'
+    '?search=openfda.brand_name:"aspirin"'
+    '&limit=3'
+))
+print(r['meta']['results']['total'])   # 441
+
+label = r['results'][0]
+openfda = label.get('openfda', {})
+print(openfda.get('brand_name'))       # ['Low Dose Aspirin']
+print(openfda.get('generic_name'))     # ['ASPIRIN']
+print(openfda.get('route'))            # ['ORAL']
+print(openfda.get('rxcui'))            # ['1191']
+print(openfda.get('product_ndc'))      # ['69536-014']
+print(openfda.get('application_number'))  # ['NDA019952']
+print(openfda.get('manufacturer_name'))   # ['Bayer HealthCare LLC']
+
+# Text sections — all are lists of strings; take [0] for the full text block
+print(label.get('purpose', [''])[0][:100])
+print(label.get('warnings', [''])[0][:100])
+print(label.get('dosage_and_administration', [''])[0][:100])
+print(label.get('indications_and_usage', [''])[0][:100])
+# Note: 'adverse_reactions' is absent on many OTC labels; always use .get()
+```
+
+Label text fields (not always present — use `.get(field, [''])[0]`):
+
+| Field | Description |
+|-------|-------------|
+| `purpose` | Drug purpose/use |
+| `warnings` | Warnings text |
+| `dosage_and_administration` | Dosing instructions |
+| `indications_and_usage` | What it treats |
+| `adverse_reactions` | Known adverse reactions |
+| `do_not_use` | Contraindications |
+| `active_ingredient` | Active ingredient list |
+| `inactive_ingredient` | Inactive ingredients |
+| `keep_out_of_reach_of_children` | Storage warning |
+| `stop_use` | When to stop |
+| `ask_doctor` | When to consult physician |
+
+### Drug NDC (National Drug Code) directory
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get(
+    'https://api.fda.gov/drug/ndc.json'
+    '?search=brand_name:"advil"'
+    '&limit=5'
+))
+ndc = r['results'][0]
+print(ndc['brand_name'])        # 'Advil PM'
+print(ndc['generic_name'])      # 'Ibuprofen and Diphenhydramine citrate'
+print(ndc['product_ndc'])       # '66715-9733'
+print(ndc['dosage_form'])       # 'TABLET, COATED'
+print(ndc['route'])             # ['ORAL']
+print(ndc['labeler_name'])      # 'Lil\' Drug Store Products, Inc.'
+```
+
+### Drug approvals (drugsfda — ANDA/NDA applications)
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get(
+    'https://api.fda.gov/drug/drugsfda.json'
+    '?search=openfda.brand_name:"tylenol"'
+    '&limit=3'
+))
+print(r['meta']['results']['total'])   # 3
+
+app = r['results'][0]
+print(app['application_number'])       # 'ANDA211544'  (ANDA=generic, NDA=brand)
+print(app['sponsor_name'])             # 'GRANULES'
+print(app['openfda']['brand_name'])    # list of brand names
+print(app['openfda']['generic_name'])  # ['ACETAMINOPHEN', 'PAIN RELIEF']
+
+# Submission history
+for sub in app['submissions'][:3]:
+    print(sub['submission_type'])          # 'SUPPL', 'ORIG'
+    print(sub['submission_status'])        # 'AP' = approved, 'TA' = tentatively approved
+    print(sub['submission_status_date'])   # '20240118' (YYYYMMDD)
+```
+
+### Food recalls
+
+```python
+import json
+from helpers import http_get
+
+# Most recent recalls
+r = json.loads(http_get(
+    "https://api.fda.gov/food/enforcement.json"
+    "?limit=5&sort=report_date:desc"
+))
+print(r['meta']['results']['total'])   # 28,759
+
+recall = r['results'][0]
+print(recall['product_description'])   # 'Prickly Pear Jelly. 9 oz (268 g)...'
+print(recall['reason_for_recall'])     # 'Undeclared milk.'
+print(recall['classification'])        # 'Class II'
+print(recall['status'])               # 'Ongoing' | 'Terminated'
+print(recall['report_date'])           # '20260408' (YYYYMMDD)
+print(recall['recall_initiation_date'])
+print(recall['recalling_firm'])        # 'The Maros Group, LLC'
+print(recall['city'], recall['state']) # 'Scottsdale', 'AZ'
+print(recall['country'])               # 'United States'
+print(recall['voluntary_mandated'])    # 'Voluntary: Firm initiated'
+print(recall['distribution_pattern'])
+print(recall['product_quantity'])
+
+# Search by reason
+r = json.loads(http_get(
+    'https://api.fda.gov/food/enforcement.json'
+    '?search=reason_for_recall:"allergen"'
+    '&limit=5'
+))
+print(r['meta']['results']['total'])   # 1,722 allergen recalls
+```
+
+Recall classification meanings:
+- `Class I` — reasonable probability of serious adverse health consequences or death
+- `Class II` — may cause adverse health consequences (temporary/reversible)
+- `Class III` — not likely to cause adverse health consequences
+
+### Food adverse events (CFSAN CAERS)
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get("https://api.fda.gov/food/event.json?limit=5"))
+fev = r['results'][0]
+print(fev['date_created'])             # '20230717' (YYYYMMDD)
+
+# Products are a list of dicts
+for prod in fev['products']:
+    print(prod.get('name_brand'))       # 'KROGER FUN DAYS SUNDAES'
+    print(prod.get('industry_name'))    # 'Ice Cream Prod'
+
+# Reactions and outcomes are lists of STRINGS (not dicts)
+print(fev['reactions'])    # ['Vomiting']
+print(fev['outcomes'])     # ['Disability']
+
+consumer = fev.get('consumer', {})
+print(consumer.get('age'), consumer.get('age_unit'))
+print(consumer.get('gender'))
+```
+
+### Device recalls
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get(
+    "https://api.fda.gov/device/recall.json"
+    "?limit=5&sort=event_date_terminated:desc"
+))
+dr = r['results'][0]
+print(dr['product_description'])    # 'Zoll AED Plus Defibrillator'
+print(dr['reason_for_recall'])      # 'Device fails to discharge...'
+print(dr['recalling_firm'])
+print(dr['event_date_initiated'])   # '2024-01-15' (ISO date, not YYYYMMDD)
+print(dr['event_date_terminated'])  # '2026-04-09'
+print(dr['recall_status'])          # 'Terminated' | 'Ongoing'
+print(dr['openfda'].get('device_class'))   # '3' (I=lowest, III=highest risk)
+print(dr['distribution_pattern'])
+print(dr['root_cause_description'])
+```
+
+### Device adverse events (MAUDE database)
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get("https://api.fda.gov/device/event.json?limit=3"))
+ev = r['results'][0]
+print(ev['event_type'])       # 'Injury' | 'Malfunction' | 'Death' | 'Other'
+print(ev['date_received'])    # '19920310' (YYYYMMDD)
+print(ev['mdr_report_key'])
+
+# Device details
+device = ev['device'][0]
+print(device['brand_name'])
+print(device['generic_name'])      # 'MANUAL HOSPITAL BED'
+print(device['manufacturer_d_name'])
+
+# Patient outcomes
+patient = ev['patient'][0]
+print(patient['patient_sequence_number'])
+print(patient['sequence_number_outcome'])  # ['Required Intervention']
+
+# Narrative text
+for txt in ev.get('mdr_text', []):
+    if txt.get('text_type_code') == 'D':   # D=event description
+        print(txt.get('text', '')[:200])
+```
+
+### Device 510(k) clearances
+
+```python
+import json
+from helpers import http_get
+
+r = json.loads(http_get("https://api.fda.gov/device/510k.json?limit=3"))
+k = r['results'][0]
+print(k['k_number'])               # 'K251300'
+print(k['applicant'])              # 'Dentsply Sirona, Inc.'
+print(k['device_name'])            # 'Plastic Surgical Kits'
+print(k['decision_date'])          # '2025-07-22'
+print(k['decision_description'])   # 'Substantially Equivalent'
+print(k['decision_code'])          # 'SESE'
+print(k['advisory_committee'])     # 'DE'
+print(k['advisory_committee_description'])  # 'Dental'
+print(k['product_code'])
+print(k['clearance_type'])         # 'Traditional'
+print(k['third_party_flag'])       # 'N'
+```
+
+### Count/aggregation queries
+
+Count returns `{term, count}` pairs (or `{time, count}` for date fields), sorted by count descending. No `results` envelope — just the list. Useful for finding top values without iterating all records.
+
+```python
+import json
+from helpers import http_get
+
+# Top 10 most-reported adverse reactions across all drugs
+r = json.loads(http_get(
+    "https://api.fda.gov/drug/event.json"
+    "?count=patient.reaction.reactionmeddrapt.exact"
+    "&limit=10"
+))
+for item in r['results']:
+    print(f"{item['count']:>10,}  {item['term']}")
+# 1,260,866  DRUG INEFFECTIVE
+#   824,385  DEATH
+#   815,408  OFF LABEL USE
+#   752,672  NAUSEA
+#   742,327  FATIGUE
+#   610,644  DIARRHOEA
+#   599,931  HEADACHE
+#   592,586  PAIN
+#   541,768  DYSPNOEA
+#   476,776  DIZZINESS
+
+# Top drug manufacturers by adverse event count
+r = json.loads(http_get(
+    "https://api.fda.gov/drug/event.json"
+    "?count=patient.drug.openfda.manufacturer_name.exact"
+    "&limit=5"
+))
+for item in r['results']:
+    print(f"{item['count']:>10,}  {item['term']}")
+# 4,907,099  Aurobindo Pharma Limited
+# 3,724,435  Chartwell RX, LLC
+# 3,609,145  Rising Pharma Holdings, Inc.
+# 3,529,567  Mylan Pharmaceuticals Inc.
+
+# Count by date field — key is 'time' not 'term'
+r = json.loads(http_get(
+    "https://api.fda.gov/drug/event.json"
+    "?count=receivedate"
+    "&limit=5"
+))
+for item in r['results']:
+    print(f"{item['time']}: {item['count']:,}")
+# Date fields return ascending order by default
+
+# Count food recalls by top recalling firms
+r = json.loads(http_get(
+    "https://api.fda.gov/food/enforcement.json"
+    "?count=recalling_firm.exact"
+    "&limit=5"
+))
+for item in r['results']:
+    print(f"{item['count']:>8,}  {item['term']}")
+# 633  Garden-Fresh Foods, Inc.
+```
+
+Count-able fields that confirm working (2026-04-18):
+
+| Field | Notes |
+|-------|-------|
+| `patient.reaction.reactionmeddrapt.exact` | Use `.exact` for exact term grouping |
+| `patient.drug.openfda.manufacturer_name.exact` | |
+| `patient.drug.openfda.pharm_class_epc.exact` | Pharmacological class |
+| `patient.drug.drugcharacterization` | 1=suspect, 2=concomitant, 3=interacting |
+| `serious` | 1=serious, 2=not |
+| `patient.patientsex` | 1=male, 2=female, 0=unknown |
+| `receivedate` | Returns `{time, count}` not `{term, count}` |
+| `recalling_firm.exact` | On food/enforcement |
+
+### Pagination with skip
+
+```python
+import json
+from helpers import http_get
+
+PAGE_SIZE = 100
+
+def paginate(endpoint_url, max_records=1000):
+    """Yield all results up to max_records."""
+    skip = 0
+    seen = 0
+    while seen < max_records:
+        limit = min(PAGE_SIZE, max_records - seen)
+        r = json.loads(http_get(f"{endpoint_url}&limit={limit}&skip={skip}"))
+        batch = r['results']
+        if not batch:
+            break
+        yield from batch
+        seen += len(batch)
+        total = r['meta']['results']['total']
+        if skip + limit >= total:
+            break
+        skip += limit
+
+for ev in paginate("https://api.fda.gov/drug/event.json?search=receivedate:[20240101+TO+20240131]", max_records=250):
+    print(ev['safetyreportid'], ev['receivedate'])
+```
+
+### Parallel fetch across datasets
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+def fetch_dataset(url):
+    r = json.loads(http_get(url))
+    return url, r['meta']['results']['total'], r['results']
+
+urls = [
+    "https://api.fda.gov/drug/event.json?limit=5",
+    "https://api.fda.gov/food/enforcement.json?limit=5&sort=report_date:desc",
+    "https://api.fda.gov/device/recall.json?limit=5",
+    "https://api.fda.gov/drug/event.json?count=patient.reaction.reactionmeddrapt.exact&limit=10",
+    "https://api.fda.gov/drug/label.json?search=openfda.brand_name:%22aspirin%22&limit=3",
+]
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_dataset, urls))
+# 5 parallel requests complete in ~4s confirmed
+```
+
+### Error handling
+
+OpenFDA returns gzip-compressed error bodies. Decompress before parsing:
+
+```python
+import json, gzip, urllib.error
+from helpers import http_get
+
+def safe_get(url):
+    try:
+        return json.loads(http_get(url))
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            body = json.loads(gzip.decompress(raw).decode())
+        except Exception:
+            body = {"raw": raw.decode("utf-8", errors="replace")}
+        code = body.get("error", {}).get("code", "UNKNOWN")
+        msg  = body.get("error", {}).get("message", str(body))
+        raise RuntimeError(f"OpenFDA {e.code} {code}: {msg}") from e
+
+# Example: no matches returns 404 NOT_FOUND
+try:
+    r = safe_get('https://api.fda.gov/drug/event.json?search=patient.reaction.reactionmeddrapt:"xyzzy_nonexistent"')
+except RuntimeError as e:
+    print(e)
+# OpenFDA 404 NOT_FOUND: No matches found!
+```
+
+Error codes:
+
+| HTTP | code | Meaning |
+|------|------|---------|
+| 404 | `NOT_FOUND` | No results match your search |
+| 400 | `BAD_REQUEST` | Invalid query syntax or field name |
+| 403 | `API_KEY_MISSING` | `limit` exceeds 500 and no `api_key` provided |
+| 429 | `RATE_LIMIT_EXCEEDED` | Too many requests |
+
+## Query parameter reference
+
+| Param | Description | Notes |
+|-------|-------------|-------|
+| `search` | Filter expression | `field:"value"` or `field:[X+TO+Y]` |
+| `count` | Aggregate by field | Returns term+count pairs, max 1,000 terms |
+| `limit` | Results per page | Max 500 without key, max 1,000 with key |
+| `skip` | Offset for pagination | Max 25,000; use narrow `search` to page deeper |
+| `sort` | Sort results | `field:asc` or `field:desc`; not valid with `count` |
+| `api_key` | Your API key | Pass as `&api_key=YOUR_KEY`; increases limits |
+
+### Search syntax
+
+```
+# Exact phrase (quote the value)
+search=openfda.brand_name:"tylenol"
+
+# Number/date field exact match
+search=serious:1
+
+# Date range (YYYYMMDD format for most date fields)
+search=receivedate:[20240101+TO+20241231]
+
+# AND (use + as URL-encoded space)
+search=patient.reaction.reactionmeddrapt:"nausea"+AND+patient.drug.medicinalproduct:"aspirin"
+
+# OR
+search=patient.reaction.reactionmeddrapt:"nausea"+OR+patient.reaction.reactionmeddrapt:"vomiting"
+
+# Field existence (any non-null value)
+search=_exists_:patient.drug.openfda.brand_name
+```
+
+### .exact suffix for counts
+
+Without `.exact` the field is tokenized (word-split) before counting — useful for text search but gives inflated counts. With `.exact` the full field value is used as a single token — required for drug names, firm names, reaction terms:
+
+```python
+# Wrong: tokenizes "DRUG INEFFECTIVE" into "DRUG" and "INEFFECTIVE"
+# ?count=patient.reaction.reactionmeddrapt
+
+# Correct: counts the full MedDRA term as-is
+# ?count=patient.reaction.reactionmeddrapt.exact
+```
+
+## Rate limits
+
+| Mode | Limit | How to supply key |
+|------|-------|-------------------|
+| No API key | 40 req/min, max 500 per call | (nothing) |
+| With API key | 240 req/min, max 1,000 per call | `&api_key=YOUR_KEY` |
+
+Get a free key at `https://api.fda.gov/` — instant, no payment required.
+
+## Key field reference
+
+### drug/event — patient.drug fields
+
+| Field | Description |
+|-------|-------------|
+| `medicinalproduct` | Drug name as reported |
+| `drugcharacterization` | `1`=suspect, `2`=concomitant, `3`=interacting |
+| `drugindication` | Indication for use |
+| `drugdosagetext` | Free-text dosage |
+| `openfda.brand_name` | Standardized brand names (list) |
+| `openfda.generic_name` | Standardized generic names (list) |
+| `openfda.manufacturer_name` | Manufacturer name(s) (list) |
+| `openfda.pharm_class_epc` | Pharmacological class (list) |
+| `openfda.rxcui` | RxNorm CUI codes (list) |
+
+### drug/event — patient fields
+
+| Field | Description |
+|-------|-------------|
+| `patientonsetage` | Age at onset (string) |
+| `patientonsetageunit` | Age unit (`801`=year, `802`=month, etc.) |
+| `patientsex` | `1`=male, `2`=female, `0`=unknown |
+| `reaction[].reactionmeddrapt` | MedDRA reaction term |
+| `reaction[].reactionoutcome` | `1`=recovered, `2`=recovering, `3`=not recovered, `4`=fatal, `5`=unknown, `6`=death |
+
+### drug/event — report-level fields
+
+| Field | Description |
+|-------|-------------|
+| `safetyreportid` | Unique report ID |
+| `receivedate` | Date received by FDA (YYYYMMDD) |
+| `serious` | `1`=serious, `2`=not serious |
+| `seriousnessdeath` | `1`=death reported |
+| `seriousnesshospitalization` | `1`=hospitalization |
+| `primarysource.reportercountry` | ISO country code |
+
+## Gotchas
+
+- **Never use the browser for OpenFDA.** The entire API is fully accessible via `http_get`. No JavaScript, no cookies, no session state needed.
+
+- **404 NOT_FOUND means no matches, not a bad URL.** When `search` returns zero results, OpenFDA returns HTTP 404 with `{"error": {"code": "NOT_FOUND", "message": "No matches found!"}}`. Always wrap in try/except and check for this case. The error body is gzip-compressed — use `gzip.decompress(e.read())` before parsing.
+
+- **`limit` > 500 without API key returns 403 `API_KEY_MISSING`.** The limit without a key is 500 per call, not 100. With a key, max is 1,000. There is no way to page past 25,000 total records via `skip` — narrow your `search` to work within that constraint.
+
+- **`.exact` suffix is required for meaningful count aggregations.** Without it, multi-word terms like `"DRUG INEFFECTIVE"` are tokenized and counted as individual words. Always append `.exact` to string fields used in `count=` queries: `count=patient.reaction.reactionmeddrapt.exact`.
+
+- **Date fields return `{time, count}` not `{term, count}`.** When you use a date field in `count=` (e.g. `count=receivedate`), each result object has key `time` instead of `term`. Your loop must use `item.get('time', item.get('term'))` if you want generic code.
+
+- **Sort is not compatible with count.** Adding `sort=` to a `count=` query returns 400. Count results are always ordered by count descending; there is no way to reorder them.
+
+- **Most date fields are YYYYMMDD strings, not ISO dates.** `receivedate`, `transmissiondate`, `submission_status_date` are all `"20240101"` format. Device recall fields (`event_date_initiated`, `event_date_terminated`) are ISO `"2026-04-09"` format. Check before parsing.
+
+- **`count=` on some food/enforcement fields returns 500.** `classification`, `status`, `product_type`, `state`, `country`, `voluntary_mandated` all return HTTP 500 on `food/enforcement`. Only `recalling_firm.exact` (and a few others) work reliably. On `drug/event`, almost all fields work in count.
+
+- **`food/event` reactions and outcomes are lists of strings, not lists of dicts.** Unlike `drug/event` where reactions are `[{"reactionmeddrapt": "Headache", ...}]`, the food event endpoint returns `reactions: ["Vomiting", "Headache"]` — plain strings. Do not call `.get()` on them.
+
+- **`openfda` sub-object is absent or empty on many records.** Not every event or label has standardized `openfda` fields populated. Always use `ev.get('openfda', {})` and then `.get('brand_name', [])` on the result. Never assume the key exists.
+
+- **`skip` is capped at 25,000.** For datasets with millions of records, `search` + narrowing by date range or other filters is the only way to access arbitrary records beyond position 25,000.
+
+- **`animal/event` endpoint returns 404** — confirmed not live as of 2026-04-18.
+
+- **No response headers expose rate limit status.** Unlike GitHub or Twitter APIs, OpenFDA does not return `X-RateLimit-*` headers. You will receive HTTP 429 when rate-limited — implement exponential backoff.
+
+- **The `meta.last_updated` field in count responses is a date string only.** It reflects when the dataset was last updated, not the query time. Regular (non-count) responses include `meta.results.total` which reflects live data.
+
+- **`sort=count:desc` does NOT work on count queries** — sort is for regular search queries only. Count results are always by count descending with no override.

--- a/domain-skills/pubmed/scraping.md
+++ b/domain-skills/pubmed/scraping.md
@@ -1,0 +1,421 @@
+# PubMed / NCBI — Scraping & Data Extraction
+
+`https://pubmed.ncbi.nlm.nih.gov` — 37 M+ biomedical citations. **Never use the browser for PubMed.** All data is reachable via `http_get` using the NCBI E-utilities REST API. No API key required; a free key raises the rate limit from 3 to 10 req/s.
+
+## Do this first
+
+**ESearch → ESummary is the fastest pipeline for most tasks — two calls, JSON responses, no XML parsing.**
+
+```python
+import json
+from helpers import http_get
+
+# Step 1: search → get PMIDs
+search = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    "?db=pubmed&term=deep+learning+radiology&retmax=10&retmode=json"
+))
+pmids = search['esearchresult']['idlist']   # e.g. ['41999029', '41998456', ...]
+count = search['esearchresult']['count']    # total hits across all pages
+
+# Step 2: fetch lightweight metadata for all PMIDs in one call
+summary = json.loads(http_get(
+    f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+    f"?db=pubmed&id={','.join(pmids)}&retmode=json"
+))
+result = summary['result']
+for uid in result['uids']:
+    art = result[uid]
+    print(uid, art['pubdate'], art['source'])
+    print("  ", art['title'][:80])
+    print("  authors:", [a['name'] for a in art['authors'][:3]])
+# Confirmed output (2026-04-18):
+# 41999029 2026 Apr 18 Med Sci Monit
+#    Use of Deep Learning Models in the Diagnosis of Proptosis Through Orbi
+#    authors: ['Kesimal U', 'Akkaya HE', 'Polat Ö']
+# 41998456 2026 Apr 17 Sci Rep
+#    ...
+```
+
+Use **EFetch XML** when you need: full abstract text, MeSH terms, complete author names (not just "Last I"), structured abstract labels, or the DOI from within the article record.
+
+## Common workflows
+
+### Search PubMed (ESearch)
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    "?db=pubmed"
+    "&term=large+language+models+clinical"
+    "&retmax=5"
+    "&retmode=json"
+    "&sort=pub+date"                          # newest first; default is relevance
+    "&datetype=pdat"                          # filter by publication date
+    "&mindate=2024/01/01&maxdate=2024/12/31"  # YYYY/MM/DD format
+))
+result = data['esearchresult']
+print("Total hits:", result['count'])         # '24160' — note: string, not int
+print("PMIDs:", result['idlist'])
+print("Query translation:", result['querytranslation'])
+# Confirmed output (2026-04-18):
+# Total hits: 24160
+# PMIDs: ['41996895', '41996722', '41996006', '41995888', '41995759']
+# Query translation: "large language models"[MeSH Terms] OR ...
+```
+
+#### ESearch field tags (append to term)
+
+```
+machine learning[MeSH Terms]        MeSH controlled vocabulary
+Hinton GE[Author]                   author last + initials
+attention is all you need[Title]    title words
+Nature[Journal]                     journal name
+2024[pdat]                          publication year
+```
+
+Boolean operators: `AND`, `OR`, `NOT`. Phrase search: `"exact phrase"[Title]`.
+
+#### Sort options (`sort=`)
+
+| Value | Effect |
+|---|---|
+| *(omit)* | Relevance (default) |
+| `pub+date` | Most recent publication first |
+| `Author` | First author alphabetical |
+| `JournalName` | Journal alphabetical |
+
+### Lightweight metadata — ESummary (JSON, no XML)
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+    "?db=pubmed&id=41999029,41998456,41997837&retmode=json"
+))
+result = data['result']
+for uid in result['uids']:
+    art = result[uid]
+    # Key fields available:
+    title         = art['title']            # full title string
+    source        = art['source']           # abbreviated journal name
+    fulljournalname = art['fulljournalname']
+    pubdate       = art['pubdate']          # e.g. '2026 Apr 18'
+    epubdate      = art['epubdate']         # e-pub ahead of print date (may be empty)
+    authors       = art['authors']          # list of {'name': 'Last I', 'authtype': ...}
+    volume        = art['volume']
+    issue         = art['issue']
+    pages         = art['pages']
+    pubtype       = art['pubtype']          # list: ['Journal Article', 'Review', ...]
+    # Extract DOI from elocationid or articleids:
+    doi_field     = art['elocationid']      # e.g. 'doi: 10.12659/MSM.951157'
+    article_ids   = {x['idtype']: x['value'] for x in art['articleids']}
+    doi           = article_ids.get('doi')
+    pmc_id        = article_ids.get('pmc')  # PMC ID if open access
+    print(uid, pubdate, source)
+    print(" ", title[:70])
+    print("  doi:", doi, "| pmc:", pmc_id)
+# Confirmed output (2026-04-18):
+# 41999029 2026 Apr 18 Med Sci Monit
+#    Use of Deep Learning Models in the Diagnosis of Proptosis Through Orbi
+#   doi: 10.12659/MSM.951157 | pmc: None
+```
+
+### Full article metadata — EFetch XML
+
+Use this for full abstracts, complete author names, MeSH terms, structured abstract sections.
+
+```python
+import json, xml.etree.ElementTree as ET
+from helpers import http_get
+
+raw = http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    "?db=pubmed&id=41999029,36328784&retmode=xml&rettype=abstract"
+)
+root = ET.fromstring(raw)
+
+for art in root.findall('.//PubmedArticle'):
+    mc      = art.find('MedlineCitation')
+    pmid    = mc.find('PMID').text
+    article = mc.find('Article')
+
+    # Title — use itertext() to handle embedded tags like <i>, <sub>
+    title   = ''.join(article.find('ArticleTitle').itertext()).strip()
+
+    # Abstract — plain or structured (BACKGROUND / METHODS / RESULTS / CONCLUSION)
+    abstract_el = article.find('Abstract')
+    if abstract_el is not None:
+        sections = []
+        for t in abstract_el.findall('AbstractText'):
+            label = t.get('Label', '')          # e.g. 'BACKGROUND', 'METHODS'
+            text  = ''.join(t.itertext()).strip()
+            sections.append(f"[{label}] {text}" if label else text)
+        abstract = ' '.join(sections)
+    else:
+        abstract = ''                           # ~15% of articles have no abstract
+
+    # Journal + year
+    journal  = article.find('Journal')
+    j_title  = journal.find('Title').text if journal is not None else ''
+    pub_date = journal.find('.//PubDate') if journal is not None else None
+    if pub_date is not None:
+        year_el    = pub_date.find('Year')
+        medline_el = pub_date.find('MedlineDate')   # fallback for old/seasonal dates
+        season_el  = pub_date.find('Season')        # e.g. 'Jul-Aug', 'Oct-Dec'
+        year = (year_el.text if year_el is not None
+                else medline_el.text[:4] if medline_el is not None else '')
+
+    # DOI
+    doi_el = next(
+        (e for e in article.findall('ELocationID') if e.get('EIdType') == 'doi'),
+        None
+    )
+    doi = doi_el.text if doi_el is not None else ''
+
+    # Authors — handle CollectiveName (consortium/group authors)
+    author_list = article.find('AuthorList')
+    authors = []
+    if author_list is not None:
+        for a in author_list.findall('Author'):
+            collective = a.find('CollectiveName')
+            last       = a.find('LastName')
+            fore       = a.find('ForeName')
+            initials   = a.find('Initials')
+            if collective is not None:
+                authors.append(collective.text)
+            elif last is not None:
+                full = last.text
+                if fore is not None:
+                    full += f", {fore.text}"
+                authors.append(full)
+
+    # MeSH controlled vocabulary terms
+    mesh_list = mc.find('MeshHeadingList')
+    mesh_terms = []
+    if mesh_list is not None:
+        mesh_terms = [
+            mh.find('DescriptorName').text
+            for mh in mesh_list.findall('MeshHeading')
+            if mh.find('DescriptorName') is not None
+        ]
+
+    print(f"PMID={pmid} ({year}) {j_title}")
+    print(f"  Title: {title[:70]}")
+    print(f"  Authors: {authors[:3]}")
+    print(f"  DOI: {doi}")
+    print(f"  MeSH: {mesh_terms[:4]}")
+    print(f"  Abstract: {abstract[:120]}")
+# Confirmed output (2026-04-18):
+# PMID=41999029 (2026) Medical science monitor : international medical...
+#   Title: Use of Deep Learning Models in the Diagnosis of Proptosis Thro
+#   Authors: ['Kesimal, Uğur', 'Akkaya, Habip Eser', 'Polat, Önder']
+#   DOI: 10.12659/MSM.951157
+#   MeSH: ['Humans', 'Deep Learning', 'Exophthalmos', 'Magnetic Resonance Imaging']
+#   Abstract: BACKGROUND Proptosis is a common manifestation of orbital disease...
+# PMID=36328784 (...)
+#   Abstract: [OBJECTIVES] Physical inactivity and sedentary behaviour...  ← structured
+```
+
+### Large result sets — usehistory + WebEnv
+
+When `count` exceeds `retmax` (max 10 000), use server-side history to paginate EFetch without re-running ESearch on every page.
+
+```python
+import json, xml.etree.ElementTree as ET
+from helpers import http_get
+
+# Step 1: ESearch with usehistory=y — NCBI holds result set on server
+search = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    "?db=pubmed&term=CRISPR+gene+editing&retmax=0&retmode=json&usehistory=y"
+))
+webenv    = search['esearchresult']['webenv']       # server-side session token
+query_key = search['esearchresult']['querykey']     # result set ID within session
+total     = int(search['esearchresult']['count'])
+print(f"Total: {total}, WebEnv: {webenv[:30]}..., query_key: {query_key}")
+# Confirmed output (2026-04-18):
+# Total: 24160, WebEnv: MCID_69e4203757db89391008d6f1..., query_key: 1
+
+# Step 2: EFetch pages using WebEnv (no re-searching)
+batch_size = 200
+for start in range(0, min(total, 1000), batch_size):  # cap at 1000 for demo
+    raw = http_get(
+        f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+        f"?db=pubmed&query_key={query_key}&WebEnv={webenv}"
+        f"&retstart={start}&retmax={batch_size}&retmode=xml&rettype=abstract"
+    )
+    root = ET.fromstring(raw)
+    articles = root.findall('.//PubmedArticle')
+    print(f"  Fetched {len(articles)} articles (start={start})")
+    # process articles here...
+```
+
+### EInfo — list available NCBI databases
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?retmode=json"
+))
+dbs = data['einforesult']['dblist']
+print(f"Total databases: {len(dbs)}")   # Confirmed: 39 (2026-04-18)
+print(dbs[:10])
+# ['pubmed', 'protein', 'nuccore', 'ipg', 'nucleotide', 'structure',
+#  'genome', 'annotinfo', 'assembly', 'bioproject']
+```
+
+Get PubMed-specific metadata (field list, link list):
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?db=pubmed&retmode=json"
+))
+db_info = data['einforesult']['dbinfo'][0]
+print("DB name:", db_info['dbname'])
+print("Record count:", db_info['count'])    # total PubMed records
+link_names = [l['name'] for l in db_info.get('linklist', [])]
+print(f"Link types ({len(link_names)}):", link_names[:5])
+# Confirmed (2026-04-18):
+# DB name: pubmed
+# Record count: 37620453
+# Link types (48): ['pubmed_assembly', 'pubmed_bioproject', ...]
+```
+
+### ELink — cross-database linking
+
+ELink connects a PubMed record to associated data in other NCBI databases. The `pubmed_pubmed` "related articles" linkname relies on a similarity server that is intermittently unavailable (returns `"Couldn't resolve #exLinkSrv2, the address table is empty."`). Use the non-similarity links below instead.
+
+```python
+import json
+from helpers import http_get
+
+# Link a PMID to its free full-text in PMC (if open access)
+# linkname=pubmed_pmc — may also hit the server outage; check error field
+data = json.loads(http_get(
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
+    "?dbfrom=pubmed&id=38325330&linkname=pubmed_pmc&retmode=json"
+))
+error = data.get('ERROR', '')
+if error:
+    print("ELink error:", error)   # 'Couldn't resolve #exLinkSrv2...' — NCBI server issue
+else:
+    for ls in data.get('linksets', []):
+        for lsdb in ls.get('linksetdbs', []):
+            print(lsdb['linkname'], "→", lsdb['links'][:5])
+```
+
+Available ELink linknames from pubmed (48 total):
+
+| linkname | Target |
+|---|---|
+| `pubmed_pmc` | Free full text in PMC |
+| `pubmed_pubmed_citedin` | Articles citing this paper |
+| `pubmed_pubmed_refs` | References cited by this paper |
+| `pubmed_gene` | Related Gene records |
+| `pubmed_clinvar` | Clinical variants associated with publication |
+| `pubmed_gds` | Related GEO datasets |
+
+**Practical alternative**: If ELink is down, extract DOI from EFetch/ESummary and use `https://doi.org/{doi}` directly for the full-text link.
+
+## URL and parameter reference
+
+### E-utilities base URLs
+
+```
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi   # search → PMIDs
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi  # PMIDs → JSON summary
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi    # PMIDs → full XML
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi     # cross-db links
+https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi     # DB metadata
+```
+
+### ESearch parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `db` | `pubmed` | Always `pubmed` for PubMed |
+| `term` | query string | Supports field tags like `[Author]`, `[Title]`, `[MeSH Terms]` |
+| `retmax` | integer, max 10000 | Results returned per call |
+| `retmode` | `json` | JSON output |
+| `sort` | `pub+date`, `Author`, `JournalName` | Default is relevance |
+| `datetype` | `pdat` (pub), `edat` (entrez), `mdat` (modified) | |
+| `mindate`, `maxdate` | `YYYY/MM/DD` or `YYYY` | Requires `datetype` |
+| `usehistory` | `y` | Store results on server; returns `webenv` + `querykey` |
+
+### EFetch parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `db` | `pubmed` | |
+| `id` | `38000000,37999999` | Comma-separated PMIDs; max ~200 per call |
+| `query_key` + `WebEnv` | from ESearch `usehistory=y` | Alternative to `id` for large sets |
+| `retstart` | integer | Offset for pagination with WebEnv |
+| `retmax` | integer, max 10000 | Batch size |
+| `retmode` | `xml` | Use XML for EFetch (JSON not available for full records) |
+| `rettype` | `abstract` | Returns abstract + core metadata |
+
+### PubMed article URL construction
+
+```python
+pmid = "41999029"
+pubmed_url  = f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/"
+doi         = "10.12659/MSM.951157"
+doi_url     = f"https://doi.org/{doi}"        # resolves to publisher page
+pmc_id      = "PMC9876543"                    # from ESummary articleids
+pmc_url     = f"https://www.ncbi.nlm.nih.gov/pmc/articles/{pmc_id}/"
+```
+
+## Gotchas
+
+- **`count` is a string, not int.** `search['esearchresult']['count']` returns `'24160'`, not `24160`. Always cast with `int()` before arithmetic.
+
+- **EFetch retmode must be `xml` for full records.** Unlike ESearch and ESummary, EFetch with `retmode=json` returns flat text (the MEDLINE citation text format), not structured JSON. Parse EFetch responses with `xml.etree.ElementTree`.
+
+- **`ArticleTitle` may contain embedded XML tags.** Titles with italics (`<i>Staphylococcus aureus</i>`) or math (`<sub>2</sub>`) are mixed-content nodes. Always use `''.join(el.itertext())` instead of `el.text`, which silently drops everything after the first child tag.
+
+- **~15% of articles have no abstract.** `article.find('Abstract')` returns `None` for short communications, editorials, letters, and older records. Always guard with `if abstract_el is not None`.
+
+- **Author names vary in structure — always handle `CollectiveName`.** Consortium papers list a group name (`'GeKeR Study Group'`, `'Breast Cancer Association Consortium'`) under `<CollectiveName>` instead of `<LastName>/<ForeName>`. Individual authors have `<LastName>` + optionally `<ForeName>` and `<Initials>`. Check `CollectiveName` first; falling through to `LastName` without the check produces `None` errors.
+  - Confirmed real examples (2026-04-18): PMID 37586835 (`GeKeR Study Group`), PMID 36328784 (`Breast Cancer Association Consortium`)
+
+- **PubDate has three possible structures.** Most articles have `<Year>` + optional `<Month>` + optional `<Day>`. Seasonal journals use `<Season>` (e.g. `Jul-Aug`, `Oct-Dec`) instead of `<Month>`. A minority of older records use `<MedlineDate>` (e.g. `1995 Fall`) with no `<Year>`. Safe extraction pattern:
+  ```python
+  pub_date = journal.find('.//PubDate')
+  year_el    = pub_date.find('Year')    if pub_date is not None else None
+  medline_el = pub_date.find('MedlineDate') if pub_date is not None else None
+  year = (year_el.text if year_el is not None
+          else medline_el.text[:4] if medline_el is not None else '')
+  ```
+
+- **Batch EFetch: keep IDs to ~200 per call.** The API accepts comma-separated IDs in `id=`, but very large batches (500+) occasionally time out or return truncated XML. For >200 articles, iterate in chunks or use `usehistory` + `WebEnv`.
+
+- **ELink `pubmed_pubmed` (related articles) is intermittently broken.** The NCBI similarity server returns `"Couldn't resolve #exLinkSrv2, the address table is empty."` — this is a persistent server-side issue as of 2026-04-18, not a rate-limit error. Other linknames (`pubmed_gene`, `pubmed_pmc`, `pubmed_clinvar`) fail with the same error. Use the DOI as a fallback link to publisher full text.
+
+- **Rate limits: 3 req/s without API key, 10 req/s with free key.** Exceeding 3 req/s returns HTTP 429. Insert `time.sleep(0.34)` between sequential calls without a key. Get a free API key at https://www.ncbi.nlm.nih.gov/account/ and append `&api_key=YOUR_KEY` to all URLs.
+
+- **`retmax` upper bound is 10 000 for ESearch.** To retrieve more than 10 000 PMIDs for a search, use `usehistory=y` and page through EFetch with `retstart` offsets. EFetch itself also accepts `retmax` up to 10 000 per call.
+
+- **`retmax=0` in ESearch returns only the count, not IDs — useful for counting.** Combine with `usehistory=y` to store the result for later paging without fetching IDs upfront:
+  ```python
+  search = json.loads(http_get(
+      "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+      "?db=pubmed&term=cancer&retmax=0&retmode=json&usehistory=y"
+  ))
+  total  = int(search['esearchresult']['count'])   # e.g. 4800000
+  webenv = search['esearchresult']['webenv']
+  ```
+
+- **ESummary `authors` field uses abbreviated names (`Last I`), not full names.** Use EFetch XML to get `ForeName` (e.g. `'Kesimal, Uğur'` vs ESummary `'Kesimal U'`). For bulk tasks where full names are not needed, ESummary is faster.
+
+- **`querytranslation` shows how NCBI interpreted your term.** The ESearch response includes `esearchresult.querytranslation` — a MeSH-expanded version of your query. Inspect it to verify the search matched what you intended.

--- a/domain-skills/thesportsdb/scraping.md
+++ b/domain-skills/thesportsdb/scraping.md
@@ -1,0 +1,430 @@
+# TheSportsDB — Data Extraction
+
+`https://www.thesportsdb.com/api/v1/json/3/` — free tier, no registration needed. Pure JSON REST API, no browser required.
+
+## Do this first
+
+**Use `http_get` directly — no browser needed.**
+
+```python
+import json
+data = json.loads(http_get(
+    "https://www.thesportsdb.com/api/v1/json/3/searchteams.php?t=Arsenal"
+))
+team = data["teams"][0]
+print(team["strTeam"], team["strLeague"], team["strStadium"])
+# Arsenal  English Premier League  Emirates Stadium
+```
+
+## Critical: API key "1" is dead — use "3"
+
+The free API key in all official documentation is `1`, but as of 2025 that returns HTTP 404 for every endpoint. **Use `3` instead.** Key `2` also returns 404. Key `3` works identically to the old "free" key `1`.
+
+```python
+# WRONG — returns 404
+BASE = "https://www.thesportsdb.com/api/v1/json/1/"
+
+# CORRECT
+BASE = "https://www.thesportsdb.com/api/v1/json/3/"
+```
+
+## Setup
+
+```python
+import json, urllib.request, urllib.error
+
+BASE = "https://www.thesportsdb.com/api/v1/json/3"
+
+def sdb(path):
+    """TheSportsDB API call. Returns parsed JSON dict."""
+    url = f"{BASE}/{path}"
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+        "Accept": "application/json",
+    })
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read().decode())
+```
+
+## Rate limits
+
+**Very generous — no observable limit on the free tier.** 10 rapid-fire calls in a loop all return 200 with no throttling. No `Retry-After` headers observed. No API key registration required.
+
+## Common workflows
+
+### Search for a team
+
+```python
+r = sdb("searchteams.php?t=Arsenal")
+teams = r["teams"]          # None if no match, not []
+if not teams:
+    print("No results")
+else:
+    t = teams[0]
+    print(t["idTeam"])          # "133604"  — always a string, not int
+    print(t["strTeam"])         # "Arsenal"
+    print(t["strLeague"])       # "English Premier League"
+    print(t["idLeague"])        # "4328"
+    print(t["strSport"])        # "Soccer"
+    print(t["strCountry"])      # "England"
+    print(t["strStadium"])      # "Emirates Stadium"
+    print(t["intFormedYear"])   # "1892"
+    print(t["intStadiumCapacity"])  # "60338"
+    print(t["strBadge"])        # image URL (PNG)
+    print(t["strLogo"])         # transparent logo URL (PNG)
+    print(t["strFanart1"])      # fan art image URL
+    print(t["strColour1"])      # "#EF0107"
+    print(t["strDescriptionEN"][:200])  # long Wikipedia-style bio
+```
+
+Full team object has 64 keys. Key subset:
+`idTeam`, `idLeague`, `idLeague2`–`idLeague7`, `idVenue`, `strTeam`, `strTeamAlternate`, `strTeamShort`, `strSport`, `strLeague`, `strLeague2`–`strLeague7`, `strCountry`, `strLocation`, `strStadium`, `intFormedYear`, `intStadiumCapacity`, `strBadge`, `strLogo`, `strBanner`, `strFanart1`–`strFanart4`, `strEquipment`, `strColour1`–`strColour3`, `strGender`, `strKeywords`, `strWebsite`, `strFacebook`, `strTwitter`, `strInstagram`, `strYoutube`, `strDescriptionEN`, `strDescriptionDE`, `strDescriptionFR`, `strDescriptionES`, `strDescriptionPT`, `strDescriptionIT`, `strDescriptionRU`, `strDescriptionJP`, `strDescriptionNO`, `strLocked`
+
+### Lookup team by ID
+
+```python
+r = sdb("lookupteam.php?id=133604")
+team = r["teams"][0]   # same 64-key structure as searchteams
+```
+
+### Get all teams in a league
+
+```python
+r = sdb("lookup_all_teams.php?id=4328")   # EPL id=4328
+teams = r["teams"]    # up to 24 teams on free tier (actual EPL has 20)
+```
+
+**Free tier limit: 24 results** (confirmed with EPL which has exactly 20 — so all returned).
+
+### Search for a player
+
+```python
+r = sdb("searchplayers.php?p=Mbappe")
+players = r["player"]   # None if not found (note: key is "player" not "players")
+if players:
+    p = players[0]
+    print(p["idPlayer"])        # "34162098"
+    print(p["strPlayer"])       # "Kylian Mbappé"
+    print(p["idTeam"])          # "133738"
+    print(p["strTeam"])         # "Real Madrid"
+    print(p["strNationality"])  # "France"
+    print(p["strPosition"])     # "Centre-Forward"
+    print(p["dateBorn"])        # "1998-12-20"
+    print(p["strStatus"])       # "Active"
+    print(p["strSport"])        # "Soccer"
+    print(p["strThumb"])        # player photo URL
+    print(p["strCutout"])       # transparent cutout URL
+    print(p["relevance"])       # float — search relevance score
+```
+
+Search response has only 13 keys. For full player biography (69 keys including height, weight, description, social links):
+
+```python
+r = sdb("lookupplayer.php?id=34162098")
+player = r["players"][0]   # note: "players" not "player"
+print(player["strHeight"])         # "180 cm"
+print(player["strWeight"])         # "73 kg"
+print(player["strDescriptionEN"])  # Wikipedia-style bio
+print(player["strFanart1"])        # fan art URL
+```
+
+### Get squad for a team
+
+```python
+r = sdb("lookup_all_players.php?id=133604")   # Arsenal
+players = r["player"]    # up to 10 on free tier
+```
+
+**Free tier limit: 10 players per team** (usually returns coaching staff + selected players, not full squad).
+
+### League metadata
+
+```python
+# Lookup a specific league by ID
+r = sdb("lookupleague.php?id=4328")
+league = r["leagues"][0]
+print(league["strLeague"])          # "English Premier League"
+print(league["strCurrentSeason"])   # "2025-2026"
+print(league["intFormedYear"])      # "1992"
+print(league["strCountry"])         # "England"
+print(league["strSport"])           # "Soccer"
+print(league["dateFirstEvent"])     # "1992-08-15"
+print(league["strComplete"])        # "yes"
+print(league["strBadge"])           # badge image URL
+print(league["strLogo"])            # logo URL
+print(league["strTvRights"])        # TV broadcast info (freeform text)
+print(league["strNaming"])          # "{strHomeTeam} vs {strAwayTeam}"
+```
+
+League object has 47 keys including multi-language descriptions.
+
+### Search leagues by country/sport
+
+```python
+# Both params required to get useful results
+r = sdb("search_all_leagues.php?c=England&s=Soccer")
+leagues = r["countries"]    # note: "countries" not "countrys"
+# Returns up to 10 leagues on free tier
+
+# Country only (still returns up to 36, all in UK Soccer for England)
+r2 = sdb("search_all_leagues.php?c=England")
+leagues2 = r2["countries"]
+for l in leagues2:
+    print(l["idLeague"], l["strLeague"], l["intDivision"])
+# 4328  English Premier League  0
+# 4329  English League Championship  2
+# 4396  English League 1  3
+# 4397  English League 2  4
+# ...
+```
+
+**Response key is always `"countries"`, not `"countrys"`** (the URL path says "countrys" but the JSON response key is "countries").
+
+**Free tier limit: 10 results** regardless of how many leagues exist.
+
+### League seasons
+
+```python
+r = sdb("search_all_seasons.php?id=4328&round=1")
+seasons = r["seasons"]
+# Free tier limit: 5 seasons
+# Each entry is just: {"strSeason": "2023-2024"}
+for s in seasons:
+    print(s["strSeason"])
+# 1992-1993
+# 1993-1994  ...
+```
+
+**Free tier limit: 5 seasons** per query. Newer seasons appear first (descending order).
+
+### Standings / league table
+
+```python
+r = sdb("lookuptable.php?l=4328&s=2023-2024")
+table = r["table"]
+# Free tier limit: 5 rows (not the full 20-team table)
+for row in table:
+    print(f"{row['intRank']:2d}. {row['strTeam']:<25} {row['intPoints']}pts "
+          f"P{row['intPlayed']} W{row['intWin']} D{row['intDraw']} L{row['intLoss']} "
+          f"GD{row['intGoalDifference']}")
+# 1. Manchester City           91pts P38 W28 D7 L3 GD62
+```
+
+Standings fields: `intRank`, `strTeam`, `idTeam`, `strBadge`, `intPlayed`, `intWin`, `intDraw`, `intLoss`, `intGoalsFor`, `intGoalsAgainst`, `intGoalDifference`, `intPoints`, `strForm`, `strDescription`, `strLeague`, `strSeason`, `dateUpdated`
+
+**Free tier limit: 5 rows** — use a paid key to get the full table.
+
+### Events (fixtures & results)
+
+```python
+# Next 15 events for a league
+r = sdb("eventsnextleague.php?id=4328")
+events = r["events"]
+
+# Past 15 events for a league
+r = sdb("eventspastleague.php?id=4328")
+events = r["events"]
+
+# All events for a season (free tier: 15)
+r = sdb("eventsseason.php?id=4328&s=2023-2024")
+events = r["events"]
+
+# Events on a specific date (optionally filter by league name)
+r = sdb("eventsday.php?d=2023-08-11&l=English+Premier+League")
+events = r["events"]
+
+# Next events for a specific team (returns 5 typically)
+r = sdb("eventsnext.php?id=133604")
+events = r["events"]
+
+# Last events for a specific team
+r = sdb("eventslast.php?id=133604")
+events = r["results"]   # NOTE: key is "results" not "events"
+
+# Lookup specific event by ID
+r = sdb("lookupevent.php?id=1818395")
+events = r["events"]
+```
+
+### Event object fields
+
+```python
+e = events[0]
+print(e["idEvent"])          # "1818395"
+print(e["strEvent"])         # "Burnley vs Manchester City"
+print(e["strHomeTeam"])      # "Burnley"
+print(e["strAwayTeam"])      # "Manchester City"
+print(e["intHomeScore"])     # "0"  — STRING when finished, None when upcoming
+print(e["intAwayScore"])     # "3"  — STRING when finished, None when upcoming
+print(e["strStatus"])        # "Match Finished" | "Not Started" | None (older events)
+print(e["dateEvent"])        # "2023-08-11"
+print(e["strTime"])          # "19:00:00"  (UTC)
+print(e["strTimeLocal"])     # "19:00:00"  (local)
+print(e["dateEventLocal"])   # "2023-08-11"
+print(e["strTimestamp"])     # "2023-08-11T19:00:00"
+print(e["strLeague"])        # "English Premier League"
+print(e["idLeague"])         # "4328"
+print(e["strSeason"])        # "2023-2024"
+print(e["intRound"])         # "1"
+print(e["strVenue"])         # "Turf Moor"
+print(e["strCountry"])       # "England"
+print(e["strCity"])          # "Burnley"
+print(e["strSport"])         # "Soccer"
+print(e["strPostponed"])     # "no"
+print(e["idHomeTeam"])       # "133604"
+print(e["idAwayTeam"])       # "133613"
+print(e["strHomeTeamBadge"]) # badge URL or None
+print(e["strResult"])        # "" (empty string, not useful)
+print(e["intSpectators"])    # "21567" or None
+print(e["strThumb"])         # match thumbnail URL or None
+print(e["strVideo"])         # highlight video URL or ""
+```
+
+Full event has 47 keys. Additional: `strEventAlternate`, `strFilename`, `strGroup`, `strDescriptionEN`, `strLeagueBadge`, `strBanner`, `strFanart`, `strSquare`, `strMap`, `strPoster`, `strOfficial`, `strWeather`, `strTweet1`, `intScore`, `intScoreVotes`, `idVenue`, `idAPIfootball`, `strLocked`.
+
+### Search events by name
+
+```python
+r = sdb("searchevents.php?e=Arsenal+vs+Chelsea&s=2023-2024")
+events = r["event"]    # note: "event" not "events"
+# Returns up to 25 matching events across all seasons
+# s= parameter filters by season string
+```
+
+### Lineup (match squads)
+
+```python
+r = sdb("lookuplineup.php?id=1818395")
+lineup = r["lineup"]    # None for events with no lineup data
+if lineup:
+    for player in lineup:
+        print(player["strPlayer"])       # "Emiliano Martinez"
+        print(player["strTeam"])         # "Aston Villa"
+        print(player["strPosition"])     # "Goalkeeper"
+        print(player["strSubstitute"])   # "No" | "Yes"
+        print(player["intSquadNumber"])  # "26"
+        print(player["strHome"])         # "Yes" (home team) | "No" (away team)
+        print(player["idPlayer"])        # player ID for lookupplayer
+        print(player["strThumb"])        # player photo URL
+        print(player["strCutout"])       # transparent cutout URL
+```
+
+### Venue details
+
+```python
+r = sdb("lookupvenue.php?id=15528")    # idVenue from team or event objects
+venue = r["venues"][0]
+print(venue["strVenue"])          # "Emirates Stadium"
+print(venue["intCapacity"])       # "60338"
+print(venue["strCountry"])        # "England"
+print(venue["strLocation"])       # city/area
+print(venue["strTimezone"])       # "Europe/London"
+print(venue["strArchitect"])      # architect name
+print(venue["intFormedYear"])     # year opened
+print(venue["strDescriptionEN"])  # long description
+print(venue["strMap"])            # Google Maps embed URL
+print(venue["strThumb"])          # stadium photo URL
+```
+
+## Supported sports
+
+The free tier (key=3) returns data across multiple sports. Confirmed working:
+- Soccer / Football
+- American Football (NFL)
+- Basketball (NBA, etc.)
+- Baseball (MLB, etc.)
+- Ice Hockey (NHL, etc.)
+- Tennis
+- Rugby
+- Cricket
+
+Sport names are exact strings — use them verbatim in `s=` parameters.
+
+```python
+# NBA example
+r = sdb("lookupleague.php?id=4387")     # NBA
+r = sdb("searchteams.php?t=Los+Angeles+Lakers")
+teams = r["teams"]   # returns 1 result
+team = teams[0]
+print(team["strSport"])   # "Basketball"
+```
+
+## Key league IDs (commonly used)
+
+| League | id |
+|--------|----|
+| English Premier League | 4328 |
+| English League Championship | 4329 |
+| English League 1 | 4396 |
+| English League 2 | 4397 |
+| EFL Cup | 4570 |
+| FA Cup | 4482 |
+| UEFA Champions League | 4480 |
+| NFL | 4391 |
+| NBA | 4387 |
+| MLB | 4424 |
+| NHL | 4380 |
+
+## Free tier result limits (confirmed)
+
+| Endpoint | Limit |
+|----------|-------|
+| `eventsseason.php` | 15 events |
+| `eventsnextleague.php` | 15 events |
+| `eventspastleague.php` | 15 events |
+| `eventsnext.php` (team) | ~5 events |
+| `searchevents.php` | 25 events |
+| `lookup_all_teams.php` | 24 teams |
+| `lookup_all_players.php` | 10 players |
+| `search_all_seasons.php` | 5 seasons |
+| `search_all_leagues.php` | 10 leagues |
+| `all_leagues.php` | 10 leagues |
+| `lookuptable.php` | 5 rows |
+| `all_sports.php` | 1 sport (Soccer only!) |
+| `searchteams.php` | up to 1 (exact match only) |
+| `searchplayers.php` | 2-5 results |
+
+## V2 livescores (not available)
+
+All v2 endpoints (`/api/v2/json/*/livescore.php`) return HTTP 404 regardless of the key used — including the example paid key `50130162` mentioned in various tutorials. As of April 2026, the v2 livescore endpoint appears to be decommissioned or never publicly released. There is no working livescore endpoint on the free tier.
+
+## No-result behavior
+
+```python
+# Missing data returns None, NOT an empty list
+r = sdb("searchteams.php?t=ZZZZNOTATEAM")
+print(r["teams"])    # None  ← not []
+
+r = sdb("searchplayers.php?p=ZZZZNOTAPLAYER")
+print(r["player"])   # None  ← not []
+
+# ALWAYS guard with: teams = r.get("teams") or []
+```
+
+## Gotchas
+
+**API key "1" is dead** — Returns HTTP 404 for all endpoints. Use key `3`. Keys `2` and any string ("free", "test") also return 404. Only `3` (and presumably paid numeric keys) work.
+
+**Scores are strings, not ints** — `intHomeScore` is `"3"` (a string), not `3`, when a match is finished. It is `None` (Python None) for upcoming matches. Cast before arithmetic: `int(e["intHomeScore"] or 0)`.
+
+**"player" vs "players" key inconsistency** — `searchplayers.php` returns `r["player"]`, but `lookupplayer.php` returns `r["players"]`. These are different keys.
+
+**"results" key for last team events** — `eventslast.php` returns `r["results"]`, not `r["events"]`. All other event endpoints use `r["events"]`.
+
+**"countries" key for league search** — `search_all_leagues.php` returns JSON key `"countries"` (correct English), not `"countrys"` (which the endpoint URL path suggests).
+
+**`lookuplineup` ignores invalid event IDs** — Passing a non-existent event ID does not return `None` or an empty list. It returns the lineup for the last cached event instead. Always cross-check `lineup[0]["idEvent"]` matches your requested event ID.
+
+**All numeric IDs are strings** — `idTeam`, `idLeague`, `idEvent`, `idPlayer`, etc. are all returned as strings (`"133604"`), not integers. Don't use `==` against integer literals.
+
+**`strStatus` can be `None` for historical events** — Older completed events have `strStatus: null` (Python `None`), not `"Match Finished"`. Check `intHomeScore is not None` as a more reliable way to detect a completed match.
+
+**`eventsday.php?id=` filters by event ID, not league** — The `id=` parameter on `eventsday.php` does NOT filter by league ID. Use `l=` (league name as string) to filter by league.
+
+**`searchteams.php` does partial matching inconsistently** — Searching for "Lakers" returns `None` (no match), but "Los Angeles Lakers" returns a result. For teams, use the full official name or use `lookup_all_teams.php` for a league and filter client-side.
+
+**`all_sports.php` returns only Soccer on free tier** — Despite the endpoint name suggesting all sports, key=3 returns only one sport entry (Soccer). Use `search_all_leagues.php?s=Basketball` etc. to work with other sports.
+
+**Image URLs are on r2.thesportsdb.com CDN** — Badge, logo, fanart, and player photo URLs use `https://r2.thesportsdb.com/images/media/...`. These load without authentication.
+
+**`strTime` is in UTC** — Match times are stored in UTC. `strTimeLocal` and `dateEventLocal` reflect local kickoff time. Both are present on all event objects.

--- a/domain-skills/usgs-earthquakes/scraping.md
+++ b/domain-skills/usgs-earthquakes/scraping.md
@@ -1,0 +1,572 @@
+# USGS Earthquake Hazards Program API
+
+`https://earthquake.usgs.gov` — completely free, no authentication, no API key. Two distinct interfaces: the **Feed API** (static pre-built snapshots, fastest) and the **Query API** (flexible filtering, historical data).
+
+No browser needed. All calls are plain HTTP GETs handled by `http_get`.
+
+---
+
+## Fastest path: recent earthquakes via Feed API
+
+Pick a feed and call it directly. Results are cached server-side and return in well under 1 second.
+
+```python
+import json
+from helpers import http_get
+
+# All earthquakes in the past hour
+raw = http_get("https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson")
+data = json.loads(raw)
+
+print(data['metadata'])
+# {'generated': 1776559120000, 'url': '...', 'title': 'USGS All Earthquakes, Past Hour',
+#  'status': 200, 'api': '2.3.0', 'count': 13}
+
+for feature in data['features']:
+    props = feature['properties']
+    coords = feature['geometry']['coordinates']  # [lon, lat, depth_km]
+    lon, lat, depth_km = coords[0], coords[1], coords[2]
+    print(f"M{props['mag']} at {props['place']} | depth {depth_km}km | id={feature['id']}")
+```
+
+---
+
+## Feed URL patterns
+
+All 20 combinations work. Replace `{mag}` and `{window}`:
+
+```
+https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/{mag}_{window}.geojson
+```
+
+| `{mag}` | Threshold |
+|---------|-----------|
+| `all` | No lower bound |
+| `1.0` | M1.0+ |
+| `2.5` | M2.5+ |
+| `4.5` | M4.5+ |
+| `significant` | Significant events (high impact, large sig score) |
+
+| `{window}` | Time range |
+|------------|------------|
+| `hour` | Past 1 hour |
+| `day` | Past 24 hours |
+| `week` | Past 7 days |
+| `month` | Past 30 days |
+
+Approximate event counts (verified 2026-04):
+
+| Feed | Approx count |
+|------|-------------|
+| `all_hour` | ~5–30 |
+| `all_day` | ~240 |
+| `all_week` | ~1,700 |
+| `all_month` | ~11,500 |
+| `2.5_week` | ~370 |
+| `4.5_day` | ~25 |
+| `significant_month` | ~8 |
+
+`all_month` transfers a few MB of JSON — parse it once, don't poll it repeatedly.
+
+---
+
+## GeoJSON structure
+
+Every feed and query response is a GeoJSON `FeatureCollection`:
+
+```python
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "generated": 1776559120000,   # ms epoch, when the feed was generated
+    "url": "https://...",
+    "title": "USGS All Earthquakes, Past Hour",
+    "status": 200,
+    "api": "2.3.0",
+    "count": 13                   # total features in this response
+  },
+  "bbox": [-179.6701, -32.4116, 10, 161.575, 51.42, 198.753],
+                # [minLon, minLat, minDepth, maxLon, maxLat, maxDepth]
+  "features": [...]
+}
+```
+
+Each `feature`:
+
+```python
+{
+  "type": "Feature",
+  "id": "hv74938567",             # event ID, network-prefixed
+  "geometry": {
+    "type": "Point",
+    "coordinates": [-155.394165039062, 19.0879993438721, 45.2900009155273]
+    #               ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^
+    #               longitude (E=+)      latitude (N=+)      depth in km
+  },
+  "properties": {
+    "mag":       1.78,            # Richter/moment magnitude; can be None for unreviewed
+    "magType":   "md",            # magnitude method: mww, mw, ml, md, mb, ...
+    "place":     "15 km SE of Pāhala, Hawaii",
+    "time":      1776558489040,   # ms since Unix epoch (UTC) — divide by 1000 for seconds
+    "updated":   1776558697000,   # ms epoch of last update
+    "tz":        None,            # deprecated, always None
+    "url":       "https://earthquake.usgs.gov/earthquakes/eventpage/hv74938567",
+    "detail":    "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=hv74938567&format=geojson",
+    "felt":      None,            # number of "Did You Feel It?" reports; None if none
+    "cdi":       None,            # max reported intensity (DYFI), 1-10; None if no reports
+    "mmi":       None,            # max estimated ShakeMap intensity; None if not computed
+    "alert":     None,            # PAGER alert level: "green"/"yellow"/"orange"/"red"/None
+    "status":    "automatic",     # "automatic" or "reviewed"
+    "tsunami":   0,               # 1 if tsunami message issued, else 0 (integer, not bool)
+    "sig":       49,              # significance 0-1000 (combines mag, felt reports, PAGER)
+    "net":       "hv",            # network that authored the event
+    "code":      "74938567",      # network-specific event code
+    "ids":       ",hv74938567,",  # all associated IDs (comma-delimited with leading/trailing commas)
+    "sources":   ",hv,",          # networks contributing data
+    "types":     ",origin,phase-data,",  # product types available
+    "nst":       8,               # number of seismic stations used
+    "dmin":      0.1488,          # min distance to station (degrees)
+    "rms":       0.05,            # root-mean-square travel time residual (seconds)
+    "gap":       282,             # largest azimuthal gap (degrees); >180 = poorly constrained
+    "type":      "earthquake",    # event type: "earthquake", "quarry blast", "ice quake", etc.
+    "title":     "M 1.8 - 15 km SE of Pāhala, Hawaii"
+  }
+}
+```
+
+---
+
+## Critical gotchas
+
+**Coordinates are [longitude, latitude, depth] — NOT [lat, lon].**
+
+```python
+coords = feature['geometry']['coordinates']
+lon     = coords[0]   # longitude (west is negative)
+lat     = coords[1]   # latitude  (south is negative)
+depth_km = coords[2]  # depth in kilometers below surface
+```
+
+**Time is milliseconds since epoch, not seconds.**
+
+```python
+import datetime
+props = feature['properties']
+dt = datetime.datetime.fromtimestamp(props['time'] / 1000, tz=datetime.timezone.utc)
+# props['time'] = 1776558489040  →  dt = 2026-04-19T12:28:09.040000+00:00
+```
+
+**`mag` can be `None`.** Automatic detections may not have a computed magnitude yet.
+
+```python
+mags = [f['properties']['mag'] for f in data['features'] if f['properties']['mag'] is not None]
+```
+
+**`tsunami` is an integer (0 or 1), not a boolean.** `if props['tsunami']:` works, but `props['tsunami'] == True` does not.
+
+**`ids` has leading and trailing commas.** To get a clean list:
+
+```python
+ids = props['ids'].strip(',').split(',')  # ['hv74938567']
+```
+
+**`gap` > 180 means the hypocenter location is unreliable.** The azimuthal gap is the largest angle between adjacent stations; high values indicate poor station coverage.
+
+---
+
+## Query API
+
+Use when you need historical data, filtering by geography, or a specific event.
+
+Base URL: `https://earthquake.usgs.gov/fdsnws/event/1/query`
+
+Always include `format=geojson`. Response structure is identical to feeds, with additional `limit` and `offset` in `metadata`.
+
+### Parameters reference
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `starttime` | ISO datetime or date | Start of time window (UTC). `2024-01-01` or `2024-01-01T07:00:00` |
+| `endtime` | ISO datetime or date | End of time window (default: now) |
+| `minmagnitude` | float | Lower magnitude bound (inclusive) |
+| `maxmagnitude` | float | Upper magnitude bound (inclusive) |
+| `mindepth` | float | Min depth in km |
+| `maxdepth` | float | Max depth in km |
+| `latitude` | float | Center latitude for radius search |
+| `longitude` | float | Center longitude for radius search |
+| `maxradiuskm` | float | Radius in km (use with lat/lon) |
+| `maxradius` | float | Radius in degrees (use with lat/lon, alternative to maxradiuskm) |
+| `minlatitude` | float | Rectangle south boundary |
+| `maxlatitude` | float | Rectangle north boundary |
+| `minlongitude` | float | Rectangle west boundary |
+| `maxlongitude` | float | Rectangle east boundary |
+| `limit` | int | Max results per response; hard max is **20000** (400 if over) |
+| `offset` | int | 1-based offset for pagination (default: 1) |
+| `orderby` | string | `time` (default, newest first), `time-asc`, `magnitude`, `magnitude-asc` |
+| `eventid` | string | Fetch a single event by ID |
+
+### Date range + magnitude
+
+```python
+import json
+from helpers import http_get
+
+raw = http_get(
+    "https://earthquake.usgs.gov/fdsnws/event/1/query"
+    "?format=geojson"
+    "&starttime=2024-01-01"
+    "&endtime=2024-01-07"
+    "&minmagnitude=5.0"
+    "&limit=10"
+)
+data = json.loads(raw)
+print(data['metadata'])
+# {'generated': ..., 'limit': 10, 'offset': 1, 'count': 10, ...}
+
+for f in data['features']:
+    p = f['properties']
+    print(f"M{p['mag']} {p['place']}")
+# M5.5 southern East Pacific Rise
+# M5.5 31 km NNW of Pisco, Peru
+# ...
+```
+
+### Largest earthquakes in a month
+
+```python
+import json
+from helpers import http_get
+
+raw = http_get(
+    "https://earthquake.usgs.gov/fdsnws/event/1/query"
+    "?format=geojson"
+    "&starttime=2024-01-01"
+    "&endtime=2024-01-31"
+    "&minmagnitude=6.0"
+    "&orderby=magnitude"
+    "&limit=5"
+)
+data = json.loads(raw)
+for f in data['features']:
+    p = f['properties']
+    print(f"M{p['mag']} — {p['place']}")
+# M7.5 — 2024 Noto Peninsula, Japan Earthquake
+# M7.0 — 128 km WNW of Aykol, China
+# M6.7 — 93 km SE of Sarangani, Philippines
+# M6.6 — 123 km NW of Tarauacá, Brazil
+# M6.5 — 70 km W of Tarauacá, Brazil
+```
+
+### Radius search (nearest events to a point)
+
+```python
+import json
+from helpers import http_get
+
+# Earthquakes within 100 km of San Francisco, M3+
+raw = http_get(
+    "https://earthquake.usgs.gov/fdsnws/event/1/query"
+    "?format=geojson"
+    "&latitude=37.7"
+    "&longitude=-122.4"
+    "&maxradiuskm=100"
+    "&minmagnitude=3.0"
+    "&limit=10"
+    "&orderby=time"
+)
+data = json.loads(raw)
+for f in data['features']:
+    p = f['properties']
+    g = f['geometry']['coordinates']
+    print(f"M{p['mag']} depth={g[2]}km — {p['place']}")
+```
+
+### Bounding box (rectangle) search
+
+```python
+import json
+from helpers import http_get
+
+# Western US, Jan 2024, M3+
+raw = http_get(
+    "https://earthquake.usgs.gov/fdsnws/event/1/query"
+    "?format=geojson"
+    "&starttime=2024-01-01"
+    "&endtime=2024-01-31"
+    "&minlatitude=30"
+    "&maxlatitude=50"
+    "&minlongitude=-130"
+    "&maxlongitude=-110"
+    "&minmagnitude=3.0"
+    "&limit=20"
+)
+data = json.loads(raw)
+print(f"{len(data['features'])} events")
+```
+
+### Depth filter (deep earthquakes)
+
+```python
+import json
+from helpers import http_get
+
+# Deep-focus earthquakes (> 100 km), M5+
+raw = http_get(
+    "https://earthquake.usgs.gov/fdsnws/event/1/query"
+    "?format=geojson"
+    "&starttime=2024-01-01"
+    "&endtime=2024-01-07"
+    "&minmagnitude=5.0"
+    "&mindepth=100"
+    "&limit=10"
+)
+data = json.loads(raw)
+for f in data['features']:
+    p = f['properties']
+    depth = f['geometry']['coordinates'][2]
+    print(f"M{p['mag']} depth={depth}km — {p['place']}")
+# M5.7 depth=197km — 125 km W of Houma, Tonga
+# M5.0 depth=137km — Banda Sea
+```
+
+### Offset pagination (> 20,000 results)
+
+The Query API hard-caps at `limit=20000` per request (HTTP 400 if exceeded). For large windows, paginate with `offset`:
+
+```python
+import json
+from helpers import http_get
+
+def query_all(starttime, endtime, minmagnitude=0.0):
+    """Paginate through all matching events."""
+    results = []
+    offset = 1
+    limit = 10000
+    while True:
+        raw = http_get(
+            f"https://earthquake.usgs.gov/fdsnws/event/1/query"
+            f"?format=geojson"
+            f"&starttime={starttime}"
+            f"&endtime={endtime}"
+            f"&minmagnitude={minmagnitude}"
+            f"&orderby=time-asc"
+            f"&limit={limit}"
+            f"&offset={offset}"
+        )
+        data = json.loads(raw)
+        batch = data['features']
+        results.extend(batch)
+        if len(batch) < limit:
+            break
+        offset += limit
+    return results
+```
+
+---
+
+## Count endpoint
+
+Returns a plain integer count (no features). Use to check result size before fetching.
+
+```python
+from helpers import http_get
+import json
+
+# Plain text response (default)
+count_txt = http_get(
+    "https://earthquake.usgs.gov/fdsnws/event/1/count"
+    "?starttime=2024-01-01"
+    "&endtime=2024-12-31"
+    "&minmagnitude=6.0"
+)
+print(count_txt.strip())  # "99"
+
+# JSON response (includes maxAllowed)
+count_json = http_get(
+    "https://earthquake.usgs.gov/fdsnws/event/1/count"
+    "?format=geojson"
+    "&starttime=2024-01-01"
+    "&endtime=2024-01-31"
+    "&minmagnitude=5.0"
+)
+obj = json.loads(count_json)
+print(obj)  # {"count": 132, "maxAllowed": 20000}
+```
+
+---
+
+## Event detail (full metadata)
+
+The `detail` property in each feature is the full-detail URL. Fetch it for origin products, ShakeMap, moment tensor, phase data, PAGER, etc.
+
+```python
+import json
+from helpers import http_get
+
+# Method 1: use detail URL from feed/query feature
+feature_detail_url = "https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=us6000m0xl&format=geojson"
+raw = http_get(feature_detail_url)
+detail = json.loads(raw)
+
+# detail is a single Feature (not FeatureCollection)
+print(detail['type'])          # "Feature"
+print(detail['id'])            # "us6000m0xl"
+
+p = detail['properties']
+print(p['mag'])                # 7.5
+print(p['status'])             # "reviewed"
+print(list(p['products'].keys()))
+# ['dyfi', 'earthquake-name', 'finite-fault', 'general-text', 'ground-failure',
+#  'impact-link', 'impact-text', 'internal-origin', 'losspager', 'moment-tensor',
+#  'origin', 'phase-data', 'shakemap']
+
+# Method 2: fetch from the short detail URL in feed properties
+# feed_feature['properties']['detail'] is already the right URL
+```
+
+### Extracting origin product properties
+
+```python
+origin = p['products']['origin'][0]  # list, take first (preferred)
+op = origin['properties']
+print(op['depth'])              # "10" (strings, not numbers)
+print(op['latitude'])           # "37.4874"
+print(op['longitude'])          # "137.2710"
+print(op['num-phases-used'])    # "284"
+print(op['standard-error'])     # "0.55"
+print(op['azimuthal-gap'])      # "36"
+print(op['review-status'])      # "reviewed"
+```
+
+All values inside product `properties` dicts are **strings**, including numeric ones. Cast as needed.
+
+---
+
+## Catalogs and contributors (XML)
+
+These endpoints return XML, not JSON:
+
+```python
+from helpers import http_get
+
+catalogs_xml = http_get("https://earthquake.usgs.gov/fdsnws/event/1/catalogs")
+# <?xml version="1.0"?><Catalogs><Catalog>ak</Catalog><Catalog>ci</Catalog>...
+
+contributors_xml = http_get("https://earthquake.usgs.gov/fdsnws/event/1/contributors")
+# <?xml version="1.0"?><Contributors><Contributor>ak</Contributor>...
+
+# Parse with stdlib
+import xml.etree.ElementTree as ET
+root = ET.fromstring(catalogs_xml)
+catalogs = [c.text for c in root.findall('Catalog')]
+# ['20', '38457511', '=c', 'aacse', 'ak', 'at', 'atlas', 'av', 'ci', 'hv', ...]
+
+root2 = ET.fromstring(contributors_xml)
+contributors = [c.text for c in root2.findall('Contributor')]
+# ['admin', 'ak', 'at', 'atlas', 'av', 'ci', 'ew', 'hv', 'nc', 'nm', ...]
+```
+
+Network codes: `ak`=Alaska, `ci`=Southern California, `hv`=Hawaii, `nc`=Northern California, `us`=USGS national network, `uw`=Pacific Northwest.
+
+---
+
+## Feed vs Query API
+
+| | Feed API | Query API |
+|---|---------|-----------|
+| URL pattern | `/feed/v1.0/summary/{mag}_{window}.geojson` | `/fdsnws/event/1/query?format=geojson&...` |
+| Speed | Very fast (pre-cached, CDN) | Slower (live DB query) |
+| Data freshness | Updated every 1–5 minutes | Real-time |
+| Time windows | Fixed: hour/day/week/month | Any range back to 1900s |
+| Filtering | Only by magnitude tier | Full filtering |
+| Pagination | None (full result) | `limit`+`offset` |
+| Max events | ~11,500 (all_month) | 20,000 per request |
+| Use for | Dashboards, monitoring, latest data | Historical analysis, specific regions |
+
+---
+
+## Rate limits and best practices
+
+No documented rate limit. The USGS operates the API as a public service. Practical guidance:
+
+- Feed API: poll at most once per minute — feeds update every 1–5 minutes
+- Query API: space requests by at least 1 second for bulk operations
+- Do not fetch `all_month` in a tight loop — it's ~11K events and several MB
+- Use `2.5_week` or `4.5_day` for monitoring; use Query API for historical analysis
+- The `count` endpoint is cheap — use it before large paginated queries to estimate total records
+
+---
+
+## Common patterns
+
+### Convert epoch ms to datetime
+
+```python
+import datetime
+
+ms_epoch = 1776558489040
+dt = datetime.datetime.fromtimestamp(ms_epoch / 1000, tz=datetime.timezone.utc)
+# datetime.datetime(2026, 4, 19, 12, 28, 9, 40000, tzinfo=datetime.timezone.utc)
+dt.isoformat()  # '2026-04-19T12:28:09.040000+00:00'
+```
+
+### Filter significant events from a feed
+
+```python
+import json
+from helpers import http_get
+
+raw = http_get("https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson")
+data = json.loads(raw)
+
+# Events with tsunami flag, M5+, or high significance score
+notable = [
+    f for f in data['features']
+    if (f['properties']['mag'] or 0) >= 5.0
+    or f['properties']['tsunami'] == 1
+    or f['properties']['sig'] >= 600
+]
+print(f"{len(notable)} notable events this week")
+```
+
+### Check if event is well-constrained
+
+```python
+def is_well_located(feature):
+    props = feature['properties']
+    gap = props.get('gap')
+    nst = props.get('nst')
+    return (
+        props['status'] == 'reviewed'
+        and gap is not None and gap < 180
+        and nst is not None and nst >= 10
+    )
+```
+
+### Bulk fetch for a region using threading
+
+```python
+import json
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+
+def fetch_month(year, month):
+    import calendar
+    last_day = calendar.monthrange(year, month)[1]
+    raw = http_get(
+        f"https://earthquake.usgs.gov/fdsnws/event/1/query"
+        f"?format=geojson"
+        f"&starttime={year}-{month:02d}-01"
+        f"&endtime={year}-{month:02d}-{last_day}"
+        f"&minmagnitude=4.5"
+        f"&limit=20000"
+    )
+    return json.loads(raw)['features']
+
+# Fetch 6 months in parallel (be respectful — small pool)
+months = [(2024, m) for m in range(1, 7)]
+with ThreadPoolExecutor(max_workers=3) as pool:
+    all_results = list(pool.map(lambda ym: fetch_month(*ym), months))
+events = [e for batch in all_results for e in batch]
+print(f"Total M4.5+ events H1 2024: {len(events)}")
+```

--- a/domain-skills/wikidata/scraping.md
+++ b/domain-skills/wikidata/scraping.md
@@ -1,0 +1,362 @@
+# Wikidata — Structured Knowledge Base
+
+`https://www.wikidata.org` — free structured knowledge base. All APIs are free, no auth required. No browser needed for any workflow on this page.
+
+## Do this first
+
+**Use the MediaWiki API (`wbgetentities`) when you have QIDs — batch up to 50 at once, one HTTP call.**
+
+```python
+import json
+data = json.loads(http_get(
+    "https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q42|Q64|Q30&languages=en|mul&props=labels|descriptions&format=json"
+))
+# data['entities'] is a dict keyed by QID
+for qid, ent in data['entities'].items():
+    label = (ent['labels'].get('en') or ent['labels'].get('mul') or {}).get('value', '')
+    desc = ent['descriptions'].get('en', {}).get('value', '')
+    print(qid, label, '—', desc)
+# Q42 Douglas Adams — British science fiction writer and humorist (1952–2001)
+# Q64 Berlin — federated state, capital and largest city of Germany
+# Q30 United States — country located primarily in North America
+```
+
+**Use SPARQL when you need to query by property values, filter, or aggregate — it returns already-labelled rows.**
+
+**Use `Special:EntityData/{QID}.json` when you need the full entity including all claims with qualifiers.**
+
+No browser needed. No auth. No API key.
+
+---
+
+## Key concepts
+
+### QID and PID format
+
+- **Items** (things): `Q42`, `Q7186`, `Q60` — entities like people, places, concepts
+- **Properties**: `P31`, `P279`, `P17` — define the type of relationship in a claim
+- A **claim** = subject (QID) + property (PID) + value (another QID, string, date, quantity, coordinate, ...)
+
+Common property IDs confirmed working:
+
+| PID | Label |
+|-----|-------|
+| P31 | instance of |
+| P279 | subclass of |
+| P17 | country |
+| P18 | image (Wikimedia Commons URL) |
+| P50 | author |
+| P57 | director |
+| P106 | occupation |
+| P214 | VIAF cluster ID |
+| P569 | date of birth |
+| P570 | date of death |
+| P577 | publication date |
+| P625 | coordinate location |
+| P1082 | population |
+
+Look up any PID: `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=P31|P569|P1082&languages=en&props=labels&format=json`
+
+### SPARQL prefixes (built-in, no need to declare)
+
+```sparql
+wd:   = https://www.wikidata.org/entity/         (items: wd:Q42)
+wdt:  = https://www.wikidata.org/prop/direct/    (truthy property: wdt:P31)
+p:    = https://www.wikidata.org/prop/           (full statement node: p:P31)
+ps:   = https://www.wikidata.org/prop/statement/ (statement value: ps:P31)
+pq:   = https://www.wikidata.org/prop/qualifier/ (qualifier value: pq:P580)
+```
+
+`wdt:` is the shorthand for most queries — it picks the preferred-rank value (or best normal-rank). Use `p:/ps:` only when you need qualifiers or multiple ranked values.
+
+---
+
+## Common workflows
+
+### Search for an entity by name (API)
+
+```python
+import json
+data = json.loads(http_get(
+    "https://www.wikidata.org/w/api.php?action=wbsearchentities&search=Marie+Curie&language=en&type=item&limit=5&format=json"
+))
+for r in data['search']:
+    print(r['id'], r['label'], '—', r.get('description', '')[:60])
+# Q7186  Marie Curie — Polish-French physicist and chemist (1867–1934)
+# Q114939443  Marie Curie — 2022 Czech book edition
+```
+
+To search for properties instead of items: `&type=property`
+
+### Batch entity lookup (API) — up to 50 QIDs per call
+
+```python
+import json
+ids = "|".join(["Q42", "Q7186", "Q64", "Q30", "Q5"])
+data = json.loads(http_get(
+    f"https://www.wikidata.org/w/api.php?action=wbgetentities&ids={ids}&languages=en|mul&props=labels|descriptions|sitelinks&format=json"
+))
+for qid, ent in data['entities'].items():
+    if 'missing' in ent:
+        continue  # entity does not exist
+    label = (ent['labels'].get('en') or ent['labels'].get('mul') or {}).get('value', '')
+    desc  = ent['descriptions'].get('en', {}).get('value', '')
+    wiki  = ent.get('sitelinks', {}).get('enwiki', {}).get('title', '')
+    print(qid, label, wiki)
+```
+
+`props` options: `labels`, `descriptions`, `aliases`, `claims`, `sitelinks` — omit `claims` for faster responses when you just need metadata.
+
+### Full entity data with claims
+
+```python
+import json
+data = json.loads(http_get("https://www.wikidata.org/wiki/Special:EntityData/Q42.json"))
+ent = data['entities']['Q42']
+
+label = (ent['labels'].get('en') or ent['labels'].get('mul') or {}).get('value', '')
+desc  = ent['descriptions'].get('en', {}).get('value', '')
+
+# Claims: each property maps to a list of statement objects
+for claim in ent['claims'].get('P31', []):          # instance of
+    snak = claim['mainsnak']
+    if snak.get('datavalue'):
+        val = snak['datavalue']['value']
+        print('P31 value:', val['id'])               # e.g. 'Q5' (human)
+    print('rank:', claim['rank'])                    # 'preferred', 'normal', 'deprecated'
+
+# Sitelinks — Wikipedia page name for this entity
+print('enwiki:', ent['sitelinks'].get('enwiki', {}).get('title'))   # 'Douglas Adams'
+```
+
+### Reading claim value types
+
+Claim values differ by datatype — always check `snak['datavalue']['type']`:
+
+```python
+import json
+data = json.loads(http_get("https://www.wikidata.org/wiki/Special:EntityData/Q60.json"))
+q60 = data['entities']['Q60']
+
+# Item reference (type='wikibase-entityid')
+place_claims = q60['claims'].get('P17', [])
+for c in place_claims:
+    val = c['mainsnak']['datavalue']['value']
+    print(val['id'])         # e.g. 'Q30' (United States)
+
+# Time (type='time')
+# {'time': '+1952-03-11T00:00:00Z', 'precision': 11, ...}
+# precision: 9=year, 10=month, 11=day
+
+# Coordinate (type='globecoordinate')
+coord = q60['claims']['P625'][0]['mainsnak']['datavalue']['value']
+print(coord['latitude'], coord['longitude'])  # 40.71277... -74.00611...
+
+# Quantity (type='quantity')
+pop = q60['claims']['P1082'][0]['mainsnak']['datavalue']['value']
+print(pop['amount'])   # '+8405837'  (string with sign prefix)
+print(pop['unit'])     # '1' means dimensionless (no unit item)
+
+# String (type='string') — no nesting, just a plain string value
+# Monolingualtext (type='monolingualtext') — {'text': '...', 'language': 'en'}
+```
+
+### Claim qualifiers
+
+Qualifiers are metadata on statements (e.g., start/end dates for employment):
+
+```python
+import json
+data = json.loads(http_get("https://www.wikidata.org/wiki/Special:EntityData/Q42.json"))
+q42 = data['entities']['Q42']
+
+for claim in q42['claims'].get('P69', []):  # educated at
+    school_id = claim['mainsnak']['datavalue']['value']['id']
+    quals = claim.get('qualifiers', {})
+    start = quals.get('P580', [{}])[0].get('datavalue', {}).get('value', {}).get('time', '')
+    end   = quals.get('P582', [{}])[0].get('datavalue', {}).get('value', {}).get('time', '')
+    print(f"school={school_id}, {start[:5]}–{end[:5]}")
+# school=Q4961791, +1959–+1970
+```
+
+### SPARQL queries
+
+All SPARQL requests require `User-Agent` and `Accept` headers — the endpoint returns HTTP errors without them:
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+SPARQL_URL = "https://query.wikidata.org/sparql"
+HEADERS = {
+    "User-Agent": "browser-harness/1.0",
+    "Accept": "application/sparql-results+json",
+}
+
+def sparql(query):
+    url = SPARQL_URL + "?query=" + urllib.parse.quote(query) + "&format=json"
+    return json.loads(http_get(url, headers=HEADERS, timeout=30))['results']['bindings']
+```
+
+**Countries by population (ORDER BY + LIMIT):**
+
+```python
+rows = sparql("""
+SELECT ?country ?countryLabel ?population WHERE {
+  ?country wdt:P31 wd:Q6256 ;
+           wdt:P1082 ?population .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul" }
+}
+ORDER BY DESC(?population)
+LIMIT 10
+""")
+for r in rows:
+    print(r['countryLabel']['value'], int(r['population']['value']))
+# India 1477519529
+# People's Republic of China 1442965000
+```
+
+**Films by director, deduplicated (multiple release dates cause row explosion without GROUP BY):**
+
+```python
+rows = sparql("""
+SELECT ?film ?filmLabel (MIN(?date) AS ?firstRelease) WHERE {
+  ?film wdt:P31 wd:Q11424 ;
+        wdt:P57 wd:Q25191 ;   # directed by Christopher Nolan
+        wdt:P577 ?date .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul" }
+}
+GROUP BY ?film ?filmLabel
+ORDER BY ?firstRelease
+""")
+for r in rows:
+    print(r['firstRelease']['value'][:4], r['filmLabel']['value'])
+# 1998 Following
+# 2000 Memento
+# 2023 Oppenheimer
+```
+
+**Books by author:**
+
+```python
+rows = sparql("""
+SELECT ?book ?bookLabel ?year WHERE {
+  ?book wdt:P31 wd:Q571 ;
+        wdt:P50 wd:Q3335 .   # author: George Orwell
+  OPTIONAL { ?book wdt:P577 ?date . BIND(YEAR(?date) AS ?year) }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul" }
+}
+ORDER BY ?year
+""")
+```
+
+**Humans born in a city (FILTER on date):**
+
+```python
+rows = sparql("""
+SELECT ?person ?personLabel ?born WHERE {
+  ?person wdt:P31 wd:Q5 ;
+          wdt:P106 wd:Q36180 ;  # occupation: writer
+          wdt:P27 wd:Q145 ;     # citizenship: United Kingdom
+          wdt:P569 ?born .
+  FILTER(YEAR(?born) >= 1900 && YEAR(?born) <= 1910)
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul" }
+}
+LIMIT 10
+""")
+for r in rows:
+    print(r['personLabel']['value'], r['born']['value'][:4])
+# George Orwell 1903
+# W. H. Auden 1907
+```
+
+**Look up specific items with VALUES clause:**
+
+```python
+rows = sparql("""
+SELECT ?item ?itemLabel ?population WHERE {
+  VALUES ?item { wd:Q60 wd:Q64 wd:Q90 wd:Q84 }
+  OPTIONAL { ?item wdt:P1082 ?population }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul" }
+}
+""")
+for r in rows:
+    print(r['itemLabel']['value'], r.get('population', {}).get('value', ''))
+# New York City 8804190
+# Berlin 3782202
+```
+
+**Multilingual labels inline (without SERVICE block):**
+
+```python
+rows = sparql("""
+SELECT ?item ?label_en ?label_fr WHERE {
+  VALUES ?item { wd:Q42 wd:Q64 wd:Q30 }
+  OPTIONAL { ?item rdfs:label ?label_en . FILTER(LANG(?label_en) = "en") }
+  OPTIONAL { ?item rdfs:label ?label_fr . FILTER(LANG(?label_fr) = "fr") }
+}
+""")
+```
+
+### Parallel entity fetches
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+def fetch_entity(qid):
+    data = json.loads(http_get(
+        f"https://www.wikidata.org/w/api.php?action=wbgetentities&ids={qid}&languages=en|mul&props=labels|descriptions&format=json"
+    ))
+    ent = data['entities'][qid]
+    label = (ent['labels'].get('en') or ent['labels'].get('mul') or {}).get('value', '')
+    return qid, label
+
+qids = ['Q42', 'Q7186', 'Q64', 'Q30', 'Q5']
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_entity, qids))
+# 5 entities in ~0.35s
+# Prefer the batch API endpoint when QIDs are known upfront
+```
+
+---
+
+## Gotchas
+
+- **`mul` label fallback is required.** Wikidata migrated many entities to language code `mul` (multilingual) instead of `en`. `Q7186` (Marie Curie) has no `en` label in the entity JSON — only `mul`. Always fetch `languages=en|mul` and fall back: `(ent['labels'].get('en') or ent['labels'].get('mul') or {}).get('value', '')`. In SPARQL, use `"en,mul"` in the language service param.
+
+- **SPARQL `SERVICE wikibase:label` returns the QID string when no label matches the language.** If you use `"en"` and the entity only has a `mul` label, `?itemLabel` will be `"Q7186"` not `"Marie Curie"`. Fix: always use `"en,mul"` or `"en,mul,fr,de"`.
+
+- **Duplicate rows from multiple property values.** A film has multiple P577 (release date) statements for different countries. `wdt:P577` returns all of them, one row each. Fix: wrap with `MIN(?date)` and `GROUP BY ?film ?filmLabel`.
+
+- **`wdt:` picks preferred rank; use `p:/ps:` for all statements.** `wdt:P31` returns the preferred-rank value. To iterate all statements including deprecated, use `p:P31 ?stmt . ?stmt ps:P31 ?value`.
+
+- **Property values are complex objects, not strings.** Dates come as `{'time': '+1952-03-11T00:00:00Z', 'precision': 11, ...}`. Coordinates come as `{'latitude': 40.71, 'longitude': -74.0, ...}`. Quantities come as `{'amount': '+8405837', 'unit': '1', ...}` — `amount` is a signed string, not a number. SPARQL quantities bind as plain string literals (`type='literal'`).
+
+- **Missing entities have `'missing' in ent`, not a raised error.** The API returns `{'id': 'Q999999999', 'missing': ''}` for non-existent QIDs. Check `'missing' in ent` before accessing labels/claims.
+
+- **SPARQL rate limit: 60 req/min.** The endpoint will return HTTP 429 if exceeded. Add `time.sleep(1)` between bulk SPARQL calls. The MediaWiki API has a higher limit (hundreds per minute). For lookup-heavy workflows, batch with `wbgetentities` (50 QIDs/call) rather than per-QID SPARQL.
+
+- **SPARQL timeout at 60 seconds.** Unbounded traversals (no LIMIT, cross-product joins) hit the server-side 60s wall and raise a timeout error. Always use `LIMIT`, and `FILTER` early to reduce the search space. Avoid `?x ?p ?y` open property traversal patterns without filters.
+
+- **`Special:EntityData/Q42.json` works; `Q42.json` returns 404.** The redirect URL `/wiki/Q42.json` does not exist. Use `/wiki/Special:EntityData/Q42.json` or the API endpoint. The `?format=json` query param also works: `/wiki/Special:EntityData/Q42?format=json`.
+
+- **User-Agent is required for SPARQL.** Without it the endpoint may reject requests. Use `"browser-harness/1.0"` or include your project name. The `http_get` helper sends `Mozilla/5.0` by default, which works, but setting an explicit user agent is good practice.
+
+- **Sitelinks give Wikipedia page names, not URLs.** `ent['sitelinks']['enwiki']['title']` returns `"Douglas Adams"`. Build the Wikipedia URL as `"https://en.wikipedia.org/wiki/" + title.replace(' ', '_')`.
+
+- **Image URLs are Wikimedia Commons `Special:FilePath` links.** `wdt:P18` SPARQL values look like `http://commons.wikimedia.org/wiki/Special:FilePath/Douglas%20adams%20portrait.jpg`. These redirect to the actual image file and can be downloaded directly.
+
+- **`wbgetentities` props parameter controls payload size.** Fetching `claims` for 50 entities can return megabytes. If you only need labels/descriptions/sitelinks, set `props=labels|descriptions|sitelinks` to skip claims entirely.
+
+---
+
+## Rate limits summary
+
+| Endpoint | Limit |
+|----------|-------|
+| SPARQL (`query.wikidata.org`) | 60 req/min per IP |
+| MediaWiki API (`wikidata.org/w/api.php`) | ~500 req/min unauthenticated |
+| `Special:EntityData` | same as MediaWiki API |
+| No auth required | across all endpoints |


### PR DESCRIPTION
## Summary
- **OpenFDA**: All 14 endpoints tested; `animal/event` is dead (404); 404 bodies are gzip-compressed; `.exact` required for multi-word count queries
- **USGS Earthquakes**: Feed + Query APIs; coordinates are `[lon, lat, depth]`; `time` is milliseconds; `mag` can be null; `limit` hard-capped at 20,000
- **Wikidata**: `wbgetentities`, `wbsearchentities`, SPARQL; `mul` label fallback for high-profile entities; SPARQL row explosion from multi-valued properties
- **TheSportsDB**: Free tier (v1) uses API key `1`; season format varies by sport; player images need `?w=200` suffix
- **Mastodon**: `mastodon.social` public timeline disabled without auth; use `fosstodon.org`; trending/hashtag endpoints work unauthenticated; cursor pagination via `Link` header

## Test plan
- [ ] Verify each skill file has runnable code examples
- [ ] Spot-check API endpoints still respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ten new domain-skill guides with runnable `http_get` examples and caveats for reliable, headless data access. Covers OpenFDA, USGS Earthquakes, Wikidata, TheSportsDB, Mastodon, CrossRef, FRED, MusicBrainz, OpenAlex, and PubMed.

- **New Features**
  - Added scraping guides for: OpenFDA, USGS Earthquakes, Wikidata, TheSportsDB, Mastodon.
  - Also added: CrossRef, FRED, MusicBrainz, OpenAlex, PubMed.

- **Migration**
  - TheSportsDB: use base key `3` (key `1` returns 404s).
  - Mastodon: public live timeline is disabled on `mastodon.social`; use `fosstodon.org` or trending/hashtag endpoints; paginate via `Link` headers.
  - OpenFDA: use `.exact` for multi-word counts; 404 bodies can be gzip-compressed; `animal/event` returns 404.
  - USGS Earthquakes: coordinates are `[lon, lat, depth]`; `time` is in ms; Query API `limit` capped at 20,000.
  - General: CrossRef/OpenAlex include `mailto=you@example.com`; MusicBrainz requires a `User-Agent` or you get 403; FRED needs an API key (web CSV/JSON time out headlessly); for PubMed prefer the ESearch → ESummary pipeline.

<sup>Written for commit 7c8cda81721fa105b8114a0fe1e668c289182d09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

