### PR TITLE
skill: make PATH invocation and new_tab-at-session-start unmissable

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -12,12 +12,17 @@ Easiest and most powerful way to interact with the browser.
 Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `install.md` first. For normal use, stay in this file.
 
 ```bash
-uv run browser-harness <<'PY'
-goto("https://browser-use.com")
+browser-harness <<'PY'
+new_tab("https://browser-use.com")
 wait_for_load()
 print(page_info())
 PY
 ```
+
+Two things to get right from your very first call:
+
+1. **`browser-harness` is a global command on `$PATH`.** Run it from *any* directory — cwd does not matter. Do **not** prefix with `cd /path/to/browser-harness && …`, and do **not** wrap in `uv run …`. Those are wrong, not just noisy: `uv run` outside the harness repo cwd will fail, and the `cd` leaks your assumptions about where the repo lives. The only right invocation is plain `browser-harness <<'PY' ... PY`. (If `browser-harness` is genuinely missing, read `install.md` — don't work around it with `uv run`.)
+2. **Open a new tab — don't hijack the user's current tab.** The daemon attaches to whichever tab is already active, so `goto(url)` on your first call will navigate *away from whatever the user was doing* and lose their state. Always use `new_tab(url)` for your first navigation of a session. Once the new tab is *yours*, `goto()` / clicks / etc. inside it are fine.
 
 The code is the doc.
 
@@ -50,7 +55,7 @@ uv run python - <<'PY'
 from admin import start_remote_daemon
 print(start_remote_daemon("work"))
 PY
-BU_NAME=work uv run browser-harness <<'PY'
+BU_NAME=work browser-harness <<'PY'
 print(page_info())
 PY
 ```
@@ -120,6 +125,8 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 
 ## What actually works
 
+- **Session start**: first navigation of a session should be `new_tab(url)`, never `goto(url)` — the daemon is attached to the user's current tab and `goto()` will clobber their work. After you have your own tab, `goto()` is fine.
+- **Invocation**: `browser-harness` is on `$PATH`. Just type it. No `cd`, no `uv run`.
 - **Screenshots first**: use `screenshot()` to understand the current page quickly, find visible targets, and decide whether you need a click, a selector, or more navigation.
 - **Clicking**: `screenshot()` → look → `click(x, y)` → `screenshot()` again to verify the result. Coordinate clicks pass through iframes/shadow/cross-origin at the compositor level.
 - **Bulk HTTP**: `http_get(url)` + `ThreadPoolExecutor`. No browser for static pages (249 Netflix pages in 2.8s).

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ description: Direct browser control via CDP. Use when the user wants to automate
 
 # browser-harness
 
-Easiest and most powerful way to interact with the browser. **Before editing this file, read it in full.**
+Easiest and most powerful way to interact with the browser. **Read this file in full before using or editing the harness** — it has to be in context.
 
 ## Fast start
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,11 +5,11 @@ description: Direct browser control via CDP. Use when the user wants to automate
 
 # browser-harness
 
-Easiest and most powerful way to interact with the browser.
+Easiest and most powerful way to interact with the browser. **Before editing this file, read it in full.**
 
 ## Fast start
 
-Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `install.md` first. For normal use, stay in this file.
+Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `install.md` first.
 
 ```bash
 browser-harness <<'PY'
@@ -19,10 +19,8 @@ print(page_info())
 PY
 ```
 
-Two things to get right from your very first call:
-
-1. **`browser-harness` is a global command on `$PATH`.** Run it from *any* directory — cwd does not matter. Do **not** prefix with `cd /path/to/browser-harness && …`, and do **not** wrap in `uv run …`. Those are wrong, not just noisy: `uv run` outside the harness repo cwd will fail, and the `cd` leaks your assumptions about where the repo lives. The only right invocation is plain `browser-harness <<'PY' ... PY`. (If `browser-harness` is genuinely missing, read `install.md` — don't work around it with `uv run`.)
-2. **Open a new tab — don't hijack the user's current tab.** The daemon attaches to whichever tab is already active, so `goto(url)` on your first call will navigate *away from whatever the user was doing* and lose their state. Always use `new_tab(url)` for your first navigation of a session. Once the new tab is *yours*, `goto()` / clicks / etc. inside it are fine.
+- Invoke as `browser-harness` — it's on `$PATH`. No `cd`, no `uv run`.
+- First navigation is `new_tab(url)`, not `goto(url)` — `goto` runs in the user's active tab and clobbers their work.
 
 The code is the doc.
 
@@ -125,8 +123,6 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 
 ## What actually works
 
-- **Session start**: first navigation of a session should be `new_tab(url)`, never `goto(url)` — the daemon is attached to the user's current tab and `goto()` will clobber their work. After you have your own tab, `goto()` is fine.
-- **Invocation**: `browser-harness` is on `$PATH`. Just type it. No `cd`, no `uv run`.
 - **Screenshots first**: use `screenshot()` to understand the current page quickly, find visible targets, and decide whether you need a click, a selector, or more navigation.
 - **Clicking**: `screenshot()` → look → `click(x, y)` → `screenshot()` again to verify the result. Coordinate clicks pass through iframes/shadow/cross-origin at the compositor level.
 - **Bulk HTTP**: `http_get(url)` + `ThreadPoolExecutor`. No browser for static pages (249 Netflix pages in 2.8s).


### PR DESCRIPTION
## Why

Two footguns kept biting me on the first call of a session:

1. I prefixed the harness with `cd /Users/magnus/Developer/browser-harness && uv run browser-harness …` — even though `browser-harness` is installed globally on `\$PATH`. `uv run` from the wrong cwd actively *fails*, and the `cd` also bakes an assumption about where the repo lives that's wrong for anyone else.
2. I called `goto("https://…")` as my first action, which navigates the user's **currently-active tab** (because that's what the daemon is attached to) and destroyed whatever page they had open. The user had to point this out after I clobbered their work.

Both are easy to miss because the current Fast start example models exactly the wrong behavior: `uv run browser-harness` + `goto(url)`.

## What changes

- Fast start example uses `browser-harness <<'PY'` (no `uv run`) and `new_tab(url)` instead of `goto(url)`.
- A short, two-point callout right under the example explains *why* each rule matters — so the lesson sticks even when an agent only reads as far as Fast start.
- Mirrors both rules as bullets in the "What actually works" list so a scanning agent still sees them if they skip the intro.
- Drops the stray `uv run` from the remote-browser snippet for consistency (`BU_NAME=work browser-harness <<'PY'`).

## Test plan

- [x] `browser-harness <<'PY' new_tab("https://mcdonalds.com"); wait_for_load(); print(page_info()) PY` — lands on mcdonalds.com in a fresh tab without disturbing the user's existing tab.
- [x] Skim Fast start and "What actually works" and confirm both footguns are called out.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies startup usage to prevent tab clobbering and PATH mistakes. Fast start uses `browser-harness <<'PY'` from `$PATH` (no `uv run`/`cd`) and `new_tab(url)`; a short callout highlights both rules, “What actually works” mirrors them, the remote-browser snippet drops `uv run`, and SKILL.md now requires reading in full before using or editing the harness.

<sup>Written for commit e447d1829cd23d40b05510c8b3b88ee57c9dbc8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

