### PR TITLE
detect OS-native blockers (permission prompts, file pickers, print)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -75,6 +75,7 @@ Only if you start struggling with a specific mechanic while navigating, look in 
 - `dropdowns.md`
 - `iframes.md`
 - `network-requests.md`
+- `permissions.md`
 - `print-as-pdf.md`
 - `screenshots.md`
 - `scrolling.md`

--- a/daemon.py
+++ b/daemon.py
@@ -161,8 +161,11 @@ class Daemon:
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
         for d in ("Page", "DOM", "Runtime", "Network"):
             try:
+                # Page.enable takes enableFileChooserOpenedEvent — off by default,
+                # so without it Page.fileChooserOpened never fires (CDP experimental).
+                params = {"enableFileChooserOpenedEvent": True} if d == "Page" else {}
                 await asyncio.wait_for(
-                    self.cdp.send_raw(f"{d}.enable", session_id=self.session),
+                    self.cdp.send_raw(f"{d}.enable", params, session_id=self.session),
                     timeout=5
                 )
             except Exception as e:

--- a/daemon.py
+++ b/daemon.py
@@ -46,6 +46,35 @@ BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
+# Hooks permission-gated Web APIs that open OS-native popups Chrome renders outside
+# the page viewport (geolocation, notifications, camera/mic, file pickers, print, ...).
+# Each call appends to window.__bu_blockers__ so page_info() / pending_blockers() can
+# tell the agent "something native is open" without a full-desktop screencapture.
+# Chrome emits no CDP event for these popups, hence the in-page wrapper.
+BLOCKER_JS = """(()=>{
+if(window.__bu_blockers_installed__)return;window.__bu_blockers_installed__=true;
+window.__bu_blockers__=window.__bu_blockers__||[];
+const log=k=>{const a=window.__bu_blockers__;a.push({kind:k,t:Date.now()});if(a.length>200)a.splice(0,a.length-200);};
+const w=(o,n,k)=>{if(!o)return;const f=o[n];if(typeof f!=='function')return;o[n]=function(){log(k);return f.apply(this,arguments);};};
+try{w(navigator.geolocation,'getCurrentPosition','geolocation');}catch(_){}
+try{w(navigator.geolocation,'watchPosition','geolocation');}catch(_){}
+try{w(Notification,'requestPermission','notifications');}catch(_){}
+try{w(navigator.mediaDevices,'getUserMedia','media');}catch(_){}
+try{w(navigator.mediaDevices,'getDisplayMedia','display');}catch(_){}
+try{w(navigator.clipboard,'read','clipboard-read');}catch(_){}
+try{w(navigator.clipboard,'readText','clipboard-read');}catch(_){}
+try{w(navigator.bluetooth,'requestDevice','bluetooth');}catch(_){}
+try{w(navigator.usb,'requestDevice','usb');}catch(_){}
+try{w(navigator.serial,'requestPort','serial');}catch(_){}
+try{w(navigator.hid,'requestDevice','hid');}catch(_){}
+try{w(window,'showOpenFilePicker','file-picker');}catch(_){}
+try{w(window,'showSaveFilePicker','file-picker');}catch(_){}
+try{w(window,'showDirectoryPicker','file-picker');}catch(_){}
+try{w(window,'print','print');}catch(_){}
+try{w(document,'requestStorageAccess','storage-access');}catch(_){}
+addEventListener('click',e=>{const t=e.target;if(t&&t.tagName==='INPUT'&&t.type==='file')log('file-input');},true);
+})();"""
+
 
 def log(msg):
     open(LOG, "a").write(f"{msg}\n")
@@ -103,7 +132,19 @@ class Daemon:
         self.session = None
         self.events = deque(maxlen=BUF)
         self.dialog = None
+        self.blockers = deque(maxlen=200)
         self.stop = None  # asyncio.Event, set inside start()
+
+    async def install_blocker_probe(self):
+        """Wrap permission-gated JS APIs so native popups become observable. Idempotent per page."""
+        try:
+            await asyncio.wait_for(self.cdp.send_raw(
+                "Page.addScriptToEvaluateOnNewDocument",
+                {"source": BLOCKER_JS}, session_id=self.session), timeout=3)
+            await asyncio.wait_for(self.cdp.send_raw(
+                "Runtime.evaluate", {"expression": BLOCKER_JS}, session_id=self.session), timeout=3)
+        except Exception as e:
+            log(f"install_blocker_probe: {e}")
 
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
@@ -126,6 +167,7 @@ class Daemon:
                 )
             except Exception as e:
                 log(f"enable {d}: {e}")
+        await self.install_blocker_probe()
         return pages[0]
 
     async def start(self):
@@ -144,8 +186,11 @@ class Daemon:
             self.events.append({"method": method, "params": params, "session_id": session_id})
             if method == "Page.javascriptDialogOpening":
                 self.dialog = params
+                self.blockers.append({"kind": "dialog", "params": params, "t": time.time()})
             elif method == "Page.javascriptDialogClosed":
                 self.dialog = None
+            elif method in ("Page.fileChooserOpened", "Page.downloadWillBegin"):
+                self.blockers.append({"kind": method.split(".")[-1], "params": params, "t": time.time()})
             elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
                 try: await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session), timeout=2)
                 except Exception: pass
@@ -164,8 +209,12 @@ class Daemon:
                 await asyncio.wait_for(self.cdp.send_raw("Page.enable", session_id=self.session), timeout=3)
                 await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"}, session_id=self.session), timeout=2)
             except Exception: pass
+            await self.install_blocker_probe()
             return {"session_id": self.session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
+        if meta == "pending_blockers":
+            out = list(self.blockers); self.blockers.clear()
+            return {"blockers": out}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}
 
         method = req["method"]

--- a/helpers.py
+++ b/helpers.py
@@ -68,8 +68,9 @@ def page_info():
             expression="JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight,blockers:(window.__bu_blockers__||[])})",
             returnByValue=True)
     info = json.loads(r["result"]["value"])
-    cdp_blockers = _send({"meta": "pending_blockers"}).get("blockers") or []
-    all_blockers = info.pop("blockers") + cdp_blockers
+    js_blockers = info.pop("blockers", None)
+    cdp_blockers = _send({"meta": "pending_blockers"}).get("blockers")
+    all_blockers = (js_blockers if isinstance(js_blockers, list) else []) + (cdp_blockers if isinstance(cdp_blockers, list) else [])
     if all_blockers:
         info["blockers"] = all_blockers
     return info
@@ -89,7 +90,11 @@ def pending_blockers(clear_js=False):
     """
     cdp_side = _send({"meta": "pending_blockers"}).get("blockers") or []
     js_expr = "(function(){const a=window.__bu_blockers__||[];" + ("window.__bu_blockers__=[];" if clear_js else "") + "return a;})()"
-    js_side = js(js_expr) or []
+    try:
+        raw = js(js_expr)
+    except Exception:
+        raw = None  # JS frozen (dialog), detached session, etc. — fall back to CDP-only
+    js_side = raw if isinstance(raw, list) else []
     return {"cdp": cdp_side, "js": js_side}
 
 # --- input ---

--- a/helpers.py
+++ b/helpers.py
@@ -57,14 +57,40 @@ def page_info():
 
     If a native dialog (alert/confirm/prompt/beforeunload) is open, returns
     {dialog: {type, message, ...}} instead — the page's JS thread is frozen
-    until the dialog is handled (see interaction-skills/dialogs.md)."""
+    until the dialog is handled (see interaction-skills/dialogs.md).
+
+    If an OS-native popup is suspected (permission prompt, file picker, print,
+    download bar, ...), adds a `blockers` key. See interaction-skills/permissions.md."""
     dialog = _send({"meta": "pending_dialog"}).get("dialog")
     if dialog:
         return {"dialog": dialog}
     r = cdp("Runtime.evaluate",
-            expression="JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})",
+            expression="JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight,blockers:(window.__bu_blockers__||[])})",
             returnByValue=True)
-    return json.loads(r["result"]["value"])
+    info = json.loads(r["result"]["value"])
+    cdp_blockers = _send({"meta": "pending_blockers"}).get("blockers") or []
+    all_blockers = info.pop("blockers") + cdp_blockers
+    if all_blockers:
+        info["blockers"] = all_blockers
+    return info
+
+def pending_blockers(clear_js=False):
+    """Return records of OS-native popups that Chrome renders outside the page viewport.
+
+    JS-side: permission-gated Web API calls (geolocation, notifications, mediaDevices,
+    clipboard, bluetooth/usb/serial/hid, file pickers, print, storage-access, <input type=file>).
+    CDP-side: Page.javascriptDialogOpening, Page.fileChooserOpened, Page.downloadWillBegin.
+
+    Chrome emits no CDP event for permission popups, so detection happens via an injected
+    wrapper installed on every document by the daemon.
+
+    To prevent popups rather than detect them, pre-grant with `Browser.grantPermissions` and
+    pre-seed data with `Emulation.setGeolocationOverride` — see interaction-skills/permissions.md.
+    """
+    cdp_side = _send({"meta": "pending_blockers"}).get("blockers") or []
+    js_expr = "(function(){const a=window.__bu_blockers__||[];" + ("window.__bu_blockers__=[];" if clear_js else "") + "return a;})()"
+    js_side = js(js_expr) or []
+    return {"cdp": cdp_side, "js": js_side}
 
 # --- input ---
 def click(x, y, button="left", clicks=1):

--- a/interaction-skills/permissions.md
+++ b/interaction-skills/permissions.md
@@ -1,8 +1,14 @@
 # Permissions & OS-native popups
 
 Chrome renders permission prompts, file pickers, and print dialogs in **browser chrome**,
-not in the page. They are invisible to CDP page screenshots and to `Page.*` events.
-You can't click them with `Input.dispatchMouseEvent` — coordinates go to the viewport.
+not in the page. They are invisible to CDP page screenshots, and
+`Input.dispatchMouseEvent` coordinates go to the viewport — they can't click the popup.
+
+CDP event coverage is uneven: `Page.javascriptDialogOpening` (alerts + beforeunload),
+`Page.fileChooserOpened` (requires `Page.enable({enableFileChooserOpenedEvent: true})`),
+and `Page.downloadWillBegin` do fire. **Permission popups (geolocation, notifications,
+camera/mic, ...) emit no CDP event at all** — which is why the harness injects an
+in-page wrapper to surface them.
 
 Two things to know:
 
@@ -63,6 +69,17 @@ Permission names: `geolocation`, `notifications`, `videoCapture`, `audioCapture`
 
 ```python
 cdp("Browser.resetPermissions")          # back to 'prompt' for all origins
+```
+
+`Browser.setPermission` is the finer-grained alternative — sets one permission at a
+time with explicit `setting: 'granted' | 'denied' | 'prompt'`, useful for toggling
+mid-session or explicitly denying:
+
+```python
+cdp("Browser.setPermission",
+    permission={"name": "geolocation"},
+    setting="denied",
+    origin="https://www.example.com")
 ```
 
 ## Dismissing a popup that already opened

--- a/interaction-skills/permissions.md
+++ b/interaction-skills/permissions.md
@@ -1,0 +1,95 @@
+# Permissions & OS-native popups
+
+Chrome renders permission prompts, file pickers, and print dialogs in **browser chrome**,
+not in the page. They are invisible to CDP page screenshots and to `Page.*` events.
+You can't click them with `Input.dispatchMouseEvent` — coordinates go to the viewport.
+
+Two things to know:
+
+1. **Pre-empt them.** `Browser.grantPermissions` + `Emulation.setGeolocationOverride`
+   resolve the common cases without ever showing a popup.
+2. **Detect them.** If one is already open, `page_info()` surfaces a `blockers` key, and
+   `pending_blockers()` returns the full log.
+
+## Detection
+
+`page_info()` auto-surfaces blockers. After the usual viewport keys:
+
+```python
+info = page_info()
+if info.get("blockers"):
+    # popup was triggered — Chrome is waiting for the user (or you via CDP)
+    print(info["blockers"])
+```
+
+`pending_blockers()` gives the full picture, split by source:
+
+```python
+b = pending_blockers()
+# b["js"]  — permission-gated Web API calls: geolocation, notifications,
+#            mediaDevices, clipboard, bluetooth/usb/serial/hid, file pickers,
+#            print, requestStorageAccess, <input type=file> clicks
+# b["cdp"] — Page.javascriptDialogOpening, Page.fileChooserOpened,
+#            Page.downloadWillBegin (fires without JS injection)
+```
+
+Why both? Chrome emits **no** CDP event when a permission popup opens, so the daemon
+installs a JS wrapper on every document that pushes to `window.__bu_blockers__`. CDP-side
+events are captured directly via the event tap.
+
+## Pre-grant — the preferred pattern
+
+Grant at the browser level; the popup never needs to render. Scope is the CDP session,
+which maps to "Allow this time" semantics (resets on daemon restart / CDP disconnect).
+
+```python
+cdp("Browser.grantPermissions",
+    origin="https://www.example.com",
+    permissions=["geolocation"])
+
+# For geolocation specifically, pair with an override so the site actually
+# receives coords — otherwise Chrome may fall back to OS Core Location, which
+# requires a separate macOS-level grant.
+cdp("Emulation.setGeolocationOverride",
+    latitude=37.7749, longitude=-122.4194, accuracy=50)
+```
+
+Permission names: `geolocation`, `notifications`, `videoCapture`, `audioCapture`,
+`clipboardReadWrite`, `clipboardSanitizedWrite`, `backgroundSync`, `midi`, `midiSysex`,
+`periodicBackgroundSync`, `protectedMediaIdentifier`, `sensors`, `storageAccess`,
+`durableStorage`, `paymentHandler`, `backgroundFetch`, `nfc`, `idleDetection`,
+`displayCapture`, `captureHandle`, `wakeLockScreen`, `wakeLockSystem`, `windowManagement`,
+`localFonts`, `topLevelStorageAccess`.
+
+```python
+cdp("Browser.resetPermissions")          # back to 'prompt' for all origins
+```
+
+## Dismissing a popup that already opened
+
+`Browser.grantPermissions` updates the permission *state* but does **not** close an
+already-rendered popup. Easiest path: reload the page after granting.
+
+```python
+cdp("Browser.grantPermissions", origin=..., permissions=["geolocation"])
+cdp("Emulation.setGeolocationOverride", latitude=..., longitude=..., accuracy=50)
+cdp("Page.reload")
+wait_for_load()
+# next navigator.geolocation.getCurrentPosition call returns the overridden coords, no popup.
+```
+
+## Proactive state check
+
+`navigator.permissions.query({name: 'geolocation'}).state` returns
+`'prompt' | 'granted' | 'denied'` without triggering anything. If it's `'prompt'` and
+the site is about to ask, a popup **will** appear — pre-grant before calling the API.
+
+## Rules that held up in practice
+
+- **Native popups are outside the viewport.** `screenshot()` can't see them; use `screencapture -x` on macOS if you need visual proof.
+- **Pre-grant beats reactive handling.** `Browser.grantPermissions` before the trigger means no popup, no detection overhead, no race.
+- **`Emulation.setGeolocationOverride` is required** when Chrome lacks OS-level Core Location permission — otherwise granted-but-unresolvable requests time out.
+- **The wrapper script is installed on every new document** via `Page.addScriptToEvaluateOnNewDocument`. Don't rely on it for iframes attached via a different session (install there too if needed).
+- **Callback-based APIs (`getCurrentPosition`) don't resolve promises** the wrapper can hook. A blocker entry means "the site called this" — not "the popup is still open". Use timestamps + state inspection to judge.
+- **File pickers from `<input type=file>` clicks** are caught by a capture-phase click listener, not by wrapping. Prefer `upload_file(selector, path)` (CDP `DOM.setFileInputFiles`) to avoid opening the native chooser at all.
+- **`Page.setInterceptFileChooserDialog` suppresses the native chooser.** The harness does not enable interception by default — turning it on breaks any normal file-input flow, so only enable per-task if you plan to respond to `Page.fileChooserOpened` yourself.


### PR DESCRIPTION
## Summary

Chrome renders permission prompts, file pickers, and print dialogs in browser chrome, not the page — `Input.dispatchMouseEvent` can't click them, `screenshot()` can't see them, and Chrome emits no CDP event when they open. Agents needed a full-desktop `screencapture` (or a hint from the user) to notice one.

This wires up a general detector so `page_info()` flags when a native popup is likely open.

## How

- **daemon.py** installs a wrapper via `Page.addScriptToEvaluateOnNewDocument` on every document. It logs calls to `navigator.geolocation`, `Notification.requestPermission`, `navigator.mediaDevices.getUserMedia/getDisplayMedia`, `navigator.clipboard.read*`, `navigator.bluetooth/usb/serial/hid.request*`, `showOpenFilePicker`/`showSaveFilePicker`/`showDirectoryPicker`, `window.print`, `document.requestStorageAccess`, and `<input type=file>` clicks into `window.__bu_blockers__`.
- The event tap captures `Page.javascriptDialogOpening`, `Page.fileChooserOpened`, and `Page.downloadWillBegin` into a bounded daemon-side deque.
- **helpers.py** — `page_info()` surfaces a `blockers` key when either source has entries. New `pending_blockers()` returns the full log split `{cdp: [...], js: [...]}`.
- **interaction-skills/permissions.md** documents detection plus the preferred pre-empt pattern: `Browser.grantPermissions` + `Emulation.setGeolocationOverride`.

## Why not just use CDP events?

Chrome has no public CDP event for permission popups. `drain_events()` returns empty while a geolocation prompt is open. The only reliable JS-side signal is hooking the API calls before they run — which `Page.addScriptToEvaluateOnNewDocument` makes a one-liner.

## Test plan

- [x] Baseline: `page_info()` has no `blockers` key on a fresh page.
- [x] After `navigator.geolocation.getCurrentPosition(...)` in JS, `page_info()` returns `blockers: [{kind:'geolocation', t:...}]`.
- [x] `pending_blockers()` returns `{cdp: [...], js: [...]}` with the expected split.
- [x] `Browser.grantPermissions` + `Emulation.setGeolocationOverride` + `Page.reload` dismisses a live popup and lets the site read overridden coords without a prompt.
- [ ] File picker from `<input type=file>` click is logged as `kind: 'file-input'`.
- [ ] `Page.downloadWillBegin` appears in `pending_blockers().cdp` during a real download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects OS-native blockers (permission prompts, file pickers, print) and surfaces them in `page_info()` so agents can react without full-desktop capture. Adds `pending_blockers()` and improves reliability by explicitly enabling file-chooser events and safely reading logs when page JS is frozen.

- **New Features**
  - Injects a JS wrapper to log permission-gated Web API calls and taps CDP events for JS dialogs, file chooser, and downloads.
  - `page_info()` adds a `blockers` array; `pending_blockers(clear_js)` returns `{js:[...], cdp:[...]}` and can clear the in-page buffer.

- **Bug Fixes**
  - Ensures `Page.fileChooserOpened` fires by passing `enableFileChooserOpenedEvent: true` to `Page.enable`.
  - Guards `page_info()`/`pending_blockers()` so CDP-side blockers still return if JS is blocked or the session is gone; docs clarify which events exist and add `Browser.setPermission` as a fine-grained alternative.

<sup>Written for commit a08e70c48fe9b6eef467ef447c0ca07a021897a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

