### PR TITLE
Add domain skills: NYTimes, Bluesky, HIBP, IP Geolocation, Semantic Scholar

### DIFF
--- a/domain-skills/bluesky/scraping.md
+++ b/domain-skills/bluesky/scraping.md
@@ -1,0 +1,367 @@
+# Bluesky / AT Protocol — Scraping & Data Extraction
+
+`https://public.api.bsky.app` — fully public REST API, no auth required. Never use a browser for read-only Bluesky tasks.
+
+## Do this first
+
+**Use `http_get` against the AppView API — no auth, no JS rendering, pure JSON.**
+
+Two hosts are in play:
+
+| Host | Use for |
+|------|---------|
+| `public.api.bsky.app` | Profile, feed, graph (follows/followers/likes/reposts), trending, thread |
+| `api.bsky.app` | `searchPosts`, `searchActors` (public.api returns 403 for search) |
+
+All endpoints are XRPC: `GET /xrpc/<nsid>?param=value`.
+
+```python
+import json
+data = json.loads(http_get("https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=bsky.app"))
+# Key fields: did, handle, displayName, description, followersCount, followsCount,
+#             postsCount, avatar, banner, createdAt, indexedAt, pinnedPost
+```
+
+---
+
+## Common workflows
+
+### Profile — single actor
+
+```python
+import json
+
+# Accept handle OR DID interchangeably
+profile = json.loads(http_get(
+    "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=bsky.app"
+))
+print(profile['did'], profile['handle'], profile['displayName'])
+print(profile['followersCount'], profile['postsCount'])
+# did:plc:z72i7hdynmk6r22z27h6tvur  bsky.app  Bluesky
+# 32902601  742
+```
+
+### Resolve handle → DID
+
+```python
+import json
+
+r = json.loads(http_get(
+    "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=bsky.app"
+))
+did = r['did']   # 'did:plc:z72i7hdynmk6r22z27h6tvur'
+```
+
+### Batch profiles (up to 25 actors per call)
+
+```python
+import json
+from urllib.parse import quote
+
+dids = [
+    "did:plc:z72i7hdynmk6r22z27h6tvur",
+    "did:plc:ry3hbexak5ytsum7aazhpkbv",
+]
+qs = "&".join(f"actors={quote(d)}" for d in dids)
+resp = json.loads(http_get(
+    f"https://public.api.bsky.app/xrpc/app.bsky.actor.getProfiles?{qs}"
+))
+for p in resp['profiles']:
+    print(p['handle'], p['followersCount'])
+```
+
+### Author feed (posts by a user)
+
+```python
+import json
+from urllib.parse import quote
+
+feed = json.loads(http_get(
+    "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed"
+    "?actor=bsky.app&limit=100"
+    # filter options: posts_no_replies (default) | posts_with_replies |
+    #                 posts_and_author_threads | posts_with_media
+))
+for item in feed['feed']:
+    post = item['post']
+    rec  = post['record']
+    print(post['uri'], rec['text'][:60])
+    print(f"  likes={post['likeCount']} reposts={post['repostCount']} replies={post['replyCount']}")
+    # item['reply'] is present if this post IS a reply (contains root + parent refs)
+
+cursor = feed.get('cursor')  # ISO timestamp; pass as &cursor= for next page
+```
+
+### Post thread (replies tree)
+
+```python
+import json
+from urllib.parse import quote
+
+uri = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3mjprnr5ptk2m"
+thread = json.loads(http_get(
+    f"https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread"
+    f"?uri={quote(uri)}&depth=6"
+))
+root = thread['thread']          # keys: post, replies, threadContext, $type
+top_replies = root['replies']    # list of thread nodes, each with nested replies
+```
+
+### Search posts
+
+```python
+import json
+
+# Use api.bsky.app (NOT public.api.bsky.app) for search — public returns 403
+results = json.loads(http_get(
+    "https://api.bsky.app/xrpc/app.bsky.feed.searchPosts"
+    "?q=machine+learning&limit=25&sort=top"
+    # sort: top (engagement) | latest (default)
+    # lang=en  filters by language tag
+    # since=2026-04-01T00:00:00Z  and  until=2026-04-10T00:00:00Z  for date range
+))
+for p in results['posts']:
+    print(p['uri'], p['record']['text'][:80])
+
+cursor = results.get('cursor')  # numeric offset string e.g. "25"; pass as &cursor= for next page
+# No hitsTotal field — cursor is None when results are exhausted
+```
+
+### Search actors
+
+```python
+import json
+
+actors = json.loads(http_get(
+    "https://api.bsky.app/xrpc/app.bsky.actor.searchActors?q=climate+scientist&limit=25"
+))
+for a in actors['actors']:
+    print(a['handle'], a['displayName'], a.get('description', '')[:60])
+cursor = actors.get('cursor')  # numeric offset
+```
+
+### Trending topics
+
+```python
+import json
+
+trends = json.loads(http_get(
+    "https://public.api.bsky.app/xrpc/app.bsky.unspecced.getTrendingTopics"
+))
+# Two lists:
+for t in trends['topics']:    # real-time trending
+    print(t['topic'], t['link'])   # link is a relative /profile/... path
+
+for s in trends['suggested']:  # curated category feeds
+    print(s['topic'], s['link'])
+```
+
+### Follows and followers
+
+```python
+import json
+from urllib.parse import quote
+
+# Follows (who this actor follows) — max 100 per page
+follows = json.loads(http_get(
+    "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows?actor=bsky.app&limit=100"
+))
+for f in follows['follows']:
+    print(f['did'], f['handle'])
+cursor = follows.get('cursor')   # opaque string; URL-encode before passing
+
+# Followers (who follows this actor) — max 100 per page
+followers = json.loads(http_get(
+    "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollowers?actor=bsky.app&limit=100"
+))
+cursor = followers.get('cursor')
+```
+
+### Likes and reposts on a post
+
+```python
+import json
+from urllib.parse import quote
+
+uri = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3mjprnr5ptk2m"
+
+likes = json.loads(http_get(
+    f"https://public.api.bsky.app/xrpc/app.bsky.feed.getLikes?uri={quote(uri)}&limit=100"
+))
+for like in likes['likes']:
+    print(like['actor']['handle'], like['createdAt'])
+# cursor: ISO timestamp
+
+reposts = json.loads(http_get(
+    f"https://public.api.bsky.app/xrpc/app.bsky.feed.getRepostedBy?uri={quote(uri)}&limit=100"
+))
+```
+
+### Custom / curated feed
+
+```python
+import json
+from urllib.parse import quote
+
+# Feed generator AT URI from trending link or known feeds
+feed_uri = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot"
+feed = json.loads(http_get(
+    f"https://public.api.bsky.app/xrpc/app.bsky.feed.getFeed?feed={quote(feed_uri)}&limit=30"
+))
+cursor = feed.get('cursor')  # base64-encoded opaque token
+```
+
+### Parallel fetching
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+handles = ["bsky.app", "jay.bsky.team", "pfrazee.com"]
+
+def fetch_profile(handle):
+    return json.loads(http_get(
+        f"https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor={handle}"
+    ))
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    profiles = list(ex.map(fetch_profile, handles))
+# 3 profiles in ~0.23s vs ~0.7s sequential
+```
+
+### Cursor pagination (generic pattern)
+
+```python
+import json
+from urllib.parse import quote
+
+def paginate(base_url, result_key, max_pages=10):
+    cursor = None
+    for _ in range(max_pages):
+        url = base_url + (f"&cursor={quote(str(cursor))}" if cursor else "")
+        data = json.loads(http_get(url))
+        items = data.get(result_key, [])
+        yield from items
+        cursor = data.get('cursor')
+        if not cursor or not items:
+            break
+
+posts = list(paginate(
+    "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=bsky.app&limit=100",
+    "feed"
+))
+```
+
+---
+
+## Data model reference
+
+### AT URI anatomy
+
+```
+at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3mjprnr5ptk2m
+    └─ authority (DID) ──────────────┘  └─ NSID (collection) ──┘  └─ rkey ┘
+```
+
+Convert to web URL:
+```python
+uri = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3mjprnr5ptk2m"
+_, _, did, collection, rkey = uri.split("/")
+web_url = f"https://bsky.app/profile/{did}/post/{rkey}"
+```
+
+### Post record (`record` field)
+
+```python
+{
+    "$type": "app.bsky.feed.post",
+    "text": "The full plain text of the post",
+    "createdAt": "2026-04-17T20:36:31.198Z",
+    "langs": ["en"],
+    # If reply:
+    "reply": {
+        "root":   {"uri": "at://...", "cid": "bafy..."},
+        "parent": {"uri": "at://...", "cid": "bafy..."}
+    },
+    # If facets (links, mentions, hashtags):
+    "facets": [ ... ]  # see below
+}
+```
+
+### Facets (rich text annotations)
+
+Facets annotate byte ranges of `text`. All indices are **UTF-8 byte offsets**, not character positions.
+
+```python
+# Three feature $types:
+# app.bsky.richtext.facet#link     — hyperlink
+# app.bsky.richtext.facet#mention  — @mention (includes resolved DID)
+# app.bsky.richtext.facet#tag      — #hashtag
+
+for facet in post['record'].get('facets', []):
+    start = facet['index']['byteStart']
+    end   = facet['index']['byteEnd']
+    text_bytes = post['record']['text'].encode('utf-8')
+    slice_text = text_bytes[start:end].decode('utf-8')   # e.g. "@bsky.app" or "#AI"
+
+    for feature in facet['features']:
+        ftype = feature['$type']
+        if ftype == 'app.bsky.richtext.facet#link':
+            print("link →", feature['uri'])
+        elif ftype == 'app.bsky.richtext.facet#mention':
+            print("mention →", slice_text, "DID:", feature['did'])
+        elif ftype == 'app.bsky.richtext.facet#tag':
+            print("hashtag →", feature['tag'])
+```
+
+### Embed types (on the `post.embed` view field)
+
+| `$type` | Description |
+|---------|-------------|
+| `app.bsky.embed.images#view` | Image post — `embed['images']` list with `thumb`, `fullsize`, `alt`, `aspectRatio` |
+| `app.bsky.embed.external#view` | Link card — `embed['external']` with `uri`, `title`, `description`, `thumb` |
+| `app.bsky.embed.record#view` | Quote post — `embed['record']` contains the quoted post |
+| `app.bsky.embed.video#view` | Video post |
+
+### CDN image URLs
+
+```
+https://cdn.bsky.app/img/{type}/plain/{did}/{cid}
+
+Types: avatar  banner  feed_thumbnail  feed_fullsize
+```
+
+Avatar and banner CIDs come from the profile. Post image CIDs come from `post.embed.images[].thumb/fullsize` (already fully formed URLs).
+
+---
+
+## Gotchas
+
+- **Search endpoint split**: `searchPosts` and `searchActors` return HTTP 403 from `public.api.bsky.app`. Use `api.bsky.app` instead. All other read endpoints work on `public.api.bsky.app`.
+
+- **Cursor formats differ by endpoint** — treat them as opaque strings; always URL-encode before appending:
+  - `getAuthorFeed`, `getLikes`, `getRepostedBy`: ISO timestamp (`2026-04-16T23:47:25.966Z`)
+  - `getFollows`, `getFollowers`: opaque base36 or UUID string
+  - `searchPosts`, `searchActors`: numeric offset string (`"25"`, `"50"`)
+  - `getFeed`: base64-encoded opaque token
+  - When cursor is absent or `None`, results are exhausted.
+
+- **Facet indices are UTF-8 byte offsets, not codepoint indices** — emoji and non-ASCII characters widen the byte span. Always slice on `.encode('utf-8')[start:end].decode('utf-8')`, never on `text[start:end]`.
+
+- **Mention facets include the resolved DID** — `feature['did']` gives you the DID of the mentioned user without a separate resolve call.
+
+- **DID vs handle** — DIDs (`did:plc:...`) are stable permanent identifiers; handles (`user.bsky.social`) can change. Use DIDs for storage and joins. All profile/feed endpoints accept either.
+
+- **AT URI is not a web URL** — The `uri` field on every post is an AT URI (`at://did/.../rkey`). Construct the bsky.app web URL manually: `https://bsky.app/profile/{did}/post/{rkey}`.
+
+- **`getFollows` on bsky.app returns only 5 results** — bsky.app follows only 5 accounts; limit=100 still returns 5. This is correct data, not a bug.
+
+- **`searchPosts` has no `hitsTotal`** — The response contains `posts` and `cursor` only; there is no total count. Paginate until `cursor` is absent.
+
+- **No rate limit headers exposed** — The public API does not return `X-RateLimit-*` headers. Burst of 20 sequential calls completes without errors. Use `ThreadPoolExecutor` with `max_workers≤5` for parallel safety.
+
+- **`item['reply']` vs `record['reply']`** — In a feed response, `item['reply']` (top-level) contains hydrated `root`/`parent` post objects. `item['post']['record']['reply']` contains only `{uri, cid}` refs. Use the former for display context, the latter for thread structure.
+
+- **`getPostThread` depth** — Default depth is 6 levels of replies. Each reply node has a `replies` list with nested thread nodes. Nodes at the depth limit have `$type: app.bsky.feed.defs#threadViewPost` with an empty `replies` array.
+
+- **`getTrendingTopics` links are relative** — `topic['link']` is `/profile/trending.bsky.app/feed/688534877`, not a full URL. Prepend `https://bsky.app` to build the feed URL, or extract the feed AT URI from the path.

--- a/domain-skills/hibp/scraping.md
+++ b/domain-skills/hibp/scraping.md
@@ -1,0 +1,322 @@
+# Have I Been Pwned — Scraping & Data Extraction
+
+`https://haveibeenpwned.com` / `https://api.pwnedpasswords.com` — public data breach database and password exposure checker. **Never use the browser.** All useful data is available via `http_get`. The Pwned Passwords API is completely free, no auth. The breach account-lookup endpoints require a paid API key.
+
+## Do this first
+
+**Use the Pwned Passwords range API for password checking — free, no auth, privacy-preserving k-anonymity.**
+
+```python
+import hashlib, json
+from helpers import http_get
+
+def check_password_pwned(password: str) -> int:
+    """Returns how many times this password has appeared in known breaches. 0 = not found."""
+    sha1 = hashlib.sha1(password.encode('utf-8')).hexdigest().upper()
+    prefix, suffix = sha1[:5], sha1[5:]
+    body = http_get(f'https://api.pwnedpasswords.com/range/{prefix}')
+    for line in body.splitlines():
+        h, count = line.split(':')
+        if h == suffix:
+            return int(count)
+    return 0
+
+print(check_password_pwned('password'))               # 52256179
+print(check_password_pwned('correct horse battery staple'))  # 387
+print(check_password_pwned('very_unique_str_xyz9283'))       # 0
+```
+
+Use `http_get` on `https://haveibeenpwned.com/api/v3/breaches` for the full breach list — one call, fully parsed JSON, no auth.
+
+**Never use the browser.** All pages are just wrappers around the same API data.
+
+## The k-anonymity model (Pwned Passwords)
+
+You never send the full password or its hash to the API. The flow:
+
+1. SHA1-hash the password (or NTLM-hash for Windows credential checking)
+2. Send only the **first 5 hex characters** to `api.pwnedpasswords.com/range/{prefix}`
+3. The API returns ~1900 matching hash suffixes + counts (all hashes in the database sharing that prefix)
+4. Search the response locally for your **remaining 35 characters** — no plaintext ever leaves your machine
+
+```python
+import hashlib
+
+password = 'password'
+sha1 = hashlib.sha1(password.encode('utf-8')).hexdigest().upper()
+# SHA1 = 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8
+prefix = sha1[:5]   # '5BAA6'   — sent to API
+suffix = sha1[5:]   # '1E4C9B93F3F0682250B6CF8331B7EE68FD8'  — matched locally
+
+# API response lines look like:
+# 1E4C9B93F3F0682250B6CF8331B7EE68FD8:52256179
+# (suffix:count)
+```
+
+The response is plain text, `\r\n` line endings, ~1,900–2,000 lines per prefix, ~75 KB. CDN-cached for up to 31 days per prefix.
+
+## Common workflows
+
+### Check a single password
+
+```python
+import hashlib
+from helpers import http_get
+
+def check_password_pwned(password: str) -> int:
+    sha1 = hashlib.sha1(password.encode('utf-8')).hexdigest().upper()
+    prefix, suffix = sha1[:5], sha1[5:]
+    body = http_get(f'https://api.pwnedpasswords.com/range/{prefix}')
+    for line in body.splitlines():
+        h, count = line.split(':')
+        if h == suffix:
+            return int(count)
+    return 0
+
+count = check_password_pwned('letmein')
+if count > 0:
+    print(f'Compromised! Seen {count:,} times in breaches.')
+else:
+    print('Not found in known breaches.')
+# Confirmed output: Compromised! Seen 1,406,394 times in breaches.
+```
+
+### Check multiple passwords in parallel
+
+```python
+import hashlib
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+
+def check_password_pwned(password: str) -> dict:
+    sha1 = hashlib.sha1(password.encode('utf-8')).hexdigest().upper()
+    prefix, suffix = sha1[:5], sha1[5:]
+    body = http_get(f'https://api.pwnedpasswords.com/range/{prefix}')
+    for line in body.splitlines():
+        h, count = line.split(':')
+        if h == suffix:
+            return {'password': password, 'count': int(count)}
+    return {'password': password, 'count': 0}
+
+passwords = ['password', 'letmein', 'correct horse battery staple', 'hunter2']
+with ThreadPoolExecutor(max_workers=4) as ex:
+    results = list(ex.map(check_password_pwned, passwords))
+
+for r in results:
+    status = f"seen {r['count']:,}x" if r['count'] else "not found"
+    print(f"{r['password']!r}: {status}")
+# Confirmed working; safe to use max_workers=5–10 — endpoint is CDN-cached, not rate-limited
+```
+
+### All breaches (full list)
+
+```python
+import json
+from helpers import http_get
+
+breaches = json.loads(http_get('https://haveibeenpwned.com/api/v3/breaches'))
+print(f'Total breaches: {len(breaches)}')   # 974 (confirmed 2026-04-18)
+
+# Key fields per breach object:
+# Name, Title, Domain, BreachDate, AddedDate, ModifiedDate,
+# PwnCount, Description (HTML), LogoPath, DataClasses (list),
+# IsVerified, IsFabricated, IsSensitive, IsRetired, IsSpamList,
+# IsMalware, IsSubscriptionFree, IsStealerLog, Attribution, DisclosureUrl
+
+# Find largest breaches
+top5 = sorted(breaches, key=lambda b: b['PwnCount'], reverse=True)[:5]
+for b in top5:
+    print(f"{b['Name']}: {b['PwnCount']:,} accounts ({b['BreachDate']})")
+# SynthientCredentialStuffingThreatData: 1,957,476,021 accounts
+# Collection1: 772,904,991 accounts
+# VerificationsIO: 763,117,241 accounts
+# OnlinerSpambot: 711,477,622 accounts
+# PDL: 622,161,052 accounts
+```
+
+### Filter breaches by domain
+
+```python
+import json
+from helpers import http_get
+
+result = json.loads(http_get('https://haveibeenpwned.com/api/v3/breaches?domain=adobe.com'))
+for b in result:
+    print(b['Name'], b['PwnCount'])
+# Adobe 152445165
+```
+
+### Single breach by name
+
+```python
+import json
+from helpers import http_get
+
+adobe = json.loads(http_get('https://haveibeenpwned.com/api/v3/breach/Adobe'))
+print(adobe['Name'], adobe['PwnCount'], adobe['BreachDate'])
+print(adobe['DataClasses'])
+# Adobe 152445165 2013-10-04
+# ['Email addresses', 'Password hints', 'Passwords', 'Usernames']
+
+# 404 for unknown breach — raises HTTPError, not a JSON error
+try:
+    http_get('https://haveibeenpwned.com/api/v3/breach/NonExistentXYZ')
+except Exception as e:
+    print(e)   # HTTP Error 404: Not Found
+    # curl returns plain text "Not found" body (application/json content-type despite being plain text)
+```
+
+### Latest breach added
+
+```python
+import json
+from helpers import http_get
+
+latest = json.loads(http_get('https://haveibeenpwned.com/api/v3/latestbreach'))
+print(latest['Name'], latest['BreachDate'])
+# Amtrak 2026-04-03  (confirmed 2026-04-18)
+```
+
+### All data classes (taxonomy of what was leaked)
+
+```python
+import json
+from helpers import http_get
+
+dcs = json.loads(http_get('https://haveibeenpwned.com/api/v3/dataclasses'))
+print(f'Total categories: {len(dcs)}')   # 157
+print(dcs[:5])
+# ['Account balances', 'Address book contacts', 'Age groups', 'Ages', 'AI prompts']
+```
+
+### Parallel fetch of specific breaches
+
+```python
+import json
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+
+names = ['Adobe', 'LinkedIn', 'Yahoo', 'Dropbox', 'MySpace']
+
+def fetch_breach(name):
+    data = json.loads(http_get(f'https://haveibeenpwned.com/api/v3/breach/{name}'))
+    return {'name': data['Name'], 'pwn_count': data['PwnCount'], 'date': data['BreachDate']}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_breach, names))
+
+for r in results:
+    print(f"{r['name']}: {r['pwn_count']:,} ({r['date']})")
+# Adobe: 152,445,165 (2013-10-04)
+# LinkedIn: 164,611,595 (2012-05-05)
+# Yahoo: 453,427 (2012-07-11)
+# Dropbox: 68,648,009 (2012-07-01)
+# MySpace: 359,420,698 (2008-07-01)
+# Time: 0.26s (all 5 in parallel)
+```
+
+### Account breach lookup (requires paid API key)
+
+This endpoint is **not freely available** — requires a purchased API key from `haveibeenpwned.com/API/Key`.
+
+```python
+import json
+from helpers import http_get
+
+API_KEY = 'your-hibp-api-key'
+
+# All breaches for an email address
+breaches = json.loads(http_get(
+    'https://haveibeenpwned.com/api/v3/breachedaccount/user@example.com',
+    headers={'hibp-api-key': API_KEY}
+))
+# Returns list of breach objects (same structure as /breaches, but truncated)
+# If no breaches found: raises HTTPError 404 (not an empty list — actual 404)
+
+# Pastes (also requires API key)
+pastes = json.loads(http_get(
+    'https://haveibeenpwned.com/api/v3/pasteaccount/user@example.com',
+    headers={'hibp-api-key': API_KEY}
+))
+# Each paste: Source, Id, Title, Date, EmailCount
+```
+
+Without a key: HTTP 401 `{ "statusCode": 401, "message": "Access denied due to improperly formed hibp-api-key." }`
+
+## API reference
+
+### Pwned Passwords
+
+| Endpoint | Auth | Notes |
+|---|---|---|
+| `GET api.pwnedpasswords.com/range/{prefix}` | None | prefix = first 5 chars of SHA1 (uppercase hex) |
+| `GET api.pwnedpasswords.com/range/{prefix}?mode=ntlm` | None | NTLM mode for Windows credential hashes; 27-char suffixes instead of 35 |
+
+Response format: plain text, one line per matching hash, `SUFFIX:COUNT\r\n`. ~1,900 lines per prefix.
+
+Cache: CDN-cached up to 31 days (`cache-control: public, max-age=2678400`). Repeated calls for the same prefix are free and instant.
+
+### HIBP REST API v3 (base: `https://haveibeenpwned.com/api/v3`)
+
+| Endpoint | Auth | Notes |
+|---|---|---|
+| `GET /breaches` | None | All 974 breaches |
+| `GET /breaches?domain={domain}` | None | Filter by domain |
+| `GET /breach/{name}` | None | Single breach by Name field |
+| `GET /latestbreach` | None | Most recently added breach |
+| `GET /dataclasses` | None | 157 data category strings |
+| `GET /breachedaccount/{email}` | API key | Paid only |
+| `GET /pasteaccount/{email}` | API key | Paid only |
+
+API key header: `hibp-api-key: {key}`. No version header required; v3 is the current and only active version.
+
+### Breach object fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `Name` | string | Unique ID used in URLs (e.g., `"Adobe"`) |
+| `Title` | string | Display name |
+| `Domain` | string | Primary domain (may be empty string) |
+| `BreachDate` | string | `YYYY-MM-DD` |
+| `AddedDate` | string | ISO 8601 datetime |
+| `ModifiedDate` | string | ISO 8601 datetime |
+| `PwnCount` | int | Total accounts exposed |
+| `Description` | string | HTML — contains `<a>` tags, `<em>`, etc. |
+| `LogoPath` | string | `https://logos.haveibeenpwned.com/{Name}.png` |
+| `DataClasses` | list[str] | Types of data exposed |
+| `IsVerified` | bool | Confirmed authentic breach |
+| `IsFabricated` | bool | Known to be fake/fabricated |
+| `IsSensitive` | bool | Contains sensitive info (adult sites, etc.) |
+| `IsRetired` | bool | No longer actively indexed |
+| `IsSpamList` | bool | Email spam list rather than a breach |
+| `IsMalware` | bool | Sourced from malware/info-stealer |
+| `IsStealerLog` | bool | Credential stealer logs specifically |
+| `IsSubscriptionFree` | bool | Whether free subscribers can see it |
+| `Attribution` | string\|null | Source attribution if credited |
+| `DisclosureUrl` | string\|null | URL of original disclosure |
+
+## Gotchas
+
+- **Never use the browser.** The website is entirely API-driven. `http_get` is sufficient for all public data.
+
+- **Pwned Passwords response has `\r\n` line endings.** Use `.splitlines()` (not `.split('\n')`) to parse — `splitlines()` handles both `\r\n` and `\n` transparently. If you split on `\n`, each suffix will have a trailing `\r` and the comparison `h == suffix` will always be False.
+
+- **Password and hash must be uppercased.** `hashlib.sha1(...).hexdigest()` returns lowercase. Call `.upper()` before splitting into prefix/suffix. The API returns uppercase suffixes.
+
+- **404 for missing breach is a raised HTTPError, not a JSON error body.** `http_get` will raise `urllib.error.HTTPError` on 404. The response body is the string `"Not found"` with `content-type: application/json` — misleadingly labeled but not valid JSON.
+
+- **404 for missing `breachedaccount` means no breaches found, not an error.** When an email has never appeared in a breach, the API returns HTTP 404, not an empty list `[]`. When it has breaches, it returns HTTP 200 with the list. This is the opposite of what you'd expect.
+
+- **`Description` field contains raw HTML.** Strip tags with `re.sub(r'<[^>]+>', '', b['Description'])` if you need plain text.
+
+- **Pwned Passwords is CDN-cached for 31 days** (`cache-control: public, max-age=2678400`, `age` can be over 1.5 million seconds). This is intentional — password hash prefixes don't change often. Parallel requests for different prefixes are fast and safe; there's no meaningful rate limit on this endpoint.
+
+- **HIBP breach endpoints cache for 5 minutes** (`cache-control: public, max-age=300`). Rapid sequential calls to `/breach/Adobe` 10× all returned HTTP 200 without throttling. No rate limit headers observed. Still, add `time.sleep(1)` between bulk breach-name lookups to be a good citizen.
+
+- **NTLM mode suffix length differs.** `?mode=ntlm` returns 27-char suffixes (NTLM is 32 hex chars; 32−5=27) vs. 35-char for SHA1 (40−5=35). NTLM mode is only relevant for checking Windows NTLM credential hashes directly.
+
+- **`CORS: access-control-allow-origin: *`** on all endpoints — can be called from browser JS too, no proxy needed for client-side apps.
+
+- **`logoPath` URLs are reliable.** `https://logos.haveibeenpwned.com/{Name}.png` — these are stable CDN URLs, not the web page logo paths.
+
+- **The `domain` filter in `/breaches?domain=` is exact-match.** `adobe.com` matches Adobe's breach; `adobe` alone returns nothing.

--- a/domain-skills/ip-geolocation/scraping.md
+++ b/domain-skills/ip-geolocation/scraping.md
@@ -1,0 +1,369 @@
+# IP Geolocation APIs — Data Extraction
+
+Three tested free-tier services, no browser needed. Best free option: **ip-api.com** (no key, 45 req/min, HTTP only). Use **ipinfo.io** when HTTPS is required without a key.
+
+All calls use `http_get` from helpers — no browser, no JS, pure HTTP.
+
+## Do this first: pick your service
+
+| Service | Key required | HTTPS free | Rate limit (free) | Batch | Proxy/mobile/hosting detect |
+|---|---|---|---|---|---|
+| **ip-api.com** | No | No (HTTP only; HTTPS = paid) | 45 req/min | Yes, 100 IPs/call | Yes (free) |
+| **ipinfo.io** | No (basic) | Yes | 50K req/month | No (token required) | No (paid) |
+| **ipgeolocation.io** | Yes (free tier) | Yes | 1K req/day (free) | Yes (paid) | Yes (paid) |
+| **abstractapi.com** | Yes (free tier) | Yes | 1K req/month (free) | No | Yes (paid) |
+
+**Never use a browser for any of these.** All return JSON over HTTP/HTTPS.
+
+---
+
+## ip-api.com — best free option (no key)
+
+### Single IP lookup
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get("http://ip-api.com/json/8.8.8.8"))
+# Confirmed output (2026-04-18):
+# {
+#   "status": "success",
+#   "country": "United States",
+#   "countryCode": "US",
+#   "region": "VA",
+#   "regionName": "Virginia",
+#   "city": "Ashburn",
+#   "zip": "20149",
+#   "lat": 39.03,
+#   "lon": -77.5,
+#   "timezone": "America/New_York",
+#   "isp": "Google LLC",
+#   "org": "Google Public DNS",
+#   "as": "AS15169 Google LLC",
+#   "query": "8.8.8.8"
+# }
+assert data["status"] == "success"
+print(data["city"], data["countryCode"])    # Ashburn US
+print(data["lat"], data["lon"])             # 39.03 -77.5
+print(data["isp"], data["as"])              # Google LLC  AS15169 Google LLC
+```
+
+### Own IP (omit the IP segment)
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get("http://ip-api.com/json/"))
+print(data["query"])    # your public IP address
+print(data["city"], data["regionName"], data["countryCode"])
+```
+
+### All available fields (including proxy/mobile/hosting detection)
+
+```python
+import json
+from helpers import http_get
+
+FIELDS = "status,message,country,countryCode,region,regionName,city,zip,lat,lon,timezone,isp,org,as,asname,reverse,mobile,proxy,hosting,query"
+data = json.loads(http_get(f"http://ip-api.com/json/9.9.9.9?fields={FIELDS}"))
+# Confirmed extra fields for 9.9.9.9 (Quad9 DNS):
+# "asname": "QUAD9-AS-1"
+# "reverse": "dns9.quad9.net"
+# "mobile": False          — not a mobile network
+# "proxy": False           — not a known proxy/VPN
+# "hosting": False         — not a datacenter/hosting range
+# Note: 8.8.8.8 returns "hosting": True (Google datacenter)
+```
+
+### Batch lookup — up to 100 IPs per call
+
+Single POST to `/batch` beats parallel individual calls for throughput.
+
+```python
+import json, urllib.request
+from helpers import http_get
+
+ips = ["8.8.8.8", "1.1.1.1", "9.9.9.9"]
+
+data = json.dumps(ips).encode()
+req = urllib.request.Request(
+    "http://ip-api.com/batch",
+    data=data,
+    headers={"Content-Type": "application/json", "User-Agent": "Mozilla/5.0"},
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    results = json.loads(r.read().decode())
+    remaining = r.headers.get("X-Rl")    # requests left in current minute window
+    ttl       = r.headers.get("X-Ttl")   # seconds until window resets
+
+for item in results:
+    if item["status"] == "success":
+        print(item["query"], item["city"], item["countryCode"], item["isp"])
+# Confirmed output:
+# 8.8.8.8  Ashburn   US  Google LLC
+# 1.1.1.1  South Brisbane  AU  Cloudflare, Inc
+# 9.9.9.9  Berkeley  US  Quad9
+```
+
+### Batch with per-IP field filtering and language
+
+```python
+import json, urllib.request
+
+payload = [
+    {"query": "8.8.8.8",  "fields": "status,country,city,lat,lon,isp", "lang": "de"},
+    {"query": "1.1.1.1",  "fields": "status,country,city,lat,lon,isp", "lang": "de"},
+]
+data = json.dumps(payload).encode()
+req = urllib.request.Request(
+    "http://ip-api.com/batch",
+    data=data,
+    headers={"Content-Type": "application/json", "User-Agent": "Mozilla/5.0"},
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    results = json.loads(r.read().decode())
+# Returns country names in German: "Vereinigte Staaten", "Australien"
+```
+
+Supported `lang` values: `en` (default), `de`, `es`, `pt-BR`, `fr`, `ja`, `zh-CN`, `ru`.
+
+### Chunked bulk lookup (> 100 IPs)
+
+```python
+import json, urllib.request, time
+
+def ip_api_bulk(ips: list[str], fields: str = None, sleep_between=0.0) -> list[dict]:
+    """Look up any number of IPs in batches of 100."""
+    results = []
+    chunk_size = 100
+    for i in range(0, len(ips), chunk_size):
+        chunk = ips[i:i + chunk_size]
+        payload = chunk
+        if fields:
+            payload = [{"query": ip, "fields": fields} for ip in chunk]
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            "http://ip-api.com/batch",
+            data=data,
+            headers={"Content-Type": "application/json", "User-Agent": "Mozilla/5.0"},
+        )
+        with urllib.request.urlopen(req, timeout=20) as r:
+            batch = json.loads(r.read().decode())
+            remaining = int(r.headers.get("X-Rl", 45))
+            ttl = int(r.headers.get("X-Ttl", 60))
+            results.extend(batch)
+        # Only sleep if nearly rate-limited (< 5 requests left in window)
+        if remaining < 5:
+            time.sleep(ttl + 1)
+        elif sleep_between:
+            time.sleep(sleep_between)
+    return results
+```
+
+### Rate limit headers
+
+Every response carries:
+- `X-Rl` — integer, requests remaining in the current 60-second window (starts at 45)
+- `X-Ttl` — integer seconds until the window resets
+
+```python
+import json, urllib.request
+
+req = urllib.request.Request("http://ip-api.com/json/8.8.8.8", headers={"User-Agent": "Mozilla/5.0"})
+with urllib.request.urlopen(req, timeout=20) as r:
+    data   = json.loads(r.read().decode())
+    rl     = int(r.headers.get("X-Rl",  45))   # e.g. 44
+    ttl    = int(r.headers.get("X-Ttl", 60))   # e.g. 60
+```
+
+---
+
+## ipinfo.io — best free HTTPS option (no key for basic)
+
+Returns fewer fields than ip-api.com but works over HTTPS without a token for up to ~50K req/month.
+
+### Single IP lookup
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get("https://ipinfo.io/8.8.8.8/json"))
+# Confirmed output (2026-04-18):
+# {
+#   "ip": "8.8.8.8",
+#   "hostname": "dns.google",
+#   "city": "Mountain View",
+#   "region": "California",
+#   "country": "US",
+#   "loc": "37.4056,-122.0775",    ← combined "lat,lon" string, NOT separate fields
+#   "org": "AS15169 Google LLC",   ← ASN + org name combined
+#   "postal": "94043",
+#   "timezone": "America/Los_Angeles",
+#   "readme": "https://ipinfo.io/missingauth",   ← appears when no token; data still valid
+#   "anycast": true
+# }
+
+lat, lon = map(float, data["loc"].split(","))    # split "37.4056,-122.0775"
+asn, org = data["org"].split(" ", 1)             # "AS15169" and "Google LLC"
+```
+
+### Own IP
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get("https://ipinfo.io/json"))
+print(data["ip"], data["city"], data["country"])
+```
+
+### Single-field endpoints (ultra-lightweight)
+
+```python
+from helpers import http_get
+
+country  = http_get("https://ipinfo.io/8.8.8.8/country").strip()   # "US"
+city     = http_get("https://ipinfo.io/8.8.8.8/city").strip()      # "Mountain View"
+org      = http_get("https://ipinfo.io/8.8.8.8/org").strip()       # "AS15169 Google LLC"
+```
+
+Returns plain text, not JSON. Strip trailing newline.
+
+---
+
+## ipgeolocation.io — key required (free tier available)
+
+Requires API key (free tier: 1,000 req/day). Sign up at `https://app.ipgeolocation.io/login`.
+
+```python
+import json
+from helpers import http_get
+
+API_KEY = "YOUR_KEY_HERE"
+data = json.loads(http_get(f"https://api.ipgeolocation.io/ipgeo?apiKey={API_KEY}&ip=8.8.8.8"))
+# Returns: ip, continent_code, country_name, country_code2, state_prov,
+#          city, zipcode, latitude, longitude, isp, organization,
+#          time_zone.name, currency.code, languages, calling_code
+```
+
+Without a key: `HTTP 401 {"message": "Please provide an API key..."}`.
+
+---
+
+## abstractapi.com — key required (free tier available)
+
+Free tier: 1,000 req/month. Sign up at `https://app.abstractapi.com/`.
+
+```python
+import json
+from helpers import http_get
+
+API_KEY = "YOUR_KEY_HERE"
+data = json.loads(http_get(
+    f"https://ipgeolocation.abstractapi.com/v1/?api_key={API_KEY}&ip_address=8.8.8.8"
+))
+# Returns: ip_address, city, city_geoname_id, region, region_geoname_id,
+#          postal_code, country, country_code, country_geoname_id,
+#          latitude, longitude, is_vpn, connection.*, timezone.*, flag.*
+```
+
+Without a key: `HTTP 401 {"error": {"message": "Invalid API key provided.", "code": "unauthorized"}}`.
+
+---
+
+## Comparison: field coverage
+
+| Field | ip-api.com | ipinfo.io | ipgeolocation.io |
+|---|---|---|---|
+| IP | `query` | `ip` | `ip` |
+| City | `city` | `city` | `city` |
+| Region/State | `regionName` + `region` (code) | `region` (full name only) | `state_prov` |
+| Country | `country` + `countryCode` | `country` (code only) | `country_name` + `country_code2` |
+| Latitude | `lat` (float) | first part of `loc` (string) | `latitude` (string) |
+| Longitude | `lon` (float) | second part of `loc` (string) | `longitude` (string) |
+| Timezone | `timezone` | `timezone` | `time_zone.name` |
+| ISP | `isp` | part of `org` | `isp` |
+| ASN | `as` (combined) | part of `org` | `asn` |
+| Hostname/reverse | `reverse` | `hostname` | — |
+| Proxy/VPN detect | `proxy` (free) | — (paid) | `threat.*` (paid) |
+| Mobile detect | `mobile` (free) | — (paid) | — |
+| Hosting/datacenter | `hosting` (free) | — (paid) | — |
+| Anycast flag | — | `anycast` (free) | — |
+| Currency | — | — | `currency.code` |
+
+---
+
+## Complete end-to-end pattern: enrich a list of IPs
+
+```python
+import json, urllib.request, time
+
+def enrich_ips(ips: list[str]) -> list[dict]:
+    """Return geolocation data for up to 100 IPs in one call.
+    
+    Returns list of dicts. Failed lookups have status='fail' and message field.
+    """
+    payload = json.dumps(ips).encode()
+    req = urllib.request.Request(
+        "http://ip-api.com/batch",
+        data=payload,
+        headers={"Content-Type": "application/json", "User-Agent": "Mozilla/5.0"},
+    )
+    with urllib.request.urlopen(req, timeout=20) as r:
+        results = json.loads(r.read().decode())
+        remaining = int(r.headers.get("X-Rl", 45))
+        if remaining < 5:
+            ttl = int(r.headers.get("X-Ttl", 60))
+            time.sleep(ttl + 1)
+    return results
+
+
+# Usage
+ips = ["8.8.8.8", "1.1.1.1", "192.168.1.1", "9.9.9.9"]
+rows = enrich_ips(ips)
+for row in rows:
+    if row["status"] == "success":
+        print(f"{row['query']:16s}  {row['city']:20s}  {row['countryCode']}  {row['isp']}")
+    else:
+        print(f"{row['query']:16s}  FAILED: {row['message']}")
+# Confirmed output:
+# 8.8.8.8           Ashburn               US  Google LLC
+# 1.1.1.1           South Brisbane        AU  Cloudflare, Inc
+# 192.168.1.1       FAILED: private range
+# 9.9.9.9           Berkeley              US  Quad9
+```
+
+---
+
+## Gotchas
+
+**ip-api.com HTTPS is paid.** `https://ip-api.com/json/8.8.8.8` returns `HTTP 403 {"status":"fail","message":"SSL unavailable for this endpoint, order a key at https://members.ip-api.com/"}`. Always use `http://` for the free tier.
+
+**ip-api.com rate limit is 45 req/min per IP address** (not per key). The batch endpoint counts as 1 request regardless of how many IPs are in the payload. Sending 100 IPs in one POST uses 1 of your 45 requests. Track `X-Rl` and sleep when it approaches 0.
+
+**ip-api.com batch max is 100 IPs.** Sending 101 returns `HTTP 422 Unprocessable Entity` (empty body). Chunk at 100.
+
+**ip-api.com private/reserved IPs return `status: "fail"`, not an error.** `192.168.x.x`, `10.x.x.x`, `127.x.x.x`, `::1` all return `{"status":"fail","message":"private range","query":"..."}`. Always check `data["status"] == "success"` before reading geo fields.
+
+**ip-api.com invalid IPs return `status: "fail"` too.** `{"status":"fail","message":"invalid query","query":"..."}`. HTTP status is still 200.
+
+**ip-api.com `fields` param filters the JSON keys in the response.** Use it to reduce payload size when you only need a subset. Both named fields (`fields=city,country`) and numeric bitmask (`fields=61439`) work. If `fields` omits `status`, a failed lookup returns an empty object `{}`.
+
+**ipinfo.io `loc` is a combined `"lat,lon"` string**, not two separate fields. Always split: `lat, lon = map(float, data["loc"].split(","))`.
+
+**ipinfo.io `org` combines ASN and org name**: `"AS15169 Google LLC"`. Split on first space to separate them: `asn, name = data["org"].split(" ", 1)`.
+
+**ipinfo.io `readme` key appears when no token is provided.** Its presence does not indicate an error — the data is still valid. The field simply points to the auth docs.
+
+**ipinfo.io `anycast` key is only present for anycast IPs** (e.g., `8.8.8.8`, `1.1.1.1`). Use `.get("anycast", False)` — don't assume it's always in the response.
+
+**ipinfo.io single-field endpoints return plain text, not JSON.** `https://ipinfo.io/8.8.8.8/country` returns `US\n`. Always `.strip()` before use.
+
+**ipinfo.io batch requires a token.** `POST https://ipinfo.io/batch` with a payload returns `{"error":"API token required"}` without a token. For free batch lookups use ip-api.com instead.
+
+**ipgeolocation.io and abstractapi.com require signup even for free use.** Both return `HTTP 401` immediately without a key — there is no anonymous/no-key path. Use ip-api.com or ipinfo.io for keyless access.
+
+**ip-api.com returns `lat`/`lon` as JSON floats.** ipinfo.io returns them as a single `"lat,lon"` string inside `loc`. ipgeolocation.io returns them as numeric strings (`"37.4056"`). Normalize to float before any math.

--- a/domain-skills/nytimes/scraping.md
+++ b/domain-skills/nytimes/scraping.md
@@ -1,0 +1,535 @@
+# New York Times — Data Extraction
+
+`https://www.nytimes.com` and `https://api.nytimes.com` — Two entirely separate access paths exist. The **RSS feeds** are free, no key, no JS rendering, return 17–58 articles per section. The **official APIs** (`api.nytimes.com`) require a free key from `https://developer.nytimes.com/get-started` and cover search, top stories, books, and more. Article full-text is behind a paywall and Cloudflare blocks direct `http_get` on article URLs (403).
+
+## Do this first: pick your access path
+
+| Goal | Best approach | Latency | Auth needed |
+|------|--------------|---------|------------|
+| Current headlines by section | RSS feed | ~60–110ms | None |
+| Most viewed / most emailed | RSS feed | ~77ms | None |
+| Homepage article list with summaries | `window.__preloadedData` parse | ~250ms | None |
+| Keyword search across all NYT content | Article Search API | ~300ms | Free API key |
+| Top stories by section | Top Stories API | ~250ms | Free API key |
+| Best-seller book lists | Books API | ~250ms | Free API key |
+| Archive by month | Archive API | ~400ms | Free API key |
+| Article full text | Browser + subscription session | Slow | Paid sub |
+
+**Never use a browser for RSS feeds or API calls.** `http_get` is sufficient for all metadata tasks.
+
+**Article pages 403 immediately** — Cloudflare DDoS protection blocks all non-browser `http_get` calls regardless of User-Agent. Full text requires a subscribed browser session.
+
+---
+
+## Path 1: RSS feeds (fastest, no key — confirmed working 2026-04-18)
+
+55 section feeds. Cache TTL is 5 minutes (`Cache-Control: public, max-age=300`). Each feed returns 15–60 items.
+
+```python
+import xml.etree.ElementTree as ET
+from helpers import http_get
+
+MEDIA = 'http://search.yahoo.com/mrss/'
+DC    = 'http://purl.org/dc/elements/1.1/'
+
+def fetch_rss(section_url):
+    """Parse any NYT RSS feed. Returns list of article dicts."""
+    _, _, body = http_get(section_url)
+    root    = ET.fromstring(body)
+    channel = root.find('channel')
+    results = []
+    for item in channel.findall('item'):
+        media   = item.find(f'{{{MEDIA}}}content')
+        results.append({
+            'title':       item.findtext('title'),
+            'url':         item.findtext('link'),
+            'description': item.findtext('description'),
+            'pub_date':    item.findtext('pubDate'),         # 'Sat, 18 Apr 2026 20:17:14 +0000'
+            'byline':      item.findtext(f'{{{DC}}}creator'),
+            'categories':  [c.text for c in item.findall('category')],
+            'image_url':   media.get('url') if media is not None else None,
+        })
+    return results
+
+# Usage
+articles = fetch_rss('https://rss.nytimes.com/services/xml/rss/nyt/World.xml')
+# articles[0] confirmed output:
+# {'title': 'Iran War Live Updates: Tensions Rise in Strait of Hormuz...',
+#  'url': 'https://www.nytimes.com/live/2026/04/18/world/iran-us-war-trump-hormuz',
+#  'description': "Iran's Revolutionary Guards said they were closing...",
+#  'pub_date': 'Sat, 18 Apr 2026 23:51:55 +0000',
+#  'byline': 'The New York Times',
+#  'categories': [],
+#  'image_url': 'https://static01.nyt.com/images/...mediumSquareAt3X.jpg'}
+```
+
+### Complete RSS feed catalog (55 feeds total)
+
+```
+# Top-level sections
+https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml        # 17 items
+https://rss.nytimes.com/services/xml/rss/nyt/World.xml           # 58 items
+https://rss.nytimes.com/services/xml/rss/nyt/Africa.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Americas.xml
+https://rss.nytimes.com/services/xml/rss/nyt/AsiaPacific.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Europe.xml
+https://rss.nytimes.com/services/xml/rss/nyt/MiddleEast.xml
+https://rss.nytimes.com/services/xml/rss/nyt/US.xml              # 20 items
+https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml        # 20 items
+https://rss.nytimes.com/services/xml/rss/nyt/Education.xml
+https://rss.nytimes.com/services/xml/rss/nyt/NYRegion.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Upshot.xml
+
+# Business / Economy
+https://rss.nytimes.com/services/xml/rss/nyt/Business.xml        # 50 items
+https://rss.nytimes.com/services/xml/rss/nyt/Economy.xml
+https://rss.nytimes.com/services/xml/rss/nyt/EnergyEnvironment.xml
+https://rss.nytimes.com/services/xml/rss/nyt/SmallBusiness.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Dealbook.xml
+https://rss.nytimes.com/services/xml/rss/nyt/MediaandAdvertising.xml
+https://rss.nytimes.com/services/xml/rss/nyt/YourMoney.xml
+https://rss.nytimes.com/services/xml/rss/nyt/PersonalTech.xml
+
+# Sports
+https://rss.nytimes.com/services/xml/rss/nyt/Sports.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Baseball.xml
+https://rss.nytimes.com/services/xml/rss/nyt/ProBasketball.xml
+https://rss.nytimes.com/services/xml/rss/nyt/ProFootball.xml
+https://rss.nytimes.com/services/xml/rss/nyt/CollegeBasketball.xml
+https://rss.nytimes.com/services/xml/rss/nyt/CollegeFootball.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Golf.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Hockey.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Soccer.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Tennis.xml
+
+# Science / Health
+https://rss.nytimes.com/services/xml/rss/nyt/Science.xml         # 20 items
+https://rss.nytimes.com/services/xml/rss/nyt/Climate.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Space.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Well.xml
+
+# Arts / Culture
+https://rss.nytimes.com/services/xml/rss/nyt/Arts.xml            # 44 items
+https://rss.nytimes.com/services/xml/rss/nyt/ArtandDesign.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Books.xml
+https://rss.nytimes.com/services/xml/rss/nyt/SundayBookReview.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Dance.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Movies.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Music.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Television.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Theater.xml
+https://rss.nytimes.com/services/xml/rss/nyt/FashionandStyle.xml
+https://rss.nytimes.com/services/xml/rss/nyt/DiningandWine.xml
+https://rss.nytimes.com/services/xml/rss/nyt/tmagazine.xml
+
+# Opinion
+https://rss.nytimes.com/services/xml/rss/nyt/Opinion.xml         # 49 items
+https://rss.nytimes.com/services/xml/rss/nyt/sunday-review.xml
+
+# Engagement lists
+https://rss.nytimes.com/services/xml/rss/nyt/MostViewed.xml      # 19 items
+https://rss.nytimes.com/services/xml/rss/nyt/MostEmailed.xml     # 17 items
+https://rss.nytimes.com/services/xml/rss/nyt/MostShared.xml
+
+# Other
+https://rss.nytimes.com/services/xml/rss/nyt/Jobs.xml
+https://rss.nytimes.com/services/xml/rss/nyt/RealEstate.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Automobiles.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Lens.xml
+https://rss.nytimes.com/services/xml/rss/nyt/Obituaries.xml
+```
+
+Full feed index: `https://archive.nytimes.com/www.nytimes.com/services/xml/rss/`
+
+---
+
+## Path 2: Homepage `window.__preloadedData` (no key, richer fields)
+
+The homepage embeds a 576KB JS object with full article metadata including summaries. The structure uses JS `undefined` (invalid JSON) — replace before parsing.
+
+```python
+import json, re
+from helpers import http_get
+
+def fetch_homepage_articles():
+    """Returns list of article dicts from homepage embedded JSON. No API key needed."""
+    _, _, body = http_get('https://www.nytimes.com/')
+    
+    idx = body.find('window.__preloadedData =')
+    if idx < 0:
+        return []
+    
+    # Extract JSON by brace-counting (regex .+ fails due to undefined values)
+    start = body.index('{', idx)
+    depth = 0
+    for i in range(start, start + 2_000_000):
+        c = body[i]
+        if c == '{':   depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                raw = re.sub(r'\bundefined\b', 'null', body[start:i+1])
+                break
+    
+    pd = json.loads(raw)
+    
+    results = []
+    seen    = set()
+    ARTICLE_URL = re.compile(r'https://www\.nytimes\.com/\d{4}/\d{2}/\d{2}/')
+
+    def walk(node, depth=0):
+        if not isinstance(node, dict) or depth > 15:
+            return
+        url = node.get('url', '')
+        if isinstance(url, str) and ARTICLE_URL.match(url) and url not in seen:
+            seen.add(url)
+            hl = node.get('headline', {})
+            results.append({
+                'url':      url,
+                'headline': hl.get('default', '') if isinstance(hl, dict) else '',
+                'summary':  node.get('summary', ''),
+                'type':     node.get('__typename', ''),   # 'Article', 'Video', 'Interactive'
+            })
+        for v in node.values():
+            if isinstance(v, dict):
+                walk(v, depth + 1)
+            elif isinstance(v, list):
+                for item in v:
+                    if isinstance(item, dict):
+                        walk(item, depth + 1)
+
+    walk(pd)
+    return results
+
+articles = fetch_homepage_articles()
+# Confirmed output (2026-04-18, 51 unique articles):
+# articles[0] = {
+#   'url': 'https://www.nytimes.com/2026/04/18/us/politics/iran-hormuz-strait-trump.html',
+#   'headline': 'For Iran, Flexing Control Over Waterway Is New Deterrent',
+#   'summary': "Iran's government could emerge from the conflict with a blueprint...",
+#   'type': 'Article'
+# }
+```
+
+---
+
+## Path 3: Official APIs (requires free key)
+
+Register at `https://developer.nytimes.com/get-started`. Key arrives instantly via email. Rate limits: **10 requests/minute, 4,000/day** (free tier). Pass the key as `?api-key=YOUR_KEY`.
+
+Error format on invalid/missing key (HTTP 401):
+```json
+{"fault": {"faultstring": "Invalid ApiKey", "detail": {"errorcode": "oauth.v2.InvalidApiKey"}}}
+```
+
+Rate limit exceeded returns HTTP 429. No rate-limit headers in responses — stay under 10/minute manually.
+
+### Article Search API
+
+Searches the full NYT archive (1851–present).
+
+```python
+import json
+from helpers import http_get
+
+KEY = "your_api_key_here"
+
+# Basic search
+data = json.loads(http_get(
+    f"https://api.nytimes.com/svc/search/v2/articlesearch.json"
+    f"?q=climate+change&api-key={KEY}"
+)[2])
+
+# data structure:
+# data['response']['docs']    — list of article objects
+# data['response']['meta']    — {'hits': 123456, 'offset': 0, 'time': 30}
+
+docs = data['response']['docs']
+for doc in docs[:3]:
+    print(doc['headline']['main'])   # Main headline
+    print(doc['web_url'])            # Full article URL
+    print(doc['abstract'])           # Short summary
+    print(doc['pub_date'])           # '2026-04-18T12:00:00+0000'
+    print(doc['byline']['original']) # 'By Jane Smith'
+    print(doc['section_name'])       # 'U.S.'
+    print(doc['news_desk'])          # 'Washington'
+    print(doc['word_count'])         # integer
+    print(doc['_id'])                # 'nyt://article/uuid...'
+
+# Pagination: use page= param (0-indexed, max 100 pages = 1000 results)
+page2 = json.loads(http_get(
+    f"https://api.nytimes.com/svc/search/v2/articlesearch.json"
+    f"?q=climate&page=1&api-key={KEY}"
+)[2])
+
+# Date range filter
+filtered = json.loads(http_get(
+    f"https://api.nytimes.com/svc/search/v2/articlesearch.json"
+    f"?q=elections&begin_date=20260101&end_date=20260418&api-key={KEY}"
+)[2])
+
+# Field filter (reduce response size)
+compact = json.loads(http_get(
+    f"https://api.nytimes.com/svc/search/v2/articlesearch.json"
+    f"?q=economy&fl=headline,web_url,pub_date,byline&api-key={KEY}"
+)[2])
+
+# Sort (newest first)
+recent = json.loads(http_get(
+    f"https://api.nytimes.com/svc/search/v2/articlesearch.json"
+    f"?q=technology&sort=newest&api-key={KEY}"
+)[2])
+```
+
+**Article Search field reference:**
+```
+doc['headline']['main']         — primary headline
+doc['headline']['print_headline'] — print edition headline (may differ)
+doc['abstract']                 — short description (~1 sentence)
+doc['snippet']                  — excerpt matching query
+doc['lead_paragraph']           — first paragraph of article
+doc['web_url']                  — canonical article URL
+doc['pub_date']                 — ISO 8601 timestamp
+doc['byline']['original']       — 'By First Last and First Last'
+doc['byline']['person']         — list of {firstname, lastname, role}
+doc['section_name']             — e.g. 'U.S.', 'World', 'Technology'
+doc['subsection_name']          — e.g. 'Politics'
+doc['news_desk']                — editorial desk, e.g. 'Washington'
+doc['type_of_material']         — 'News', 'Op-Ed', 'Review', 'Letter', etc.
+doc['word_count']               — integer
+doc['keywords']                 — list of {name, value, rank} for tags
+doc['multimedia']               — list of image objects with url, subtype
+doc['_id']                      — 'nyt://article/<uuid>'
+doc['uri']                      — same as _id
+```
+
+### Top Stories API
+
+Returns the current top stories for a given section. ~15–40 articles per section.
+
+```python
+import json
+from helpers import http_get
+
+KEY = "your_api_key_here"
+
+# Available sections: arts, automobiles, books, business, fashion, food,
+# health, home, insider, magazine, movies, nyregion, obituaries, opinion,
+# politics, realestate, science, sports, sundayreview, technology, theater,
+# t-magazine, travel, upshot, us, world
+
+data = json.loads(http_get(
+    f"https://api.nytimes.com/svc/topstories/v2/technology.json?api-key={KEY}"
+)[2])
+
+# data structure:
+# data['section']              — section name
+# data['last_updated']         — ISO 8601
+# data['num_results']          — count
+# data['results']              — list of story objects
+
+for story in data['results'][:3]:
+    print(story['title'])
+    print(story['abstract'])
+    print(story['url'])
+    print(story['byline'])          # 'By First Last'
+    print(story['published_date'])  # '2026-04-18T20:08:40-04:00'
+    print(story['updated_date'])
+    print(story['section'])
+    print(story['subsection'])
+    print(story['des_facet'])       # list of topic tags
+    print(story['geo_facet'])       # list of location tags
+    print(story['per_facet'])       # list of person tags
+    print(story['org_facet'])       # list of org tags
+    # Multimedia: story['multimedia'] — list of images with url, format, caption
+    if story.get('multimedia'):
+        img = story['multimedia'][0]
+        print(img['url'], img['format'])  # format: 'Standard Thumbnail', 'Large Thumbnail', etc.
+```
+
+### Most Popular API
+
+```python
+import json
+from helpers import http_get
+
+KEY = "your_api_key_here"
+
+# periods: 1, 7, or 30 (days)
+# types: viewed, shared, emailed
+
+most_viewed = json.loads(http_get(
+    f"https://api.nytimes.com/svc/mostpopular/v2/viewed/1.json?api-key={KEY}"
+)[2])
+# most_viewed['results'] — 20 articles, same shape as Top Stories
+
+most_shared_week = json.loads(http_get(
+    f"https://api.nytimes.com/svc/mostpopular/v2/shared/7.json?api-key={KEY}"
+)[2])
+```
+
+### Books API — Best Seller Lists
+
+```python
+import json
+from helpers import http_get
+
+KEY = "your_api_key_here"
+
+# Get all available list names
+lists = json.loads(http_get(
+    f"https://api.nytimes.com/svc/books/v3/lists/names.json?api-key={KEY}"
+)[2])
+# lists['results'] — each has: list_name, list_name_encoded, display_name,
+#                   updated (WEEKLY/MONTHLY), oldest_published_date, newest_published_date
+
+# Current best sellers for a list
+fiction = json.loads(http_get(
+    f"https://api.nytimes.com/svc/books/v3/lists/current/hardcover-fiction.json?api-key={KEY}"
+)[2])
+# fiction['results']['books'] — list of book objects
+for book in fiction['results']['books'][:3]:
+    print(book['rank'])              # 1, 2, 3...
+    print(book['title'])
+    print(book['author'])
+    print(book['description'])
+    print(book['weeks_on_list'])
+    print(book['primary_isbn13'])
+    print(book['buy_links'])         # list of {name, url} for retailers
+    print(book['book_image'])        # cover image URL
+
+# Historical list (specific date)
+historical = json.loads(http_get(
+    f"https://api.nytimes.com/svc/books/v3/lists/2025-01-05/hardcover-fiction.json?api-key={KEY}"
+)[2])
+
+# Common list_name_encoded values:
+# hardcover-fiction, hardcover-nonfiction, trade-fiction-paperback,
+# paperback-nonfiction, combined-print-and-e-book-fiction,
+# young-adult-hardcover, childrens-middle-grade-hardcover, business-books,
+# graphic-books-and-manga, science, advice-how-to-and-miscellaneous
+```
+
+### Archive API
+
+Returns all articles for a given month — useful for historical bulk fetching.
+
+```python
+import json
+from helpers import http_get
+
+KEY = "your_api_key_here"
+
+# All articles from January 2025
+data = json.loads(http_get(
+    f"https://api.nytimes.com/svc/archive/v1/2025/1.json?api-key={KEY}"
+)[2])
+# data['response']['docs'] — list of all articles (same shape as Article Search)
+# Typically 5,000–9,000 articles per month
+print(len(data['response']['docs']))
+```
+
+---
+
+## Article URL structure
+
+```
+https://www.nytimes.com/{YYYY}/{MM}/{DD}/{section}/{subsection}/{slug}.html
+
+# Examples:
+https://www.nytimes.com/2026/04/18/us/politics/iran-hormuz-strait-trump.html
+https://www.nytimes.com/2026/04/18/world/middleeast/hezbollah-cease-fire.html
+https://www.nytimes.com/2026/04/18/opinion/pope-trump-hegseth-iran.html
+
+# Live blogs use /live/ path:
+https://www.nytimes.com/live/2026/04/18/world/iran-us-war-trump-hormuz
+
+# Interactive / multimedia:
+https://www.nytimes.com/interactive/2026/04/18/world/middleeast/iran-us-war-drones-cost.html
+```
+
+Parse section from URL:
+```python
+parts = url.split('/')
+# parts: ['https:', '', 'www.nytimes.com', 'YYYY', 'MM', 'DD', 'section', ...]
+section = parts[6] if len(parts) > 7 else None  # 'us', 'world', 'opinion', etc.
+```
+
+Image URLs follow the pattern:
+```
+https://static01.nyt.com/images/{YYYY}/{MM}/{DD}/multimedia/{slug}/{slug}-mediumSquareAt3X.jpg
+```
+Common image format suffixes: `mediumSquareAt3X`, `thumbStandard`, `jumbo`, `superJumbo`, `videoSixteenByNine1050`
+
+---
+
+## Parallel fetch across multiple feeds
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import xml.etree.ElementTree as ET
+from helpers import http_get
+
+MEDIA = 'http://search.yahoo.com/mrss/'
+DC    = 'http://purl.org/dc/elements/1.1/'
+
+FEEDS = [
+    'https://rss.nytimes.com/services/xml/rss/nyt/World.xml',
+    'https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml',
+    'https://rss.nytimes.com/services/xml/rss/nyt/Science.xml',
+    'https://rss.nytimes.com/services/xml/rss/nyt/Opinion.xml',
+]
+
+def fetch_one(url):
+    try:
+        _, _, body = http_get(url)
+        root = ET.fromstring(body)
+        channel = root.find('channel')
+        return [
+            {
+                'title':    item.findtext('title'),
+                'url':      item.findtext('link'),
+                'desc':     item.findtext('description'),
+                'byline':   item.findtext(f'{{{DC}}}creator'),
+                'pub_date': item.findtext('pubDate'),
+                'cats':     [c.text for c in item.findall('category')],
+            }
+            for item in channel.findall('item')
+        ]
+    except Exception:
+        return []
+
+with ThreadPoolExecutor(max_workers=4) as ex:
+    all_results = list(ex.map(fetch_one, FEEDS))
+
+articles = [a for feed in all_results for a in feed]
+print(f"Total articles: {len(articles)}")  # ~150 across 4 feeds
+```
+
+---
+
+## Gotchas
+
+- **Article pages return 403 unconditionally.** Cloudflare blocks all `http_get` calls to `www.nytimes.com/{year}/...` regardless of User-Agent (Chrome, Googlebot tested — both 403). The only way to read article full text is via a browser with a valid subscriber session cookie. For metadata only, RSS + API are sufficient.
+
+- **`window.__preloadedData` contains JS `undefined`, not valid JSON.** Running `json.loads()` directly on the extracted blob fails. Replace `undefined` with `null` first: `re.sub(r'\bundefined\b', 'null', raw)`. The blob is ~576KB; do brace-counting extraction, not regex `.+`, which will OOM on the 1MB homepage.
+
+- **RSS `<title>` and `<description>` are plain text, not CDATA.** Parse with `item.findtext('title')` — no CDATA unwrapping needed. Exception: older or less common feeds may use CDATA; ET handles both transparently.
+
+- **RSS `dc:creator` can be "The New York Times" for wire-service or multi-byline pieces,** not a named journalist. Check before treating as a person name.
+
+- **API `section` field in the URL is not the same as `section_name` in the response.** URL might be `/us/politics/` but `section_name` returns `"U.S."` and `news_desk` returns `"Washington"`. Use `section_name` for display; use the URL path for programmatic grouping.
+
+- **Article Search `fl=` field filter silently drops missing fields.** If you request `fl=headline,byline` and a doc has no byline, the key is absent from the dict (not `null`). Always use `.get()`.
+
+- **Top Stories and Most Popular return at most ~20–40 results per call.** There is no pagination param. For more results, use Article Search with `sort=newest`.
+
+- **Archive API responses are large** — January 2025 returns ~6,000 articles in one call (~15MB JSON). Parse iteratively or filter fields with `fl=` if using Article Search instead.
+
+- **Rate limit 429 response has no `Retry-After` header.** The API uses Google Apigee; after hitting 10 req/min you get a bare 429 with no backoff hint. Wait 60 seconds and retry.
+
+- **RSS `pubDate` is in RFC 2822 format** (`Sat, 18 Apr 2026 20:17:14 +0000`), not ISO 8601. Parse with `email.utils.parsedate_to_datetime()` or `datetime.strptime(pub_date, "%a, %d %b %Y %H:%M:%S %z")`.
+
+- **Image URLs from RSS are `mediumSquareAt3X` (1800×1800 px).** For smaller sizes, substitute the suffix: `thumbStandard` (75×75), `thumbLarge` (150×150), `articleInline` (~190px wide), `jumbo` (1024px wide).
+
+- **`www.nytimes.com/section/{name}` pages load correctly** (200 OK, ~963KB), but their `initialData.data` dict is empty — section page data lives in `initialState` keyed by a base64 section ID, not a predictable string. Use RSS feeds for section content instead.

--- a/domain-skills/semantic-scholar/scraping.md
+++ b/domain-skills/semantic-scholar/scraping.md
@@ -1,0 +1,365 @@
+# Semantic Scholar — Scraping & Data Extraction
+
+`https://api.semanticscholar.org` — free academic paper graph API. **Never use the browser.** All data is reachable via `http_get` or HTTP POST to the REST API. No API key required for basic use; key unlocks higher rate limits.
+
+## Do this first
+
+**Use the batch POST endpoint for known paper IDs — fast (0.2s for 5 papers), position-aligned results, up to 500 IDs per call.**
+
+```python
+import json
+from helpers import http_get
+
+# Batch fetch by S2 paper ID or external ID (ArXiv, PMID, CorpusID)
+import urllib.request
+
+ids = [
+    'arXiv:1706.03762',         # Attention Is All You Need
+    'arXiv:1810.04805',         # BERT
+    'arXiv:2005.14165',         # GPT-3
+]
+body = json.dumps({'ids': ids}).encode()
+req = urllib.request.Request(
+    'https://api.semanticscholar.org/graph/v1/paper/batch'
+    '?fields=title,year,citationCount,influentialCitationCount,authors,tldr',
+    data=body,
+    headers={'Content-Type': 'application/json', 'User-Agent': 'Mozilla/5.0'},
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    papers = json.loads(r.read())
+
+for p in papers:
+    if p is None:
+        continue   # null = ID not found; result list is position-aligned with request
+    print(p['year'], p['citationCount'], p['title'][:60])
+    if p.get('tldr'):
+        print('  TL;DR:', p['tldr']['text'][:80])
+# Confirmed output (2026-04-19):
+# 2017 173155 Attention is All you Need
+#   TL;DR: A new simple network architecture, the Transformer, based solely on attention me...
+# 2019 113137 BERT: Pre-training of Deep Bidirectional Transform
+#   TL;DR: A new language representation model, BERT, designed to pre-train deep bidirectio...
+# 2020  56710 Language Models are Few-Shot Learners
+#   TL;DR: GPT-3 achieves strong performance on many NLP datasets, including translation, q...
+```
+
+For full-text **keyword search**, use `/paper/search/bulk` — it returns relevance-ranked results and supports sort, year filter, and token-based pagination. The `/paper/search` endpoint has extremely low unauthenticated rate limits (see Gotchas).
+
+## Common workflows
+
+### Fetch a single paper by ID
+
+```python
+import json
+from helpers import http_get
+
+# Supported ID prefixes: S2 hash (bare), arXiv:, PMID:, CorpusID:, MAG:
+fields = 'title,year,authors,citationCount,influentialCitationCount,abstract,tldr,' \
+         'externalIds,publicationDate,venue,journal,fieldsOfStudy,s2FieldsOfStudy,' \
+         'openAccessPdf,publicationTypes,referenceCount'
+
+paper = json.loads(http_get(
+    f'https://api.semanticscholar.org/graph/v1/paper/arXiv:1706.03762?fields={fields}'
+))
+print(paper['paperId'])           # S2 hash ID (stable)
+print(paper['externalIds'])       # {'ArXiv': '1706.03762', 'MAG': '...', 'CorpusId': 13756489}
+print(paper['citationCount'])     # 173155
+print(paper['influentialCitationCount'])  # 19629
+print(paper['tldr']['text'])      # AI-generated one-sentence summary
+print(paper['publicationDate'])   # '2017-06-12'
+print(paper['openAccessPdf'])     # {'url': '...', 'status': None, 'license': None}
+# Confirmed output (2026-04-19):
+# paperId: 204e3073870fae3d05bcbc2f6a8e263d9b72e776
+# citationCount: 173155  influentialCitationCount: 19629
+```
+
+### Keyword search — use /paper/search/bulk
+
+The bulk search endpoint supports large result sets with token pagination, sort, and filters. Returns up to 1000 papers per page regardless of the `limit` param.
+
+```python
+import json
+from helpers import http_get
+
+# Sort options: citationCount:desc, publicationDate:desc, paperId (default, random-ish)
+resp = json.loads(http_get(
+    'https://api.semanticscholar.org/graph/v1/paper/search/bulk'
+    '?query=attention+transformer'
+    '&fields=title,year,citationCount'
+    '&sort=citationCount:desc'
+    '&year=2020-2026'              # optional year range
+    # '&publicationTypes=JournalArticle,Conference'  # optional type filter
+    # '&fieldsOfStudy=Computer+Science'              # optional domain filter
+))
+
+print(resp['total'])               # e.g. 50908 total matches
+token = resp.get('token')         # use for next page
+for p in resp['data'][:5]:
+    print(p['year'], p['citationCount'], p['title'][:60])
+# Confirmed output (2026-04-19):
+# total: 50908
+# 2017 173155 Attention is All you Need
+# 2020  60619 An Image is Worth 16x16 Words: Transformers for Im
+# 2021  31188 Swin Transformer: Hierarchical Vision Transformer
+# 2020   8846 Training data-efficient image transformers & disti
+# 2021   7880 SegFormer: Simple and Efficient Design for Semanti
+```
+
+### Pagination through bulk search results
+
+```python
+import json
+from helpers import http_get
+
+BASE = (
+    'https://api.semanticscholar.org/graph/v1/paper/search/bulk'
+    '?query=large+language+models&fields=title,year,citationCount&sort=citationCount:desc'
+)
+
+resp = json.loads(http_get(BASE))
+all_papers = list(resp['data'])
+total = resp['total']
+token = resp.get('token')
+
+while token and len(all_papers) < total:
+    resp = json.loads(http_get(f'{BASE}&token={token}'))
+    all_papers.extend(resp['data'])
+    token = resp.get('token')
+    # Add time.sleep(1) here for sustained crawls to stay within rate limits
+
+print(f'Fetched {len(all_papers)} of {total} papers')
+```
+
+### Best-match search (single result, fast)
+
+Use `/paper/search/match` when you want the closest title match for a known paper name — faster than bulk search and rarely rate-limited.
+
+```python
+import json
+from helpers import http_get
+
+result = json.loads(http_get(
+    'https://api.semanticscholar.org/graph/v1/paper/search/match'
+    '?query=attention+is+all+you+need'
+    '&fields=title,year,paperId,citationCount'
+))
+p = result['data'][0]
+print(p['paperId'], p['year'], p['citationCount'], p['title'])
+# Confirmed output (2026-04-19):
+# 204e3073870fae3d05bcbc2f6a8e263d9b72e776 2017 173155 Attention is All you Need
+# matchScore is also present in each result
+```
+
+### Paginated citations and references
+
+```python
+import json
+from helpers import http_get
+
+paper_id = '204e3073870fae3d05bcbc2f6a8e263d9b72e776'
+
+# Citations: papers that cite this paper
+# 'citingPaper' key wraps each result
+resp = json.loads(http_get(
+    f'https://api.semanticscholar.org/graph/v1/paper/{paper_id}/citations'
+    '?fields=title,year,citationCount,authors&limit=100&offset=0'
+))
+print('offset:', resp['offset'], 'next:', resp['next'])   # 'next' is None at last page
+for item in resp['data']:
+    cp = item['citingPaper']
+    print(cp['year'], cp['citationCount'], cp['title'][:50])
+
+# References: papers this paper cites
+# 'citedPaper' key wraps each result
+resp = json.loads(http_get(
+    f'https://api.semanticscholar.org/graph/v1/paper/{paper_id}/references'
+    '?fields=title,year,citationCount&limit=50&offset=0'
+))
+# resp also contains 'citingPaperInfo' with metadata about the source paper
+for item in resp['data']:
+    ref = item['citedPaper']
+    print(ref.get('year'), ref.get('title', '')[:50])
+```
+
+### Author lookup and search
+
+```python
+import json
+from helpers import http_get
+
+# Direct author fetch by S2 author ID
+author = json.loads(http_get(
+    'https://api.semanticscholar.org/graph/v1/author/1751762'
+    '?fields=name,affiliations,homepage,paperCount,citationCount,hIndex,papers'
+))
+print(author['name'])            # 'Yoshua Bengio'
+print(author['hIndex'])          # 213
+print(author['citationCount'])   # 566931
+# 'papers' list is capped at 500 inline — use /author/{id}/papers endpoint for full list
+
+# Author search by name
+results = json.loads(http_get(
+    'https://api.semanticscholar.org/graph/v1/author/search'
+    '?query=yoshua+bengio&fields=name,paperCount,citationCount,hIndex&limit=3'
+))
+print(results['total'])          # 17
+for a in results['data']:
+    print(a['authorId'], a['citationCount'], a['name'])
+# Confirmed output (2026-04-19):
+# total: 17
+# 1751762 566931 Yoshua Bengio
+# 2211024206 1019 Y. Bengio
+# 1865800402 20339 Y. Bengio
+
+# Paginated papers for an author
+papers_resp = json.loads(http_get(
+    'https://api.semanticscholar.org/graph/v1/author/1751762/papers'
+    '?fields=title,year,citationCount,venue&limit=10&offset=0'
+))
+print(papers_resp['next'])       # offset for next page; None when exhausted
+```
+
+### Bulk author fetch
+
+```python
+import json, urllib.request
+
+ids = ['1751762', '2262347']     # Yoshua Bengio, A. Turing
+body = json.dumps({'ids': ids}).encode()
+req = urllib.request.Request(
+    'https://api.semanticscholar.org/graph/v1/author/batch'
+    '?fields=name,paperCount,citationCount,hIndex',
+    data=body,
+    headers={'Content-Type': 'application/json', 'User-Agent': 'Mozilla/5.0'},
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    authors = json.loads(r.read())
+for a in authors:
+    print(a['authorId'], a['hIndex'], a['name'])
+# Confirmed output (2026-04-19):
+# 1751762 213 Yoshua Bengio
+# 2262347  20 A. Turing
+```
+
+### Paper recommendations
+
+```python
+import json, urllib.request
+
+# POST: supply positive (and optionally negative) paper IDs as seeds
+body = json.dumps({
+    'positivePaperIds': ['649def34f8be52c8b66281af98ae884c09aef38b'],
+    'negativePaperIds': [],
+}).encode()
+req = urllib.request.Request(
+    'https://api.semanticscholar.org/recommendations/v1/papers/'
+    '?fields=title,year,citationCount&limit=5',
+    data=body,
+    headers={'Content-Type': 'application/json', 'User-Agent': 'Mozilla/5.0'},
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    recs = json.loads(r.read())['recommendedPapers']
+for p in recs:
+    print(p['year'], p['citationCount'], p['title'][:60])
+# Confirmed working (2026-04-19) — returns 5 results ordered by model score
+```
+
+## API reference
+
+### ID formats for `/paper/{id}` and batch `ids` list
+
+| Format | Example |
+|---|---|
+| S2 hash (bare) | `204e3073870fae3d05bcbc2f6a8e263d9b72e776` |
+| `arXiv:` | `arXiv:1706.03762` |
+| `PMID:` | `PMID:25462856` |
+| `CorpusID:` | `CorpusID:13756489` |
+| `MAG:` | `MAG:2963403868` |
+
+### Paper fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `paperId` | string | Stable S2 hash ID |
+| `externalIds` | object | `ArXiv`, `MAG`, `DBLP`, `CorpusId`, `PMID`, `DOI` |
+| `title` | string | |
+| `abstract` | string | May be null |
+| `year` | int | May be null |
+| `publicationDate` | string | `YYYY-MM-DD`, may be null |
+| `venue` | string | Conference/journal name |
+| `journal` | object | `{pages, name}` |
+| `publicationTypes` | list | `JournalArticle`, `Conference`, `Review`, etc. |
+| `citationCount` | int | Total citations |
+| `influentialCitationCount` | int | Highly-influential citations only |
+| `referenceCount` | int | Number of references |
+| `authors` | list | `[{authorId, name}]`; request `authors.affiliations` for more |
+| `fieldsOfStudy` | list | Coarse field labels, e.g. `["Computer Science"]` |
+| `s2FieldsOfStudy` | list | `[{category, source}]`, finer-grained |
+| `openAccessPdf` | object | `{url, status, license}` |
+| `tldr` | object | `{model, text}` — AI-generated one-sentence summary |
+| `embedding` | object | S2 vector embedding (often null without API key) |
+| `citations` | list | Inline, capped at 1000 — use `/citations` endpoint instead |
+| `references` | list | Inline, complete — or use `/references` endpoint |
+
+### Author fields
+
+`authorId`, `name`, `affiliations`, `homepage`, `paperCount`, `citationCount`, `hIndex`, `papers`
+
+### Bulk search filters (`/paper/search/bulk`)
+
+| Param | Example | Notes |
+|---|---|---|
+| `query` | `attention+transformer` | URL-encoded keyword query |
+| `fields` | `title,year,citationCount` | Comma-separated field names |
+| `sort` | `citationCount:desc` | `citationCount:asc/desc`, `publicationDate:asc/desc`, `paperId` |
+| `year` | `2020-2024` or `2023` | Year range or single year |
+| `publicationTypes` | `JournalArticle,Conference` | Comma-separated |
+| `fieldsOfStudy` | `Computer+Science` | URL-encoded |
+| `token` | opaque string | From previous response, for next page |
+
+### Rate limits (unauthenticated)
+
+| Endpoint | Observed limit |
+|---|---|
+| `/paper/{id}` GET | ~1–5 req/min |
+| `/paper/search` GET | Very strict — ~1 req/hour or less; **avoid without API key** |
+| `/paper/search/match` GET | Moderate; rarely blocked |
+| `/paper/search/bulk` GET | Most generous search option |
+| `/paper/batch` POST | Moderate; 500 IDs max per call |
+| `/author/{id}` GET | ~1–5 req/min |
+| `/author/search` GET | Moderate |
+| `/author/batch` POST | Moderate |
+| `/author/{id}/papers` GET | Moderate |
+| `/paper/{id}/citations` GET | Moderate |
+| `/paper/{id}/references` GET | Moderate |
+| `/recommendations/v1/papers/` POST | Most generous |
+
+No rate limit headers in 429 responses — no `Retry-After`. For sustained crawls, add `time.sleep(1)` between calls. Apply for an API key at `https://www.semanticscholar.org/product/api#api-key-form` for 1 req/s+ limits.
+
+## Gotchas
+
+- **`/paper/search` is effectively unusable unauthenticated.** After just a few calls it returns 429 for 60+ minutes. Use `/paper/search/bulk` for keyword search (more generous limit, returns 1000 results per page with token pagination) or `/paper/search/match` for single best-title-match lookups.
+
+- **`/paper/search/bulk` ignores the `limit` parameter** — it always returns up to 1000 results per page. The `token` field in the response is the cursor for the next page; when absent, you've exhausted results.
+
+- **Batch result list is position-aligned, not filtered.** Missing IDs return `null` at their position in the result array. Always check `if p is not None` before accessing fields.
+
+- **Batch max is 500 IDs.** Sending 501 returns `HTTP 400: Maximum 500 ids allowed in input list`.
+
+- **`citations` and `references` inline in paper detail are capped.** `citations` is capped at 1000 (even when `citationCount` is 173,000+). Use `/paper/{id}/citations?limit=1000&offset=N` for full traversal. `references` inline appears complete.
+
+- **`/citations` response wraps each item in `{citingPaper: {...}}`**, not a flat paper object. `/references` wraps in `{citedPaper: {...}}`. The `/references` response also includes a top-level `citingPaperInfo` field with metadata about the source paper.
+
+- **Pagination on `/citations` and `/references` has no `total` field.** The total citation count is only available from the paper's `citationCount` field. Use `next` key — when it's absent (or equal to offset + returned items past total), you've hit the last page. Max `limit` is 1000 per request.
+
+- **`tldr` is null for many older or low-profile papers.** The AI summary model has limited coverage; always check `if p.get('tldr')` before accessing `.text`.
+
+- **`openAccessPdf.url` is often an empty string**, even when the paper is on ArXiv. The `externalIds.ArXiv` field is more reliable for constructing a PDF URL: `f"https://arxiv.org/pdf/{paper['externalIds']['ArXiv']}"`.
+
+- **Author `papers` list inline is capped at 500.** Use `/author/{id}/papers?limit=1000&offset=N` for the full publication list.
+
+- **Author search returns duplicates for the same person.** The API may return multiple `authorId` values for the same real-world author (disambiguation is imperfect). Pick the entry with highest `citationCount` or largest `paperCount` when looking up a well-known researcher.
+
+- **No `Retry-After` header on 429.** The API gives no guidance on when to retry. For the `/paper/search` endpoint, don't retry without a key — the cooldown is very long (observed 60+ minutes). For other endpoints, 10–15s is usually sufficient.
+
+- **`http_get` from helpers.py works for GET requests.** For POST (batch, recommendations), use `urllib.request.Request` with `data=` and `Content-Type: application/json` header directly, as `http_get` does not support POST bodies.


### PR DESCRIPTION
## Summary
- NYTimes: RSS feeds are best no-auth path (55 sections); homepage window.__preloadedData has 51 articles; article pages 403 Cloudflare; API requires free key (10 req/min)
- Bluesky: Two-host split (public.api.bsky.app vs api.bsky.app for search); facet indices are UTF-8 byte offsets not codepoints; cursor formats inconsistent by endpoint
- HIBP: k-anonymity password check (SHA1 prefix); \r\n line endings need .splitlines(); 974 breaches; account lookup needs paid key
- IP Geolocation: ip-api.com best free option (HTTP only, 45 req/min); ipinfo.io best HTTPS option; loc is combined lat,lon string on ipinfo
- Semantic Scholar: /paper/search 429s quickly unauthenticated; use /paper/search/bulk instead; batch POST fetches 500 papers; tldr field for AI summaries

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new domain-skill guides (NYTimes, Bluesky, HIBP, IP Geolocation, Semantic Scholar) with runnable examples and “gotchas” to enable reliable, no-browser data extraction. This expands coverage for common public data sources and clarifies rate limits, pagination, and best endpoints.

- **New Features**
  - NYTimes: Full RSS feed catalog, homepage `window.__preloadedData` parser, and `api.nytimes.com` examples with limits; note article pages return 403 via Cloudflare.
  - Bluesky: Clear split between `public.api.bsky.app` and `api.bsky.app` (search only); cursor formats vary by endpoint; facets use UTF‑8 byte offsets; profiles/feeds/threads/trending/likes with pagination patterns.
  - HIBP: K‑anonymity password checks via `api.pwnedpasswords.com/range` with `.splitlines()` for `\r\n`; `/breaches`, `/breach/{name}`, `/latestbreach`, and notes on paid `breachedaccount`/`pasteaccount`.
  - IP Geolocation: Guidance on `ip-api.com` (HTTP, 45 req/min, batch 100 with `X-Rl`/`X-Ttl`), `ipinfo.io` (HTTPS, `loc` as "lat,lon", `org` combines ASN), and key-required providers; bulk helpers and field normalization tips.
  - Semantic Scholar: Prefer `/paper/batch` and `/paper/search/bulk` with token pagination; `/paper/search` is highly throttled; citations/references pagination, author lookups, and recommendations; `tldr` field usage.

<sup>Written for commit 36747a4766497d49d5ad309446a1d101ac71e2c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

