### PR TITLE
Add domain skills: NVD/CVE, Exchange Rates, HackerNews, OpenSky, Libraries.io

### DIFF
--- a/domain-skills/exchange-rates/scraping.md
+++ b/domain-skills/exchange-rates/scraping.md
@@ -1,0 +1,346 @@
+# Exchange Rate APIs — Data Extraction
+
+Three tested free services, no browser needed. Best free option: **fawazahmed0 CDN** (no key, no rate limit, 301 currencies + crypto, historical back to 2024-03-02). Use **Frankfurter** for ECB-sourced fiat-only data with clean time-series. Use **open.er-api.com** for all-in-one latest rates across 166 currencies.
+
+All calls use `http_get` from helpers — no browser, no JS, pure HTTP.
+
+## Do this first: pick your service
+
+| Service | Key required | Historical | Currencies | Update freq | Rate limit |
+|---|---|---|---|---|---|
+| **fawazahmed0 CDN** | No | Yes (2024-03-02+) | 301 (incl. crypto, gold) | Daily | None observed |
+| **Frankfurter** | No | Yes (ECB data, multi-decade) | 30 fiat only | ~16:00 CET weekdays | None observed |
+| **open.er-api.com** | No (basic) | No (paid only) | 166 fiat | Daily | None observed |
+| **exchangerate.host** | Yes (required) | Paid | Many | — | — |
+
+**Never use a browser for any of these.** All return JSON over HTTPS.
+
+---
+
+## fawazahmed0 CDN — best free option (no key, widest coverage)
+
+Served via jsDelivr CDN. Includes crypto, precious metals, and 301 total assets. Historical data available from 2024-03-02 onward via versioned npm package URLs.
+
+### Latest rates
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/usd.json"
+))
+# Confirmed output (2026-04-18):
+# {
+#   "date": "2026-04-18",
+#   "usd": {
+#     "eur": 0.84940406,
+#     "gbp": 0.73942577,
+#     "jpy": 158.6450315,
+#     "btc": 1.2934433e-05,
+#     "eth": 0.0004132211,
+#     "xau": 0.00020640519,   # gold
+#     "xag": 0.01234354,      # silver
+#     ...301 total entries
+#   }
+# }
+rates = data["usd"]
+print(rates["eur"])    # 0.84940406
+print(rates["jpy"])    # 158.6450315
+print(rates["btc"])    # 1.2934433e-05
+```
+
+The outer key always matches the base currency code (lowercase). `data["usd"]` for USD base, `data["eur"]` for EUR base.
+
+### All supported currencies (with names)
+
+```python
+import json
+from helpers import http_get
+
+currencies = json.loads(http_get(
+    "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies.json"
+))
+# 301 entries. Keys are lowercase codes, values are display names.
+# Includes fiat (aed, aud, ...), crypto (btc, eth, sol, ada, ...), metals (xau, xag)
+print(currencies["usd"])    # "US Dollar"
+print(currencies["btc"])    # "Bitcoin"
+print(currencies["xau"])    # "Gold Ounce"
+```
+
+### Historical rates
+
+Version format is `YYYY.M.D` (no zero-padding on month or day). Oldest available: 2024-03-02.
+
+```python
+import json
+from datetime import date
+from helpers import http_get
+
+def fawazahmed0_historical(base: str, target_date: date) -> dict:
+    """Fetch all rates for `base` on `target_date`. Returns dict of {currency: rate}."""
+    version = f"{target_date.year}.{target_date.month}.{target_date.day}"
+    base = base.lower()
+    url = f"https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{version}/v1/currencies/{base}.json"
+    data = json.loads(http_get(url))
+    return data[base]
+
+# Confirmed: date(2024, 4, 18) → EUR 0.93691965
+rates = fawazahmed0_historical("usd", date(2024, 4, 18))
+print(rates["eur"])    # 0.93691965
+print(rates["gbp"])    # ...
+print(rates["btc"])    # crypto included in historical too
+```
+
+Version string for `date(2025, 6, 15)` is `"2025.6.15"` (not `"2025.06.15"`).
+
+### Fallback CDN (if jsDelivr is down)
+
+```python
+import json
+from helpers import http_get
+
+# Identical response, alternate CDN
+data = json.loads(http_get(
+    "https://latest.currency-api.pages.dev/v1/currencies/usd.json"
+))
+```
+
+---
+
+## Frankfurter — best for ECB fiat data + time series
+
+ECB (European Central Bank) source. Data only on business days. 30 fiat currencies, no crypto. Default base is EUR; any of the 30 supported currencies can be the base.
+
+### Latest rates
+
+```python
+import json
+from helpers import http_get
+
+# All rates against USD base
+data = json.loads(http_get("https://api.frankfurter.app/latest?from=USD"))
+# {
+#   "amount": 1.0,
+#   "base": "USD",
+#   "date": "2026-04-17",   ← last ECB business day
+#   "rates": {"AUD": 1.3934, "BRL": 4.9764, "CAD": 1.3672, ..., "ZAR": 18.44}
+# }
+# 29 target currencies (all supported except the base)
+print(data["rates"]["EUR"])    # 0.84767
+print(data["rates"]["GBP"])    # 0.7389
+print(data["date"])            # "2026-04-17"
+```
+
+### Selective targets and amount conversion
+
+```python
+import json
+from helpers import http_get
+
+# Convert 100 USD to EUR and GBP
+data = json.loads(http_get(
+    "https://api.frankfurter.app/latest?from=USD&to=EUR,GBP&amount=100"
+))
+# {"amount": 100.0, "base": "USD", "date": "2026-04-17", "rates": {"EUR": 84.77, "GBP": 73.892}}
+print(data["rates"]["EUR"])    # 84.77
+```
+
+### Historical rate on a specific date
+
+```python
+import json
+from helpers import http_get
+
+# Date is snapped to the nearest prior business day
+data = json.loads(http_get("https://api.frankfurter.app/2024-01-01"))
+# {"amount": 1.0, "base": "EUR", "date": "2023-12-29", "rates": {...}}
+# Note: 2024-01-01 is a holiday, snapped back to 2023-12-29
+print(data["date"])              # "2023-12-29"
+print(data["rates"]["USD"])      # 1.105
+print(data["rates"]["JPY"])      # 156.33
+```
+
+Default base on date endpoints is **EUR**. Pass `?from=USD` to change it.
+
+```python
+data = json.loads(http_get("https://api.frankfurter.app/2024-01-01?from=USD&to=EUR,GBP,JPY"))
+print(data["rates"]["JPY"])    # 141.48 (USD/JPY on 2023-12-29)
+```
+
+### Time series
+
+```python
+import json
+from helpers import http_get
+
+# Daily rates for a date range — only business days are included
+data = json.loads(http_get(
+    "https://api.frankfurter.app/2023-01-01..2023-12-31?from=USD&to=EUR"
+))
+# {
+#   "amount": 1.0,
+#   "base": "USD",
+#   "start_date": "2022-12-30",   ← snapped to nearest prior business day
+#   "end_date": "2023-12-29",
+#   "rates": {
+#     "2022-12-30": {"EUR": 0.93756},
+#     "2023-01-02": {"EUR": 0.93607},
+#     ...256 business days total
+#   }
+# }
+rates_dict = data["rates"]     # keyed by ISO date string
+print(len(rates_dict))         # 256 business days for full year
+print(rates_dict["2023-06-15"])  # {"EUR": 0.92028}
+
+# Multiple targets
+data = json.loads(http_get(
+    "https://api.frankfurter.app/2024-01-01..2024-01-07?from=USD&to=EUR,GBP,JPY"
+))
+for date_str, rates in data["rates"].items():
+    print(date_str, rates)
+# 2023-12-29  {'EUR': 0.90498, 'GBP': 0.78647, 'JPY': 141.48}
+# 2024-01-02  {'EUR': 0.90832, 'GBP': 0.78758, 'JPY': 141.62}
+# ...
+```
+
+### Supported currencies list
+
+```python
+import json
+from helpers import http_get
+
+currencies = json.loads(http_get("https://api.frankfurter.app/currencies"))
+# 30 entries: {"AUD": "Australian Dollar", "BRL": "Brazilian Real", ...}
+# All 30 can be used as base or target.
+```
+
+---
+
+## open.er-api.com — simple latest rates (166 currencies)
+
+No key for latest rates. 166 fiat currencies (no crypto). Updates once daily. Historical data requires a paid registered API key.
+
+### Latest rates
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get("https://open.er-api.com/v6/latest/USD"))
+# {
+#   "result": "success",
+#   "base_code": "USD",
+#   "time_last_update_utc": "Sun, 19 Apr 2026 00:02:31 +0000",
+#   "time_next_update_utc": "Mon, 20 Apr 2026 00:05:01 +0000",
+#   "rates": {
+#     "USD": 1.0, "EUR": 0.848763, "GBP": 0.739001,
+#     "JPY": 158.669348, "CAD": 1.368266, ...166 total
+#   }
+# }
+assert data["result"] == "success"
+rates = data["rates"]
+print(rates["EUR"])    # 0.848763
+print(rates["JPY"])    # 158.669348
+
+# Update schedule
+print(data["time_last_update_utc"])   # "Sun, 19 Apr 2026 00:02:31 +0000"
+print(data["time_next_update_utc"])   # "Mon, 20 Apr 2026 00:05:01 +0000"
+```
+
+Any of the 166 supported currencies can be the base: `/v6/latest/EUR`, `/v6/latest/JPY`, etc. Crypto codes (`BTC`) and metals (`XAU`) return `{"result": "error", "error-type": "unsupported-code"}`.
+
+---
+
+## Cross-rate calculation (any pair)
+
+None of these APIs return arbitrary cross-rates directly (e.g., GBP/JPY). Calculate via USD or EUR:
+
+```python
+import json
+from helpers import http_get
+
+def get_cross_rate(from_ccy: str, to_ccy: str) -> float:
+    """Calculate cross-rate using USD as pivot via open.er-api.com."""
+    data = json.loads(http_get("https://open.er-api.com/v6/latest/USD"))
+    rates = data["rates"]
+    # from_ccy/to_ccy = (USD/to_ccy) / (USD/from_ccy)
+    return rates[to_ccy] / rates[from_ccy]
+
+print(get_cross_rate("GBP", "JPY"))   # ~214.7
+print(get_cross_rate("EUR", "CHF"))   # ~0.921
+```
+
+Alternatively, Frankfurter accepts any of its 30 currencies as `from=`:
+```python
+data = json.loads(http_get("https://api.frankfurter.app/latest?from=GBP&to=JPY,CHF,AUD"))
+print(data["rates"]["JPY"])    # 215.35
+```
+
+---
+
+## Batch: fetch time series for multiple pairs
+
+```python
+import json
+from datetime import date
+from helpers import http_get
+
+def fawazahmed0_range(base: str, start: date, end: date) -> dict[str, dict]:
+    """Fetch daily rates for `base` over a date range. Business days only.
+    Returns {date_str: {currency: rate, ...}}."""
+    from datetime import timedelta
+    base = base.lower()
+    results = {}
+    current = start
+    while current <= end:
+        version = f"{current.year}.{current.month}.{current.day}"
+        url = f"https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{version}/v1/currencies/{base}.json"
+        try:
+            data = json.loads(http_get(url))
+            results[str(current)] = data[base]
+        except Exception:
+            pass   # weekends/holidays have no data file — skip silently
+        current += timedelta(days=1)
+    return results
+
+# Note: for long ranges, prefer Frankfurter's built-in time-series endpoint
+# (one call vs one-per-day). Frankfurter only covers 30 fiat currencies.
+```
+
+---
+
+## Gotchas
+
+**exchangerate.host requires an API key.** Despite being listed as "free", `https://api.exchangerate.host/latest` returns `{"success": false, "error": {"code": 101, "type": "missing_access_key"}}` without a key. Not usable anonymously.
+
+**fawazahmed0 version strings are not zero-padded.** `2024.04.18` returns 404. Use `2024.4.18`. Build the string with `f"{dt.year}.{dt.month}.{dt.day}"` — Python's default int formatting has no leading zeros.
+
+**fawazahmed0 historical only goes back to 2024-03-02.** Attempting versions before `2024.3.2` returns HTTP 404. For pre-2024 historical fiat data, use Frankfurter instead.
+
+**fawazahmed0 base currency key is lowercase.** `data["usd"]` not `data["USD"]`. The URL path is also lowercase: `/currencies/usd.json`.
+
+**Frankfurter dates snap to prior business day.** Requesting `2024-01-01` (New Year's Day) returns data dated `2023-12-29`. The `date` field in the response always shows the actual data date, not your requested date. Always read `data["date"]` to confirm.
+
+**Frankfurter time series start/end dates also snap.** `start_date` and `end_date` in the response may differ from your requested range. Read them from the response, not from your input.
+
+**Frankfurter covers 30 fiat currencies only.** No crypto, no precious metals, no exotic currencies. CNY is supported (despite being outside the ECB basket) but many EM currencies are not. Invalid currency codes return `HTTP 404 {"message": "not found"}`.
+
+**open.er-api.com includes USD in its own rates dict.** `rates["USD"]` is always `1.0` when `base=USD`. This is harmless but don't confuse it for an error.
+
+**open.er-api.com has no historical endpoint on the free tier.** `/v6/history/*` returns HTTP 404 without a registered API key. Use fawazahmed0 or Frankfurter for historical lookups.
+
+**open.er-api.com does not support crypto or metals.** `BTC`, `ETH`, `XAU`, `XAG` as base return `{"result": "error", "error-type": "unsupported-code"}`. Use fawazahmed0 for those.
+
+**All three services observed zero rate-limiting** in tests (5+ rapid-fire calls, all succeeded without throttling). The CDN-backed fawazahmed0 in particular is effectively unlimited for reasonable workloads. Don't abuse it.
+
+**Frankfurter `amount` parameter scales the output, not the base.** `?from=USD&to=EUR&amount=100` returns EUR equivalent of 100 USD in the `rates.EUR` field. Without `amount`, the default is `1.0`.
+
+**SSL certificates may fail with the standard `http_get` from helpers.** If you get `CERTIFICATE_VERIFY_FAILED`, add an SSL context or use `certifi`:
+```python
+import ssl, urllib.request, json
+ctx = ssl.create_default_context()
+# or: import certifi; ctx = ssl.create_default_context(cafile=certifi.where())
+with urllib.request.urlopen(url, context=ctx) as r:
+    data = json.loads(r.read())
+```

--- a/domain-skills/hackernews/scraping.md
+++ b/domain-skills/hackernews/scraping.md
@@ -1,39 +1,164 @@
 # Hacker News — Data Extraction
 
-`https://news.ycombinator.com` — YCombinator's link aggregator. Three access paths tested: `http_get` DOM scraping, Algolia search API, and the official HN Firebase API. All work without a browser.
+`https://news.ycombinator.com` — YCombinator's link aggregator. Three access paths: `http_get` DOM scraping, Algolia search API, and the official HN Firebase API. All work without a browser, no auth required.
 
 ## Do this first: pick your access path
 
-| Goal | Best approach | Latency |
+| Goal | Best approach | Latency (measured) |
 |------|--------------|---------|
 | Current front page (30 stories, real-time) | `http_get` + regex | ~170ms |
-| Historical / keyword search | Algolia search API | ~400ms |
-| Full comment tree (nested) | Algolia items API | ~300ms |
-| Specific item by ID | Firebase API | ~200ms |
-| 500 ranked story IDs | Firebase topstories | ~200ms (+ ~190ms/item after) |
+| Historical / keyword search | Algolia search API | ~370ms |
+| Full nested comment tree | Algolia items API | ~1000ms |
+| Specific item by ID | Firebase API | ~170ms |
+| 500 ranked story IDs | Firebase topstories | ~200ms |
+| Parallel bulk item fetch | Firebase + ThreadPoolExecutor | ~210ms for 5 items |
 
 **Never use a browser for read-only HN tasks.** Everything is accessible over HTTP with no auth, no JS rendering needed.
 
 ---
 
-## Path 1: http_get front page (fastest for real-time data)
+## Path 1: Algolia search API (best for search and filtering)
 
-The front page HTML is ~34KB. Story order matches Firebase `/topstories.json` exactly — confirmed identical on 2026-04-18.
+No auth, no rate limiting observed. Two endpoints: `search` (relevance-ranked) and `search_by_date` (newest first).
+
+```python
+import json
+
+# Keyword search — sorted by relevance
+data = json.loads(http_get(
+    "https://hn.algolia.com/api/v1/search"
+    "?query=llm&tags=story&hitsPerPage=20"
+))
+# data keys: hits, nbHits, nbPages, page, hitsPerPage, query, processingTimeMS
+
+# Date-sorted (most recent first) — query='' returns all
+data = json.loads(http_get(
+    "https://hn.algolia.com/api/v1/search_by_date"
+    "?tags=story&hitsPerPage=20"
+))
+
+# Paginate: add &page=N (0-indexed). Max page index = data['nbPages']-1
+# hitsPerPage max = 1000. Pages beyond nbPages return 0 hits.
+```
+
+**Fields per story hit** (from `search` / `search_by_date`):
+```
+objectID       – string ID ("44567857")
+story_id       – int version of the same ID
+title          – story title
+url            – linked URL (absent for self-posts)
+author         – submitter username
+points         – upvote count (int)
+num_comments   – total comment count including replies (int)
+children       – list of TOP-LEVEL comment IDs only (ints) — NOT all comment IDs
+created_at     – ISO 8601 string ("2025-07-15T04:35:35Z")
+created_at_i   – unix timestamp (int)
+updated_at     – last index update timestamp
+story_text     – self-post body (HTML), only present for Ask HN / self-posts
+_tags          – ["story", "author_username", "story_44567857"]
+```
+
+**Fields per comment hit** (when `tags=comment`):
+```
+objectID, author, comment_text,  ← "comment_text" NOT "text"
+story_id, story_title, story_url,
+parent_id, created_at, created_at_i,
+points  ← usually None for comments
+```
+
+### Tag filters
+
+Tags are AND by default, OR with parentheses:
+
+```python
+# Story types
+"tags=story"                    # regular link/self posts
+"tags=show_hn"                  # Show HN
+"tags=ask_hn"                   # Ask HN
+"tags=poll"                     # polls
+"tags=job"                      # job posts
+"tags=comment"                  # comments only
+
+# Combined AND
+"tags=story,front_page"         # currently on front page (~75 items)
+"tags=story,author_pg"          # stories submitted by user 'pg'
+
+# OR
+"tags=(ask_hn,show_hn)"         # Ask OR Show HN (no story tag needed)
+
+# All items in a thread (story + all its comments)
+"tags=story_44567857"
+```
+
+### Numeric filters
+
+```python
+# Date range (unix timestamps)
+"numericFilters=created_at_i>1745000000"
+"numericFilters=created_at_i>1700000000,created_at_i<1750000000"
+
+# Point threshold
+"numericFilters=points>500"
+"numericFilters=points>100,points<500"
+```
+
+Combine tags and numericFilters freely:
+```python
+data = json.loads(http_get(
+    "https://hn.algolia.com/api/v1/search"
+    "?query=rust&tags=story"
+    "&numericFilters=points>100"
+    "&hitsPerPage=20&page=0"
+))
+```
+
+---
+
+## Path 2: Algolia items API (full nested comment tree)
+
+Returns the story with its full comment tree, recursively nested. ~1000ms for a large thread.
+
+```python
+import json
+
+thread = json.loads(http_get(
+    "https://hn.algolia.com/api/v1/items/44567857"
+))
+# thread keys: id, type, author, title, url, text, points, parent_id,
+#              story_id, created_at, created_at_i, options, children
+
+# children = list of TOP-LEVEL comment objects (each with their own children)
+# comment object keys: same as thread keys — author, text (HTML), created_at, children
+
+# Walk all comments recursively:
+stack = list(thread.get('children', []))
+total = 0
+while stack:
+    node = stack.pop()
+    total += 1
+    stack.extend(node.get('children', []))
+# total = all comments (deleted items are omitted, so count may be < descendants)
+```
+
+**Items API comment `text` field is HTML** — contains `<p>` tags, `<a>` links, HTML entities (`&#x27;` `&gt;` `&#x2F;`). Strip tags if you need plain text.
+
+---
+
+## Path 3: http_get front page (fastest for real-time)
+
+The front page HTML is ~34KB. Matches Firebase `/topstories.json` rank order exactly.
 
 ```python
 import re, html as htmllib
 
 page = http_get("https://news.ycombinator.com")
 
-# Extract all 30 story IDs (in rank order)
 story_ids = re.findall(r'<tr class="athing submission" id="(\d+)">', page)
 
-# Extract titles + URLs (same order as IDs)
 titles_urls = re.findall(
     r'class="titleline"[^>]*><a href="([^"]*)"[^>]*>(.*?)</a>', page
 )
 
-# Extract scores keyed by story ID (job posts have no score row)
 scores_by_id = {
     m.group(1): int(m.group(2))
     for m in re.finditer(
@@ -41,16 +166,6 @@ scores_by_id = {
     )
 }
 
-# Extract authors keyed by story ID (anchor on score span)
-authors_by_id = {}
-for m in re.finditer(
-    r'<span class="score" id="score_(\d+)">\d+ points</span>'
-    r'.*?class="hnuser">(.*?)</a>',
-    page, re.DOTALL
-):
-    authors_by_id[m.group(1)] = m.group(2)
-
-# Extract comment counts keyed by story ID
 comments_by_id = {
     m.group(1): int(m.group(2))
     for m in re.finditer(
@@ -64,180 +179,133 @@ for i, sid in enumerate(story_ids):
     stories.append({
         'rank': i + 1,
         'id': sid,
-        'title': htmllib.unescape(raw_title),   # MUST unescape — titles contain &#x27; etc.
+        'title': htmllib.unescape(raw_title),
         'url': url,
-        'score': scores_by_id.get(sid),          # None for job posts
-        'author': authors_by_id.get(sid),
+        'score': scores_by_id.get(sid),       # None for job posts
         'comments': comments_by_id.get(sid, 0),
     })
 ```
 
-**Gotchas:**
-- Titles contain HTML entities (`&#x27;` `&amp;` `&quot;` `&gt;`). Always call `html.unescape()`.
-- `<tr class="athing submission" id="...">` — the class is `athing submission`, not just `athing`. The `athing comtr` class is for comment rows.
-- Job/hiring posts (YC ads) appear in the list but have no score or author. `scores_by_id.get(sid)` returns `None` for them — check before comparing.
-- `re.DOTALL` multi-line patterns can cross story boundaries. Use ID-anchored patterns (as above) instead of positional zip for score/author.
-- The page only serves page 1 (30 items). Pages 2–4 exist at `?p=2` etc. but require a login cookie for page 3+.
+Page 2–4 at `?p=2` etc., but page 3+ requires a login cookie.
 
 ---
 
-## Path 2: Algolia search API (best for historical / keyword search)
+## Path 4: Official HN Firebase API
 
-No rate limiting observed. Returns up to 1000 hits per query (`hitsPerPage` max is capped at ~1000 per Algolia plan).
-
-```python
-import json
-
-# Keyword search — sorted by relevance
-data = json.loads(http_get(
-    "https://hn.algolia.com/api/v1/search"
-    "?query=llm&tags=story&hitsPerPage=20"
-))
-
-# Date-sorted (most recent first)
-data = json.loads(http_get(
-    "https://hn.algolia.com/api/v1/search_by_date"
-    "?tags=story&hitsPerPage=20"
-))
-
-# Paginate: add &page=N (0-indexed), up to data['nbPages']-1
-```
-
-**Fields returned per story hit:**
-```
-objectID, title, url, author, points, num_comments,
-created_at (ISO 8601), created_at_i (unix ts), story_id,
-children (list of comment IDs — flat, not tree),
-_tags, _highlightResult
-```
-
-**Fields returned per comment hit:**
-```
-objectID, comment_text, author, story_id, story_title, story_url,
-parent_id, created_at, created_at_i, points
-```
-Note: comment hits use `comment_text`, NOT `text`. Story hits use `story_text` for self-post body.
-
-### Tag filters
-
-Tags are AND by default, OR with parentheses:
-
-```python
-# Story types
-"tags=story"           # regular link/self posts
-"tags=show_hn"         # Show HN
-"tags=ask_hn"          # Ask HN
-"tags=poll"            # polls
-"tags=job"             # job posts
-
-# Combined AND
-"tags=story,front_page"          # currently on front page
-"tags=story,author_pg"           # stories submitted by pg
-
-# OR
-"tags=(ask_hn,show_hn),story"    # Ask OR Show HN
-
-# By story ID (gets story + all its comments)
-"tags=story_47806725"
-```
-
-### Numeric filters
-
-```python
-# Date range (unix timestamps)
-"numericFilters=created_at_i>1745000000"
-"numericFilters=created_at_i>1700000000,created_at_i<1750000000"
-
-# Point threshold
-"numericFilters=points>100"
-"numericFilters=points>500,points<1000"
-```
-
-### Full Algolia items API (nested comment tree)
+Clean JSON, no scraping. Use for fetching specific items or live feeds.
 
 ```python
 import json
 
-thread = json.loads(http_get(
-    "https://hn.algolia.com/api/v1/items/47806725"
-))
-# thread['children'] = list of top-level comment objects
-# Each comment: author, text (HTML), created_at, children (nested replies)
-# Recursively walk children for full thread
+# Ranked ID lists (IDs only — no metadata)
+top   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/topstories.json"))   # 500 IDs
+new   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/newstories.json"))   # 500 IDs
+best  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/beststories.json"))  # 200 IDs
+ask   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/askstories.json"))   # ~31 IDs
+show  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/showstories.json"))  # ~131 IDs
+jobs  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/jobstories.json"))   # ~31 IDs
 
-# Total comment count (recursive walk with stack):
-stack = list(thread.get('children', []))
-total = 0
-while stack:
-    node = stack.pop()
-    total += 1
-    stack.extend(node.get('children', []))
-```
-
-Confirmed: Algolia items returns 653 total comments for a 659-comment thread (some deleted). `text` field in items API is HTML with `<p>` tags and `<a>` links — may need to strip tags.
-
----
-
-## Path 3: Official HN Firebase API
-
-Clean JSON, no scraping. Use for fetching specific items or building live feeds.
-
-```python
-import json
-
-# Ranked story ID lists (no metadata — just IDs)
-top   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/topstories.json"))  # 500 IDs
-new   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/newstories.json"))  # 500 IDs
-best  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/beststories.json")) # 200 IDs
-ask   = json.loads(http_get("https://hacker-news.firebaseio.com/v0/askstories.json"))  # ~32 IDs
-show  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/showstories.json")) # ~119 IDs
-jobs  = json.loads(http_get("https://hacker-news.firebaseio.com/v0/jobstories.json"))  # ~31 IDs
-
-# Fetch a single item
+# Single item — story fields
 item = json.loads(http_get(
-    "https://hacker-news.firebaseio.com/v0/item/47806725.json"
+    "https://hacker-news.firebaseio.com/v0/item/44567857.json"
 ))
-# Fields: id, type, by, title, url, score, descendants (total comment count),
-#         time (unix ts), kids (list of top-level comment IDs), text (self-post body)
+# Story keys: id, type, by, title, url, score, descendants, time, kids, text
+# Comment keys: id, type, by, text, time, parent, kids
 
-# Fetch a user profile
+# User profile
 user = json.loads(http_get(
     "https://hacker-news.firebaseio.com/v0/user/pg.json"
 ))
-# Fields: id, karma, created (unix ts), about (HTML), submitted (list of item IDs)
+# Keys: id, karma, created (unix ts), about (HTML), submitted (list of item IDs)
 
-# Highest current item ID (useful for polling new items)
+# Highest current item ID (for polling new items)
 maxid = json.loads(http_get("https://hacker-news.firebaseio.com/v0/maxitem.json"))
+
+# Recently changed items and profiles
+updates = json.loads(http_get("https://hacker-news.firebaseio.com/v0/updates.json"))
+# keys: items (list of IDs), profiles (list of usernames)
 ```
 
-**Firebase vs Algolia tradeoff:**
-- Firebase `topstories` gives you 500 IDs in one call but then requires one HTTP call per item (~190ms each). Fetching all 500 items sequentially would take ~100 seconds.
-- Algolia returns full story data (title, points, author, comments) in one call for up to ~1000 results.
-- For "top 30 stories with full metadata": use `http_get` front page scrape (170ms total). For "top 500 stories with full metadata": use Algolia with `tags=front_page` or loop pages.
+### Parallel fetch of multiple Firebase items
 
----
-
-## Comment thread HTML (item page)
-
-For a large thread, the item page HTML (~1MB for 659 comments) loads ALL comments flat in a single request — no pagination, no JS required.
+Firebase has no rate limit concern at small scale. 5 items in ~210ms parallel vs ~850ms sequential:
 
 ```python
-import re, html as htmllib
+import json
+from concurrent.futures import ThreadPoolExecutor
 
-page = http_get("https://news.ycombinator.com/item?id=47806725")
+top_ids = json.loads(http_get("https://hacker-news.firebaseio.com/v0/topstories.json"))[:30]
 
-# Count all comment IDs
-comment_ids = re.findall(r'<tr class="athing comtr" id="(\d+)">', page)
-# len(comment_ids) matches total comment count
+def fetch_item(iid):
+    return json.loads(http_get(
+        f"https://hacker-news.firebaseio.com/v0/item/{iid}.json"
+    ))
 
-# Extract comment texts (careful: text spans multiple lines with <p> tags)
-# Use Algolia items API instead for structured access
+with ThreadPoolExecutor(max_workers=10) as ex:
+    items = list(ex.map(fetch_item, top_ids))
+# ~600ms for 30 items parallel vs ~5100ms sequential
 ```
-
-For structured comment access prefer Algolia items API — it returns a proper nested tree. The HTML item page is useful only when you need approximate comment count without an API call.
 
 ---
 
-## Do NOT use a browser for HN
+## Gotchas
 
-All data is in plain HTML or JSON APIs. `goto()` + `wait_for_load()` takes 3–8 seconds; `http_get` takes 170–400ms. The JS `querySelectorAll` approach works (tested, returns correct data) but is 20–50x slower with no benefit.
+### Field naming differs across APIs
+
+This is the #1 source of bugs. The three APIs use **different names** for the same data:
+
+| Field | Algolia search hit | Algolia items API | Firebase item |
+|-------|--------------------|-------------------|---------------|
+| Vote score | `points` | `points` | `score` |
+| Total comments | `num_comments` | *(absent)* | `descendants` |
+| Submitter | `author` | `author` | `by` |
+| Child comment IDs | `children` (int list) | `children` (object list) | `kids` (int list) |
+
+- Algolia `search` hit `children` = flat list of **top-level comment IDs only** (ints). A story with 1628 `num_comments` has 137 entries in `children`.
+- Algolia `items` API `children` = list of **full nested comment objects** (dicts with their own `children`).
+- Firebase `kids` = list of **top-level comment IDs** (ints), same as Algolia search `children`.
+
+### Comment text field name
+
+- Algolia `search` endpoint with `tags=comment`: field is `comment_text`
+- Algolia `items` API nested comment objects: field is `text` (HTML)
+- Firebase comment item: field is `text` (HTML with entities)
+
+### HTML entities in text fields
+
+Algolia `items` API comment `text` and Firebase `text` both contain raw HTML: `<p>` tags, `<a>` links, and HTML entities (`&#x27;` = `'`, `&#x2F;` = `/`, `&gt;` = `>`). Algolia `search` hit titles and `story_text` also contain entities. Always unescape before displaying.
+
+### Algolia `search` hit has no `num_comments` on items API
+
+If you fetch `items/ID`, the returned object has no `num_comments` field. Use `descendants` from Firebase or count by walking `children` recursively.
+
+### Deleted and dead items return null
+
+Firebase returns `null` (Python `None`) for deleted or dead items. Check before accessing fields:
+```python
+item = json.loads(http_get(f"https://hacker-news.firebaseio.com/v0/item/{iid}.json"))
+if item is None:
+    continue  # deleted/dead
+```
+
+### Algolia page cap
+
+Algolia caps at 1000 pages max. Requesting `page=1000` returns `nbPages: 0, hits: []`. Max retrievable results per query = `hitsPerPage * min(nbPages, 1000)` — effectively 1,000,000 items but Algolia won't return more than 1000 pages regardless.
+
+### Job posts have no score or author on the front page
+
+Front-page HTML scrape: job/hiring posts appear in `story_ids` but have no `<span class="score">` row. `scores_by_id.get(sid)` returns `None` — don't compare directly to integers.
+
+### Title HTML entities on front page
+
+Front-page titles contain HTML entities (`&#x27;` `&amp;` `&quot;`). Always call `html.unescape()` on raw title strings from regex.
+
+### Firebase vs Algolia for bulk data
+
+- Firebase `topstories` gives 500 IDs in one call, then one HTTP call per item (~170ms each) — too slow sequentially for large sets.
+- Algolia `search?tags=front_page` returns full story metadata for all ~75 current front-page stories in one call.
+- For top-30 with metadata: front-page HTML scrape is fastest (170ms total). For top-500 with metadata: Algolia pagination (multiple calls of 1000 hits each).
+
+### `athing` vs `athing comtr` CSS classes
+
+Front-page scrape: `<tr class="athing submission" id="...">` are story rows. `<tr class="athing comtr" id="...">` are comment rows (on item pages). Both match `athing` — use the full class string.

--- a/domain-skills/libraries-io/scraping.md
+++ b/domain-skills/libraries-io/scraping.md
@@ -1,0 +1,244 @@
+# Libraries.io — Scraping & Data Extraction
+
+`https://libraries.io` — open-source package dependency tracking across 31 package managers. **Use `http_get` / pure HTTP for everything — no browser required.** Most endpoints return JSON without an API key; search requires a free key.
+
+## Do this first
+
+**Use the REST API — one call, JSON response, no browser.**
+
+```python
+import json
+data = json.loads(http_get("https://libraries.io/api/pypi/requests"))
+# Key fields: name, platform, description, rank, stars, forks,
+#             latest_release_number, latest_stable_release_number,
+#             latest_release_published_at, dependents_count,
+#             dependent_repos_count, contributions_count,
+#             licenses, normalized_licenses, repository_url,
+#             package_manager_url, homepage, keywords, language, versions[]
+```
+
+API key is **optional** for project info and dependency lookups. Get a free key at `https://libraries.io/account` to unlock search and raise rate limits.
+
+## Common workflows
+
+### Project metadata (no key required)
+
+```python
+import json
+
+data = json.loads(http_get("https://libraries.io/api/pypi/requests"))
+print(data['name'], data['latest_release_number'], data['rank'])
+print("Stars:", data['stars'], "Forks:", data['forks'])
+print("Dependents:", data['dependents_count'], "Dependent repos:", data['dependent_repos_count'])
+print("License:", data['licenses'])
+print("Repo:", data['repository_url'])
+# Confirmed output (2026-04-18):
+# requests 2.33.1 32
+# Stars: 53897 Forks: 9840
+# Dependents: 108138 Dependent repos: 55851
+# License: Apache-2.0
+# Repo: https://github.com/psf/requests
+```
+
+Works for any supported platform — replace `pypi` with `npm`, `cargo`, `rubygems`, `maven`, `nuget`, etc.
+
+```python
+import json
+
+express = json.loads(http_get("https://libraries.io/api/npm/express"))
+serde   = json.loads(http_get("https://libraries.io/api/cargo/serde"))
+rails   = json.loads(http_get("https://libraries.io/api/rubygems/rails"))
+```
+
+### Version list
+
+The `versions` array in every project response lists all published versions:
+
+```python
+import json
+
+data  = json.loads(http_get("https://libraries.io/api/pypi/requests"))
+versions = data['versions']   # list of dicts
+for v in versions[-3:]:       # last 3 (oldest first in array)
+    print(v['number'], v['published_at'])
+# Example: 2.33.0  2026-02-12T...  |  2.33.1  2026-03-30T...
+# Each version: {number, published_at, spdx_expression, original_license,
+#                researched_at, repository_sources[]}
+```
+
+### Dependencies for a specific version (no key required)
+
+```python
+import json
+
+url  = "https://libraries.io/api/pypi/requests/2.31.0/dependencies"
+data = json.loads(http_get(url))
+# Response adds two extra keys on top of normal project fields:
+#   dependencies_for_version: "2.31.0"
+#   dependencies: list of dependency dicts
+for dep in data['dependencies']:
+    if not dep['optional']:
+        print(dep['name'], dep['requirements'], dep['kind'])
+# Confirmed output (2026-04-18):
+# charset-normalizer  <4,>=2        runtime
+# idna                <4,>=2.5      runtime
+# urllib3             <3,>=1.21.1   runtime
+# certifi             >=2017.4.17   runtime
+# (PySocks and cryptography are optional extras)
+
+# Each dependency dict:
+# {project_name, name, platform, requirements, latest_stable, latest,
+#  deprecated, outdated, filepath, kind, optional, normalized_licenses[]}
+```
+
+### Search packages (API key required)
+
+```python
+import json, os
+
+key = os.environ.get('LIBRARIES_IO_API_KEY', '')
+url = f"https://libraries.io/api/search?q=http+client&platforms=Pypi&per_page=10&api_key={key}"
+results = json.loads(http_get(url))  # list of project dicts, same shape as project endpoint
+for r in results:
+    print(r['name'], r['rank'], r['dependents_count'])
+```
+
+Search parameters:
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `q` | any string | URL-encode spaces as `+` |
+| `platforms` | `Pypi`, `NPM`, `Cargo`, `Rubygems`, `Maven`, `NuGet`, etc. | Case-sensitive. Omit for all platforms |
+| `languages` | `Python`, `JavaScript`, `Rust`, `Ruby`, etc. | Optional filter |
+| `licenses` | `MIT`, `Apache-2.0`, `GPL-3.0`, etc. | Optional filter |
+| `keywords` | comma-separated | Optional filter |
+| `sort` | `rank`, `stars`, `dependents_count`, `dependent_repos_count`, `latest_release_published_at`, `contributions_count`, `created_at` | Default: `rank` |
+| `per_page` | 1–100 (default 30) | |
+| `page` | integer | 1-indexed |
+
+### All platforms and counts (no key required)
+
+```python
+import json
+
+platforms = json.loads(http_get("https://libraries.io/api/platforms"))
+# Returns list of 31 platform dicts
+for p in platforms:
+    print(f"{p['name']}: {p['project_count']:,} projects")
+# Confirmed output (2026-04-18):
+# NPM: 5,610,617 projects
+# Pypi: 815,927 projects
+# Maven: 801,455 projects
+# Go: 746,949 projects
+# NuGet: 637,571 projects
+# Packagist: 489,543 projects
+# Cargo: 268,817 projects
+# Rubygems: 196,782 projects
+# CocoaPods: 104,659 projects
+# Pub: 80,565 projects
+# ... (31 total)
+
+# Each platform dict: {name, project_count, homepage, color,
+#                      default_language, package_manager_url}
+```
+
+### Parallel fetch for multiple packages
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+def fetch_pkg(platform_name):
+    platform, name = platform_name
+    return json.loads(http_get(f"https://libraries.io/api/{platform}/{name}"))
+
+pkgs = [("pypi", "requests"), ("pypi", "httpx"), ("pypi", "aiohttp")]
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(fetch_pkg, pkgs))
+for r in results:
+    print(r['name'], r['rank'], r['dependents_count'])
+# CAUTION: unauthenticated limit is 10 req/hour — parallel fetches burn it fast
+# Add api_key param when doing bulk work
+```
+
+### Rate limit check before bulk work
+
+```python
+import json, urllib.request
+
+req = urllib.request.Request("https://libraries.io/api/pypi/requests",
+                             headers={"User-Agent": "Mozilla/5.0"})
+with urllib.request.urlopen(req, timeout=20) as r:
+    remaining = r.headers.get("X-RateLimit-Remaining")
+    limit      = r.headers.get("X-RateLimit-Limit")
+    reset_secs = r.headers.get("X-RateLimit-Reset")   # seconds until reset
+    print(f"Rate limit: {remaining}/{limit} remaining, resets in {reset_secs}s")
+    data = json.loads(r.read().decode())
+```
+
+## URL reference
+
+### Endpoints (all base URL: `https://libraries.io/api`)
+
+| Endpoint | Auth | Notes |
+|---|---|---|
+| `GET /platforms` | No | 31 platforms with project counts |
+| `GET /{platform}/{name}` | No | Full project metadata + all versions |
+| `GET /{platform}/{name}/{version}/dependencies` | No | Project metadata + `dependencies[]` for one version |
+| `GET /{platform}/{name}/dependents` | No | Returns `{"message":"Disabled for performance reasons"}` |
+| `GET /search?q=...&api_key=KEY` | **Yes** | Full-text search across packages |
+
+### Platform identifiers (case-sensitive in URLs)
+
+```
+Pypi  NPM  Maven  Go  NuGet  Packagist  Cargo  Rubygems  CocoaPods  Pub
+Bower  Clojars  CPAN  CRAN  Hackage  Hex  Homebrew  Julia  Meteor
+Nimble  Puppet  PyPI  Racket  SwiftPM  Wordpress
+```
+
+### Rate limits
+
+| Mode | Limit | Window |
+|---|---|---|
+| Unauthenticated | 10 req | per hour (per IP) |
+| API key (free tier) | 60 req | per minute |
+
+Rate limit headers on every response:
+- `X-RateLimit-Limit` — total allowed
+- `X-RateLimit-Remaining` — calls left
+- `X-RateLimit-Reset` — seconds until window resets
+- `Retry-After` — same as Reset, seconds to wait after 429
+
+## Gotchas
+
+- **10 req/hour unauthenticated is very low.** Even basic exploration burns through it quickly. Get a free API key at `https://libraries.io/account` — the free tier allows 60 req/min. Pass as `?api_key=KEY` query param.
+
+- **Invalid API key returns HTTP 403 `Forbidden` (plain text), not JSON.** Wrap calls in try/except and check `Content-Type` before parsing:
+  ```python
+  try:
+      data = json.loads(http_get(url))
+  except Exception as e:
+      print("API error (bad key or rate limited):", e)
+  ```
+
+- **Search endpoint always requires API key.** `GET /api/search` without a key returns `HTTP 403 {"error":"Error 403, you don't have permissions for this operation."}` — no anonymous fallback.
+
+- **Dependents endpoint is disabled.** `GET /api/{platform}/{name}/dependents` returns `HTTP 200 {"message":"Disabled for performance reasons"}` for all packages. Use `dependents_count` and `dependent_repos_count` fields from the project endpoint instead.
+
+- **`versions[]` array is sorted oldest-first.** `data['versions'][0]` is the first published version; `data['versions'][-1]` is the most recent. `latest_release_number` is more reliable than indexing `versions[-1]`.
+
+- **Platform names are case-sensitive in URLs.** Use `pypi` (lowercase) in the URL path: `https://libraries.io/api/pypi/requests`. The `platforms` endpoint returns names like `"Pypi"` and `"NPM"` but the URL path must be lowercase (`pypi`, `npm`).
+
+- **`latest_stable_release_number` can differ from `latest_release_number`.** Pre-releases (alpha, beta, rc) increment `latest_release_number` but not `latest_stable_release_number`. Use `latest_stable_release_number` for production dependency checks.
+
+- **`rank` is Libraries.io's composite score** — lower number = more popular. `requests` ranks 32 on Pypi (2026-04-18). It combines dependents count, stars, and other signals; it is not a simple sort position.
+
+- **`http_get` from helpers.py uses urllib and may hit SSL cert errors** on some systems. Use `requests` library directly if you see `[SSL: CERTIFICATE_VERIFY_FAILED]`:
+  ```python
+  import requests, json
+  data = requests.get("https://libraries.io/api/pypi/requests", timeout=20).json()
+  ```
+
+- **`X-RateLimit-Reset` is seconds-until-reset, not a Unix timestamp.** When rate limited (HTTP 429), `Retry-After` also gives seconds to wait — typically 3,300–3,600 seconds (close to 1 hour).
+
+- **Dependencies `kind` field distinguishes runtime vs extras.** Runtime dependencies have `kind: "runtime"`. Optional extras have `kind` set to the extra name string (e.g., `"extra == 'socks'"`). Filter with `dep['optional'] == False` to get only required dependencies.

--- a/domain-skills/nvd-cve/scraping.md
+++ b/domain-skills/nvd-cve/scraping.md
@@ -1,0 +1,380 @@
+# NVD / CVE API — Scraping & Data Extraction
+
+`https://services.nvd.nist.gov` — NIST National Vulnerability Database REST API v2.0. **Never use the browser.** All CVE data is available via direct HTTP. No API key required for public access; key unlocks higher rate limit.
+
+## Do this first
+
+**`http_get` from helpers.py fails on NVD due to macOS SSL cert chain issues. Use `requests` or a manual SSL-bypass wrapper instead.**
+
+```python
+import urllib.request, ssl, json, time
+
+# SSL bypass — required on macOS where system cert chain may not include NIST root
+_ctx = ssl.create_default_context()
+_ctx.check_hostname = False
+_ctx.verify_mode = ssl.CERT_NONE
+
+def nvd_get(url, api_key=None):
+    headers = {"User-Agent": "Mozilla/5.0"}
+    if api_key:
+        headers["apiKey"] = api_key
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=_ctx) as r:
+            return json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            raise RuntimeError("NVD rate limit hit (5 req/30s without key). Wait 30s or add apiKey header.")
+        raise
+
+BASE = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+```
+
+Alternatively, `import requests; r = requests.get(url, headers={"apiKey": key}); r.raise_for_status(); return r.json()` also works and handles SSL automatically.
+
+## Common workflows
+
+### Single CVE lookup
+
+```python
+import json, urllib.request, ssl
+
+_ctx = ssl.create_default_context()
+_ctx.check_hostname = False
+_ctx.verify_mode = ssl.CERT_NONE
+
+def nvd_get(url, api_key=None):
+    headers = {"User-Agent": "Mozilla/5.0"}
+    if api_key:
+        headers["apiKey"] = api_key
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30, context=_ctx) as r:
+        return json.loads(r.read().decode())
+
+BASE = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+
+data = nvd_get(f"{BASE}?cveId=CVE-2021-44228")
+cve = data["vulnerabilities"][0]["cve"]
+
+# English description
+desc = next(d["value"] for d in cve["descriptions"] if d["lang"] == "en")
+
+# CWE IDs
+cwes = [
+    w["description"][0]["value"]
+    for w in cve.get("weaknesses", [])
+    if w.get("description")
+]
+
+# CISA KEV (Known Exploited Vulnerabilities) fields — only present if in catalog
+cisa_name = cve.get("cisaVulnerabilityName")     # e.g. "Apache Log4j2 Remote Code Execution Vulnerability"
+cisa_add  = cve.get("cisaExploitAdd")             # e.g. "2021-12-10"
+cisa_due  = cve.get("cisaActionDue")              # e.g. "2021-12-24"
+
+print(cve["id"], cve["published"][:10], cve["vulnStatus"])
+# CVE-2021-44228 2021-12-10 Analyzed
+print(cwes)
+# ['CWE-20', 'CWE-917']
+print(cisa_name)
+# Apache Log4j2 Remote Code Execution Vulnerability
+```
+
+### Extract CVSS score (handles v2 / v3.0 / v3.1 / v4.0)
+
+**CVSS version differences are the main gotcha — see Gotchas section.**
+
+```python
+def extract_cvss(cve: dict) -> dict:
+    """Return highest-priority CVSS entry: v4 > v3.1 > v3.0 > v2. Prefers 'Primary' source."""
+    m = cve.get("metrics", {})
+    for key in ("cvssMetricV40", "cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+        metrics = m.get(key, [])
+        entry = next((x for x in metrics if x.get("type") == "Primary"), metrics[0] if metrics else None)
+        if not entry:
+            continue
+        d = entry["cvssData"]
+        return {
+            "version":  d.get("version"),
+            "score":    d.get("baseScore"),
+            # v2: severity lives at metric level, NOT in cvssData
+            "severity": entry.get("baseSeverity") if key == "cvssMetricV2" else d.get("baseSeverity"),
+            "vector":   d.get("vectorString"),
+        }
+    return {}
+
+# Confirmed outputs:
+# CVE-2021-44228 → {'version': '3.1', 'score': 10.0, 'severity': 'CRITICAL', 'vector': 'CVSS:3.1/...'}
+# CVE-2008-7261  → {'version': '2.0', 'score': 2.1,  'severity': 'LOW',      'vector': 'AV:L/AC:L/...'}
+# CVE-2026-34477 → {'version': '4.0', 'score': 6.3,  'severity': 'MEDIUM',   'vector': 'CVSS:4.0/...'}
+```
+
+### Keyword search
+
+```python
+data = nvd_get(f"{BASE}?keywordSearch=log4j")
+print(data["totalResults"])   # 31 (2026-04-18)
+
+for v in data["vulnerabilities"]:
+    cve  = v["cve"]
+    cvss = extract_cvss(cve)
+    print(cve["id"], cvss.get("score"), cvss.get("severity"))
+# CVE-2008-7261 2.1 LOW
+# CVE-2021-44228 10.0 CRITICAL
+# ...
+```
+
+Use `keywordExactMatch` (no value — boolean flag) to require exact phrase rather than any word match:
+```
+?keywordSearch=apache+log4j&keywordExactMatch
+```
+
+### Filter by CVSS severity
+
+```python
+# cvssV3Severity values: CRITICAL, HIGH, MEDIUM, LOW
+data = nvd_get(f"{BASE}?cvssV3Severity=CRITICAL&resultsPerPage=5")
+print(data["totalResults"])   # 30049 (2026-04-18)
+
+# cvssV2Severity also supported
+data = nvd_get(f"{BASE}?cvssV2Severity=HIGH&resultsPerPage=5")
+print(data["totalResults"])   # 56837
+```
+
+### Filter by date range
+
+```python
+# pubStartDate / pubEndDate — publication date (ISO 8601, milliseconds required)
+data = nvd_get(
+    f"{BASE}?pubStartDate=2024-01-01T00:00:00.000"
+    f"&pubEndDate=2024-01-07T23:59:59.999"
+    f"&resultsPerPage=5"
+)
+print(data["totalResults"])   # 394
+
+# lastModStartDate / lastModEndDate — last modification date (same format)
+data = nvd_get(
+    f"{BASE}?lastModStartDate=2024-01-01T00:00:00.000"
+    f"&lastModEndDate=2024-01-02T23:59:59.999"
+    f"&resultsPerPage=3"
+)
+print(data["totalResults"])   # 69
+```
+
+### Filter by CPE (affected software)
+
+```python
+# cpeName — exact CPE 2.3 URI
+data = nvd_get(f"{BASE}?cpeName=cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*")
+print(data["totalResults"])   # 5
+for v in data["vulnerabilities"]:
+    print(v["cve"]["id"])
+# CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, ...
+```
+
+### Filter to CISA KEV catalog
+
+```python
+# hasKev — boolean flag (no value), returns CVEs in CISA's Known Exploited Vulnerabilities catalog
+data = nvd_get(f"{BASE}?hasKev&resultsPerPage=5")
+print(data["totalResults"])   # 1569 (2026-04-18)
+```
+
+### Paginate full result sets
+
+Max `resultsPerPage` is 2000. Default (omitted) is also 2000. Use `startIndex` to page through.
+
+```python
+import time
+
+def fetch_all_cves(params: dict, page_size=2000, sleep_s=6.5) -> list:
+    """Paginate NVD CVE results. sleep_s=6.5 keeps safely under 5 req/30s limit."""
+    all_cves = []
+    idx = 0
+    total = None
+    qs_base = "&".join(f"{k}={v}" for k, v in params.items())
+
+    while total is None or idx < total:
+        url = f"{BASE}?{qs_base}&resultsPerPage={page_size}&startIndex={idx}"
+        data = nvd_get(url)
+        total = data["totalResults"]
+        batch = data["vulnerabilities"]
+        all_cves.extend(batch)
+        idx += len(batch)
+        if idx < total:
+            time.sleep(sleep_s)
+
+    return all_cves
+
+# Fetch all CRITICAL CVEs published in a week
+cves = fetch_all_cves({
+    "pubStartDate": "2024-01-01T00:00:00.000",
+    "pubEndDate":   "2024-01-07T23:59:59.999",
+    "cvssV3Severity": "CRITICAL",
+})
+print(f"Fetched {len(cves)} CVEs")
+```
+
+### CPE match strings (affected product ranges)
+
+```python
+CPE_BASE = "https://services.nvd.nist.gov/rest/json/cpematch/2.0"
+
+data = nvd_get(f"{CPE_BASE}?cveId=CVE-2021-44228")
+print(data["totalResults"])   # 395
+
+# Each matchString shows a version range and the specific CPE names that match
+for ms in data["matchStrings"][:2]:
+    ms = ms["matchString"]
+    print(ms["criteria"])          # e.g. cpe:2.3:a:apache:log4j:2.0:rc1:*:*:*:*:*:*
+    print(ms["status"])            # Active
+    print(len(ms.get("matches", [])), "specific CPEs")
+```
+
+### Parallel batch lookup (multiple known CVE IDs)
+
+```python
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+def fetch_cve(cve_id):
+    data = nvd_get(f"{BASE}?cveId={cve_id}")
+    if not data["vulnerabilities"]:
+        return None
+    return data["vulnerabilities"][0]["cve"]
+
+cve_ids = ["CVE-2021-44228", "CVE-2021-45046", "CVE-2021-45105", "CVE-2021-44832"]
+
+# Without API key: max ~4-5 parallel workers before hitting 429
+# With API key: safe up to ~10 workers
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = list(ex.map(fetch_cve, cve_ids))
+
+for cve in results:
+    if cve:
+        cvss = extract_cvss(cve)
+        print(cve["id"], cvss.get("score"), cvss.get("severity"))
+# CVE-2021-44228 10.0 CRITICAL
+# CVE-2021-45046 9.0 CRITICAL
+# CVE-2021-45105 5.9 MEDIUM
+# CVE-2021-44832 6.6 MEDIUM
+# Time: ~5s for 4 CVEs with workers=3
+```
+
+### With API key (higher rate limit)
+
+```python
+API_KEY = "your-nvd-api-key"   # Register free at https://nvd.nist.gov/developers/request-an-api-key
+
+data = nvd_get(f"{BASE}?cveId=CVE-2021-44228", api_key=API_KEY)
+# Key goes in header: apiKey: {key}
+# Rate limit with key: 50 requests per 30 seconds (vs 5 without)
+# Use sleep_s=0.6 between pages (50/30s = 1 req/0.6s)
+```
+
+## API reference
+
+### Endpoints
+
+| Endpoint | Notes |
+|---|---|
+| `GET /rest/json/cves/2.0` | CVE list (default 2000/page, max 2000/page) |
+| `GET /rest/json/cves/2.0?cveId=CVE-YYYY-NNNNN` | Single CVE |
+| `GET /rest/json/cpematch/2.0?cveId=CVE-YYYY-NNNNN` | CPE match strings for a CVE |
+
+### Query parameters (CVE endpoint)
+
+| Parameter | Example | Notes |
+|---|---|---|
+| `cveId` | `CVE-2021-44228` | Single CVE lookup |
+| `keywordSearch` | `log4j` | Searches description text |
+| `keywordExactMatch` | *(flag, no value)* | Require exact phrase match |
+| `pubStartDate` | `2024-01-01T00:00:00.000` | ISO 8601 with milliseconds |
+| `pubEndDate` | `2024-01-07T23:59:59.999` | Pair with `pubStartDate` |
+| `lastModStartDate` | `2024-01-01T00:00:00.000` | Filter by last-modified |
+| `lastModEndDate` | `2024-01-02T23:59:59.999` | Pair with `lastModStartDate` |
+| `cvssV3Severity` | `CRITICAL` | CRITICAL, HIGH, MEDIUM, LOW |
+| `cvssV2Severity` | `HIGH` | HIGH, MEDIUM, LOW |
+| `cpeName` | `cpe:2.3:a:apache:log4j:...` | Exact CPE 2.3 URI |
+| `hasKev` | *(flag, no value)* | CISA KEV catalog members only |
+| `resultsPerPage` | `2000` | Max 2000; default 2000 |
+| `startIndex` | `0` | Pagination offset |
+
+### Top-level response fields
+
+```json
+{
+  "resultsPerPage": 2000,
+  "startIndex": 0,
+  "totalResults": 345194,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2026-04-19T01:02:03.536",
+  "vulnerabilities": [...]
+}
+```
+
+### CVE object structure (key fields)
+
+```json
+{
+  "cve": {
+    "id": "CVE-2021-44228",
+    "sourceIdentifier": "security@apache.org",
+    "published": "2021-12-10T10:15:09.143",
+    "lastModified": "2026-02-20T16:15:59.363",
+    "vulnStatus": "Analyzed",
+    "descriptions": [{"lang": "en", "value": "..."}],
+    "metrics": {
+      "cvssMetricV40": [...],   // present for recent CVEs
+      "cvssMetricV31": [...],   // most CVEs from 2019+
+      "cvssMetricV30": [...],   // older format
+      "cvssMetricV2":  [...]    // pre-2019; always present for historical CVEs
+    },
+    "weaknesses": [{"source": "...", "type": "Primary|Secondary", "description": [{"lang":"en","value":"CWE-20"}]}],
+    "configurations": [...],    // CPE match trees (complex nested AND/OR)
+    "references": [{"url": "...", "source": "...", "tags": [...]}],
+    "cisaExploitAdd": "2021-12-10",           // only if in CISA KEV
+    "cisaActionDue": "2021-12-24",            // only if in CISA KEV
+    "cisaVulnerabilityName": "...",           // only if in CISA KEV
+    "cisaRequiredAction": "..."               // only if in CISA KEV
+  }
+}
+```
+
+### CVSS metric structure per version
+
+| Version key | `baseSeverity` location | Unique fields |
+|---|---|---|
+| `cvssMetricV2` | `metric["baseSeverity"]` (NOT in `cvssData`) | `acInsufInfo`, `obtainAllPrivilege`, `obtainUserPrivilege` |
+| `cvssMetricV30` / `cvssMetricV31` | `cvssData["baseSeverity"]` | `scope`, `privilegesRequired`, `userInteraction` |
+| `cvssMetricV40` | `cvssData["baseSeverity"]` | `attackRequirements`, `vulnConfidentialityImpact`, `subIntegrityImpact`, `exploitMaturity` |
+
+Each metric entry also has `"type": "Primary"` or `"Secondary"` — always prefer `Primary` when multiple sources score the same CVE.
+
+## Gotchas
+
+- **`http_get` from helpers.py fails with SSL error on macOS.** The NIST server uses a cert chain not trusted by macOS's system store. Use the `ssl.create_default_context()` bypass shown above, or use `requests` (which bundles `certifi` and works out of the box). Do not modify helpers.py.
+
+- **v2 `baseSeverity` is at the metric level, not inside `cvssData`.** For `cvssMetricV2`, `entry["baseSeverity"]` exists but `entry["cvssData"]["baseSeverity"]` does not. For v3.x and v4.0, it's inside `cvssData`. The `extract_cvss()` function above handles this correctly.
+
+- **`metrics` key may be empty or missing entirely.** Some CVEs (especially newly published or disputed ones) have `"metrics": {}`. Always guard with `.get("metrics", {})` before checking version keys.
+
+- **Multiple CVSS entries per version (Primary vs Secondary).** A single CVE can have multiple v3.1 entries from different sources (`nvd@nist.gov` as Primary, CNA as Secondary). Use `type == "Primary"` for the authoritative NVD score; Secondary scores are from the assigning CNA and may differ.
+
+- **CVSS v4.0 is increasingly common** (all-new CVEs from 2026+). A CVE may have only `cvssMetricV40` with no v3 at all. Hardcoded `cvssMetricV31` access will miss these — always iterate the precedence list.
+
+- **Rate limit: 5 req/30s without key, 50 req/30s with key.** The window is a sliding 30-second window per IP. HTTP 429 is returned with `Retry-After: 0` header and body `error code: 1015`. Recovery is automatic after ~30s. Safe pacing: 6.5s sleep between requests without a key; 0.6s with one.
+
+- **`resultsPerPage` max is 2000.** Requesting more returns HTTP 403 (empty body). The default when omitted is also 2000.
+
+- **Date parameters require milliseconds.** `pubStartDate=2024-01-01T00:00:00` fails silently (returns 0 results). Must include `.000`: `pubStartDate=2024-01-01T00:00:00.000`.
+
+- **`startIndex` + `resultsPerPage` can overshoot `totalResults`.** The API returns whatever is available — the last page will have fewer items than `resultsPerPage`. Always check `len(batch)` not `page_size` when advancing the index.
+
+- **`totalResults` can shift between pages during bulk harvesting.** NVD updates continuously. For consistency, use `lastModStartDate`/`lastModEndDate` windows rather than offset pagination over unbounded queries.
+
+- **`vulnStatus` values:** `Analyzed` (NVD fully reviewed), `Modified` (updated post-analysis), `Awaiting Analysis`, `Undergoing Analysis`, `Deferred`, `Rejected`. Only `Analyzed` CVEs are guaranteed to have complete CPE configurations.
+
+- **`configurations` is complex nested AND/OR.** The `configurations[]` array uses `"operator": "AND"|"OR"` with nested `nodes` — not a flat list of affected versions. Parse it recursively or use the `cpematch` endpoint for a flat list of matching CPEs instead.
+
+- **CISA KEV fields are absent (not null) when not in catalog.** Do `cve.get("cisaExploitAdd")` — if the CVE is not in KEV, the key simply doesn't exist in the response object.

--- a/domain-skills/opensky/scraping.md
+++ b/domain-skills/opensky/scraping.md
@@ -1,0 +1,214 @@
+# OpenSky Network — Real-Time & ADS-B Flight Data
+
+`https://opensky-network.org/api` — live and historical ADS-B/MLAT flight state data. **No browser needed.** All responses are JSON over HTTPS. Anonymous access covers the live states endpoint; historical data and flight records require a free account.
+
+## Do this first
+
+**Use `http_get` with SSL verification disabled** — the OpenSky cert chain fails with Python's default `urllib` on some systems. Wrap once at the top of your script:
+
+```python
+import json, ssl, urllib.request, gzip
+
+_ctx = ssl.create_default_context()
+_ctx.check_hostname = False
+_ctx.verify_mode = ssl.CERT_NONE
+
+def opensky_get(url, username=None, password=None, timeout=20.0):
+    headers = {"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"}
+    if username and password:
+        import base64
+        creds = base64.b64encode(f"{username}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {creds}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout, context=_ctx) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        remaining = r.headers.get("X-Rate-Limit-Remaining")
+        return json.loads(data.decode()), remaining
+```
+
+---
+
+## State vector field index (position matters — it's an array, not a dict)
+
+Every aircraft in `states` is a 17-element list. Fields are always in this order:
+
+| Index | Name | Type | Units / Notes |
+|---|---|---|---|
+| 0 | `icao24` | str | ICAO 24-bit hex transponder address, e.g. `"4bb46f"` |
+| 1 | `callsign` | str or None | 8-char padded with trailing spaces — always `.strip()` |
+| 2 | `origin_country` | str | Derived from ICAO prefix |
+| 3 | `time_position` | int or None | Unix epoch of last position update |
+| 4 | `last_contact` | int | Unix epoch of last message received |
+| 5 | `longitude` | float or None | Degrees WGS-84, −180 to +180 |
+| 6 | `latitude` | float or None | Degrees WGS-84, −90 to +90 |
+| 7 | `baro_altitude` | float or None | Barometric altitude in **meters** |
+| 8 | `on_ground` | bool | True = aircraft reports on ground |
+| 9 | `velocity` | float or None | Ground speed in **m/s** |
+| 10 | `true_track` | float or None | Track angle degrees clockwise from north |
+| 11 | `vertical_rate` | float or None | Climb/descent in **m/s**, negative = descending |
+| 12 | `sensors` | list or None | ICAO ids of receivers that contributed (usually None anon) |
+| 13 | `geo_altitude` | float or None | GPS/geometric altitude in **meters** |
+| 14 | `squawk` | str or None | 4-digit octal transponder code as string, e.g. `"6015"` |
+| 15 | `spi` | bool | Special Purpose Indicator (distress flag) |
+| 16 | `position_source` | int | 0=ADS-B, 1=ASTERIX, 2=MLAT, 3=FLARM |
+
+---
+
+## Common workflows
+
+### Live states — anonymous, global
+
+```python
+obj, remaining = opensky_get("https://opensky-network.org/api/states/all")
+print(f"Data timestamp: {obj['time']}  Aircraft: {len(obj['states'])}  Rate limit left: {remaining}")
+# Confirmed: ~6300 aircraft worldwide, epoch time matches wall clock
+```
+
+### Live states — bounding box (Western Europe)
+
+```python
+obj, remaining = opensky_get(
+    "https://opensky-network.org/api/states/all"
+    "?lamin=45.0&lomin=-5.0&lamax=55.0&lomax=15.0"
+)
+# Confirmed: ~96 aircraft in bounding box
+states = obj["states"]
+```
+
+### Live states — filter by one or more ICAO24
+
+Repeat the `icao24` param for multiple aircraft:
+
+```python
+# Single
+obj, _ = opensky_get("https://opensky-network.org/api/states/all?icao24=4bb46f")
+# Returns {'time': ..., 'states': None} when aircraft not currently visible
+
+# Multiple
+icaos = ["4bb46f", "440209", "471f00"]
+params = "&".join(f"icao24={i}" for i in icaos)
+obj, _ = opensky_get(f"https://opensky-network.org/api/states/all?{params}")
+# Confirmed: returns exactly the matching aircraft
+```
+
+### Parse state vectors into dicts
+
+```python
+obj, _ = opensky_get(
+    "https://opensky-network.org/api/states/all"
+    "?lamin=45.0&lomin=-5.0&lamax=55.0&lomax=15.0"
+)
+
+aircraft = []
+for s in obj["states"]:
+    if s[8]:          # on_ground — skip if you only want airborne
+        continue
+    if s[7] is None:  # no altitude
+        continue
+    aircraft.append({
+        "icao24":       s[0],
+        "callsign":     (s[1] or "").strip(),
+        "country":      s[2],
+        "lon":          s[5],
+        "lat":          s[6],
+        "baro_alt_m":   s[7],
+        "baro_alt_ft":  s[7] / 0.3048,
+        "velocity_ms":  s[9],
+        "heading_deg":  s[10],
+        "vert_rate_ms": s[11],   # None if unknown
+        "squawk":       s[14],
+        "source":       s[16],   # 0=ADS-B
+    })
+
+# Sort by altitude descending
+aircraft.sort(key=lambda x: x["baro_alt_m"], reverse=True)
+for a in aircraft[:5]:
+    print(f"{a['icao24']}  {a['callsign']:8s}  alt={a['baro_alt_ft']:.0f}ft  vel={a['velocity_ms']:.0f}m/s")
+# Confirmed output (Western Europe box):
+# 4bb46f  MNB213    alt=39000ft  vel=258m/s
+# 4bccaf  SXS7KN    alt=39000ft  vel=237m/s
+# 4bce1a  SXS3WE    alt=39000ft  vel=242m/s
+```
+
+### Authenticated endpoints (account required)
+
+Register free at `https://opensky-network.org/index.php?option=com_users&view=registration`. Pass credentials as HTTP Basic Auth.
+
+```python
+USERNAME = "your_username"
+PASSWORD = "your_password"
+
+# Arrivals at Frankfurt airport — time window as Unix epoch
+obj, _ = opensky_get(
+    "https://opensky-network.org/api/flights/arrival"
+    "?airport=EDDF&begin=1517227200&end=1517313600",
+    username=USERNAME, password=PASSWORD
+)
+# Returns list of flight records (not state vectors)
+
+# Departures
+obj, _ = opensky_get(
+    "https://opensky-network.org/api/flights/departure"
+    "?airport=EDDF&begin=1517227200&end=1517313600",
+    username=USERNAME, password=PASSWORD
+)
+
+# Track for a specific aircraft at a given time
+obj, _ = opensky_get(
+    "https://opensky-network.org/api/tracks/all?icao24=3c6444&time=0",
+    username=USERNAME, password=PASSWORD
+)
+# time=0 returns the most recent track
+
+# Historical states at a past time (authenticated only)
+obj, _ = opensky_get(
+    "https://opensky-network.org/api/states/all"
+    "?time=1517227200&lamin=45.0&lomin=-5.0&lamax=55.0&lomax=15.0",
+    username=USERNAME, password=PASSWORD
+)
+```
+
+### Rate limit check
+
+```python
+obj, remaining = opensky_get(
+    "https://opensky-network.org/api/states/all?lamin=51.0&lomin=-0.5&lamax=52.0&lomax=1.0"
+)
+print(f"Requests remaining in window: {remaining}")
+# Anonymous pool: ~400 per day (resets daily). No per-minute window observed.
+# Authenticated accounts get higher limits.
+```
+
+---
+
+## Gotchas
+
+**SSL cert verification fails with Python's default opener on some systems.** `opensky-network.org` uses a cert chain that may not be trusted by the system store. Always create an `ssl.SSLContext` with `check_hostname=False` / `CERT_NONE` as shown above, or install `certifi` and pass `cafile=certifi.where()`.
+
+**`states` is `None` when no aircraft match**, not an empty list. Always guard: `for s in (obj.get("states") or []):`.
+
+**`icao24=` filter returns `None` states when the aircraft is not currently transmitting.** Even valid ICAO24s return `{'time': ..., 'states': None}` if the aircraft is out of coverage or on the ground with transponder off.
+
+**Callsign is padded to 8 characters with trailing spaces.** `"MBU6146 "` not `"MBU6146"`. Always `.strip()`.
+
+**All altitudes are in meters, not feet.** Convert: `feet = meters / 0.3048`. Barometric (`baro_altitude`, index 7) and geometric GPS (`geo_altitude`, index 13) differ by 10–200 m in cruise.
+
+**Velocity is ground speed in m/s, not knots.** Convert: `knots = m_per_s * 1.944`.
+
+**`squawk` is a string, not an int.** `"6015"`, `"7700"`, etc. Leading zeros are preserved. Parse as string, not int.
+
+**`baro_altitude` is `None` for grounded aircraft** (when `on_ground=True`). `geo_altitude` and `vertical_rate` are also frequently `None`. The `sensors` field (index 12) is always `None` in anonymous responses.
+
+**Historical states (`?time=...`) require authentication.** Anonymous requests with a `time` parameter return HTTP 403, not an empty result.
+
+**Flights and tracks endpoints require authentication.** Anonymous calls return HTTP 403 for flights and HTTP 404 for tracks.
+
+**The `time` field in the response is a Unix epoch integer (seconds), not milliseconds.** Use `datetime.utcfromtimestamp(obj['time'])` to convert.
+
+**Rate limit is tracked by `X-Rate-Limit-Remaining` response header.** Anonymous pool is approximately 400 requests per day per IP. There is no observed per-minute throttle for anonymous state queries — rapid sequential calls are allowed until the daily pool depletes.
+
+**Bounding box params are `lamin`, `lamax`, `lomin`, `lomax`** — latitude min/max, longitude min/max. Order matters: `lamin` < `lamax`, `lomin` < `lomax`. The API does not validate reversed bounds; it simply returns no results.
+
+**Multiple `icao24=` params must be repeated, not comma-separated.** `?icao24=abc&icao24=def` works. `?icao24=abc,def` does not match anything.


### PR DESCRIPTION
## Summary
- NVD/CVE: CVSS 4 path keys (cvssMetricV40/V31/V30/V2); SSL bypass needed; date params need .000 ms suffix; CISA KEV fields absent not null on non-KEV CVEs; rate limit 5 req/30s
- Exchange Rates: fawazahmed0 CDN (no key, 301 currencies) and frankfurter.app (no key, 30 ECB currencies) are best free options; date format YYYY.M.D without zero-padding for fawazahmed0
- HackerNews: Algolia uses points/num_comments/author; Firebase uses score/descendants/by; Algolia children is flat IDs in search but nested dicts in items API
- OpenSky: SSL bypass required; states is None not [] when no aircraft; callsign has trailing spaces; all units are meters/m-s; anonymous ~400 req/day
- Libraries.io: 10 req/hour unauthenticated (not 60/min); dependents endpoint disabled; platform names case-sensitive; free key raises limit to 60/min

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add five new domain skills (NVD/CVE, Exchange Rates, Hacker News, OpenSky, Libraries.io) with runnable HTTP examples, key params, and rate-limit/SSL gotchas. All use `http_get` (no browser) and show pagination, filtering, and safe defaults.

- **New Features**
  - NVD/CVE: CVSS v4/v3/v2 extraction with precedence; date filters require `.000` ms; CISA KEV fields present only on KEV CVEs; rate limit 5 req/30s (50/30s with key); SSL bypass or `requests` recommended.
  - Exchange Rates: `@fawazahmed0/currency-api` via CDN as default (no key, 301 currencies, version `YYYY.M.D` without zero-padding); Frankfurter for ECB time series; `open.er-api.com` for simple latest fiat.
  - Hacker News: Algolia search/items for search and full comment trees; Firebase for IDs/items and parallel fetch; front-page HTML scrape for fastest top 30; note field name differences (`points` vs `score`, `num_comments` vs `descendants`, `comment_text` vs `text`).
  - OpenSky: Live `states` parsing with 17-index array and meter/m/s units; SSL bypass helper; `states` may be `None`; callsign has trailing spaces; authenticated endpoints for flights/tracks/history; ~400 anon req/day.
  - Libraries.io: Project and version/dependency endpoints work without a key; search requires key; unauth limit 10/hour (free key 60/min); platform names are case-sensitive in URLs; dependents endpoint is disabled.

<sup>Written for commit 11a261574a1b8beb1edace15d02e5c18c5cc28c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

