### PR TITLE
Add domain skills: Lemmy, BundlePhobia, Can I Use, DBpedia, jsDelivr

### DIFF
--- a/domain-skills/bundlephobia/scraping.md
+++ b/domain-skills/bundlephobia/scraping.md
@@ -1,0 +1,266 @@
+# BundlePhobia — npm Package Size Analysis
+
+`https://bundlephobia.com` — bundle size (minified + gzip), tree-shaking signals, and dependency breakdown for npm packages. Fully public JSON API, no auth required. Never use a browser — all data is available over HTTP.
+
+Tested 2026-04-18 with `http_get`.
+
+---
+
+## Do this first: `http_get` the size API
+
+**Fastest path: one call, fully parsed JSON.**
+
+```python
+import json
+
+# Latest version
+data = json.loads(http_get("https://bundlephobia.com/api/size?package=react"))
+# Pinned version
+data = json.loads(http_get("https://bundlephobia.com/api/size?package=react@18.2.0"))
+
+# Key fields:
+# data['size']            – minified size in bytes (NOT gzip)
+# data['gzip']            – gzip size in bytes  ← the number shown on the site
+# data['version']         – resolved version string
+# data['hasSideEffects']  – False = safe to tree-shake (package.json sideEffects:false)
+# data['hasJSModule']     – path string or False; truthy = has ESM entry point
+# data['isModuleType']    – True if package.json type:"module"
+# data['dependencyCount'] – number of bundled dependencies
+# data['dependencySizes'] – list of {name, approximateSize} for each dep
+# data['assets']          – list of {name, type, size, gzip} per bundle asset
+# data['scoped']          – True for @scope/name packages
+# data['description']     – npm package description
+# data['repository']      – git repo URL
+```
+
+Measured latency for cached popular packages: **80–120ms**.
+
+---
+
+## Latency reference (measured)
+
+| Endpoint | Latency |
+|----------|---------|
+| `/api/size` (cached popular package) | ~80–120ms |
+| `/api/size` (uncached/first-build) | up to 30s or timeout |
+| `/api/package-history` (react, 129 versions) | ~100ms |
+| 5 packages parallel via ThreadPoolExecutor | ~300ms |
+
+---
+
+## Common workflows
+
+### Single package — latest or pinned version
+
+```python
+import json
+
+react = json.loads(http_get("https://bundlephobia.com/api/size?package=react"))
+print(react['version'])        # '19.2.5'
+print(react['gzip'])           # 2908  (bytes)
+print(react['size'])           # 7593  (bytes, minified)
+print(react['hasSideEffects']) # True
+print(react['hasJSModule'])    # False  (no ESM entry)
+print(react['dependencyCount'])# 0
+
+# Pinned version
+r18 = json.loads(http_get("https://bundlephobia.com/api/size?package=react@18.2.0"))
+print(r18['gzip'], r18['size'])  # 2598  6542
+```
+
+### Scoped packages
+
+Pass the `@scope/name` directly — no URL encoding needed.
+
+```python
+import json
+
+babel = json.loads(http_get("https://bundlephobia.com/api/size?package=@babel/core"))
+print(babel['version'])   # '7.29.0'
+print(babel['gzip'])      # 292003
+print(babel['scoped'])    # True
+```
+
+### Parallel fetch for multiple packages
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+packages = ["react", "lodash", "axios", "vue", "express"]
+
+def fetch_size(pkg):
+    try:
+        data = json.loads(http_get(f"https://bundlephobia.com/api/size?package={pkg}"))
+        return {
+            "name": pkg,
+            "version": data["version"],
+            "gzip_kb": round(data["gzip"] / 1024, 1),
+            "size_kb": round(data["size"] / 1024, 1),
+            "has_side_effects": data["hasSideEffects"],
+            "has_esm": bool(data.get("hasJSModule")),
+        }
+    except Exception as e:
+        return {"name": pkg, "error": str(e)}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_size, packages))
+
+for r in results:
+    if "error" not in r:
+        print(f"{r['name']}@{r['version']}: {r['gzip_kb']}KB gzip, esm={r['has_esm']}, sideEffects={r['has_side_effects']}")
+# react@19.2.5:   2.8KB gzip, esm=False, sideEffects=True
+# lodash@4.18.1: 24.7KB gzip, esm=False, sideEffects=True
+# axios@1.15.0:  14.1KB gzip, esm=False, sideEffects=False
+# vue@3.5.32:    41.5KB gzip, esm=False, sideEffects=True
+# express@5.2.1: 236.1KB gzip, esm=False, sideEffects=True
+```
+
+### Scan a package.json's dependencies
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+package_json = json.loads(http_get("https://raw.githubusercontent.com/owner/repo/main/package.json"))
+deps = {**package_json.get("dependencies", {}), **package_json.get("devDependencies", {})}
+
+# Build pinned package strings
+pinned = []
+for name, version_range in deps.items():
+    # Strip semver range prefixes (^, ~, >=, etc.)
+    v = version_range.lstrip("^~>=<").split(" ")[0]
+    pinned.append(f"{name}@{v}" if v and v[0].isdigit() else name)
+
+def fetch_size(pkg_str):
+    try:
+        data = json.loads(http_get(f"https://bundlephobia.com/api/size?package={pkg_str}", timeout=15.0))
+        return {"pkg": pkg_str, "gzip": data["gzip"], "size": data["size"],
+                "version": data["version"], "hasSideEffects": data["hasSideEffects"]}
+    except Exception as e:
+        return {"pkg": pkg_str, "error": str(e)[:80]}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_size, pinned))
+
+# Sort by gzip size descending
+ok = [r for r in results if "error" not in r]
+ok.sort(key=lambda x: x["gzip"], reverse=True)
+for r in ok:
+    print(f"{r['pkg']}: {r['gzip']/1024:.1f}KB gzip")
+```
+
+### Version history — all versions with cached size data
+
+```python
+import json
+
+history = json.loads(http_get("https://bundlephobia.com/api/package-history?package=react"))
+# Returns a dict: version_string -> size_data_object (or empty dict {})
+# Only versions that have been previously built have data; the rest are empty {}
+
+versions_with_data = {k: v for k, v in history.items() if v}
+print(f"Total versions: {len(history)}, with size data: {len(versions_with_data)}")
+# Total versions: 129, with size data: 32
+
+# Most recently cached version with size data:
+for version, data in list(versions_with_data.items())[-3:]:
+    print(f"  {version}: gzip={data['gzip']} size={data['size']}")
+# 18.2.0: gzip=2598 size=6542
+# 19.2.4: gzip=2908 size=7593
+# 19.2.5: gzip=2908 size=7593
+```
+
+### Error handling
+
+```python
+import json, urllib.error
+
+def safe_fetch(pkg):
+    try:
+        data = json.loads(http_get(
+            f"https://bundlephobia.com/api/size?package={pkg}",
+            timeout=15.0
+        ))
+        return data
+    except urllib.error.HTTPError as e:
+        err = json.loads(e.read())["error"]
+        return {"error_code": err["code"], "pkg": pkg}
+    except Exception as e:
+        # Timeout or connection error — package may be uncached and slow to build
+        return {"error_code": "Timeout", "pkg": pkg}
+
+# Known error codes (HTTP 404):
+# PackageNotFoundError      – package does not exist on npm
+# PackageVersionMismatchError – version does not exist; response includes valid versions list
+# Known error codes (HTTP 403):
+# UnsupportedPackageError   – @types/* and similar non-runtime-code packages
+
+result = safe_fetch("@types/node")
+print(result)
+# {'error_code': 'UnsupportedPackageError', 'pkg': '@types/node'}
+
+result = safe_fetch("react@999.999.999")
+print(result["error_code"])  # 'PackageVersionMismatchError'
+```
+
+---
+
+## Response shape reference
+
+```
+/api/size response
+├── name              str    package name
+├── version           str    resolved version
+├── description       str    npm description
+├── repository        str    git URL
+├── scoped            bool   True for @scope/name
+├── size              int    minified bytes (no compression)
+├── gzip              int    gzip bytes ← use this for "bundle size"
+├── hasSideEffects    bool   False = package.json sets sideEffects:false → tree-shakeable
+├── hasJSModule       str|False  ESM entry point path, or False if CJS-only
+├── hasJSNext         str|False  "jsnext:main" field (older ESM signal, usually False)
+├── isModuleType      bool   True if package.json type:"module"
+├── dependencyCount   int    number of dependencies bundled in
+├── dependencySizes   list[{name, approximateSize}]
+└── assets            list[{name, type, size, gzip}]  per-output-file breakdown
+```
+
+---
+
+## Rate limits
+
+Headers on every response:
+- `X-RateLimit-Limit: 60`
+- `X-RateLimit-Remaining: N`
+- `X-RateLimit-Reset: <epoch-ms>`
+
+**60 requests per window** (the reset timestamp indicates the next window boundary). The window appears to be per-minute or per-session — `Remaining` was not always present on cached (Cloudflare HIT) responses, suggesting Cloudflare may serve cached results without decrementing the counter.
+
+At 5 workers parallel, 5 cached packages complete in ~300ms — well within any practical rate budget. Add `time.sleep(1)` between large batches if scanning 50+ packages.
+
+---
+
+## Gotchas
+
+- **Build-on-demand latency** — Uncached packages (first query for that version) are built in real time. This can take 10–30+ seconds and sometimes returns HTTP 502/520 (Cloudflare upstream error). Popular packages (react, lodash, axios) are always cached and return in under 200ms. Retry once after a 2-second delay if you get 502/520.
+
+- **Nonexistent packages time out, not 404** — `PackageNotFoundError` takes ~28 seconds to return because bundlephobia must first verify the package is absent from npm. Always set `timeout=15.0` and treat timeout as a likely "not found or uncached" signal.
+
+- **`@types/*` packages return 403, not 404** — Type-only packages raise `UnsupportedPackageError` (HTTP 403) almost instantly. No bundle size exists for them.
+
+- **`gzip` is the canonical size** — The site UI shows the gzip size. `size` is the raw minified size before compression — always larger. Use `data['gzip']` to match what users see on the website.
+
+- **`hasJSModule` is a path string, not a boolean** — It's either `False` or a non-empty string like `"./index.mjs"`. Use `bool(data.get('hasJSModule'))` for a boolean check.
+
+- **`package-history` returns empty dicts for most versions** — Versions that have never been queried on bundlephobia have `{}` as their value. Only filter for `v for v in history.values() if v` to get real data.
+
+- **`PackageVersionMismatchError` includes valid versions** — The `message` field contains an HTML-formatted list of valid versions. Useful for discovery but requires HTML stripping to read cleanly.
+
+- **Scoped packages work without encoding** — `@babel/core` works fine directly in the query string. URL-encoding the `@` and `/` also works but is not required.
+
+- **Bulk endpoint does not exist** — There is no `bulk-sizes` or `scan` API endpoint. Use `ThreadPoolExecutor` with the single-package `/api/size` endpoint for multi-package queries.
+
+- **`X-RateLimit-Remaining` may be absent** — Cloudflare-cached responses sometimes omit this header. Don't rely on it for precise counting; use the Limit header and track your own request count.
+
+- **`size` ≠ `assets[0].size` for multi-asset packages** — Some packages produce multiple output files; `size` and `gzip` reflect the main/primary asset. Check `assets` for the full breakdown.

--- a/domain-skills/caniuse/scraping.md
+++ b/domain-skills/caniuse/scraping.md
@@ -1,0 +1,293 @@
+# Can I Use — Browser Compatibility Data
+
+`https://caniuse.com` — browser feature compatibility database. **Never use the browser.** All data is available as a single JSON file with no auth, no rate limiting, and no API key. The full dataset is ~4.5MB gzipped.
+
+## Do this first: pick your source
+
+| Source | URL | Notes |
+|--------|-----|-------|
+| GitHub raw (preferred) | `https://raw.githubusercontent.com/Fyrd/caniuse/main/data.json` | ~200ms, updated on each caniuse release |
+| caniuse.com direct | `https://caniuse.com/data.json` | ~270ms, slightly more current (updated between releases) |
+| Single feature file | `https://raw.githubusercontent.com/Fyrd/caniuse/main/features-json/{feature-id}.json` | Lighter if you only need one feature |
+
+Both sources require an SSL bypass on macOS (same as NVD). Use GitHub raw for most tasks — it is faster and cacheable.
+
+---
+
+## Fetch the full dataset
+
+```python
+import urllib.request, ssl, gzip, json
+
+_ctx = ssl.create_default_context()
+_ctx.check_hostname = False
+_ctx.verify_mode = ssl.CERT_NONE
+
+def caniuse_fetch(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"})
+    with urllib.request.urlopen(req, timeout=30, context=_ctx) as r:
+        raw = r.read()
+        if r.headers.get("Content-Encoding") == "gzip" or raw[:2] == b"\x1f\x8b":
+            raw = gzip.decompress(raw)
+        return json.loads(raw.decode())
+
+# Full dataset — ~200ms, 554 features
+obj = caniuse_fetch("https://raw.githubusercontent.com/Fyrd/caniuse/main/data.json")
+# obj keys: eras, agents, statuses, cats, updated, data
+# obj["data"]   — dict of {feature_id: feature_object}  (554 features)
+# obj["agents"] — dict of {browser_id: agent_object}    (19 browsers)
+# obj["updated"] — unix timestamp of last update
+```
+
+---
+
+## Data structure
+
+### Top-level keys
+
+```python
+obj["eras"]     # mapping of era names to date ranges (cosmetic, rarely needed)
+obj["statuses"] # W3C spec status codes: {"rec": "W3C Recommendation", "cr": ..., "wd": ..., "ls": ..., "other": ..., "unoff": ...}
+obj["cats"]     # category groupings: {"CSS": ["CSS2","CSS3","CSS"], "JS API": [...], ...}
+obj["updated"]  # unix timestamp (int)
+```
+
+### Feature object (`obj["data"]["css-grid"]`)
+
+```python
+feat = obj["data"]["css-grid"]
+# feat["title"]          – human name: "CSS Grid Layout (level 1)"
+# feat["description"]    – one-sentence HTML description
+# feat["spec"]           – spec URL
+# feat["status"]         – "rec" | "cr" | "wd" | "ls" | "other" | "unoff"
+# feat["links"]          – list of {"url": ..., "title": ...}
+# feat["categories"]     – list of strings, e.g. ["CSS"]
+# feat["stats"]          – {browser_id: {version_string: support_code}}
+# feat["notes"]          – prose HTML notes (may be empty)
+# feat["notes_by_num"]   – {"1": "note text", "2": "..."} referenced by #N in support codes
+# feat["usage_perc_y"]   – float: % of global users with full support (pre-computed)
+# feat["usage_perc_a"]   – float: % of global users with partial support (pre-computed)
+# feat["keywords"]       – comma-separated search terms
+# feat["parent"]         – parent feature ID (e.g. "css-grid" is parent of "css-subgrid"), or ""
+```
+
+### Support codes (`feat["stats"][browser_id][version]`)
+
+Support codes are **space-separated tokens**. The first token is the base status; additional tokens are modifiers.
+
+| Token | Meaning |
+|-------|---------|
+| `y` | Supported |
+| `n` | Not supported |
+| `a` | Partial support (see notes) |
+| `p` | Supported via polyfill |
+| `u` | Unknown / untested |
+| `x` | Requires vendor prefix (e.g. `-webkit-`) |
+| `d` | Disabled by default (must be enabled in flags) |
+| `#N` | References note number N in `notes_by_num` |
+
+Codes compose: `"a x #2"` = partial support, requires prefix, see note 2. `"p d #3"` = polyfill only, disabled by default, see note 3. `"y #4"` = supported but with caveat in note 4.
+
+```python
+import re
+
+def parse_support(code):
+    """Parse a support code string into components."""
+    base = re.match(r"^([yanpu])", code)
+    return {
+        "code":     base.group(1) if base else "?",   # y/a/n/p/u
+        "prefix":   "x" in code,                       # needs vendor prefix
+        "disabled": "d" in code,                       # off by default
+        "notes":    [int(n) for n in re.findall(r"#(\d+)", code)],
+    }
+
+parse_support("a x #2")  # {'code': 'a', 'prefix': True, 'disabled': False, 'notes': [2]}
+parse_support("p d #3")  # {'code': 'p', 'prefix': False, 'disabled': True, 'notes': [3]}
+parse_support("y")       # {'code': 'y', 'prefix': False, 'disabled': False, 'notes': []}
+```
+
+### Agent object (`obj["agents"]["chrome"]`)
+
+```python
+agent = obj["agents"]["chrome"]
+# agent["browser"]       – display name: "Chrome"
+# agent["long_name"]     – "Google Chrome"
+# agent["abbr"]          – "Chr."
+# agent["prefix"]        – CSS vendor prefix: "webkit"
+# agent["type"]          – "desktop" | "mobile"
+# agent["versions"]      – ordered list of version strings; None = placeholder for future/unreleased
+# agent["usage_global"]  – {version: float} global usage percentage per version
+```
+
+**Browser IDs:** `ie`, `edge`, `firefox`, `chrome`, `safari`, `opera`, `ios_saf`, `op_mini`, `android`, `bb`, `op_mob`, `and_chr`, `and_ff`, `ie_mob`, `and_uc`, `samsung`, `and_qq`, `baidu`, `kaios`
+
+---
+
+## Common workflows
+
+### Look up current support for a feature across major browsers
+
+```python
+def current_support(obj, feature_id, browser_ids=None):
+    """Return {browser_id: {browser, version, support}} for current stable versions."""
+    feat = obj["data"].get(feature_id)
+    if not feat:
+        raise KeyError(f"Unknown feature: {feature_id!r}. Search obj['data'].keys().")
+
+    agents = obj["agents"]
+    result = {}
+    for bid, stats in feat["stats"].items():
+        if browser_ids and bid not in browser_ids:
+            continue
+        agent = agents.get(bid, {})
+        # Current stable = last non-None entry in versions list
+        current = next((v for v in reversed(agent.get("versions", [])) if v is not None), None)
+        if current and current in stats:
+            result[bid] = {
+                "browser": agent.get("browser", bid),
+                "version": current,
+                "support": stats[current],
+            }
+    return result
+
+# Example
+support = current_support(obj, "css-grid", ["chrome", "firefox", "safari", "edge", "ie"])
+for bid, info in support.items():
+    print(f"{info['browser']:15} v{info['version']:6} {info['support']}")
+# Chrome          v150   y
+# Firefox         v152   y
+# Safari          vTP    y
+# Edge            v146   y
+# IE              v11    a x #2
+```
+
+### Search features by keyword
+
+```python
+def find_features(obj, query, category=None):
+    """Search feature IDs, titles, and descriptions. Returns [(id, title, usage_perc_y)]."""
+    q = query.lower()
+    results = []
+    for fid, feat in obj["data"].items():
+        if category and category not in feat.get("categories", []):
+            continue
+        if q in fid or q in feat.get("title", "").lower() or q in feat.get("keywords", "").lower():
+            results.append((fid, feat["title"], feat["usage_perc_y"]))
+    return sorted(results, key=lambda x: x[2], reverse=True)
+
+find_features(obj, "grid")
+# [('css-grid', 'CSS Grid Layout (level 1)', 96.08), ('css-subgrid', 'CSS Subgrid', 92.5), ...]
+
+find_features(obj, "fetch")
+# [('fetch', 'Fetch', 96.6), ...]
+
+find_features(obj, "animation", category="CSS")
+# CSS-only results
+```
+
+### Get full version history for a feature in one browser
+
+```python
+def version_history(obj, feature_id, browser_id):
+    """Return [(version, support_code)] in chronological order, skipping 'u' (unknown)."""
+    feat = obj["data"].get(feature_id, {})
+    stats = feat.get("stats", {}).get(browser_id, {})
+    agent_versions = obj["agents"].get(browser_id, {}).get("versions", [])
+    ordered = [(v, stats[v]) for v in agent_versions if v and v in stats and stats[v] != "u"]
+    return ordered
+
+version_history(obj, "css-grid", "firefox")
+# [('19', 'p'), ('20', 'p'), ... ('52', 'y #4'), ('53', 'y #4'), ...]
+```
+
+### Fetch only a single feature (lightweight)
+
+```python
+# ~50-100KB instead of 4.5MB — good when you only need one feature
+feat = caniuse_fetch("https://raw.githubusercontent.com/Fyrd/caniuse/main/features-json/css-grid.json")
+# Same structure as obj["data"]["css-grid"] with one extra field:
+# feat["shown"] – bool, whether shown on the main caniuse.com listing
+```
+
+### Check global usage coverage
+
+```python
+# Pre-computed: fastest approach
+feat = obj["data"]["css-grid"]
+print(feat["usage_perc_y"])  # 96.08 — % of global users with full support
+print(feat["usage_perc_a"])  # 0.29  — % with partial support
+
+# Compute yourself from usage_global (matches stored value exactly):
+total_y = sum(
+    obj["agents"][bid]["usage_global"].get(v, 0)
+    for bid, stats in feat["stats"].items()
+    if bid in obj["agents"]
+    for v, code in stats.items()
+    if code.startswith("y")
+)
+# total_y ≈ 96.08
+```
+
+### Enumerate all features with low support (find things not yet safe to use)
+
+```python
+low_support = [
+    (fid, feat["title"], feat["usage_perc_y"])
+    for fid, feat in obj["data"].items()
+    if feat["usage_perc_y"] < 70
+]
+low_support.sort(key=lambda x: x[2])
+# Most experimental features at the top
+```
+
+---
+
+## Browser IDs and types reference
+
+| ID | Name | Type |
+|----|------|------|
+| `chrome` | Chrome | desktop |
+| `firefox` | Firefox | desktop |
+| `safari` | Safari | desktop |
+| `edge` | Edge | desktop |
+| `ie` | IE | desktop |
+| `opera` | Opera | desktop |
+| `ios_saf` | Safari on iOS | mobile |
+| `and_chr` | Chrome for Android | mobile |
+| `samsung` | Samsung Internet | mobile |
+| `android` | Android Browser | mobile |
+| `and_ff` | Firefox for Android | mobile |
+| `op_mini` | Opera Mini | mobile |
+| `op_mob` | Opera Mobile | mobile |
+| `ie_mob` | IE Mobile | mobile |
+| `and_uc` | UC Browser for Android | mobile |
+| `and_qq` | QQ Browser | mobile |
+| `baidu` | Baidu Browser | mobile |
+| `kaios` | KaiOS Browser | mobile |
+| `bb` | Blackberry Browser | mobile |
+
+---
+
+## Gotchas
+
+- **SSL fails on macOS with plain `http_get`.** GitHub raw uses a cert chain that isn't trusted by the macOS system store. Use the `ssl.create_default_context()` bypass shown above. Same issue affects `caniuse.com/data.json`. Do not modify helpers.py.
+
+- **`None` in `agent["versions"]` means unreleased/future slots**, not missing data. Edge has `['145', '146', None, None, None]` — the last three are placeholders. Use `next((v for v in reversed(versions) if v is not None), None)` to get current stable.
+
+- **`u` (unknown) is common for old/obscure browsers.** Baidu, KaiOS, QQ Browser have `"u"` for most features. Filter with `if code != "u"` when building support matrices.
+
+- **Support codes are strings, not single characters.** `"a x #2"` is one value. Never compare with `== "a"` — use `.startswith("a")` or the `parse_support()` helper above.
+
+- **`usage_perc_y` and `usage_perc_a` are pre-computed and authoritative.** Don't recompute unless you need custom browser subsets. The stored values match computing from `usage_global` exactly.
+
+- **`notes_by_num` keys are strings, not ints.** `notes_by_num["1"]` not `notes_by_num[1]`. Note references in support codes are `#1`, `#2`, etc.
+
+- **`parent` field chains sub-features.** `css-subgrid` has `"parent": "css-grid"`. Features with a parent are subsets — their stats describe support for the sub-feature only.
+
+- **`feat["stats"]` always contains all 19 browser IDs**, even if all versions are `"u"`. Never assume a browser is absent — check the values, not the key presence.
+
+- **`safari` desktop `vTP` is Safari Technology Preview**, not a stable release. Its support code is real data but indicates upcoming support, not current shipping support.
+
+- **`caniuse.com/data.json` is slightly more current** than the GitHub raw file (updated between repo releases), but both are refreshed frequently. For automation, prefer GitHub raw (no CORS issues, stable URL, CDN-cached).
+
+- **Feature IDs are kebab-case and stable** (e.g. `css-grid`, `fetch`, `arrow-functions`). They do not change. Use them as stable keys for caching or cross-referencing.

--- a/domain-skills/dbpedia/scraping.md
+++ b/domain-skills/dbpedia/scraping.md
@@ -1,0 +1,394 @@
+# DBpedia — Structured Wikipedia Data via SPARQL
+
+`https://dbpedia.org` — structured data extracted from Wikipedia infoboxes, exposed as Linked Open Data. **Never use the browser.** All data is reachable via `http_get` using the SPARQL endpoint, the Lookup API, or the entity JSON API.
+
+DBpedia has ~1.4 billion triples. It cross-links to Wikidata via `owl:sameAs`, carries Wikipedia infobox fields as `dbp:` properties, and maps them to a cleaner ontology as `dbo:` properties.
+
+---
+
+## Do this first
+
+**Use the SPARQL endpoint for structured queries. Use the Lookup API for fuzzy name → URI resolution. Use `data/{Name}.json` for a quick property dump of a single entity.**
+
+```python
+import json, urllib.parse, urllib.request, urllib.error
+
+def sparql(query: str, timeout_ms: int = 30000) -> list[dict]:
+    """Run a SPARQL SELECT query. Returns list of binding dicts."""
+    url = "https://dbpedia.org/sparql?" + urllib.parse.urlencode({
+        "query": query,
+        "format": "application/sparql-results+json",
+        "timeout": str(timeout_ms),
+    })
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=timeout_ms / 1000 + 10) as r:
+        return json.loads(r.read())["results"]["bindings"]
+```
+
+The function is synchronous and safe to call directly. `format=json` (shorthand) also works.
+
+---
+
+## Common workflows
+
+### Name → URI (Lookup API)
+
+Fuzzy search: accepts misspellings and partial names. Always do this before querying SPARQL if you only have a human-readable name.
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+def lookup(query: str, max_results: int = 5, type_filter: str = "") -> list[dict]:
+    """Resolve a human-readable name to DBpedia resource URIs."""
+    params = {"query": query, "format": "json", "maxResults": str(max_results)}
+    if type_filter:
+        params["typeName"] = type_filter  # e.g. 'City', 'Person', 'Film'
+    raw = http_get(
+        "https://lookup.dbpedia.org/api/search?" + urllib.parse.urlencode(params)
+    )
+    return json.loads(raw)["docs"]
+
+docs = lookup("Albert Einstein")
+# docs[0]['resource'][0]   == 'http://dbpedia.org/resource/Albert_Einstein'
+# docs[0]['id'][0]         == 'http://dbpedia.org/resource/Albert_Einstein'
+# docs[0]['label'][0]      == '<B>Albert</B> <B>Einstein</B>'  (HTML-highlighted)
+# docs[0]['comment'][0]    == '<B>Albert</B> <B>Einstein</B> ( EYEN-styne...'  (snippet)
+# docs[0]['typeName']      == ['Person', 'Scientist', 'Agent']
+# docs[0]['type']          == ['http://dbpedia.org/ontology/Person', ...]
+# docs[0]['score'][0]      == '10724.388'
+# docs[0]['refCount'][0]   == '71'   (number of inbound links)
+# docs[0]['category']      == ['http://dbpedia.org/resource/Category:...', ...]
+# docs[0]['redirectlabel'] == ['A. <B>Einstein</B>', ...]  (alternate spellings)
+
+resource_uri = docs[0]['resource'][0]
+resource_name = resource_uri.split('/')[-1]  # 'Albert_Einstein'
+
+# Type-filtered example: only cities named Paris
+city_docs = lookup("Paris", type_filter="City")
+# city_docs[0]['resource'][0] == 'http://dbpedia.org/resource/Paris'
+# city_docs[1]['resource'][0] == 'http://dbpedia.org/resource/Paris,_Texas'
+# Confirmed 2026-04-18
+```
+
+### Entity property dump (data.json)
+
+Returns all RDF triples where the entity is the subject. Fast, no SPARQL needed. Does **not** include `dbo:abstract` — see gotchas.
+
+```python
+import json
+from helpers import http_get
+
+raw = http_get("https://dbpedia.org/data/Nikola_Tesla.json")
+d = json.loads(raw)
+resource_uri = "http://dbpedia.org/resource/Nikola_Tesla"
+props = d[resource_uri]   # dict: predicate URI → list of value dicts
+
+# Value dict shape:
+# {'type': 'literal', 'value': '1856-07-10', 'lang': 'en'}     ← string literal
+# {'type': 'literal', 'value': '1856-07-10', 'datatype': 'http://www.w3.org/2001/XMLSchema#date'}
+# {'type': 'uri', 'value': 'http://dbpedia.org/resource/Smiljan,_Croatia'}  ← URI ref
+
+# Common predicates:
+birthdate = props.get("http://dbpedia.org/ontology/birthDate", [{}])[0].get("value")
+# '1856-07-10'
+birthplace = props.get("http://dbpedia.org/ontology/birthPlace", [{}])[0].get("value")
+# 'http://dbpedia.org/resource/Smiljan,_Croatia'
+thumbnail  = props.get("http://dbpedia.org/ontology/thumbnail", [{}])[0].get("value")
+# 'http://commons.wikimedia.org/wiki/Special:FilePath/Tesla_circa_1890.jpeg?width=300'
+
+# Filter labels by language (data.json uses 'lang' key, NOT 'xml:lang')
+labels = props.get("http://www.w3.org/2000/01/rdf-schema#label", [])
+en_label = next((l["value"] for l in labels if l.get("lang") == "en"), None)
+# 'Nikola Tesla'
+# Confirmed 2026-04-18
+```
+
+### SPARQL: entity metadata
+
+```python
+import json, urllib.parse, urllib.request
+
+def sparql(query: str, timeout_ms: int = 30000) -> list[dict]:
+    url = "https://dbpedia.org/sparql?" + urllib.parse.urlencode({
+        "query": query,
+        "format": "application/sparql-results+json",
+        "timeout": str(timeout_ms),
+    })
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=timeout_ms / 1000 + 10) as r:
+        return json.loads(r.read())["results"]["bindings"]
+
+bindings = sparql("""
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbr: <http://dbpedia.org/resource/>
+SELECT ?name ?birthDate ?birthPlace ?bpLabel WHERE {
+  dbr:Nikola_Tesla rdfs:label ?name ;
+                   dbo:birthDate ?birthDate ;
+                   dbo:birthPlace ?birthPlace .
+  ?birthPlace rdfs:label ?bpLabel .
+  FILTER(lang(?name) = 'en')
+  FILTER(lang(?bpLabel) = 'en')
+} LIMIT 3
+""")
+for b in bindings:
+    print(b["name"]["value"], b["birthDate"]["value"], b["bpLabel"]["value"])
+# Nikola Tesla 1856-07-10 Smiljan, Croatia
+# Confirmed 2026-04-18
+
+# SPARQL JSON response uses 'xml:lang' key, NOT 'lang':
+# bindings[0]['name'] == {'type': 'literal', 'xml:lang': 'en', 'value': 'Nikola Tesla'}
+# Access with: b['name'].get('xml:lang') or b['name'].get('lang')
+# BUT: lang() FILTER in SPARQL works correctly regardless — use FILTER(lang(?x)='en')
+```
+
+### SPARQL: batch lookup by known URIs (VALUES)
+
+```python
+bindings = sparql("""
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+SELECT ?person ?name ?birthDate WHERE {
+  VALUES ?person {
+    <http://dbpedia.org/resource/Albert_Einstein>
+    <http://dbpedia.org/resource/Nikola_Tesla>
+    <http://dbpedia.org/resource/Marie_Curie>
+  }
+  ?person rdfs:label ?name ;
+          dbo:birthDate ?birthDate .
+  FILTER(lang(?name) = 'en')
+}
+""")
+for b in bindings:
+    print(b["name"]["value"], b["birthDate"]["value"])
+# Albert Einstein 1879-03-14
+# Marie Curie 1867-11-07
+# Nikola Tesla 1856-07-10
+# Confirmed 2026-04-18
+```
+
+### SPARQL: films by director
+
+```python
+bindings = sparql("""
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?film ?title WHERE {
+  ?film a dbo:Film ;
+        dbo:director <http://dbpedia.org/resource/Christopher_Nolan> ;
+        rdfs:label ?title .
+  FILTER(lang(?title) = 'en')
+} ORDER BY ?title LIMIT 10
+""")
+for b in bindings:
+    print(b["title"]["value"])
+# Batman Begins
+# Doodlebug (film)
+# Dunkirk (2017 film)
+# Following
+# Inception
+# ... (10 total)
+# Confirmed 2026-04-18
+
+# With optional budget (scientific notation — see gotchas):
+bindings2 = sparql("""
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?film ?title ?budget WHERE {
+  ?film a dbo:Film ;
+        dbo:director <http://dbpedia.org/resource/Christopher_Nolan> ;
+        rdfs:label ?title .
+  OPTIONAL { ?film dbo:budget ?budget }
+  FILTER(lang(?title) = 'en')
+} LIMIT 10
+""")
+for b in bindings2:
+    budget = b.get("budget", {}).get("value", "N/A")
+    print(f"{b['title']['value']}: {budget}")
+# Inception: 1.6E8    ← $160M, stored as float
+# Batman Begins: 1.5E8
+# Following: 6000.0
+# Confirmed 2026-04-18
+```
+
+### SPARQL: cities by population
+
+```python
+bindings = sparql("""
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?city ?name ?pop WHERE {
+  ?city a dbo:City ;
+        rdfs:label ?name ;
+        dbo:populationTotal ?pop .
+  FILTER(lang(?name) = 'en')
+  FILTER(?pop > 5000000)
+  FILTER(?pop < 100000000)
+} ORDER BY DESC(?pop) LIMIT 10
+""")
+for b in bindings:
+    print(f"{b['name']['value']}: {b['pop']['value']}")
+# Beijing: 21893095
+# Chengdu: 20937757
+# Karachi: 18868021
+# ...
+# Confirmed 2026-04-18 — upper bound filter required; see dirty data gotcha
+```
+
+### SPARQL: cross-link to Wikidata
+
+```python
+bindings = sparql("""
+PREFIX dbr: <http://dbpedia.org/resource/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+SELECT ?wd WHERE {
+  dbr:Albert_Einstein owl:sameAs ?wd .
+  FILTER(strstarts(str(?wd), 'http://www.wikidata.org/entity/Q'))
+}
+""")
+print([b["wd"]["value"] for b in bindings])
+# ['http://www.wikidata.org/entity/Q937']
+# Confirmed 2026-04-18
+```
+
+---
+
+## Prefix reference
+
+These are the five prefixes you need for 95% of queries:
+
+```sparql
+PREFIX dbo:  <http://dbpedia.org/ontology/>      # clean ontology: dbo:birthDate, dbo:Film, dbo:populationTotal
+PREFIX dbr:  <http://dbpedia.org/resource/>      # named resources: dbr:Albert_Einstein
+PREFIX dbp:  <http://dbpedia.org/property/>      # raw Wikipedia infobox properties (messier)
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>   # rdfs:label
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>    # owl:sameAs (Wikidata cross-links)
+```
+
+Additional prefixes seen in responses:
+
+```sparql
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>        # foaf:depiction (images), foaf:isPrimaryTopicOf
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>  # skos:exactMatch
+PREFIX dct:  <http://purl.org/dc/terms/>         # dct:subject (categories)
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#> # xsd:date, xsd:integer (for typed literals in FILTER)
+```
+
+---
+
+## SPARQL endpoint reference
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Endpoint | `https://dbpedia.org/sparql` | GET with URL-encoded params |
+| `format` | `application/sparql-results+json` or `json` | Both work |
+| `timeout` | milliseconds, e.g. `30000` | Soft limit; server may ignore for cheap queries |
+| `default-graph-uri` | `http://dbpedia.org` | Optional; omitting still works for most queries |
+| Error on bad query | HTTP 400 | Body: `Virtuoso 37000 Error SP030: ...` |
+| Total triples | ~1.43 billion | As of 2026-04-18 |
+
+---
+
+## Gotchas
+
+**`dbo:abstract` is not available on the public SPARQL endpoint.** As of 2026-04-18, `SELECT (count(*) as ?c) WHERE { ?s dbo:abstract ?ab }` returns 0. The predicate is documented but the data is not loaded into the public instance. Use the Lookup API `comment` field for a snippet, or `dbo:description` (multi-language, short) as a fallback.
+
+**`data.json` uses `'lang'` key; SPARQL JSON responses use `'xml:lang'`.** Both formats: `{'type': 'literal', 'value': 'Nikola Tesla', 'lang': 'en'}` (data.json) vs `{'type': 'literal', 'xml:lang': 'en', 'value': 'Nikola Tesla'}` (SPARQL JSON). Use `b['name'].get('xml:lang') or b['name'].get('lang')` if you read both. Inside SPARQL, `FILTER(lang(?x) = 'en')` always works regardless.
+
+**Dirty numeric data from Wikipedia infoboxes.** `dbo:populationTotal` can contain wildly wrong values: Dusmareb (Somalia) shows 680,000,407; Rabaul shows 388,517,044. Always add sanity bounds: `FILTER(?pop > 0) FILTER(?pop < 100000000)`. Budget values are stored as floats with scientific notation (`1.6E8`); some have clearly wrong values from parsing failures.
+
+**`dbo:` vs `dbp:` — prefer `dbo:` for reliability.** `dbp:` properties are raw Wikipedia infobox keys (e.g., `dbp:wikiPageUsesTemplate`, `dbp:nativeNameLang`) and vary by article. `dbo:` is the cleaned ontological mapping and is more consistent across entities. For numeric data always use `dbo:` when available.
+
+**Duplicate results without `DISTINCT`.** Joining via multiple predicates (e.g., `dbo:birthPlace` with multiple values) multiplies rows. Always use `SELECT DISTINCT` unless you specifically want all combinations.
+
+**Resource names are underscore-encoded Wikipedia article titles.** `"Albert Einstein"` → `dbr:Albert_Einstein` or `https://dbpedia.org/resource/Albert_Einstein`. Construct directly only when you are certain of the article title; use the Lookup API otherwise.
+
+**The `label` and `comment` fields in Lookup API contain HTML `<B>` bold tags** around matched query terms. Strip with regex before displaying: `re.sub(r'<[^>]+>', '', s)`.
+
+**`default-graph-uri` matters for unbound subject queries.** `SELECT ?s ?p ?o WHERE { ?s ?p ?o }` without `default-graph-uri=http://dbpedia.org` may return results from internal Virtuoso system graphs. Specify `default-graph-uri=http://dbpedia.org` when doing full-graph scans.
+
+**DBpedia SPARQL availability is unreliable.** The public endpoint at `dbpedia.org/sparql` has periods of downtime or very slow response. If you get HTTP 500 or a connection timeout, retry once after 5s. There is no official mirror; the endpoint either responds within ~3s or hangs.
+
+**HTTP 400 on query errors, not HTTP 200 with error body.** Unlike some SPARQL endpoints that return HTTP 200 with an error inside the JSON, DBpedia returns HTTP 400 with a Virtuoso error string in the body. Wrap calls in `try/except urllib.error.HTTPError`.
+
+**SSL certificates may fail with Python's default context on some systems.** The `helpers.http_get` function uses `urllib` and may raise `SSLCertVerificationError` on macOS Python 3.11 without the `certifi` bundle. The SPARQL endpoint works fine with `curl`. If `http_get` raises SSL errors, use `urllib.request.urlopen` directly or install `certifi`.
+
+**`dbo:releaseDate` on films is frequently absent or multi-valued.** Many films have multiple release dates (premiere, wide release, country-specific). Use `OPTIONAL { ?film dbo:releaseDate ?year }` and take the minimum, or drop the date filter entirely and filter by title substring.
+
+**Wikidata `owl:sameAs` links return multiple Wikidata entity IDs** (e.g., Einstein returns Q937, Q19088, Q215627 — the person, the wikidata type for physicists, etc.). Filter by `strstarts(str(?wd), 'http://www.wikidata.org/entity/Q')` and look for the lowest Q-number, which is typically the main entity.
+
+---
+
+## Complete working example
+
+```python
+import json, re, urllib.parse, urllib.request, urllib.error
+from helpers import http_get
+
+def sparql(query: str, timeout_ms: int = 30000) -> list[dict]:
+    """Run SPARQL SELECT. Returns list of binding dicts."""
+    url = "https://dbpedia.org/sparql?" + urllib.parse.urlencode({
+        "query": query,
+        "format": "application/sparql-results+json",
+        "timeout": str(timeout_ms),
+    })
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=timeout_ms / 1000 + 10) as r:
+            return json.loads(r.read())["results"]["bindings"]
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"SPARQL error {e.code}: {e.read().decode()[:300]}")
+
+def lookup_uri(name: str, type_filter: str = "") -> str | None:
+    """Resolve a human name to a DBpedia resource URI. Returns None if not found."""
+    params = {"query": name, "format": "json", "maxResults": "1"}
+    if type_filter:
+        params["typeName"] = type_filter
+    raw = http_get("https://lookup.dbpedia.org/api/search?" + urllib.parse.urlencode(params))
+    docs = json.loads(raw)["docs"]
+    return docs[0]["resource"][0] if docs else None
+
+def entity_props(resource_uri: str) -> dict:
+    """Fetch all properties for an entity. Returns predicate→values dict."""
+    name = resource_uri.split("/")[-1]
+    raw = http_get(f"https://dbpedia.org/data/{name}.json")
+    return json.loads(raw).get(resource_uri, {})
+
+def strip_html(s: str) -> str:
+    return re.sub(r"<[^>]+>", "", s)
+
+# --- Example: look up a scientist and get structured data ---
+uri = lookup_uri("Nikola Tesla", type_filter="Scientist")
+# uri == 'http://dbpedia.org/resource/Nikola_Tesla'
+
+props = entity_props(uri)
+birthdate  = props.get("http://dbpedia.org/ontology/birthDate", [{}])[0].get("value")
+thumbnail  = props.get("http://dbpedia.org/ontology/thumbnail", [{}])[0].get("value")
+labels     = props.get("http://www.w3.org/2000/01/rdf-schema#label", [])
+en_label   = next((l["value"] for l in labels if l.get("lang") == "en"), None)
+print(en_label, birthdate, thumbnail)
+# Nikola Tesla  1856-07-10  http://commons.wikimedia.org/.../Tesla_circa_1890.jpeg?width=300
+
+# SPARQL for richer context: birthplace label + Wikidata cross-link
+bindings = sparql(f"""
+PREFIX dbo:  <http://dbpedia.org/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+SELECT ?bpLabel ?wd WHERE {{
+  <{uri}> dbo:birthPlace ?bp .
+  ?bp rdfs:label ?bpLabel .
+  OPTIONAL {{
+    <{uri}> owl:sameAs ?wd .
+    FILTER(strstarts(str(?wd), 'http://www.wikidata.org/entity/Q'))
+  }}
+  FILTER(lang(?bpLabel) = 'en')
+}} LIMIT 3
+""")
+for b in bindings:
+    bp  = b.get("bpLabel", {}).get("value")
+    wd  = b.get("wd", {}).get("value")
+    print(f"  birthPlace: {bp}  wikidata: {wd}")
+# birthPlace: Smiljan, Croatia  wikidata: http://www.wikidata.org/entity/Q9036
+# Confirmed 2026-04-18
+```

--- a/domain-skills/jsdelivr/scraping.md
+++ b/domain-skills/jsdelivr/scraping.md
@@ -1,0 +1,233 @@
+# jsDelivr — Data Extraction
+
+`data.jsdelivr.com` (stats/metadata API) + `cdn.jsdelivr.net` (file serving). No auth, no browser, pure `http_get`. All endpoints return JSON. API is fully public.
+
+## Do this first
+
+**Use `http_get` directly — no browser needed for any jsDelivr task.** The data API serves CORS-open JSON. The CDN serves raw files. Both work without cookies or tokens.
+
+```python
+import json
+data = json.loads(http_get("https://data.jsdelivr.com/v1/packages/npm/react"))
+# data keys: type, name, tags, versions
+# tags keys: latest, beta, canary, next, etc.
+# versions: list of dicts with .version and .links
+latest = data['tags']['latest']   # e.g. "19.2.5"
+```
+
+| Goal | Endpoint | Latency (measured) |
+|------|----------|-------------------|
+| Package tags + version list | `v1/packages/npm/{pkg}` | ~200ms |
+| Resolve semver/tag to exact version | `v1/package/resolve/npm/{pkg}@{range}` | ~230ms |
+| Download stats (hits + bandwidth) | `v1/stats/packages/npm/{pkg}?period=month` | ~60–280ms |
+| Stats by version | `v1/stats/packages/npm/{pkg}/versions?period=month` | ~250ms |
+| Stats by file | `v1/stats/packages/npm/{pkg}@{ver}/files?period=month` | ~250ms |
+| Top packages across CDN | `v1/stats/packages?period=month&limit=N` | ~3–8s |
+| List all files in a version | `v1/package/npm/{pkg}@{ver}/flat` | ~100ms |
+| Fetch actual file | `cdn.jsdelivr.net/npm/{pkg}@{ver}/{file}` | ~80–400ms |
+| package.json metadata | `cdn.jsdelivr.net/npm/{pkg}@{ver}/package.json` | ~80ms |
+| ESM-bundled module | `cdn.jsdelivr.net/npm/{pkg}@{ver}/+esm` | ~70ms |
+
+---
+
+## Common workflows
+
+### Package metadata and latest version
+
+```python
+import json
+
+data = json.loads(http_get("https://data.jsdelivr.com/v1/packages/npm/react"))
+print(data['tags']['latest'])     # "19.2.5"
+print(data['tags'].get('beta'))   # "19.0.0-beta-..."
+print(len(data['versions']))      # total version count
+
+# Resolve semver range or tag to exact version
+resolved = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/package/resolve/npm/react@^18"
+))
+print(resolved['version'])   # "18.3.1"
+
+# Also works with: @latest, @17, @^17, @~16.0
+```
+
+### Download statistics
+
+```python
+import json
+
+stats = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/stats/packages/npm/react?period=month"
+))
+# stats keys: hits, bandwidth, links
+# hits keys: rank, typeRank, total, dates, prev
+# bandwidth keys: rank, typeRank, total, dates, prev
+
+print(stats['hits']['total'])           # e.g. 283,243,887
+print(stats['hits']['rank'])            # CDN-wide rank (all types)
+print(stats['hits']['typeRank'])        # rank among npm packages only
+print(stats['bandwidth']['total'])      # bytes served this period
+
+# dates dict: {"2026-03-19": 9144085, ...}  — one entry per day
+daily = stats['hits']['dates']
+```
+
+**Valid `period` values** (confirmed): `day` (1 date), `week` (7 dates), `month` (30 dates), `year` (365 dates).
+
+### Stats broken down by version
+
+```python
+import json
+
+versions = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/stats/packages/npm/react/versions?period=month"
+))
+# returns list sorted by hits desc
+for v in versions[:5]:
+    print(v['version'], v['hits']['total'])
+# "18.3.1"  89898312
+# "18.2.0"  84329445
+# "16.14.0" 32173878
+```
+
+### Stats broken down by file (within a version)
+
+```python
+import json
+
+files = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/stats/packages/npm/react@18.2.0/files?period=month"
+))
+for f in files[:3]:
+    print(f['name'], f['hits']['total'])
+# "/+esm"                    43924116
+# "/umd/react.production.min.js" 38476714
+```
+
+### Top packages globally
+
+```python
+import json
+
+top = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/stats/packages?period=month&limit=10"
+))
+# Each item: type, name, hits, bandwidth, prev, links
+for pkg in top:
+    print(pkg['type'], pkg['name'], pkg['hits'])
+# Includes both npm and gh (GitHub) packages mixed together
+
+# Filter to npm only:
+top_npm = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/stats/packages?period=month&limit=10&type=npm"
+))
+```
+
+Warning: this endpoint is slow (3–8s). Always specify `limit` to cap results.
+
+### List all files in a version
+
+```python
+import json
+
+# Flat list (simpler for iteration)
+listing = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/package/npm/react@18.2.0/flat"
+))
+print(listing['default'])          # "/index.min.js"  — CDN default entrypoint
+for f in listing['files']:
+    print(f['name'], f['size'])    # name, hash, time, size
+# e.g. "/cjs/react.development.js"  87574
+
+# Tree listing (nested dirs)
+tree = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/package/npm/react@18.2.0"
+))
+# tree['files'] = list of {type: "directory"|"file", name, files?, hash?, size?}
+```
+
+### Fetch files from CDN
+
+```python
+# Specific version + file
+content = http_get("https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js")
+
+# package.json for metadata (description, keywords, deps, license)
+meta = json.loads(http_get("https://cdn.jsdelivr.net/npm/lodash@latest/package.json"))
+print(meta['version'], meta['description'], meta['license'])
+
+# ESM bundle (auto-generated by jsDelivr)
+esm = http_get("https://cdn.jsdelivr.net/npm/react@18.2.0/+esm")
+
+# GitHub repository files
+bootstrap_js = http_get(
+    "https://cdn.jsdelivr.net/gh/twbs/bootstrap@v5.3.2/dist/js/bootstrap.min.js"
+)
+
+# Tag/range in CDN URL — resolved server-side
+http_get("https://cdn.jsdelivr.net/npm/react@latest/package.json")   # resolves to latest
+http_get("https://cdn.jsdelivr.net/npm/react@18/package.json")       # resolves to 18.x
+```
+
+### Parallel fetch multiple packages
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+pkgs = ['react', 'lodash', 'vue', 'axios', 'jquery']
+
+def fetch_stats(name):
+    data = json.loads(http_get(
+        f"https://data.jsdelivr.com/v1/stats/packages/npm/{name}?period=month"
+    ))
+    return name, data['hits']['total'], data['hits']['rank']
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_stats, pkgs))
+# 5 packages in ~280ms parallel vs ~1400ms sequential
+for name, total, rank in sorted(results, key=lambda x: x[1], reverse=True):
+    print(f"#{rank:4d}  {total:>15,}  {name}")
+```
+
+### GitHub packages
+
+```python
+import json
+
+# GitHub package (gh type): owner/repo
+data = json.loads(http_get("https://data.jsdelivr.com/v1/packages/gh/twbs/bootstrap"))
+# Same shape: tags (often empty {}), versions list
+
+stats = json.loads(http_get(
+    "https://data.jsdelivr.com/v1/stats/packages/gh/twbs/bootstrap?period=month"
+))
+print(stats['hits']['total'])
+
+# CDN URL for GitHub:
+http_get("https://cdn.jsdelivr.net/gh/twbs/bootstrap@v5.3.2/dist/css/bootstrap.min.css")
+```
+
+---
+
+## Gotchas
+
+- **v1/package (deprecated) vs v1/packages (current)** — The old endpoint `GET /v1/package/npm/{pkg}` still works but returns a flatter shape (`{tags, versions: ["1.0.0", ...]}` as plain strings). The new `GET /v1/packages/npm/{pkg}` returns versions as objects with `links`. Both exist. The `Link: rel="deprecation"` header flags the old one. Use `/v1/packages/` for new code.
+
+- **`/v1/package/resolve/npm/{pkg}@{range}` is the correct resolve endpoint** — `GET /v1/package/npm/react/resolved` returns HTTP 400. The working form is `/v1/package/resolve/npm/{pkg}@{tag_or_range}`. Range syntax: `@latest`, `@18`, `@^17`, `@~16.0`.
+
+- **`/flat` for files, not `/files`** — File listing lives at `/v1/package/npm/{pkg}@{ver}/flat`. The path `/v1/packages/npm/{pkg}@{ver}/files` returns HTTP 400. `/flat` returns `{default, files: [{name, hash, time, size}]}`. Without `/flat`, you get a directory tree instead.
+
+- **No rate limit headers** — Responses include no `X-RateLimit-*` headers. No published rate limit. 10+ rapid sequential requests returned no errors. CDN responses are cached (Cloudflare + Fastly, `Cache-Control: public, max-age=300`). Burst-friendly for scraping.
+
+- **Top packages endpoint is slow** — `GET /v1/stats/packages?period=month` can take 3–8s. Always add `&limit=N` (max observed working: 100). Filter by type with `&type=npm` or `&type=gh` to cut response size and time.
+
+- **`hits` vs `bandwidth` are separate rank trees** — A package can rank #117 by hits but #432 by bandwidth. Check both if you care about either metric. `prev` gives last-period totals for delta comparison.
+
+- **404 returns JSON, not HTML** — `{"status": 404, "message": "Couldn't fetch versions for {pkg}."}`. The body is gzip-encoded even on 404. Catch `urllib.error.HTTPError` and decompress the body manually if needed.
+
+- **File `time` field is synthetic** — Files in npm packages served by jsDelivr show `"time": "1985-10-26T08:15:00.000Z"` (the Back to the Future timestamp). This is a known quirk of how npm stores file mtimes. Do not use it for anything real.
+
+- **`@latest` in CDN URL resolves server-side** — `cdn.jsdelivr.net/npm/react@latest/package.json` works and resolves to the current latest tag. Same for named tags (`@beta`, `@next`) and major version shorthand (`@18`). The data API does not support this shorthand natively — use `/v1/package/resolve/npm/{pkg}@{range}` instead.
+
+- **ESM endpoint `/+esm` is auto-bundled** — `cdn.jsdelivr.net/npm/{pkg}@{ver}/+esm` returns an ESM module auto-generated by jsDelivr using Rollup + Terser. The comment at top explicitly warns against SRI hashes for this file since the content can change even for the same version. Use it for `<script type="module">` snippets, not for integrity-sensitive fetches.

--- a/domain-skills/lemmy/scraping.md
+++ b/domain-skills/lemmy/scraping.md
@@ -1,0 +1,402 @@
+# Lemmy — Data Extraction
+
+`https://lemmy.world` / `https://lemmy.ml` — federated Reddit alternative (ActivityPub). Full REST API, no auth, no JS rendering needed. **Never use a browser for read-only Lemmy tasks.**
+
+Base API path: `https://{instance}/api/v3/`
+
+## Do this first: pick your access path
+
+| Goal | Endpoint | Latency |
+|------|----------|---------|
+| Hot/trending posts (global or per community) | `post/list` | ~300ms |
+| Keyword search across posts/communities/users | `search` | ~400ms |
+| Community metadata + subscriber counts | `community` | ~200ms |
+| Comments on a post | `comment/list` | ~300ms |
+| User profile + their posts/comments | `user` | ~300ms |
+| All federated instances (10 000+) | `federated_instances` | ~400ms |
+
+---
+
+## Posts
+
+### Global hot feed
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://lemmy.world/api/v3/post/list?sort=Hot&limit=50"
+))
+# data keys: posts (list of PostView objects)
+
+for pv in data['posts']:
+    p   = pv['post']       # core post fields
+    c   = pv['community']  # which community it lives in
+    cr  = pv['creator']    # author
+    cnt = pv['counts']     # engagement metrics
+    print(p['id'], p['name'][:80])
+    print("  community:", c['actor_id'])   # e.g. https://lemmy.world/c/technology
+    print("  score:", cnt['score'], "comments:", cnt['comments'])
+    print("  ap_id:", p['ap_id'])          # canonical ActivityPub URL
+```
+
+### PostView field reference
+
+```python
+# pv['post'] — core post
+{
+    'id':          45779800,
+    'name':        'Post title here',
+    'url':         'https://...',          # linked URL (absent for text posts)
+    'body':        'Self-post text ...',   # absent for link posts
+    'ap_id':       'https://lemmy.world/post/45779800',  # canonical AP URL
+    'published':   '2026-04-18T23:31:42.738137Z',
+    'creator_id':  12345,
+    'community_id': 678,
+    'nsfw':        False,
+    'locked':      False,
+    'local':       True,   # False = post originated on another instance
+    'embed_title': '...',  # OG title of linked URL
+    'thumbnail_url': 'https://...',
+}
+
+# pv['counts']
+{
+    'score':       101,     # upvotes - downvotes
+    'upvotes':     108,
+    'downvotes':   7,
+    'comments':    9,
+    'newest_comment_time': '2026-04-18T23:55:00Z',
+}
+
+# pv['creator']
+{
+    'id':       12345,
+    'name':     'Sunflier',
+    'actor_id': 'https://lemmy.world/u/Sunflier',  # home instance URL
+    'local':    True,   # False = user registered on another instance
+    'bot_account': False,
+}
+
+# pv['community']
+{
+    'id':        2478,
+    'name':      'technology',
+    'title':     'Technology',
+    'actor_id':  'https://lemmy.world/c/technology',
+    'local':     True,
+    'instance_id': 1,
+}
+```
+
+### Sort options
+
+Valid values for `sort=` on `post/list` and `search`:
+```
+Hot  Active  Scaled  Controversial  New  Old
+TopHour  TopSixHour  TopTwelveHour  TopDay  TopWeek
+TopMonth  TopYear  TopAll  MostComments  NewComments
+```
+
+### Pagination
+
+```python
+import json
+
+# page is 1-indexed; limit max is 50 (returns error above 50)
+def iter_posts(sort="Hot", limit=50, max_pages=10):
+    for page in range(1, max_pages + 1):
+        data = json.loads(http_get(
+            f"https://lemmy.world/api/v3/post/list"
+            f"?sort={sort}&limit={limit}&page={page}"
+        ))
+        posts = data.get('posts', [])
+        if not posts:
+            break
+        yield from posts
+
+all_posts = list(iter_posts(sort="TopWeek", max_pages=5))
+```
+
+### Posts by community
+
+```python
+import json
+
+# By community name (local community on this instance)
+data = json.loads(http_get(
+    "https://lemmy.world/api/v3/post/list"
+    "?community_name=technology&sort=Hot&limit=50"
+))
+
+# By community_id (faster if you already have the ID)
+data = json.loads(http_get(
+    "https://lemmy.world/api/v3/post/list"
+    "?community_id=2478&sort=Hot&limit=50"
+))
+```
+
+---
+
+## Communities
+
+```python
+import json
+
+# Single community by name
+data = json.loads(http_get(
+    "https://lemmy.world/api/v3/community?name=technology"
+))
+cv = data['community_view']
+c  = cv['community']
+cnt = cv['counts']
+
+print(c['actor_id'])              # https://lemmy.world/c/technology
+print(cnt['subscribers'])         # total across federation
+print(cnt['subscribers_local'])   # only on this instance
+print(cnt['users_active_week'])   # weekly active users
+print(cnt['posts'], cnt['comments'])
+```
+
+### Community counts field reference
+
+```python
+{
+    'community_id':          2478,
+    'subscribers':           145000,
+    'subscribers_local':     12000,
+    'posts':                 88000,
+    'comments':              430000,
+    'users_active_day':      120,
+    'users_active_week':     680,
+    'users_active_month':    2100,
+    'users_active_half_year': 5400,
+}
+```
+
+---
+
+## Search
+
+```python
+import json
+
+# Posts
+results = json.loads(http_get(
+    "https://lemmy.world/api/v3/search"
+    "?q=linux&type_=Posts&sort=TopWeek&limit=50&page=1"
+))
+# results keys: type_, posts, comments, communities, users
+for pv in results['posts']:
+    print(pv['post']['ap_id'], pv['post']['name'][:60])
+
+# Communities
+results = json.loads(http_get(
+    "https://lemmy.world/api/v3/search"
+    "?q=linux&type_=Communities&limit=20"
+))
+for cv in results['communities']:
+    print(cv['community']['actor_id'], cv['counts']['subscribers'])
+
+# Users
+results = json.loads(http_get(
+    "https://lemmy.world/api/v3/search"
+    "?q=linux&type_=Users&limit=20"
+))
+for uv in results['users']:
+    print(uv['person']['actor_id'], uv['counts']['post_count'])
+```
+
+Valid `type_` values: `Posts`, `Comments`, `Communities`, `Users`, `All`
+
+---
+
+## Comments
+
+```python
+import json
+
+# All comments on a post — flat list with ltree path for threading
+data = json.loads(http_get(
+    "https://lemmy.world/api/v3/comment/list"
+    "?post_id=45779800&sort=Hot&limit=50"
+))
+for cv in data['comments']:
+    c   = cv['comment']
+    cnt = cv['counts']
+    cr  = cv['creator']
+    print(c['id'], c['path'])            # e.g. "0.23292774.23301445" — ltree
+    print("  content:", c['content'][:80])
+    print("  score:", cnt['score'], "children:", cnt['child_count'])
+    print("  author:", cr['actor_id'])   # home-instance URL
+```
+
+### Comment field reference
+
+```python
+# cv['comment']
+{
+    'id':          23292774,
+    'post_id':     45779800,
+    'creator_id':  99,
+    'content':     'Comment text (markdown)',
+    'path':        '0.23292774',          # ltree; parent is last segment before this id
+    'ap_id':       'https://lemmy.world/comment/23292774',
+    'published':   '2026-04-18T23:40:00Z',
+    'local':       True,
+    'removed':     False,
+    'deleted':     False,
+    'distinguished': False,
+}
+
+# cv['counts']
+{
+    'comment_id':  23292774,
+    'score':       30,
+    'upvotes':     32,
+    'downvotes':   2,
+    'child_count': 1,    # direct children only
+}
+```
+
+### Reconstruct comment tree from path
+
+```python
+# path is a dot-separated ltree: "0.parent_id.child_id.grandchild_id"
+# The last segment is the comment's own ID; second-to-last is its parent.
+def parent_id(cv):
+    parts = cv['comment']['path'].split('.')
+    return int(parts[-2]) if len(parts) >= 3 else None   # None = top-level (parent is "0")
+
+# Build a parent→children mapping
+from collections import defaultdict
+children = defaultdict(list)
+by_id = {}
+for cv in data['comments']:
+    by_id[cv['comment']['id']] = cv
+    pid = parent_id(cv)
+    children[pid].append(cv['comment']['id'])
+# children[None] = top-level comment IDs
+```
+
+---
+
+## Users
+
+```python
+import json
+
+# User profile + recent posts + comments
+data = json.loads(http_get(
+    "https://lemmy.world/api/v3/user?username=Sunflier&limit=20"
+))
+pv  = data['person_view']
+p   = pv['person']
+cnt = pv['counts']
+
+print(p['actor_id'])           # https://lemmy.world/u/Sunflier
+print(p['local'])              # False = registered on another instance
+print(cnt['post_count'], cnt['comment_count'])
+
+for post_view in data['posts']:        # their recent posts
+    print(post_view['post']['name'])
+for comment_view in data['comments']:  # their recent comments
+    print(comment_view['comment']['content'][:60])
+
+# Paginate their history
+data_p2 = json.loads(http_get(
+    "https://lemmy.world/api/v3/user?username=Sunflier&limit=20&page=2"
+))
+```
+
+---
+
+## Federated instances
+
+```python
+import json
+
+data = json.loads(http_get("https://lemmy.world/api/v3/federated_instances"))
+fi = data['federated_instances']
+# fi keys: linked, allowed, blocked
+
+print(f"linked instances: {len(fi['linked'])}")   # ~10 735
+
+# Each instance entry
+for inst in fi['linked'][:5]:
+    print(inst['domain'], inst['software'], inst['version'])
+    # software: 'lemmy', 'kbin', 'mbin', 'mastodon', etc.
+    # domain: 'lemmy.ml', 'sh.itjust.works', 'kbin.social', ...
+```
+
+### Parallel bulk collection across instances
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+instances = ['lemmy.world', 'lemmy.ml', 'sh.itjust.works', 'beehaw.org']
+
+def fetch_hot(instance):
+    try:
+        data = json.loads(http_get(
+            f"https://{instance}/api/v3/post/list?sort=Hot&limit=20"
+        ))
+        return [(pv['post']['ap_id'], pv['post']['name'], pv['counts']['score'])
+                for pv in data.get('posts', [])]
+    except Exception:
+        return []
+
+with ThreadPoolExecutor(max_workers=4) as ex:
+    results = list(ex.map(fetch_hot, instances))
+```
+
+---
+
+## Gotchas
+
+### Hard limit of 50 on post/list
+`limit > 50` returns `{"error": "couldnt_get_posts"}` — not a soft cap. Use `page=` to iterate: `page=1`, `page=2`, etc. (1-indexed). Same cap applies to `search`.
+
+### Federated community naming: `name@instance`
+When querying via `community?name=` or `post/list?community_name=` you must use `name@instance` for remote communities:
+```python
+# Local (on lemmy.world):
+"?community_name=technology"
+# Remote (on lemmy.ml):
+"?community_name=technology@lemmy.ml"
+"?name=technology@lemmy.ml"
+```
+`community['local']` is `False` and `community['actor_id']` points to the home instance (`https://lemmy.ml/c/technology`).
+
+### `ap_id` vs local `id` — use `ap_id` for stable cross-instance keys
+Numeric `id` (e.g. `45779800`) is local to the queried instance. The same post on another instance may have a completely different numeric ID. Use `ap_id` (a full URL) as the canonical unique identifier for posts, comments, and users:
+```python
+# Post: https://lemmy.world/post/45779800
+# Comment: https://lemmy.ca/comment/23292774
+# User: https://lemmy.ca/u/ech
+```
+
+### `local: False` means content originated elsewhere
+Both posts and users have a `local` boolean. `local: False` means the post/user lives on another Fediverse instance — the queried instance is caching it. The authoritative copy is at the URL in `ap_id`.
+
+### Comment `path` is ltree, not parent_id
+`comment['path']` is `"0.grandparent_id.parent_id.comment_id"`. There is no dedicated `parent_id` field. Parse the second-to-last segment for the parent ID (the root sentinel is `"0"`).
+
+### `child_count` in counts is direct children only
+`counts['child_count']` counts direct replies, not the full subtree depth. To get the full thread, paginate `comment/list` and reconstruct from `path`.
+
+### Removed/deleted posts still appear
+`post['removed']` or `post['deleted']` may be `True`. These posts show up in list results with an empty `name` and no `url`. Filter them:
+```python
+posts = [pv for pv in data['posts'] if not pv['post']['removed'] and not pv['post']['deleted']]
+```
+
+### No next-page cursor — use `page=`
+Unlike AT Protocol/Bluesky there is no cursor token. Pagination is strictly `page=N` (1-indexed). An empty `posts: []` signals exhaustion.
+
+### Instance availability varies
+Not all federated instances expose the same API version or stay online. Wrap cross-instance fetches in try/except. `fi['blocked']` lists instances this node has defederated from — those will likely fail.
+
+### `subscribers` vs `subscribers_local`
+`counts['subscribers']` is total federation-wide; `counts['subscribers_local']` is only users on the queried instance. For "community size" comparisons use `subscribers`.


### PR DESCRIPTION
## Summary
- Lemmy: limit hard-capped at 50 (returns error not truncation); ap_id is stable cross-instance key; comment path is ltree format; federated community naming uses name@instance
- BundlePhobia: bulk/scan endpoints return 404 (use ThreadPoolExecutor instead); nonexistent packages timeout 28s; hasJSModule is a path string not boolean; use gzip field not size
- Can I Use: 4.5MB JSON from GitHub raw; support codes are space-separated tokens; None in versions = future slots; vTP = Safari Tech Preview; usage_perc_y is pre-computed
- DBpedia: dbo:abstract not loaded on public endpoint; dirty numeric data from bad Wikipedia infoboxes; data.json uses lang key vs xml:lang in SPARQL; describe endpoint requires HTML form
- jsDelivr: /v1/package deprecated, use /v1/packages; resolve endpoint is /v1/package/resolve not /resolved; file timestamps are 1985-10-26 (npm quirk); top packages endpoint is slow (3-8s)

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new domain-skill guides (Lemmy, BundlePhobia, Can I Use, DBpedia, jsDelivr) with runnable examples, correct endpoints, and key pitfalls. Improves scraping reliability by documenting limits, response shapes, and error handling.

- New Features
  - Lemmy: hard cap `limit=50`, use `ap_id` as stable cross-instance key, comments use ltree `path`, federated names are `name@instance`.
  - BundlePhobia: use `/api/size` (no bulk API), nonexistent packages often time out, `hasJSModule` is a path string, prefer `gzip` over `size`, parallelize with `ThreadPoolExecutor`.
  - Can I Use: fetch ~4.5MB `data.json` from GitHub raw, support codes are space-separated tokens, `None` indicates future browser slots, `vTP` is Safari Tech Preview, use `usage_perc_y` precomputed.
  - DBpedia: public SPARQL lacks `dbo:abstract`, `data.json` uses `lang` (SPARQL JSON uses `xml:lang`), numeric infobox data can be dirty (add bounds), use Lookup API for name→URI and `owl:sameAs` for Wikidata.
  - jsDelivr: prefer `/v1/packages` (old `/v1/package` deprecated), resolver is `/v1/package/resolve/...`, file list via `/flat`, file times are `1985-10-26` (npm quirk), “top packages” endpoint is slow—always set `limit`.

<sup>Written for commit bece7dd0ac4517fdbb18fd61cc16ee1e8827480f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

