### PR TITLE
skill: surface remote browser liveUrl and tell agents to share it

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -51,12 +51,14 @@ Run this from the repo root:
 ```bash
 uv run python - <<'PY'
 from admin import start_remote_daemon
-print(start_remote_daemon("work"))
+print(start_remote_daemon("work")["liveUrl"])
 PY
 BU_NAME=work browser-harness <<'PY'
 print(page_info())
 PY
 ```
+
+**Paste the `liveUrl` to the user as soon as you get it** — it's a watch-along link so they can see the remote browser in real time. For a local daemon the 🟢 on the tab title is the equivalent: mention which tab you attached to so the user can find it.
 
 Leaving a remote daemon running bills until the session timeout.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,7 +58,7 @@ print(page_info())
 PY
 ```
 
-**Paste the `liveUrl` to the user as soon as you get it** — it's a watch-along link so they can see the remote browser in real time. For a local daemon the 🟢 on the tab title is the equivalent: mention which tab you attached to so the user can find it.
+Share the `liveUrl` with the user — it's a watch-along link.
 
 Leaving a remote daemon running bills until the session timeout.
 


### PR DESCRIPTION
## Why

When I started a remote Browser Use daemon, the user had no way to watch what it was doing — the previous `print(start_remote_daemon(\"work\"))` dumps the whole dict, so agents tend to ignore it. But the API already returns a `liveUrl` like \`https://live.browser-use.com?wss=…\` that streams the remote browser. Agents should paste that URL back to the user, same way the 🟢 tab title is the implicit \"here's where I'm working\" signal for the local flow.

## What changes

- Example snippet prints just `start_remote_daemon(\"work\")[\"liveUrl\"]` so the output is a single clickable URL.
- One sentence after the code block tells the agent to paste that URL to the user, and calls out the 🟢 tab title as the local equivalent.

No code changes — `admin.start_remote_daemon` already returns `liveUrl` in the response dict.

## Test plan

- [x] `print(start_remote_daemon(\"work\")[\"liveUrl\"])` prints a `https://live.browser-use.com?wss=…` URL that opens the live stream of the remote browser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface the remote browser `liveUrl` in SKILL.md and tell agents to share it so users can watch sessions live. The example now prints `start_remote_daemon("work")["liveUrl"]` and adds a one-line note to share the link.

<sup>Written for commit 39c1ba4929d844a109c5d1080d8a60decd57ddb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

