### PR TITLE
remote: Python API for remote browsers, profiles, and local-profile sync

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -42,27 +42,26 @@ PY
 
 ### Remote browsers
 
-Remote is optional. Use it for parallel agents, sub-agents, or deployment.
-
-If `BROWSER_USE_API_KEY` is already present in `.env` or the environment, start a remote daemon with:
-
-Run this from the repo root:
+Use remote for **parallel sub-agents** (each gets its own isolated browser via a distinct `BU_NAME`) or on a headless server. `BROWSER_USE_API_KEY` must be set. `start_remote_daemon`, `list_cloud_profiles`, `list_local_profiles`, `sync_local_profile` are pre-imported.
 
 ```bash
-uv run python - <<'PY'
-from admin import start_remote_daemon
-print(start_remote_daemon("work")["liveUrl"])
+browser-harness <<'PY'
+start_remote_daemon("work")                               # default — clean browser, no profile
+# start_remote_daemon("work", profileName="my-work")      # reuse a cloud profile (already logged in)
+# start_remote_daemon("work", profileId="<uuid>")         # same, but by UUID
+# start_remote_daemon("work", proxyCountryCode="de", timeout=120)   # DE proxy, 2-hour timeout
+# start_remote_daemon("work", proxyCountryCode=None)      # disable the Browser Use proxy
 PY
+
 BU_NAME=work browser-harness <<'PY'
+new_tab("https://example.com")
 print(page_info())
 PY
 ```
 
-Share the `liveUrl` with the user — it's a watch-along link.
+`start_remote_daemon` prints `liveUrl` and auto-opens it in the local browser (if a GUI is detected) so the user can watch along. Headless servers print only — share the URL with the user. The daemon `PATCH`es the cloud browser to `stop` on shutdown, which persists profile state. Running remote daemons bill until timeout.
 
-Leaving a remote daemon running bills until the session timeout.
-
-Parallel agents should use distinct `BU_NAME`s and can share the same `helpers.py`; shared improvements are expected, and changes should stay general enough that other agents benefit rather than break.
+Profiles (cookies-only login state) live in `interaction-skills/profile-sync.md` — covers `list_cloud_profiles()`, the chat-driven "which profile?" pattern, and `sync_local_profile()` for uploading a local Chrome profile.
 
 ## Search first
 
@@ -78,6 +77,7 @@ Only if you start struggling with a specific mechanic while navigating, look in 
 - `iframes.md`
 - `network-requests.md`
 - `print-as-pdf.md`
+- `profile-sync.md`
 - `screenshots.md`
 - `scrolling.md`
 - `shadow-dom.md`

--- a/admin.py
+++ b/admin.py
@@ -128,12 +128,120 @@ def _cdp_ws_from_url(cdp_url):
     return json.loads(urllib.request.urlopen(f"{cdp_url}/json/version", timeout=15).read())["webSocketDebuggerUrl"]
 
 
-def start_remote_daemon(name="remote", **create_kwargs):
+def _has_local_gui():
+    """True when this machine plausibly has a browser we can open. False on headless servers."""
+    import platform
+    system = platform.system()
+    if system in ("Darwin", "Windows"):
+        return True
+    if system == "Linux":
+        return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    return False
+
+
+def _show_live_url(url):
+    """Print liveUrl and auto-open it locally if there's a GUI."""
+    import sys, webbrowser
+    if not url: return
+    print(url)
+    if _has_local_gui():
+        try:
+            webbrowser.open(url, new=2)
+            print("(opened liveUrl in your default browser)", file=sys.stderr)
+            return
+        except Exception as e:
+            print(f"(couldn't auto-open: {e})", file=sys.stderr)
+    print("(no local GUI — share the liveUrl with the user)", file=sys.stderr)
+
+
+def list_cloud_profiles():
+    """List cloud profiles under the current API key.
+
+    Returns [{id, name, userId, cookieDomains, lastUsedAt}, ...]. `cookieDomains`
+    is the array of domain strings the cloud profile has cookies for — use
+    `len(cookieDomains)` as a cheap 'how much is logged in' summary. Per-cookie
+    detail on a *local* profile before sync: `profile-use inspect --profile <name>`."""
+    listing = _browser_use("/profiles?pageSize=200", "GET")
+    items = listing.get("items", listing) if isinstance(listing, dict) else listing
+    out = []
+    for p in items:
+        detail = _browser_use(f"/profiles/{p['id']}", "GET")
+        out.append({
+            "id": detail["id"],
+            "name": detail.get("name"),
+            "userId": detail.get("userId"),
+            "cookieDomains": detail.get("cookieDomains") or [],
+            "lastUsedAt": detail.get("lastUsedAt"),
+        })
+    return out
+
+
+def _resolve_profile_name(profile_name):
+    """Find a single cloud profile by exact name; raise if 0 or >1 match."""
+    matches = [p for p in list_cloud_profiles() if p.get("name") == profile_name]
+    if not matches:
+        raise RuntimeError(f"no cloud profile named {profile_name!r} -- call list_cloud_profiles() or sync_local_profile() first")
+    if len(matches) > 1:
+        raise RuntimeError(f"{len(matches)} cloud profiles named {profile_name!r} -- pass profileId=<uuid> instead")
+    return matches[0]["id"]
+
+
+def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
+    """Provision a Browser Use cloud browser and start a daemon attached to it.
+
+    kwargs forwarded to `POST /browsers` (camelCase):
+      profileId        — cloud profile UUID; start already-logged-in. Default: none (clean browser).
+      profileName      — cloud profile name; resolved client-side to profileId via list_cloud_profiles().
+      proxyCountryCode — ISO2 country code (default "us"); pass None to disable the BU proxy.
+      timeout          — minutes, 1..240.
+      customProxy      — {host, port, username, password, ignoreCertErrors}.
+      browserScreenWidth / browserScreenHeight, allowResizing, enableRecording.
+
+    Returns the full browser dict including `liveUrl`. Prints the liveUrl and
+    auto-opens it locally when a GUI is detected, so the user can watch along."""
     if daemon_alive(name):
         raise RuntimeError(f"daemon {name!r} already alive -- restart_daemon({name!r}) first")
+    if profileName:
+        if "profileId" in create_kwargs:
+            raise RuntimeError("pass profileName OR profileId, not both")
+        create_kwargs["profileId"] = _resolve_profile_name(profileName)
     browser = _browser_use("/browsers", "POST", create_kwargs)
     ensure_daemon(
         name=name,
         env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
     )
+    _show_live_url(browser.get("liveUrl"))
     return browser
+
+
+def list_local_profiles():
+    """Detected local browser profiles on this machine. Shells out to `profile-use list --json`.
+    Returns [{BrowserName, BrowserPath, ProfileName, ProfilePath, DisplayName}, ...].
+    Requires `profile-use` (see interaction-skills/profile-sync.md for install)."""
+    import json, shutil, subprocess
+    if not shutil.which("profile-use"):
+        raise RuntimeError("profile-use not installed -- curl -fsSL https://browser-use.com/profile.sh | sh")
+    return json.loads(subprocess.check_output(["profile-use", "list", "--json"], text=True))
+
+
+def sync_local_profile(profile_name, browser=None):
+    """Sync a local profile's cookies into a new cloud profile. Returns the cloud UUID.
+
+    Shells out to `profile-use sync --profile <name> [--browser <browser>]`. Every call
+    creates a *new* cloud profile (upstream limitation — see interaction-skills/profile-sync.md).
+    Requires BROWSER_USE_API_KEY and that the target local Chrome profile is closed."""
+    import os, re, shutil, subprocess, sys
+    if not shutil.which("profile-use"):
+        raise RuntimeError("profile-use not installed -- curl -fsSL https://browser-use.com/profile.sh | sh")
+    if not os.environ.get("BROWSER_USE_API_KEY"):
+        raise RuntimeError("BROWSER_USE_API_KEY missing")
+    cmd = ["profile-use", "sync", "--profile", profile_name]
+    if browser:
+        cmd += ["--browser", browser]
+    r = subprocess.run(cmd, text=True, capture_output=True)
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    m = re.search(r"Profile created:\s+([0-9a-f-]{36})", r.stdout)
+    if not m:
+        raise RuntimeError(f"profile-use did not report a profile UUID (exit {r.returncode})")
+    return m.group(1)

--- a/admin.py
+++ b/admin.py
@@ -144,14 +144,14 @@ def _show_live_url(url):
     import sys, webbrowser
     if not url: return
     print(url)
-    if _has_local_gui():
-        try:
-            webbrowser.open(url, new=2)
-            print("(opened liveUrl in your default browser)", file=sys.stderr)
-            return
-        except Exception as e:
-            print(f"(couldn't auto-open: {e})", file=sys.stderr)
-    print("(no local GUI — share the liveUrl with the user)", file=sys.stderr)
+    if not _has_local_gui():
+        print("(no local GUI — share the liveUrl with the user)", file=sys.stderr)
+        return
+    try:
+        webbrowser.open(url, new=2)
+        print("(opened liveUrl in your default browser)", file=sys.stderr)
+    except Exception as e:
+        print(f"(couldn't auto-open: {e} — share the liveUrl with the user)", file=sys.stderr)
 
 
 def list_cloud_profiles():

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -1,0 +1,81 @@
+# Profile sync
+
+Make a remote Browser Use browser start already logged in, by uploading cookies from a local Chrome profile.
+
+## One-time install
+
+```bash
+curl -fsSL https://browser-use.com/profile.sh | sh
+```
+
+Downloads `profile-use` (macOS / Linux / Windows, x64 / arm64). The Python helpers shell out to it; you don't run `profile-use` directly.
+
+## Python API (pre-imported in `browser-harness <<'PY'`)
+
+```python
+list_cloud_profiles()
+# [{id, name, userId, cookieDomains, lastUsedAt}, ...] — every profile under this API key
+
+list_local_profiles()
+# [{BrowserName, ProfileName, DisplayName, ProfilePath, ...}, ...] — detected on this machine
+
+sync_local_profile(local_profile_name, browser=None)
+# Shells out to `profile-use sync`. Returns the new cloud profile UUID.
+
+start_remote_daemon("work", profileName="my-work")   # name→id resolved client-side
+start_remote_daemon("work", profileId="<uuid>")      # or pass UUID directly
+```
+
+## Chat-driven flow (don't guess — ask the user)
+
+Cookies are real auth. Don't sync or pick a profile unilaterally.
+
+```python
+# 1. Show what's already in the cloud.
+for p in list_cloud_profiles():
+    print(f"{p['name']:25}  {len(p['cookieDomains']):3} domains  {p['id']}")
+```
+→ Agent: *"You have these cloud profiles (<N> domains each). Want to reuse one, sync a local profile, or start clean?"*
+
+```python
+# 2a. Reuse cloud → one call.
+start_remote_daemon("work", profileName="browser-use.com")
+
+# 2b. Sync local first. Show the options:
+for lp in list_local_profiles():
+    print(lp["DisplayName"])
+```
+→ Agent: *"Which local profile?"* → user picks → before syncing, inspect domain-level cookie counts with `profile-use inspect --profile <name>` (or `--verbose` for individual cookies) and report the summary; never dump 500 cookies into chat.
+
+```python
+# 3. Sync + use. Returns the new cloud UUID.
+uuid = sync_local_profile("browser-use.com")
+start_remote_daemon("work", profileId=uuid)
+```
+
+## What actually gets synced
+
+**Cookies only.** No localStorage, no IndexedDB, no extensions. Enough for session-cookie sites (Google, GitHub, Stripe, most SaaS); not for sites that store auth in localStorage.
+
+Cookies mutated during a remote session only persist on a clean `PATCH /browsers/{id} {"action":"stop"}` — the daemon does this on shutdown when `BU_BROWSER_ID` + `BROWSER_USE_API_KEY` are set (default for remote daemons). Sessions that hit the timeout lose in-session state.
+
+## Upstream limitations
+
+These need a PR to `browser-use/profile-use` — they can't be fixed inside `browser-harness`:
+
+- `profile-use sync` **always creates a new cloud profile.** No flag to update an existing one by UUID or name. Syncing the same local profile twice produces two cloud profiles — delete the old one first (UI or `DELETE /api/v3/profiles/{id}`) if you want one-to-one mapping.
+- `profile-use sync` **uploads every cookie in the local profile.** No `--domain` / `--cookie` filter. For scoped uploads, use a dedicated local Chrome profile containing only what you want synced.
+
+The Browser Use API has no cookie upload/download endpoint — `profile-use` is the only path, so both limitations live upstream.
+
+## Cloud profile CRUD
+
+- UI: https://cloud.browser-use.com/settings?tab=profiles
+- API: `GET /api/v3/profiles`, `GET/PATCH/DELETE /api/v3/profiles/{id}`. Fields: `id`, `name`, `userId`, `lastUsedAt`, `cookieDomains[]`. `list_cloud_profiles()` wraps this.
+- Name → UUID: `profileName=` on `start_remote_daemon` resolves client-side; no API change needed.
+
+## Traps
+
+- **Close the target Chrome profile before syncing.** `profile-use` reads the `Cookies` SQLite DB, which Chrome holds with an exclusive lock — `sync` hangs otherwise.
+- **Default proxy (`proxyCountryCode="us"`) blocks some destinations** with `ERR_TUNNEL_CONNECTION_FAILED` (e.g. `cloud.browser-use.com` itself). `proxyCountryCode=None` disables the BU proxy; a different country code picks a different exit.
+- **Prefer a dedicated work profile over your personal one.** Especially while testing.

--- a/run.py
+++ b/run.py
@@ -1,6 +1,13 @@
 import sys
 
-from admin import ensure_daemon
+from admin import (
+    ensure_daemon,
+    list_cloud_profiles,
+    list_local_profiles,
+    restart_daemon,
+    start_remote_daemon,
+    sync_local_profile,
+)
 from helpers import *
 
 HELP = """Browser Harness


### PR DESCRIPTION
## Why

Two UX warts in the remote flow, plus a chat-driven profile workflow:

1. `uv run python - <<'PY' from admin import start_remote_daemon … PY` was inconsistent with the global `browser-harness` invocation (requires repo cwd + project venv).
2. `liveUrl` was buried in the returned dict; users had no watch-along link.
3. No Python-callable surface for: listing cloud profiles, sync-from-local, or starting a remote browser by profile *name* (not UUID).

First pass used a new `browser-harness-remote` CLI. Scrapped — **no CLI.** Everything is now a Python function callable from any normal `browser-harness <<'PY'` block.

## What changes

**`run.py` pre-imports the new admin functions** alongside `helpers.*`, so `browser-harness <<'PY' … PY` has them in scope.

**`admin.py` — new functions:**

- `start_remote_daemon(name=\"remote\", profileName=None, **create_kwargs)` — now forwards every documented `POST /browsers` kwarg (`profileId`, `profileName`, `proxyCountryCode`, `timeout`, `customProxy`, `browserScreenWidth/Height`, ...). `profileName` is resolved client-side via `list_cloud_profiles` — no Browser Use API change needed. Prints `liveUrl` and auto-opens it in the local browser when a GUI is detected. Headless servers print only.
- `list_cloud_profiles()` — `GET /profiles` + per-profile detail; returns `[{id, name, cookieDomains, lastUsedAt, userId}, ...]`. Agents should summarize by `len(cookieDomains)`, never dump individual cookies (a profile can have 500).
- `list_local_profiles()` — shells out to `profile-use list --json`.
- `sync_local_profile(name, browser=None)` — shells out to `profile-use sync`; returns the new cloud UUID.

**`interaction-skills/profile-sync.md`** — rewritten Python-first with a concrete chat-driven flow (list → ask → sync → start) and two upstream limitations called out:

1. `profile-use sync` always creates a *new* cloud profile (no update-existing).
2. `profile-use sync` uploads every cookie (no per-domain filter).

Both can't be fixed in this repo — the Browser Use API has no cookie upload/download endpoint, so `profile-use` is the only path. A follow-up PR to `browser-use/profile-use` would add `--profile-id <uuid>` (update existing) and `--domain` / `--exclude-domain` filters.

**SKILL.md** remote-browsers section updated to lead with the parallel sub-agent use case (distinct `BU_NAME`s → isolated browsers), show the Python kwargs as commented variants of a single `start_remote_daemon(\"work\")` call, and link the profile-sync skill.

**No new entrypoint.** No argparse. No pyproject.toml change. `run.py` stays tiny (4 extra imports).

## Test plan

- [x] End-to-end: `sync_local_profile(\"browser-use.com\")` → cloud UUID `1af27f12-…` → `start_remote_daemon(\"ptest\", profileId=\"1af27f12-…\")` → remote browser landed directly in the logged-in Gmail inbox for magnus@browser-use.com. Cookies made the round trip.
- [x] Syntax + import check: every new function callable from a fresh Python.
- [x] Cleanup: both test browsers stopped via `PATCH /browsers/{id} {\"action\":\"stop\"}` (returns 200).
- [x] Documented `ERR_TUNNEL_CONNECTION_FAILED` trap for the default US proxy on certain destinations.

## Follow-up (separate PR, different repo)

`browser-use/profile-use` needs:
- `sync --profile-id <existing-cloud-uuid>` to update existing rather than always creating new.
- `sync --domain example.com` / `--exclude-domain` for scoped cookie uploads.