### PR TITLE
Add domain skills: Bandcamp, Pixelfed, PeerTube, Nominatim, Overpass

### DIFF
--- a/domain-skills/bandcamp/scraping.md
+++ b/domain-skills/bandcamp/scraping.md
@@ -1,0 +1,526 @@
+# Bandcamp — Data Extraction
+
+Field-tested against bandcamp.com on 2026-04-18.
+No authentication required for any approach documented here. All code uses `http_get` (pure HTTP, no browser) except the search approach.
+Bandcamp has no official public API but embeds rich JSON in every page's HTML data attributes.
+
+---
+
+## Approach 1 (Fastest): `data-tralbum` — Album/Track Metadata + Full Track List
+
+Every album and track page serves complete metadata in a `data-tralbum` attribute. No JS rendering needed.
+
+```python
+from helpers import http_get
+import json, re
+from html import unescape
+import ssl, urllib.request, gzip
+
+# http_get in helpers may fail with SSL on some systems; use this drop-in:
+def _get(url):
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    h = {"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip",
+         "Accept": "text/html,application/xhtml+xml,*/*"}
+    req = urllib.request.Request(url, headers=h)
+    opener = urllib.request.build_opener(urllib.request.HTTPSHandler(context=ctx))
+    with opener.open(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return data.decode("utf-8", errors="replace")
+
+def bandcamp_album(album_url):
+    """Extract full metadata from an album or track page URL."""
+    page = _get(album_url)
+
+    m = re.search(r'data-tralbum="([^"]+)"', page)
+    if not m:
+        raise ValueError("data-tralbum not found — page may have redirected to signup")
+    tralbum = json.loads(unescape(m.group(1)))
+
+    m2 = re.search(r'data-band="([^"]+)"', page)
+    band = json.loads(unescape(m2.group(1))) if m2 else {}
+
+    current = tralbum.get("current", {})
+    art_id = tralbum.get("art_id")
+
+    return {
+        # --- Identity ---
+        "item_type":    tralbum.get("item_type"),   # 'album' or 'track'
+        "id":           current.get("id"),
+        "url":          tralbum.get("url"),
+
+        # --- Metadata ---
+        "title":        current.get("title"),
+        "artist":       tralbum.get("artist"),
+        "about":        current.get("about"),       # description
+        "credits":      current.get("credits"),
+        "upc":          current.get("upc"),
+        "release_date": current.get("release_date"),
+        "publish_date": current.get("publish_date"),
+
+        # --- Pricing ---
+        "set_price":    current.get("set_price"),   # None if name-your-price
+        "minimum_price": current.get("minimum_price"),
+        "download_pref": current.get("download_pref"),
+        # download_pref: 1=free, 2=name-your-price (FREE=1, PAID=2 are the constants)
+
+        # --- Artwork ---
+        # art_id for album cover: https://f4.bcbits.com/img/a{art_id}_{size}.jpg
+        # sizes: _0 (~800px), _2 (original), _10 (700px), _16 (700px), _23 (300px)
+        "art_id":       art_id,
+        "cover_url":    f"https://f4.bcbits.com/img/a{art_id}_10.jpg" if art_id else None,
+
+        # --- Tracks ---
+        "tracks":       _parse_tracks(tralbum.get("trackinfo", [])),
+
+        # --- Physical merch (vinyl, CD, cassette) ---
+        "packages":     _parse_packages(tralbum.get("packages", [])),
+
+        # --- Band info ---
+        "band_id":      band.get("id"),
+        "band_name":    band.get("name"),
+        "band_url":     band.get("url"),
+        "band_currency": band.get("currency"),
+        "is_label":     band.get("is_label"),
+    }
+
+def _parse_tracks(trackinfo):
+    out = []
+    for t in trackinfo:
+        stream = t.get("file") or {}
+        out.append({
+            "track_num":   t.get("track_num"),
+            "title":       t.get("title"),
+            "duration":    t.get("duration"),     # seconds (float), 0.0 if not streamable
+            "artist":      t.get("artist"),        # set if different from album artist
+            "has_lyrics":  t.get("has_lyrics"),
+            "streaming":   t.get("streaming"),    # 1=can stream
+            "is_downloadable": t.get("is_downloadable"),
+            "has_free_download": t.get("has_free_download"),
+            "play_count":  t.get("play_count"),
+            "track_url":   t.get("title_link"),   # relative path, e.g. /track/song-name
+            # Stream URL — valid for ~24h (ts param is expiry Unix timestamp)
+            "stream_mp3":  stream.get("mp3-128"),
+        })
+    return out
+
+def _parse_packages(packages):
+    out = []
+    for p in packages:
+        out.append({
+            "title":       p.get("title"),
+            "price":       p.get("price"),         # float USD
+            "type_name":   p.get("type_name"),     # e.g. "Vinyl LP"
+            "edition_size": p.get("edition_size"),
+            "quantity_available": p.get("quantity_available"),
+            "quantity_sold": p.get("quantity_sold"),
+            "url":         p.get("url"),
+        })
+    return out
+
+
+# --- Example ---
+album = bandcamp_album("https://djseinfeld.bandcamp.com/album/if-this-is-it")
+# {
+#   "item_type":    "album",
+#   "id":           3797931520,
+#   "url":          "https://djseinfeld.bandcamp.com/album/if-this-is-it",
+#   "title":        "If This Is It",
+#   "artist":       "DJ Seinfeld",
+#   "about":        "With his highly accomplished third album...",
+#   "upc":          "5054429206265",
+#   "release_date": "05 Jun 2026 00:00:00 GMT",
+#   "set_price":    9.0,
+#   "minimum_price": 9.0,
+#   "download_pref": 2,
+#   "art_id":       3871310243,
+#   "cover_url":    "https://f4.bcbits.com/img/a3871310243_10.jpg",
+#   "tracks": [
+#     {"track_num": 1, "title": "U Can't Come Home (feat. TS Graye)", "duration": 196.416,
+#      "streaming": 1, "stream_mp3": "https://t4.bcbits.com/stream/..."},
+#     {"track_num": 2, "title": "Quakin'", "duration": 0.0, "stream_mp3": None},
+#     ...  # 12 total
+#   ],
+#   "packages": [
+#     {"title": "DJ Seinfeld - 'If This Is It' Clear Vinyl [ZEN319]", "price": 30.0},
+#     {"title": "DJ Seinfeld - 'If This Is It' Colour Vinyl [ZEN319N]", "price": 30.0},
+#   ],
+#   "band_id":      205707144,
+#   "band_name":    "DJ Seinfeld",
+#   "band_currency": "GBP",
+#   "is_label":     False,
+# }
+
+# Same function works for individual track pages:
+track = bandcamp_album("https://djseinfeld.bandcamp.com/track/u-cant-come-home-feat-ts-graye")
+# track["item_type"] == "track"
+# track["tracks"] has 1 entry
+```
+
+---
+
+## Approach 2: Artist Page — Band Info + Discography Listing
+
+```python
+def bandcamp_artist(artist_url):
+    """
+    Fetch artist/band info and album listing from the artist or /music page.
+    artist_url examples:
+      'https://djseinfeld.bandcamp.com/'
+      'https://djseinfeld.bandcamp.com/music'
+    """
+    page = _get(artist_url)
+
+    # Band metadata
+    m = re.search(r'data-band="([^"]+)"', page)
+    band = json.loads(unescape(m.group(1))) if m else {}
+
+    # Meta tags
+    metas = {}
+    for mm in re.finditer(r'<meta[^>]+(?:property|name)="([^"]+)"[^>]+content="([^"]*)"', page):
+        metas[mm.group(1)] = mm.group(2)
+
+    # Album/track grid items on the /music page
+    items = []
+    for li in re.finditer(
+        r'<li[^>]+class="music-grid-item[^"]*"[^>]*>(.*?)</li>', page, re.DOTALL
+    ):
+        li_html = li.group(1)
+        href_m = re.search(r'href="([^"]+)"', li_html)
+        title_m = re.search(r'class="title"[^>]*>\s*(.*?)\s*</p>', li_html, re.DOTALL)
+        img_m = re.search(r'<img src="([^"]+)"', li_html)
+        title_raw = title_m.group(1) if title_m else ""
+        # Strip HTML from title (some have <br><span> for VA releases)
+        title_clean = re.sub(r"<[^>]+>", "", title_raw).strip()
+        items.append({
+            "path":  href_m.group(1) if href_m else None,
+            "title": title_clean,
+            "art":   img_m.group(1) if img_m else None,
+        })
+
+    # Shows / upcoming events from data-blob
+    blob_m = re.search(r'data-blob="([^"]+)"', page)
+    shows = []
+    if blob_m:
+        blob = json.loads(unescape(blob_m.group(1)))
+        for s in blob.get("shows_list", []):
+            shows.append({
+                "venue": s.get("venue"),
+                "loc":   s.get("loc"),
+                "date":  s.get("date"),
+                "url":   s.get("uri"),
+            })
+
+    return {
+        "name":        band.get("name") or metas.get("og:title"),
+        "id":          band.get("id"),
+        "url":         band.get("url") or metas.get("og:url"),
+        "description": metas.get("og:description"),
+        "image":       metas.get("og:image"),      # band photo/logo
+        "currency":    band.get("currency"),
+        "genre_id":    band.get("genre_id"),
+        "is_label":    band.get("is_label"),
+        "has_merch":   band.get("merch_enabled"),
+        "discography": items,   # all public releases visible on /music
+        "shows":       shows,
+    }
+
+
+# --- Example ---
+artist = bandcamp_artist("https://djseinfeld.bandcamp.com/music")
+# {
+#   "name":   "DJ Seinfeld",
+#   "id":     205707144,
+#   "url":    "https://djseinfeld.bandcamp.com",
+#   "description": "DJ Seinfeld\nRimbaudian\nBirds Of Sweden",
+#   "image":  "https://f4.bcbits.com/img/0042812762_23.jpg",
+#   "currency": "GBP",
+#   "is_label": False,
+#   "discography": [
+#     {"path": "/album/if-this-is-it", "title": "If This Is It",
+#      "art": "https://f4.bcbits.com/img/a3871310243_2.jpg"},
+#     {"path": "/album/of-joy",        "title": "Of Joy", ...},
+#     ...  # 16 items
+#   ],
+#   "shows": [
+#     {"venue": "Fabric", "loc": "London, UK", "date": "2026-05-10", "url": "..."},
+#     ...  # 13 upcoming
+#   ]
+# }
+```
+
+---
+
+## Approach 3: Discover API — Browse by Genre/Tag (POST)
+
+`POST https://bandcamp.com/api/hub/2/dig_deeper` — internal discovery endpoint, no auth required.
+Returns 20 items per page with streaming preview URLs.
+
+```python
+import json, ssl, urllib.request, gzip
+
+def _post_json(url, payload):
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    h = {
+        "User-Agent":   "Mozilla/5.0",
+        "Content-Type": "application/json",
+        "Accept":       "application/json",
+        "Accept-Encoding": "gzip",
+        "Referer":      "https://bandcamp.com/discover",
+        "Origin":       "https://bandcamp.com",
+    }
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=body, headers=h, method="POST")
+    opener = urllib.request.build_opener(urllib.request.HTTPSHandler(context=ctx))
+    with opener.open(req, timeout=20) as r:
+        data = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            data = gzip.decompress(data)
+        return json.loads(data.decode())
+
+def bandcamp_discover(tags=None, genre_id=None, sort="pop",
+                      format_type="all", page=1):
+    """
+    Discover releases by tag or genre.
+
+    tags:       list of tag slugs, e.g. ['ambient'], ['jazz', 'vinyl']
+                Pass [] to browse by genre_id only.
+    genre_id:   int from discover page genres (10=electronic, 23=rock, 18=metal,
+                2=alternative, 14=hip-hop-rap, 11=experimental, 20=punk,
+                12=folk, 19=pop, 3=ambient). Use 0 for all.
+    sort:       'pop' (popular), 'new' (newest), 'top' (top sellers)
+    format_type: 'all', 'digital', 'vinyl', 'cd', 'cassette'
+    page:       1-based page number (20 items per page)
+    """
+    filters = {
+        "format":   format_type,
+        "location": 0,
+        "sort":     sort,
+        "tags":     tags or [],
+    }
+    if genre_id is not None:
+        filters["genre_id"] = genre_id
+
+    result = _post_json(
+        "https://bandcamp.com/api/hub/2/dig_deeper",
+        {"filters": filters, "page": page}
+    )
+    if "error" in result:
+        raise ValueError(result.get("error_message", result))
+
+    items = []
+    for item in result.get("items", []):
+        items.append({
+            "title":         item.get("title"),
+            "artist":        item.get("artist"),
+            "band_name":     item.get("band_name"),
+            "band_url":      item.get("band_url"),
+            "album_url":     item.get("tralbum_url"),
+            "genre":         item.get("genre"),
+            "art_id":        item.get("art_id"),
+            "cover_url":     f"https://f4.bcbits.com/img/a{item['art_id']}_10.jpg"
+                             if item.get("art_id") else None,
+            "item_type":     "album" if item.get("tralbum_type") == "a" else "track",
+            "tralbum_id":    item.get("tralbum_id"),
+            "is_preorder":   item.get("is_preorder"),
+            # Preview audio URL for featured track (valid ~24h)
+            "preview_mp3":   (item.get("audio_url") or {}).get("mp3-128"),
+            "featured_track": item.get("featured_track_title"),
+            # Packages price (first physical package if any)
+            "packages":      item.get("packages", []),
+        })
+
+    return {
+        "items":          items,
+        "more_available": result.get("more_available", False),
+        "page":           page,
+        "spec":           result.get("discover_spec", {}),
+    }
+
+
+# --- Examples ---
+
+# Browse ambient tag, sorted by popularity
+ambient = bandcamp_discover(tags=["ambient"], sort="pop")
+# ambient["items"][0]:
+# {
+#   "title":    "GEO - C06; 夢裡花開 (The Flower Blooms in a Dream)",
+#   "artist":   "虛擬夢想廣場",
+#   "band_name": "Geometric Lullaby",
+#   "band_url":  "https://geometriclullaby.bandcamp.com",
+#   "album_url": "https://geometriclullaby.bandcamp.com/album/geo-c06-...",
+#   "genre":     "electronic",
+#   "cover_url": "https://f4.bcbits.com/img/a4150883668_10.jpg",
+#   "item_type": "album",
+#   "preview_mp3": "https://t4.bcbits.com/stream/...",
+# }
+# ambient["more_available"] == True
+
+# Browse newest jazz vinyl
+jazz_vinyl = bandcamp_discover(tags=["jazz"], format_type="vinyl", sort="new")
+
+# Browse by genre ID (all electronic, all formats)
+electronic = bandcamp_discover(genre_id=10, sort="top", page=2)
+
+# Paginate all pages
+def discover_all_pages(tags, sort="pop", max_pages=5):
+    for page in range(1, max_pages + 1):
+        result = bandcamp_discover(tags=tags, sort=sort, page=page)
+        yield from result["items"]
+        if not result["more_available"]:
+            break
+```
+
+---
+
+## Approach 4: Text Search
+
+`https://bandcamp.com/search?q=<query>&item_type=<type>&page=<n>`
+
+Returns HTML with structured result items. 18–20 results per page. No JS required.
+
+```python
+import re
+from html import unescape as hu
+
+def bandcamp_search(query, item_type="a", page=1):
+    """
+    Search Bandcamp.
+    item_type: 'a' = albums, 't' = tracks, 'b' = bands/artists
+    Returns list of result dicts.
+    """
+    url = f"https://bandcamp.com/search?q={query.replace(' ', '+')}&item_type={item_type}&page={page}"
+    html = _get(url)
+
+    results = []
+    for li in re.finditer(
+        r'<li[^>]+class="searchresult[^"]*"[^>]*>(.*?)</li>', html, re.DOTALL
+    ):
+        item = li.group(1)
+
+        # URL: strip tracking params
+        url_m = re.search(r'class="artcont"[^>]*href="([^"?]+)', item)
+        img_m = re.search(r'<img src="([^"]+)"', item)
+        title_m = re.search(r'class="heading".*?<a[^>]*>([^<]+)', item, re.DOTALL)
+        sub_m = re.search(r'class="subhead"[^>]*>(.*?)</div>', item, re.DOTALL)
+        released_m = re.search(r'class="released"[^>]*>([^<]+)', item)
+        length_m = re.search(r'class="length"[^>]*>([^<]+)', item)
+        # Tags are in the text content of .tags div
+        tags_m = re.search(r'class="tags[^"]*"[^>]*>(.*?)</div>', item, re.DOTALL)
+        tags = re.findall(r"[\w][\w\s\-\']+", re.sub(r"tags:", "", tags_m.group(1))) \
+               if tags_m else []
+
+        results.append({
+            "url":      url_m.group(1) if url_m else None,
+            "thumb":    img_m.group(1) if img_m else None,
+            "title":    title_m.group(1).strip() if title_m else None,
+            "subhead":  re.sub(r"<[^>]+>", "", sub_m.group(1)).strip() if sub_m else None,
+            "released": released_m.group(1).strip() if released_m else None,
+            "length":   length_m.group(1).strip() if length_m else None,
+            "tags":     [t.strip() for t in tags if t.strip()],
+        })
+    return results
+
+
+# --- Examples ---
+
+# Album search
+albums = bandcamp_search("ambient soundscapes", item_type="a")
+# [
+#   {"url": "https://..../album/...", "title": "...", "subhead": "by Artist Name",
+#    "released": "released March 4, 2023", "length": "12 tracks, 47 minutes",
+#    "tags": ["ambient", "drone", "England"]},
+#   ...
+# ]
+
+# Track search
+tracks = bandcamp_search("lo-fi jazz", item_type="t", page=2)
+
+# Artist/band search
+bands = bandcamp_search("mogwai", item_type="b")
+# bands[0]["url"] → https://mogwaiband.bandcamp.com  (no tracking params)
+```
+
+---
+
+## Artwork URL Reference
+
+```
+Base CDN: https://f4.bcbits.com/img/
+
+Album/track cover (from art_id in data-tralbum):
+  https://f4.bcbits.com/img/a{art_id}_{size}.jpg
+  sizes: _0 (~800px), _2 (original/full), _10 (700px), _16 (700px), _23 (300px)
+
+Band/artist photo (from og:image or data-band):
+  https://f4.bcbits.com/img/0{padded_id}_{size}.jpg
+  (padded_id = image_id zero-padded to 10 digits)
+  Same size suffixes apply.
+
+Search result thumbnails:
+  https://f4.bcbits.com/img/a{art_id}_7.jpg  (_7 = small square, ~150px)
+```
+
+```python
+def bandcamp_cover(art_id, size=10):
+    """Get album cover URL. size: 0=~800px, 2=original, 10=700px, 16=700px, 23=300px"""
+    return f"https://f4.bcbits.com/img/a{art_id}_{size}.jpg"
+```
+
+---
+
+## Streaming Audio URLs
+
+Preview stream URLs embedded in `data-tralbum` are real `audio/mpeg` files, accessible without auth.
+
+- Format: `mp3-128` (128kbps MP3)
+- TTL: **~24 hours** — the `ts` URL param is a Unix expiry timestamp
+- Not all tracks are streamable — check `track["streaming"] == 1` and `track["stream_mp3"] is not None`
+- For a 12-track album, typically 4–6 tracks have preview streams; the rest are preview-blocked
+
+```python
+# Verify a stream URL is still valid before use
+import time, urllib.parse
+
+def stream_expires_in(stream_url):
+    """Returns seconds until the stream token expires (negative = already expired)."""
+    qs = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(stream_url).query))
+    ts = int(qs.get("ts", 0))
+    return ts - int(time.time())
+```
+
+---
+
+## Gotchas
+
+**Artist home page redirects to signup** — `https://mogwaiband.bandcamp.com/` may serve a login/signup page (HTML title: "Signup | Bandcamp") instead of the artist page. This happens when Bandcamp geo-redirects or detects bot-like requests. Workarounds:
+- Fetch `/{artist}.bandcamp.com/music` directly instead of the root URL.
+- Add `Accept-Language: en-US,en;q=0.9` header.
+- If the redirect persists, use the browser via `goto()` instead of `http_get`.
+
+**data-tralbum is on album/track pages only** — the artist home page (`/music`) does NOT have a full `data-tralbum`; it only has `{"url": "..."}`. Fetch individual album URLs from `discography` items to get track data.
+
+**Album URL 404** — Bandcamp subdomain URLs like `https://mogwaiband.bandcamp.com/album/as-the-love-continues` can return 404 if the album was removed or the slug changed. Use links scraped from `/music` or search results.
+
+**Not all tracks are streamable** — `track["duration"] == 0.0` and `track["stream_mp3"] is None` means Bandcamp has blocked streaming for that track (artist/label choice). This is normal; only some tracks per album have preview streams.
+
+**Stream URLs expire in ~24h** — The `ts` URL parameter is a Unix timestamp. URLs fetched from a page are valid for ~24 hours. Re-fetch the album page to get fresh tokens.
+
+**dig_deeper requires `page` key** — Omitting `page` returns `{"error": "missing key page"}`. The `cursor` parameter (seen in some docs) is not accepted; only integer `page` works.
+
+**dig_deeper `sort` key required** — Using `sort_agg` instead of `sort` returns an error. The correct filter key is `sort` with values `'pop'`, `'new'`, or `'top'`.
+
+**Prices in packages are in artist's local currency** — `band["currency"]` tells you the currency. The `packages[].price` float is in that currency, not always USD.
+
+**`data-tralbum` art_id vs artist image_id** — Album cover uses `a{art_id}` prefix. Band logo/photo uses zero-padded 10-digit `image_id` without the `a` prefix. Don't mix them.
+
+**Search tags are plaintext, not JSON** — Tags in search results are in the text of the `.tags` div, not a structured attribute. Parse with regex from the div content.
+
+**Search returns 18–20 results max per page** — There is no `total_results` count. Paginate by incrementing `page` until you get fewer results than expected.
+
+**No official public API** — All approaches here use undocumented internal endpoints. The dig_deeper endpoint and page data attributes have been stable for years but can change without notice.

--- a/domain-skills/nominatim/scraping.md
+++ b/domain-skills/nominatim/scraping.md
@@ -1,0 +1,337 @@
+# Nominatim — Geocoding API
+
+`https://nominatim.openstreetmap.org` — OpenStreetMap's geocoding service. Pure HTTP, no auth, no browser needed. Rate limit: **1 req/s**.
+
+> **See also**: `openstreetmap/scraping.md` for Overpass API (spatial queries, POI lookup by tag). This skill focuses exclusively on Nominatim.
+
+---
+
+## Do this first
+
+Always pass `headers={"User-Agent": "browser-harness/1.0"}`. The default `Mozilla/5.0` is blocked. Use `format=jsonv2` (not `json`) — it replaces `class` with `category` and matches the reverse geocode field naming. All calls return JSON, no parsing gymnastics needed.
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA    = {"User-Agent": "browser-harness/1.0"}
+BASE  = "https://nominatim.openstreetmap.org"
+
+def geocode(query: str, limit: int = 5) -> list[dict]:
+    """Forward geocode. Returns [] when nothing found — never raises."""
+    raw = http_get(f"{BASE}/search?q={urllib.parse.quote(query)}&format=jsonv2&limit={limit}&addressdetails=1", headers=UA)
+    return json.loads(raw)
+
+results = geocode("Times Square, NYC")
+r = results[0]
+# r['lat']          == '40.7570095'     ← STRING — always convert: float(r['lat'])
+# r['lon']          == '-73.9859724'    ← STRING
+# r['name']         == 'Times Square'
+# r['display_name'] == 'Times Square, Manhattan Community Board 5, Manhattan, New York County, New York, 10036, United States'
+# r['category']     == 'highway'        ← was 'class' in format=json
+# r['type']         == 'pedestrian'
+# r['addresstype']  == 'road'
+# r['place_rank']   == 26
+# r['importance']   == 0.599...         ← float 0–1, higher = more notable
+# r['osm_type']     == 'relation'
+# r['osm_id']       == 14942838
+# r['boundingbox']  == ['40.7558313', '40.7591362', '-73.9870666', '-73.9845108']
+#                       south_lat        north_lat    west_lon       east_lon  ← note non-obvious order
+# r['address']['city']         == 'New York'
+# r['address']['state']        == 'New York'
+# r['address']['postcode']     == '10036'
+# r['address']['country_code'] == 'us'
+```
+
+---
+
+## All four query modes
+
+### 1. Forward geocode — free-text
+
+```python
+raw = http_get(
+    f"{BASE}/search?q=Eiffel+Tower&format=jsonv2&limit=3&addressdetails=1",
+    headers=UA
+)
+results = json.loads(raw)  # [] when nothing found
+lat = float(results[0]['lat'])
+lon = float(results[0]['lon'])
+
+# Useful optional params:
+# &addressdetails=1       → adds 'address' dict to each result
+# &extratags=1            → adds 'extratags': website, wikidata, opening_hours, fee, etc.
+# &namedetails=1          → adds 'namedetails': name:en, name:de, name:fr, etc. (~40 languages)
+# &countrycodes=fr,de     → restrict to countries (ISO 3166-1 alpha-2, comma-separated)
+# &viewbox=W,S,E,N&bounded=1  → restrict to bounding box; bbox order: lon_min,lat_min,lon_max,lat_max
+# &accept-language=es     → localized name/display_name in response (also works as HTTP header)
+# &limit=N                → max results (default 10, max 50)
+```
+
+### 2. Reverse geocode — lat/lon to address
+
+```python
+raw = http_get(
+    f"{BASE}/reverse?lat=40.7580&lon=-73.9855&format=jsonv2",
+    headers=UA
+)
+result = json.loads(raw)
+# Returns a single dict (not a list)
+# result['address']['road']         == '7th Avenue'
+# result['address']['commercial']   == 'Times Square'
+# result['address']['city']         == 'New York'
+# result['address']['postcode']     == '10019'
+# result['address']['country_code'] == 'us'
+
+# address dict is always included in /reverse (no &addressdetails=1 needed)
+
+# Optional: &zoom=N  — controls granularity of the returned address
+# zoom=0  → country, zoom=5  → state, zoom=10 → city,
+# zoom=14 → suburb, zoom=16 → street, zoom=18 → building (default)
+
+# zoom=10 example (Manhattan, not 7th Ave):
+raw10 = http_get(f"{BASE}/reverse?lat=40.7580&lon=-73.9855&format=jsonv2&zoom=10", headers=UA)
+r10 = json.loads(raw10)
+# r10['name']        == 'Manhattan'
+# r10['addresstype'] == 'suburb'
+```
+
+### 3. Structured search — field-based (avoids ambiguous free-text)
+
+```python
+raw = http_get(
+    f"{BASE}/search?street=1600+Pennsylvania+Ave+NW&city=Washington&state=DC&country=US&format=jsonv2&limit=1",
+    headers=UA
+)
+result = json.loads(raw)[0]
+# result['name']         == 'White House'
+# result['place_rank']   == 30
+# result['category']     == 'office'
+# result['display_name'] == 'White House, 1600, Pennsylvania Avenue Northwest, ...'
+
+# Supported structured params:
+# street=     → house number + street name
+# city=
+# county=
+# state=
+# country=    → country name or ISO code
+# postalcode=
+# (mix and match — more fields = more precise)
+```
+
+### 4. Lookup by OSM ID — convert OSM IDs to geocoded places
+
+```python
+# Prefix: N=node, W=way, R=relation
+raw = http_get(
+    f"{BASE}/lookup?osm_ids=R175905,W5013364&format=jsonv2",
+    headers=UA
+)
+results = json.loads(raw)
+# results[0]['name']     == 'New York'    (R175905 = NYC relation)
+# results[1]['name']     == 'Tour Eiffel' (W5013364 = Eiffel Tower way)
+
+# - Up to 50 IDs per call: osm_ids=R175905,N123456,W789
+# - Nonexistent IDs are silently omitted from the response (check len)
+# - Always include &addressdetails=1 if you need the address dict
+```
+
+---
+
+## Optional params that add data to any response
+
+| Param | Effect | Notes |
+|-------|--------|-------|
+| `&addressdetails=1` | Adds `address` dict | Required for /search; always present in /reverse |
+| `&extratags=1` | Adds `extratags` dict | OSM tags: website, wikidata, opening_hours, fee, height, etc. |
+| `&namedetails=1` | Adds `namedetails` dict | All name:XX language variants (~40 for major landmarks) |
+| `&polygon_geojson=1` | Adds `geojson` field | Full boundary geometry (Polygon or MultiPolygon); can be large |
+| `&accept-language=XX` | Localizes name/display_name | ISO 639-1 code; also works as HTTP `Accept-Language` header |
+
+```python
+# Polygon boundary — useful for city/country outlines
+raw = http_get(
+    f"{BASE}/search?q=Times+Square,+NYC&format=jsonv2&limit=1&polygon_geojson=1",
+    headers=UA
+)
+r = json.loads(raw)[0]
+geo = r['geojson']
+# geo['type']        == 'MultiPolygon'
+# geo['coordinates'] == [[[[-73.987, 40.756], [-73.986, 40.757], ...]]] ← [lon, lat] GeoJSON order
+
+# English name for any place
+raw = http_get(
+    f"{BASE}/search?q=Eiffel+Tower&format=jsonv2&limit=1&namedetails=1",
+    headers=UA
+)
+r = json.loads(raw)[0]
+en_name = r['namedetails'].get('name:en', r['name'])
+# en_name == 'Eiffel Tower'  (r['name'] would be 'Tour Eiffel' — local language)
+```
+
+---
+
+## Response field reference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `place_id` | int | Internal Nominatim ID — ephemeral, do NOT store long-term |
+| `osm_type` | str | `"node"`, `"way"`, or `"relation"` |
+| `osm_id` | int | Stable OSM element ID — use `osm_type/osm_id` as a stable key |
+| `lat` | **str** | Always a string — convert with `float(r['lat'])` |
+| `lon` | **str** | Always a string — convert with `float(r['lon'])` |
+| `display_name` | str | Full comma-separated address string |
+| `name` | str | Short local-language name (`'Tour Eiffel'`, not `'Eiffel Tower'`) |
+| `category` | str | OSM key: `"highway"`, `"boundary"`, `"amenity"`, `"office"`, etc. (`jsonv2` only; `"class"` in `format=json`) |
+| `type` | str | OSM tag value: `"pedestrian"`, `"administrative"`, `"restaurant"`, etc. |
+| `addresstype` | str | Semantic category: `"city"`, `"road"`, `"suburb"`, `"office"`, etc. |
+| `place_rank` | int | Hierarchy: 4=country, 8=state, 12-16=city, 19=suburb, 26=street, 30=POI/building |
+| `importance` | float | 0–1 relevance score (Wikipedia-derived); higher = more globally notable |
+| `boundingbox` | list[str] | `[south_lat, north_lat, west_lon, east_lon]` — all strings; note unusual order |
+| `licence` | str | ODbL attribution — include in any user-facing output |
+
+**`place_rank` reference (confirmed 2026-04-18)**:
+
+| place_rank | addresstype | Example |
+|---|---|---|
+| 4 | country | United States |
+| 8 | state | California |
+| 16 | city | Los Angeles |
+| 19 | suburb | Hollywood |
+| 26 | road | Times Square (as street) |
+| 30 | any POI | White House, restaurant, park |
+
+---
+
+## Batch geocoding pattern (rate-limit safe)
+
+```python
+import json, time, urllib.parse
+from helpers import http_get
+
+UA   = {"User-Agent": "browser-harness/1.0"}
+BASE = "https://nominatim.openstreetmap.org"
+
+def geocode_one(query: str) -> dict | None:
+    raw = http_get(
+        f"{BASE}/search?q={urllib.parse.quote(query)}&format=jsonv2&limit=1&addressdetails=1",
+        headers=UA
+    )
+    results = json.loads(raw)
+    return results[0] if results else None
+
+places = [
+    "Eiffel Tower, Paris",
+    "Big Ben, London",
+    "Colosseum, Rome",
+    "Sagrada Familia, Barcelona",
+]
+
+geocoded = []
+for place in places:
+    result = geocode_one(place)
+    if result:
+        geocoded.append({
+            "query": place,
+            "lat": float(result['lat']),
+            "lon": float(result['lon']),
+            "name": result['name'],
+            "country": result['address'].get('country'),
+        })
+    time.sleep(1)  # REQUIRED: 1 req/s limit
+
+# geocoded[0] == {'query': 'Eiffel Tower, Paris', 'lat': 48.8582..., 'lon': 2.2945...,
+#                  'name': 'Tour Eiffel', 'country': 'France'}
+```
+
+---
+
+## Complete working example
+
+```python
+import json, time, urllib.parse
+from helpers import http_get
+
+UA   = {"User-Agent": "browser-harness/1.0"}
+BASE = "https://nominatim.openstreetmap.org"
+
+# 1. Forward geocode
+raw = http_get(
+    f"{BASE}/search?q=White+House,+Washington+DC&format=jsonv2&limit=1&addressdetails=1&extratags=1",
+    headers=UA
+)
+place = json.loads(raw)[0]
+lat, lon = float(place['lat']), float(place['lon'])
+print(f"{place['name']}: ({lat:.4f}, {lon:.4f})")
+# White House: (38.8976, -77.0366)
+print(f"OSM ref: {place['osm_type']}/{place['osm_id']}")
+# OSM ref: relation/19761182
+print(f"Website: {place['extratags'].get('website', 'n/a')}")
+# Website: https://www.whitehouse.gov
+
+time.sleep(1)  # enforce rate limit between calls
+
+# 2. Reverse geocode with zoom
+raw = http_get(f"{BASE}/reverse?lat={lat}&lon={lon}&format=jsonv2&zoom=10", headers=UA)
+city_result = json.loads(raw)
+print(f"City level: {city_result['display_name']}")
+# City level: Washington, District of Columbia, United States
+
+time.sleep(1)
+
+# 3. Lookup by OSM ID with English name
+raw = http_get(
+    f"{BASE}/lookup?osm_ids=R175905&format=jsonv2&namedetails=1&addressdetails=1",
+    headers=UA
+)
+nyc = json.loads(raw)[0]
+print(f"NYC local: {nyc['name']} | English: {nyc['namedetails'].get('name:en', nyc['name'])}")
+# NYC local: New York | English: New York
+print(f"Bounding box: S={nyc['boundingbox'][0]}, N={nyc['boundingbox'][1]}, W={nyc['boundingbox'][2]}, E={nyc['boundingbox'][3]}")
+# Bounding box: S=40.4765780, N=40.9176300, W=-74.2588430, E=-73.7002330
+
+time.sleep(1)
+
+# 4. Structured search with polygon
+raw = http_get(
+    f"{BASE}/search?city=Paris&country=France&format=jsonv2&limit=1&polygon_geojson=1",
+    headers=UA
+)
+paris = json.loads(raw)[0]
+bb = paris['boundingbox']
+# IMPORTANT: Nominatim boundingbox order: [south, north, west, east]
+# Overpass bbox needs: (south, west, north, east) — requires reordering
+overpass_bbox = f"{bb[0]},{bb[2]},{bb[1]},{bb[3]}"  # south,west,north,east
+print(f"Paris Overpass bbox: {overpass_bbox}")
+# Paris Overpass bbox: 48.8155755,2.2241220,48.9021560,2.4697602
+```
+
+---
+
+## Gotchas
+
+**`python-requests` User-Agent returns HTTP 403.** Nominatim blocks `python-requests/*`, `Wget/*`, and any other generic library UA. `Mozilla/5.0` is also blocked by the stricter public instance. `browser-harness/1.0` (or any descriptive app-style string) returns 200. Confirmed: `python-requests/2.31.0` → 403; `browser-harness/1.0` → 200.
+
+**`lat`/`lon` are strings, not floats.** Every Nominatim response returns coordinates as strings: `"40.7570095"`. Always convert: `float(r['lat'])`. Contrast with Overpass, where `lat`/`lon` are native Python floats.
+
+**`/reverse` at open ocean/Null Island returns `{"error": "Unable to geocode"}`.** This is the only case where `/reverse` returns an error dict instead of a result. Check for `"error"` key before accessing other fields. For coordinates over land, `/reverse` always returns the nearest feature — it never returns `[]`.
+
+**`/search` returns `[]` on no match, `/reverse` returns `{"error": ...}` on failure.** They have different empty-case shapes. Guard both: `results = json.loads(raw); if not results: ...` for search; `if 'error' in json.loads(raw): ...` for reverse.
+
+**`boundingbox` order is `[south, north, west, east]` — not `[west, south, east, north]`.** This is unique to Nominatim and differs from both GeoJSON (`[west, south, east, north]`) and Overpass (`south, west, north, east`). When converting to Overpass: `f"({bb[0]},{bb[2]},{bb[1]},{bb[3]})"` (south, west, north, east).
+
+**`format=json` uses `class`, `format=jsonv2` uses `category`.** Prefer `jsonv2` — it matches the `/reverse` field naming and is the documented stable format. The `openstreetmap/scraping.md` examples use `format=json`; this skill uses `format=jsonv2` throughout.
+
+**`name` field is always the local-language name.** For the Eiffel Tower, `name == 'Tour Eiffel'`, not `'Eiffel Tower'`. Use `&namedetails=1` and access `namedetails.get('name:en', name)` to reliably get the English name.
+
+**`place_id` is ephemeral.** Do not store `place_id` for future lookups. Use `osm_type + osm_id` as a stable reference (e.g., `relation/175905` for New York City). Even `osm_id` can theoretically change if the OSM geometry is remapped, but it's far more stable than `place_id`.
+
+**Structured search (`?street=&city=`) is pickier than free-text.** `?street=1600+Pennsylvania+Ave&city=Washington&country=US` returns multiple PA-Ave matches across the US. Add `&state=DC` to narrow to Washington DC. Free-text `?q=1600+Pennsylvania+Ave+NW,+Washington+DC` often resolves better for well-known addresses.
+
+**Rate limit is 1 req/s — enforce it with `time.sleep(1)`.** The public instance does not return HTTP 429; it returns 403 or silently drops requests when overloaded. Rapid bursts of 3–5 requests may succeed, but sustained scraping without sleep will trigger a ban. For bulk geocoding use `time.sleep(1)` between every call — no exceptions.
+
+**`&polygon_geojson=1` geometry can be large.** A country boundary polygon for the US or France can be thousands of coordinate pairs and hundreds of KB. Only request it when you actually need the outline. For just the bounding box, use `boundingbox`.
+
+**Lookup endpoint silently drops invalid OSM IDs.** `?osm_ids=R175905,N999999999999` returns only one result (the valid one). Always check `len(results)` matches the number of IDs you sent.
+
+**`&accept-language=XX` localizes both `name` and `display_name`.** Passing `&accept-language=de` returns `'Eiffelturm'` and a fully German display name. This works as either a query param or an HTTP header. When scraping multilingual data, omit this param to get the native OSM name.

--- a/domain-skills/overpass/scraping.md
+++ b/domain-skills/overpass/scraping.md
@@ -1,0 +1,363 @@
+# Overpass API — OSM Spatial Query Engine
+
+`https://overpass-api.de` — read-only query engine over the full OpenStreetMap planet. No auth required, fully public. **Never use the browser — everything is a direct HTTP call.**
+
+Two public endpoints (use FR mirror when main is slow):
+- **Main**: `https://overpass-api.de/api/interpreter`
+- **FR mirror**: `https://overpass.openstreetmap.fr/api/interpreter` — usually more responsive
+
+**Do not use `http_get` without overriding `User-Agent`** — its default `Mozilla/5.0` is blocked with HTTP 403. Pass `headers={"User-Agent": "browser-harness/1.0"}` on every call.
+
+---
+
+## Fastest path: POST a QL query, get JSON
+
+```python
+import json, urllib.parse, urllib.request, gzip
+from helpers import http_get  # http_get is GET-only; use urllib for POST
+
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_post(query: str) -> list[dict]:
+    """POST an Overpass QL query. Returns elements list. Raises on HTML error."""
+    data = urllib.parse.urlencode({"data": query}).encode()
+    req = urllib.request.Request(
+        OVERPASS, data=data, method="POST",
+        headers={
+            "User-Agent": "browser-harness/1.0",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept-Encoding": "gzip",
+        }
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        body = r.read()
+        if r.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+    body = body.decode()
+    if not body.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML): {body[:300]}")
+    return json.loads(body)["elements"]
+
+# Cafes in lower Manhattan bbox (south_lat, west_lon, north_lat, east_lon)
+cafes = overpass_post(
+    '[out:json][timeout:25]; node["amenity"="cafe"](40.70,-74.02,40.73,-73.97); out body 10;'
+)
+# cafes[0] == {'type': 'node', 'id': ..., 'lat': 40.7033, 'lon': -74.0141, 'tags': {'amenity': 'cafe', 'name': 'Starbucks', ...}}
+for c in cafes:
+    print(c["tags"].get("name", "?"), c["lat"], c["lon"])
+# Starbucks      40.7033 -74.0141
+# 9th St Espresso 40.7251 -73.9778
+# Think Coffee   40.7254 -73.9924
+```
+
+---
+
+## GET form (simpler, subject to URL length limits)
+
+Use `http_get` when the query is short enough. For complex multi-statement QL, use POST.
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+UA = {"User-Agent": "browser-harness/1.0"}
+OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+
+def overpass_get(query: str) -> list[dict]:
+    url = f"{OVERPASS}?data={urllib.parse.quote(query)}"
+    raw = http_get(url, headers=UA)
+    if not raw.startswith("{"):
+        raise RuntimeError(f"Overpass error (HTML): {raw[:200]}")
+    return json.loads(raw)["elements"]
+
+# Same query via GET — confirmed working 2026-04-19
+cafes = overpass_get('[out:json][timeout:25]; node["amenity"="cafe"](40.728,-73.990,40.730,-73.988); out body 5;')
+# cafes[0] == {'type': 'node', 'id': ..., 'lat': 40.7298, 'lon': -73.9895, 'tags': {'name': 'The Bean', ...}}
+```
+
+---
+
+## Example queries (all confirmed 2026-04-19)
+
+### Bbox search — cafes, ATMs, restaurants
+
+```python
+# ATMs in Manhattan
+atms = overpass_post(
+    '[out:json][timeout:25]; node["amenity"="atm"](40.70,-74.02,40.80,-73.93); out body 10;'
+)
+# atms[0]['tags'].get('operator') == 'Bank of America'
+
+# Restaurants within 300m radius of Times Square (around filter)
+rests = overpass_post(
+    '[out:json][timeout:25]; node["amenity"="restaurant"](around:300,40.7580,-73.9855); out body 10;'
+)
+# rests[0]['tags'] == {'name': 'Hard Rock Cafe', 'cuisine': 'american', ...}
+
+# Multiple AND filters: cafes with outdoor seating
+cafes = overpass_post(
+    '[out:json][timeout:25]; node["amenity"="cafe"]["outdoor_seating"="yes"](40.70,-74.02,40.73,-73.97); out body 10;'
+)
+# cafes[0]['tags']['outdoor_seating'] == 'yes'
+```
+
+### Count query — how many results exist
+
+```python
+# Count pharmacies in London bbox (no element data returned)
+r = overpass_post(
+    '[out:json][timeout:25]; node["amenity"="pharmacy"](51.45,-0.15,51.55,0.0); out count;'
+)
+# r is a list with one element: {'type': 'count', 'id': 0, 'tags': {'nodes': '169', 'ways': '0', 'relations': '0', 'total': '169'}}
+count = int(r[0]["tags"]["total"])  # 169
+```
+
+### Regex and case-insensitive filters
+
+```python
+# Regex match on tag value — any cafe OR coffee amenity
+r = overpass_post(
+    '[out:json][timeout:25]; node["amenity"~"cafe|coffee"](40.72,-73.99,40.73,-73.98); out body 5;'
+)
+
+# Case-insensitive name search — anything containing "star"
+r = overpass_post(
+    '[out:json][timeout:25]; node["name"~"star",i](40.75,-73.99,40.76,-73.97); out body 5;'
+)
+# r[0]['tags']['name'] == 'Starbucks'
+```
+
+### Key existence and negation
+
+```python
+# Nodes that have a phone tag (any value)
+r = overpass_post(
+    '[out:json][timeout:25]; node["phone"](48.860,2.300,48.862,2.310); out body 5;'
+)
+# r[0]['tags']['phone'] == '+33 1 45 51 56 74'
+
+# Cafes WITHOUT a name tag
+r = overpass_post(
+    '[out:json][timeout:25]; node["amenity"="cafe"][!"name"](48.855,2.295,48.862,2.310); out body 5;'
+)
+# r[0]['tags'] == {'amenity': 'cafe', 'indoor_seating': 'yes', 'outdoor_seating': 'yes'}
+```
+
+### Node + way union with center coordinates
+
+```python
+# Banks as both nodes AND ways — get lat/lon for both via "out center"
+r = overpass_post(
+    '[out:json][timeout:25]; '
+    '(node["amenity"="bank"](40.725,-73.995,40.735,-73.985);'
+    ' way["amenity"="bank"](40.725,-73.995,40.735,-73.985););'
+    'out center 10;'
+)
+for el in r:
+    if el["type"] == "node":
+        lat, lon = el["lat"], el["lon"]
+    else:  # way — has 'center' dict, not top-level lat/lon
+        lat, lon = el["center"]["lat"], el["center"]["lon"]
+    print(el["tags"].get("name", "?"), lat, lon)
+# Citizens Bank  40.7292 -73.9875
+# Citibank       40.7304 -73.9928
+```
+
+### nwr shorthand (node + way + relation in one statement)
+
+```python
+# Any element type matching the filter — use when you don't know if data is stored as node, way, or relation
+r = overpass_post(
+    '[out:json][timeout:25]; nwr["amenity"="cafe"](40.728,-73.990,40.730,-73.988); out center 5;'
+)
+# Bryant Park stored as a way — nwr finds it where node[] would miss it:
+r = overpass_post(
+    '[out:json][timeout:25]; nwr["name"="Bryant Park"](40.750,-73.990,40.755,-73.982); out center 3;'
+)
+# r[0] == {'type': 'way', 'id': 22727025, 'center': {'lat': 40.7536, 'lon': 40.7536}, 'tags': {'name': 'Bryant Park', ...}}
+```
+
+### Way with full polygon geometry
+
+```python
+# out geom returns the full node list with lat/lon for each (for ways)
+r = overpass_post(
+    '[out:json][timeout:25]; way["amenity"="cafe"](48.855,2.295,48.870,2.320); out geom 2;'
+)
+el = r[0]
+# el keys: ['type', 'id', 'bounds', 'nodes', 'geometry', 'tags']
+# el['geometry'] == [{'lat': 48.8659, 'lon': 2.3154}, {'lat': 48.8659, 'lon': 2.3152}, ...]
+# el['bounds']   == {'minlat': 48.8659, 'minlon': 2.3152, 'maxlat': 48.8661, 'maxlon': 2.3154}
+centroid_lat = sum(g["lat"] for g in el["geometry"]) / len(el["geometry"])
+```
+
+### Relations (routes, boundaries)
+
+```python
+# NYC subway route relations
+r = overpass_post(
+    '[out:json][timeout:25]; relation["type"="route"]["route"="subway"](40.73,-74.00,40.75,-73.97); out body 5;'
+)
+# r[0] == {'type': 'relation', 'id': ..., 'members': [...], 'tags': {'name': 'NYCS - 1 Train: ...', 'ref': '1', ...}}
+# members list: [{'type': 'way', 'ref': 12345, 'role': ''}, ...]  — no geometry unless out geom used
+```
+
+---
+
+## Response structure
+
+```python
+# Full response from overpass_post(query_raw) before slicing ["elements"]:
+{
+    "version": 0.6,
+    "generator": "Overpass API 0.7.62.7 375dc00a",
+    "osm3s": {
+        "timestamp_osm_base": "2026-04-19T01:26:37Z",
+        "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+    },
+    "elements": [...]  # ← this is what overpass_post() returns
+}
+
+# Node element (out body):
+{"type": "node", "id": 308684349, "lat": 48.8609068, "lon": 2.3015143,
+ "tags": {"amenity": "cafe", "name": "Café de l'Alma", "phone": "+33 1 45 51 56 74"}}
+
+# Way element (out center):
+{"type": "way", "id": 338411946,
+ "center": {"lat": 48.8660087, "lon": 2.3153233},
+ "nodes": [3454913623, ...],   # node IDs forming the polygon
+ "tags": {"amenity": "cafe", "name": "Café 1902"}}
+
+# Way element (out geom): adds 'geometry' and 'bounds', no separate node fetching needed
+{"type": "way", ..., "bounds": {"minlat": ..., "minlon": ..., "maxlat": ..., "maxlon": ...},
+ "geometry": [{"lat": 48.8659, "lon": 2.3154}, ...]}
+
+# Relation element (out body):
+{"type": "relation", "id": 123,
+ "members": [{"type": "way", "ref": 456, "role": "outer"}, ...],
+ "tags": {"type": "route", "route": "subway", "name": "..."}}
+
+# out meta adds: version, timestamp, changeset, user, uid
+{"type": "node", ..., "version": 7, "timestamp": "2025-08-04T18:29:16Z", "user": "osm_user1234", ...}
+
+# out tags (no geometry at all — fastest for tag-only operations):
+{"type": "node", "id": 308684349, "tags": {...}}
+
+# out count:
+{"type": "count", "id": 0, "tags": {"nodes": "169", "ways": "0", "relations": "0", "total": "169"}}
+```
+
+---
+
+## QL syntax reference
+
+```
+[out:json][timeout:25]           # Required header: JSON output, 25s server timeout
+[out:xml][timeout:25]            # XML output (starts with <?xml ...) — not JSON parseable
+[maxsize:52428800]               # Optional: 50MB result cap (default: server decides)
+
+# Filters (all combinable):
+node["amenity"="cafe"](bbox);           # exact tag match
+node["amenity"~"cafe|restaurant"](bbox); # regex match on value
+node["name"~"Star",i](bbox);            # case-insensitive regex
+node["phone"](bbox);                    # key exists (any value)
+node[!"name"](bbox);                    # key does NOT exist
+node["amenity"="cafe"]["wifi"="yes"](bbox); # AND: multiple filters
+
+# Spatial filters:
+(south_lat, west_lon, north_lat, east_lon)   # bbox — latitude FIRST
+(around:RADIUS_METERS, LAT, LON)             # radius — lat before lon
+# Note: bbox order differs from GeoJSON [west, south, east, north]
+
+# Element types:
+node[...](filter);    # point elements
+way[...](filter);     # polygons/lines — no direct lat/lon; use out center or out geom
+relation[...](filter); # groups of elements (routes, boundaries)
+nwr[...](filter);      # shorthand: node + way + relation
+
+# Union (combine multiple type queries):
+(node["amenity"="cafe"](bbox); way["amenity"="cafe"](bbox););out center 20;
+
+# Output modifiers:
+out body N;    # type + id + lat/lon (nodes) + tags, limit N results
+out tags N;    # type + id + tags only (no geometry — fastest)
+out center N;  # for ways/relations: adds 'center' dict {lat, lon} — most useful
+out geom N;    # for ways: adds 'geometry' list [{lat,lon},...] and 'bounds' — full polygon
+out meta N;    # adds version, timestamp, user, uid, changeset to each element
+out count;     # returns count summary only, no element data
+```
+
+---
+
+## Rate limits and status check
+
+```python
+import urllib.request, gzip
+from helpers import http_get
+
+# Check quota remaining before heavy queries
+raw = http_get("https://overpass-api.de/api/status", headers={"User-Agent": "browser-harness/1.0"})
+print(raw)
+# Connected as: 1657779650
+# Current time: 2026-04-19T01:24:58Z
+# Announced endpoint: gall.openstreetmap.de/
+# Rate limit: 2
+# 2 slots available now.
+# Currently running queries (pid, space limit, time limit, start time):
+```
+
+Rate model: **2 concurrent query slots per IP**, not 2/s. Sequential queries run immediately. A 3rd simultaneous query returns an HTML error page (HTTP 200 with HTML body).
+
+```python
+import time
+
+def overpass_post_with_retry(query: str, max_retries: int = 3) -> list[dict]:
+    import json, urllib.parse, urllib.request, gzip
+    OVERPASS = "https://overpass.openstreetmap.fr/api/interpreter"
+    for attempt in range(max_retries):
+        data = urllib.parse.urlencode({"data": query}).encode()
+        req = urllib.request.Request(
+            OVERPASS, data=data, method="POST",
+            headers={"User-Agent": "browser-harness/1.0",
+                     "Content-Type": "application/x-www-form-urlencoded",
+                     "Accept-Encoding": "gzip"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as r:
+            body = r.read()
+            if r.headers.get("Content-Encoding") == "gzip":
+                body = gzip.decompress(body)
+        body = body.decode()
+        if body.startswith("{"):
+            return json.loads(body)["elements"]
+        if "rate_limited" in body or "too busy" in body or "timeout" in body.lower():
+            time.sleep(2 ** attempt * 10)  # 10s, 20s, 40s
+            continue
+        raise RuntimeError(f"Overpass error: {body[:200]}")
+    raise RuntimeError("Overpass: exceeded max retries")
+```
+
+---
+
+## Gotchas
+
+**`http_get` default UA (`Mozilla/5.0`) is blocked.** Both main and FR instances return HTTP 403. Always pass `headers={"User-Agent": "browser-harness/1.0"}`. Confirmed: `browser-harness/1.0` → 200.
+
+**Error responses are HTML with HTTP 200.** Rate-limit and busy errors return `Content-Type: text/html` with HTTP status 200 — not 4xx/5xx. Always check `body.startswith("{")` before JSON parsing.
+
+**bbox order is `(south, west, north, east)` — latitude first.** This is the opposite of GeoJSON `[west, south, east, north]`. The `around:` filter uses `(around:METERS, LAT, LON)` — lat before lon. Nominatim `boundingbox` field is `[south, north, west, east]` — different again; reorder to feed into Overpass: `f"({bb[0]},{bb[2]},{bb[1]},{bb[3]})"`.
+
+**`out body` on ways gives NO lat/lon** — ways are polygons with node ID lists, not points. Use `out center` to get a centroid `{"lat": ..., "lon": ...}` dict, or `out geom` for the full polygon vertex list. `out body 10` on a way-only query will return elements with no `lat`/`lon` keys — always check `el.get("lat")` before using.
+
+**`out N` limits total results.** Without a limit, large bboxes can return tens of thousands of elements and hit the 512MB memory cap, returning a `maxsize` error (HTML). Default safe limit: `out 50` for exploration, `out 500` for bulk. Omitting the number entirely means unlimited — avoid on wide queries.
+
+**`nwr` is the correct shorthand, not `(node; way; relation;)`.** Use `nwr["amenity"="park"](bbox)` when you don't know if OSM stores the feature as a node, way, or relation. Many parks, buildings, and named places are ways or relations, not nodes.
+
+**Area queries by name are unreliable in plain QL.** `area["name"="Berlin"]` often returns 0 results due to how Overpass caches area derivations. Prefer bbox or `around:` filters. For area-based queries, use the numeric area ID: `area(3600062422)` (relation ID + 3,600,000,000 for relations).
+
+**Relation `members` have no geometry with `out body`.** Relation elements list member refs (`{'type': 'way', 'ref': 12345, 'role': 'outer'}`). To get actual geometry for relation members, use `out geom` — but this significantly increases response size and query time.
+
+**`http_get` POST workaround.** `helpers.http_get` only supports GET. For complex queries that exceed URL length limits (roughly 2000 chars encoded), use `urllib.request.Request` with `method="POST"` as shown in the `overpass_post()` function above.
+
+**`name` tag is the local-language name.** In Paris, `name` is French; in Tokyo, Japanese. For English names use `name:en` — but that tag is often absent. Never assume `name` is in English.
+
+**Sequential calls are fine; concurrent calls are limited.** Run multiple queries in a loop with no sleep between them — they run sequentially and each completes before the next starts. Only concurrent (threaded/async) calls consume multiple slots.

--- a/domain-skills/peertube/scraping.md
+++ b/domain-skills/peertube/scraping.md
@@ -1,0 +1,447 @@
+# PeerTube — Scraping & Data Extraction
+
+`https://sepiasearch.org` / `https://framatube.org` / `https://peertube.tv` — federated open-source video platform (ActivityPub). **Never use the browser.** All data is reachable via `http_get`. No API key required for read operations.
+
+Federation model: thousands of independent instances run the same software and share/mirror content. SepiaSearch indexes the public federation; individual instances expose the same REST API.
+
+## Do this first: pick your access path
+
+| Goal | Endpoint |
+|------|----------|
+| Cross-instance search | `https://sepiasearch.org/api/v1/search/videos?search=…` |
+| Instance trending/recent | `https://{instance}/api/v1/videos?sort=-trending` |
+| Video detail + streaming URLs | `https://{instance}/api/v1/videos/{uuid}` |
+| Channel search (federated) | `https://sepiasearch.org/api/v1/search/video-channels?search=…` |
+| Channel's video list | `https://{instance}/api/v1/video-channels/{handle}/videos` |
+| Comments on a video | `https://{instance}/api/v1/videos/{uuid}/comment-threads` |
+| Captions/subtitles | `https://{instance}/api/v1/videos/{uuid}/captions` |
+| Instance metadata | `https://{instance}/api/v1/config` |
+
+Use **SepiaSearch** when you don't know which instance hosts the content. Use a **specific instance** when you want trending/recent videos from that community, or when you already have a UUID.
+
+---
+
+## SepiaSearch — cross-instance video search
+
+```python
+import json
+from helpers import http_get
+
+# Search across all federated instances
+resp = json.loads(http_get(
+    "https://sepiasearch.org/api/v1/search/videos"
+    "?search=linux&count=20&start=0&sort=-views"
+))
+print("total:", resp["total"])   # up to 10000 capped
+
+for v in resp["data"]:
+    print(v["uuid"], v["name"][:60])
+    print("  host:", v["account"]["host"])       # originating instance
+    print("  views:", v["views"], "duration:", v["duration"])
+    print("  url:", v["url"])                    # canonical watch URL
+# Confirmed output (2026-04-18):
+# da5463ca-... Installing Linux Doesn't Need to Change. The Experience Does.
+#   host: spectra.video
+#   views: 880 duration: 639
+#   url: https://spectra.video/videos/watch/da5463ca-fbc7-4311-948a-356594d5c70a
+```
+
+### SepiaSearch video object fields
+
+```python
+{
+    "id":          167978,                    # numeric ID on host instance
+    "uuid":        "da5463ca-...",            # stable global identifier
+    "shortUUID":   "abc123",                  # short alias for watch URLs
+    "name":        "Installing Linux...",
+    "duration":    639,                       # seconds
+    "views":       880,
+    "viewers":     0,                         # current live viewers
+    "likes":       5,
+    "dislikes":    0,
+    "comments":    2,
+    "publishedAt": "2024-12-15T10:00:00.000Z",
+    "isLive":      False,
+    "nsfw":        False,
+    "thumbnailUrl": "https://spectra.video/lazy-static/thumbnails/da5463ca-....jpg",
+    "embedUrl":    "https://spectra.video/videos/embed/da5463ca-...",
+    "url":         "https://spectra.video/videos/watch/da5463ca-...",
+    "isLocal":     False,                     # False = federated (lives on another instance)
+    "tags":        ["linux", "open-source"],
+    "category":    {"id": 15, "label": "Science & Technology"},
+    "language":    {"id": "en", "label": "English"},
+    "licence":     {"id": 1, "label": "Attribution"},
+    "account": {
+        "name":        "trafotin.com",
+        "displayName": "Trafotin",
+        "host":        "spectra.video",
+        "url":         "https://spectra.video/accounts/trafotin.com",
+    },
+    "channel": {
+        "name":        "trafotin",
+        "displayName": "Trafotin",
+        "host":        "spectra.video",
+        "url":         "https://spectra.video/video-channels/trafotin",
+    },
+    # NOTE: streamingPlaylists and files are ABSENT in search results.
+    # Fetch the detail endpoint on the host instance to get streaming URLs.
+}
+```
+
+### SepiaSearch query parameters
+
+| Parameter | Values | Notes |
+|-----------|--------|-------|
+| `search` | string | Required |
+| `count` | 1–100 | Default 15 |
+| `start` | integer | Offset for pagination |
+| `sort` | `-views`, `-publishedAt`, `-createdAt`, `-likes` | `-trending` not supported on SepiaSearch (400 error) |
+| `durationMin` | seconds | Filter: minimum duration |
+| `durationMax` | seconds | Filter: maximum duration |
+| `languageOneOf` | `en`, `fr`, … | Filter by language code |
+| `categoryOneOf` | integer | Category ID (15=Science & Technology, etc.) |
+| `isLive` | `true`/`false` | Filter live streams |
+| `nsfw` | `false` | Exclude NSFW |
+
+### SepiaSearch pagination
+
+```python
+import json
+from helpers import http_get
+
+def sepia_search(query, max_results=100, sort="-views"):
+    videos = []
+    start = 0
+    count = min(100, max_results)
+    while len(videos) < max_results:
+        resp = json.loads(http_get(
+            f"https://sepiasearch.org/api/v1/search/videos"
+            f"?search={query}&count={count}&start={start}&sort={sort}"
+        ))
+        batch = resp.get("data", [])
+        if not batch:
+            break
+        videos.extend(batch)
+        start += len(batch)
+        if start >= resp["total"]:
+            break
+    return videos[:max_results]
+
+results = sepia_search("open source", max_results=200)
+```
+
+### SepiaSearch channel search
+
+```python
+import json
+from helpers import http_get
+
+resp = json.loads(http_get(
+    "https://sepiasearch.org/api/v1/search/video-channels"
+    "?search=linux&count=20"
+))
+for ch in resp["data"]:
+    print(ch["name"], "@", ch["host"])
+    print("  followers:", ch["followersCount"], "videos:", ch["videosCount"])
+# Confirmed output (2026-04-18):
+# linux @ diode.zone
+#   followers: 6 videos: 1
+```
+
+---
+
+## Instance API — trending / recent videos
+
+```python
+import json
+from helpers import http_get
+
+# Trending on framatube.org (20k+ videos)
+resp = json.loads(http_get(
+    "https://framatube.org/api/v1/videos?count=20&sort=-trending"
+))
+print("total:", resp["total"])   # 20156 (2026-04-18)
+for v in resp["data"]:
+    print(v["uuid"], v["views"], v["name"][:50])
+```
+
+Valid `sort` values for instance `/api/v1/videos`:
+```
+-trending  -hot  -views  -likes  -publishedAt  -createdAt
+```
+
+### Pagination on instance
+
+```python
+import json
+from helpers import http_get
+
+def iter_instance_videos(instance, sort="-publishedAt", max_videos=500):
+    start = 0
+    count = 100
+    while start < max_videos:
+        resp = json.loads(http_get(
+            f"https://{instance}/api/v1/videos"
+            f"?count={count}&start={start}&sort={sort}"
+        ))
+        batch = resp.get("data", [])
+        if not batch:
+            break
+        yield from batch
+        start += len(batch)
+        if start >= resp["total"]:
+            break
+
+for v in iter_instance_videos("diode.zone", sort="-views", max_videos=200):
+    print(v["uuid"], v["name"][:50])
+```
+
+### Known active public instances
+
+```python
+INSTANCES = [
+    "framatube.org",      # 20k+ videos, Framasoft
+    "diode.zone",         # 8.8k videos, tech focus
+    "tilvids.com",        # 3.3k videos, educational
+    "video.blender.org",  # 1.2k videos, Blender Foundation official
+    "peertube.tv",        # 16.8k videos, general
+]
+```
+
+---
+
+## Video detail — streaming URLs
+
+The list and search endpoints omit `streamingPlaylists` and `files`. Fetch the detail endpoint using the UUID and the video's **host instance**.
+
+```python
+import json
+from helpers import http_get
+
+uuid = "9c9de5e8-0a1e-484a-b099-e80766180a6d"
+v = json.loads(http_get(f"https://framatube.org/api/v1/videos/{uuid}"))
+
+# HLS master playlist (always present on modern instances, type=1)
+for sp in v.get("streamingPlaylists", []):
+    hls_master = sp["playlistUrl"]
+    # e.g. https://framatube.org/static/streaming-playlists/hls/{uuid}/{id}-master.m3u8
+
+    # Per-resolution files within the HLS playlist
+    for f in sp.get("files", []):
+        print(f["resolution"]["label"], f["fps"], f["size"])
+        print("  HLS segment file:", f["fileUrl"])
+        print("  Direct download:", f["fileDownloadUrl"])
+        print("  Torrent URL:", f["torrentUrl"])
+        print("  Magnet URI:", f["magnetUri"][:80])
+
+# Legacy WebTorrent / direct MP4 (top-level v["files"], older instances only)
+for f in v.get("files", []):
+    print(f["resolution"]["label"], f.get("fileUrl", "")[:80])
+# Confirmed output for 9c9de5e8 on framatube.org (2026-04-18):
+# 1080p 24 16815344
+#   HLS segment file: https://framatube.org/static/streaming-playlists/hls/9c9de5e8-.../9c9de5e8-...-1080-fragmented.mp4
+#   Direct download: https://framatube.org/download/streaming-playlists/hls/videos/9c9de5e8-...-1080-fragmented.mp4
+#   Torrent URL: https://framatube.org/lazy-static/torrents/...-1080-hls.torrent
+#   Magnet URI: magnet:?xs=https%3A%2F%2Fframatube.org%2Flazy-static%2Ftorrents%2F...
+# (also 720p, 480p, 360p, 240p)
+```
+
+### StreamingPlaylist file fields reference
+
+```python
+{
+    "id":          1337952,
+    "resolution":  {"id": 1080, "label": "1080p"},
+    "width":       1920,
+    "height":      1080,
+    "fps":         24,
+    "size":        16815344,                  # bytes
+    "hasAudio":    True,
+    "hasVideo":    True,
+    "fileUrl":     "https://…/9c9de5e8-…-1080-fragmented.mp4",   # direct stream
+    "fileDownloadUrl": "https://…/download/…/9c9de5e8-…-1080-fragmented.mp4",
+    "torrentUrl":  "https://…/lazy-static/torrents/…-1080-hls.torrent",
+    "torrentDownloadUrl": "https://…/…",
+    "magnetUri":   "magnet:?xs=…&xt=urn:btih:…&dn=…&tr=…&ws=…",
+    "metadataUrl": "https://…",
+    "storage":     1,
+}
+```
+
+### Tracker and redundancy
+
+```python
+v["trackerUrls"]           # list: HTTP announce + WebSocket announce
+v["streamingPlaylists"][0]["redundancies"]  # list of {baseUrl} for CDN mirrors
+# e.g. 14 redundancy mirrors for the framatube "What is PeerTube?" video
+```
+
+---
+
+## Comments
+
+```python
+import json
+from helpers import http_get
+
+uuid = "9c9de5e8-0a1e-484a-b099-e80766180a6d"
+resp = json.loads(http_get(
+    f"https://framatube.org/api/v1/videos/{uuid}/comment-threads"
+    "?count=25&start=0"
+))
+print("total threads:", resp["total"])
+
+for thread in resp["data"]:
+    c = thread
+    print(c["id"], c["createdAt"][:10])
+    print("  text (HTML):", c["text"][:100])
+    print("  replies:", c["totalReplies"])
+    print("  author:", c["account"]["name"] if c.get("account") else "[deleted]")
+
+# Fetch replies to a specific thread
+thread_id = resp["data"][0]["threadId"]
+replies = json.loads(http_get(
+    f"https://framatube.org/api/v1/videos/{uuid}/comment-threads/{thread_id}"
+))
+# replies["detail"]["children"] — nested reply tree
+```
+
+---
+
+## Captions / subtitles
+
+```python
+import json
+from helpers import http_get
+
+uuid = "9c9de5e8-0a1e-484a-b099-e80766180a6d"
+resp = json.loads(http_get(
+    f"https://framatube.org/api/v1/videos/{uuid}/captions"
+))
+print("caption count:", resp["total"])  # e.g. 34 languages for the "What is PeerTube?" video
+
+for cap in resp["data"]:
+    print(cap["language"]["id"], cap["language"]["label"])
+    print("  VTT URL:", cap["fileUrl"])
+    # e.g. https://framatube.org/lazy-static/video-captions/…-en.vtt
+
+# Download a caption file
+vtt = http_get(resp["data"][0]["fileUrl"])
+```
+
+---
+
+## Channels
+
+```python
+import json
+from helpers import http_get
+
+# Channel videos (by handle@instance or just handle on local instance)
+resp = json.loads(http_get(
+    "https://framatube.org/api/v1/video-channels"
+    "?count=20&sort=-createdAt"
+))
+for ch in resp["data"]:
+    print(ch["name"], "@", ch["host"])
+    print("  followers:", ch["followersCount"])
+    print("  url:", ch["url"])
+
+# Videos belonging to a specific channel
+ch_handle = "framasoft_channel@framatube.org"   # or just "framasoft_channel" on local instance
+videos = json.loads(http_get(
+    f"https://framatube.org/api/v1/video-channels/{ch_handle}/videos"
+    "?count=20&sort=-views"
+))
+```
+
+---
+
+## Instance metadata
+
+```python
+import json
+from helpers import http_get
+
+info = json.loads(http_get("https://framatube.org/api/v1/config"))
+print(info["instance"]["name"])          # "Framatube"
+print(info["instance"]["shortDescription"])
+print(info["serverVersion"])             # "8.1.5"
+print(info["signup"]["allowed"])         # False
+print(info["search"]["remoteUri"]["users"])     # True = logged-in users can search federation
+print(info["search"]["remoteUri"]["anonymous"]) # False = anon users cannot
+```
+
+---
+
+## Parallel collection across instances
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+INSTANCES = ["framatube.org", "diode.zone", "tilvids.com", "video.blender.org"]
+
+def fetch_top(instance, n=20):
+    try:
+        resp = json.loads(http_get(
+            f"https://{instance}/api/v1/videos?count={n}&sort=-views"
+        ))
+        return [(v["uuid"], v["name"], v["views"], instance)
+                for v in resp.get("data", [])]
+    except Exception:
+        return []
+
+with ThreadPoolExecutor(max_workers=4) as ex:
+    results = list(ex.map(fetch_top, INSTANCES))
+
+all_videos = [v for batch in results for v in batch]
+all_videos.sort(key=lambda x: x[2], reverse=True)
+```
+
+---
+
+## URL construction reference
+
+```python
+uuid = "9c9de5e8-0a1e-484a-b099-e80766180a6d"
+instance = "framatube.org"
+
+watch_url     = f"https://{instance}/videos/watch/{uuid}"
+embed_url     = f"https://{instance}/videos/embed/{uuid}"
+api_detail    = f"https://{instance}/api/v1/videos/{uuid}"
+thumbnail     = f"https://{instance}/lazy-static/thumbnails/{uuid}.jpg"
+api_comments  = f"https://{instance}/api/v1/videos/{uuid}/comment-threads"
+api_captions  = f"https://{instance}/api/v1/videos/{uuid}/captions"
+```
+
+---
+
+## Gotchas
+
+**`streamingPlaylists` and `files` are empty in list/search responses.** Both fields are `null`/absent on the list endpoint (`/api/v1/videos`) and SepiaSearch results. Always fetch `/api/v1/videos/{uuid}` on the video's host instance to get actual streaming URLs.
+
+**Always use the host instance for detail fetches.** The UUID in SepiaSearch points to a video hosted on `v["account"]["host"]`. Fetching the UUID from a different instance will return a 404 or a federated copy that may lack streaming data. Use `v["url"]` to extract the canonical host.
+
+```python
+from urllib.parse import urlparse
+host = urlparse(v["url"]).netloc   # "spectra.video"
+detail = json.loads(http_get(f"https://{host}/api/v1/videos/{v['uuid']}"))
+```
+
+**`sort=-trending` is rejected by SepiaSearch (HTTP 400).** Valid SepiaSearch sorts: `-views`, `-publishedAt`, `-createdAt`, `-likes`. The `-trending` sort works only on instance endpoints.
+
+**`isLocal: False` in list results means the video is federated.** The queried instance caches it. The authoritative copy and streaming files live at the host instance (see `account.host`).
+
+**Direct MP4 `files` (WebTorrent) vs HLS `streamingPlaylists`.** Modern PeerTube instances (v5+) transcode into HLS only; `v["files"]` at the top level is empty. Older instances may have both. Always check `streamingPlaylists[0]["files"]` first; fall back to `v["files"]` for older instances.
+
+**`magnetUri` in `streamingPlaylists[].files[]` points to HLS-fragmented MP4 segments**, not a complete MP4. Use `fileDownloadUrl` for a direct HTTP download of the full file.
+
+**SepiaSearch caps total at 10000** regardless of the actual federated count. Use `start` to page up to that cap; beyond it you won't get more results from a single query. Narrow with `languageOneOf`, `categoryOneOf`, or `durationMin`/`durationMax` to dig into deeper slices.
+
+**Comment text is HTML**, not plain text. Strip tags or parse with an HTML library before processing.
+
+**Instance availability varies.** Wrap any cross-instance fetch in `try/except`. Some instances defederate, rate-limit, or go offline without warning. Check `/api/v1/config` first if you need to verify an instance is reachable.
+
+**`count` max per request is 100** on most instance endpoints. SepiaSearch also caps at 100 per call. Page with `start`.

--- a/domain-skills/pixelfed/scraping.md
+++ b/domain-skills/pixelfed/scraping.md
@@ -1,0 +1,386 @@
+# Pixelfed — Data Extraction
+
+`https://pixelfed.social` — federated photo-sharing platform (Instagram alternative). Implements a **Mastodon-compatible API**, but with critical divergences: almost every Mastodon API endpoint requires user-level OAuth auth, even the public timeline. The fastest unauthenticated path is the ActivityPub/Atom layer. **Never use a browser for public read-only tasks.**
+
+Base API path: `https://pixelfed.social/api/v1/`  
+ActivityPub base: `https://pixelfed.social/users/{username}`  
+Post URL pattern: `https://pixelfed.social/p/{username}/{snowflake_id}`  
+Media CDN: `https://pxscdn.com/` (separate from `pixelfed.social/storage/`)
+
+---
+
+## Access matrix — what needs auth
+
+| Endpoint | Auth needed? |
+|----------|-------------|
+| `GET /api/v1/instance` | No |
+| `GET /api/v1/accounts/lookup?acct={username}` | No |
+| `GET /api/v1/custom_emojis` | No |
+| `GET /.well-known/webfinger?resource=acct:{user}@{instance}` | No |
+| `GET /users/{username}` (AP actor) | No |
+| `GET /users/{username}.atom` (Atom feed, last 10 posts) | No |
+| `GET /p/{username}/{id}` (AP Note, full attachments) | No |
+| `GET /api/v1/timelines/public` | **Yes** |
+| `GET /api/v1/timelines/tag/{tag}` | **Yes** |
+| `GET /api/v1/trends` | **Yes** |
+| `GET /api/v1/accounts/{id}` | **Yes** |
+| `GET /api/v1/accounts/{id}/statuses` | **Yes** |
+| `GET /api/v2/search` | **Yes** |
+| All other Mastodon-compat endpoints | **Yes** |
+
+---
+
+## Unauthenticated: fastest path to posts
+
+### Account profile + last 10 posts
+
+```python
+import json, xml.etree.ElementTree as ET
+
+# Step 1: get account metadata (id, follower count, bio, avatar)
+acct = json.loads(http_get(
+    "https://pixelfed.social/api/v1/accounts/lookup?acct=dansup"
+))
+print(acct['id'], acct['username'], acct['followers_count'], acct['statuses_count'])
+# => '2'  'dansup'  87953  382
+
+# Step 2: get last 10 posts via Atom feed
+atom_xml = http_get("https://pixelfed.social/users/dansup.atom")
+root = ET.fromstring(atom_xml)
+ns  = {'atom': 'http://www.w3.org/2005/Atom',
+       'media': 'http://search.yahoo.com/mrss/'}
+
+posts = []
+for entry in root.findall('atom:entry', ns):
+    post_url = entry.find('atom:id', ns).text    # e.g. https://pixelfed.social/p/dansup/948948726609726866
+    title    = entry.find('atom:title', ns).text  # caption / first line of text
+    updated  = entry.find('atom:updated', ns).text
+    media_el = entry.find('media:content', ns)
+    media    = media_el.attrib if media_el is not None else {}
+    posts.append({'url': post_url, 'title': title, 'updated': updated, 'first_media': media})
+    print(post_url)
+    print('  caption:', title[:80])
+    print('  media:', media.get('url', '')[:60], '|', media.get('type'))
+```
+
+Note: Atom feed always returns exactly the last 10 posts — no pagination param works.
+
+### Individual post — full attachment list + alt text
+
+```python
+import json
+
+# Fetch a single post as an ActivityPub Note (public, no auth)
+post = json.loads(http_get(
+    "https://pixelfed.social/p/dansup/948948726609726866",
+    headers={"Accept": "application/activity+json"}
+))
+
+# Core fields
+print('id:          ', post['id'])          # https://pixelfed.social/p/dansup/948948726609726866
+print('type:        ', post['type'])        # "Note"
+print('published:   ', post['published'])   # "2026-04-12T14:23:27+00:00"
+print('content:     ', post['content'][:120])  # HTML — hashtags are <a> links
+print('sensitive:   ', post['sensitive'])
+print('commentsEnabled:', post.get('commentsEnabled'))  # Pixelfed-only field
+
+# Hashtags (Pixelfed-specific: always lowercase href, mixed-case name)
+for tag in post.get('tag', []):
+    print('hashtag:', tag['name'], '->', tag['href'])
+    # => '#DogsOfPixelFed' -> 'https://pixelfed.social/discover/tags/dogsofpixelfed'
+
+# Attachments — photos or video, up to 20 per album
+for att in post.get('attachment', []):
+    print('type:     ', att['type'])           # "Document"
+    print('mediaType:', att['mediaType'])       # "image/jpeg" | "image/png" | "video/mp4" | "image/webp" | "image/gif" | "image/heic"
+    print('url:      ', att['url'])             # direct CDN URL (pxscdn.com for pixelfed.social)
+    print('width/height:', att['width'], 'x', att['height'])
+    print('alt text: ', att.get('name'))        # per-image alt text (often set, can be None)
+    print('blurhash: ', att.get('blurhash'))    # always present
+    print('focalPoint:', att.get('focalPoint')) # [x, y] in [-1,1]; [0,0] = center
+    print()
+```
+
+### Batch: all recent posts from a user
+
+```python
+import json, xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor
+
+def get_posts_for_user(username):
+    """Returns last 10 posts with full AP data. No auth needed."""
+    # Step 1: atom feed for URLs
+    atom_xml = http_get(f"https://pixelfed.social/users/{username}.atom")
+    root = ET.fromstring(atom_xml)
+    ns = {'atom': 'http://www.w3.org/2005/Atom'}
+    urls = [e.find('atom:id', ns).text
+            for e in root.findall('atom:entry', ns)]
+
+    # Step 2: parallel AP fetch for full data
+    def fetch_ap(url):
+        try:
+            return json.loads(http_get(url, headers={"Accept": "application/activity+json"}))
+        except Exception:
+            return None
+
+    with ThreadPoolExecutor(max_workers=5) as ex:
+        posts = list(ex.map(fetch_ap, urls))
+    return [p for p in posts if p]
+
+posts = get_posts_for_user("dansup")
+for p in posts:
+    n_media = len(p.get('attachment', []))
+    hashtags = [t['name'] for t in p.get('tag', []) if t['type'] == 'Hashtag']
+    print(p['id'], f'({n_media} media, {len(hashtags)} tags)')
+```
+
+---
+
+## Instance metadata
+
+```python
+import json
+
+info = json.loads(http_get("https://pixelfed.social/api/v1/instance"))
+print(info['uri'])                   # "pixelfed.social"
+print(info['version'])               # "3.5.3 (compatible; Pixelfed 0.12.7)"
+print(info['stats']['user_count'])   # 552315
+print(info['stats']['status_count']) # 15921797
+print(info['stats']['domain_count']) # 38758 federated instances
+print(info['registrations'])         # False — pixelfed.social is invite-only
+```
+
+---
+
+## Account lookup
+
+```python
+import json
+
+# By username (works for any public account on this instance)
+acct = json.loads(http_get(
+    "https://pixelfed.social/api/v1/accounts/lookup?acct=dansup"
+))
+
+# Key fields
+print(acct['id'])               # "2"  — snowflake string ID
+print(acct['username'])         # "dansup"
+print(acct['acct'])             # "dansup" (local) or "user@other.instance" (remote)
+print(acct['display_name'])     # "dansup"
+print(acct['followers_count'])  # 87953
+print(acct['following_count'])  # 213
+print(acct['statuses_count'])   # 382
+print(acct['discoverable'])     # True
+print(acct['locked'])           # False — open follow
+print(acct['note'])             # HTML bio
+print(acct['url'])              # "https://pixelfed.social/dansup"
+print(acct['avatar'])           # direct URL
+print(acct['created_at'])       # "2018-06-01T05:01:59.000000Z"
+```
+
+---
+
+## Federated account lookup via Webfinger
+
+```python
+import json
+
+# Find any fediverse account's canonical ActivityPub URL
+wf = json.loads(http_get(
+    "https://pixelfed.social/.well-known/webfinger"
+    "?resource=acct:dansup@pixelfed.social"
+))
+# wf['subject']  = "acct:dansup@pixelfed.social"
+# wf['aliases']  = ["https://pixelfed.social/dansup", "https://pixelfed.social/users/dansup"]
+# wf['links']    = list of rel/type/href dicts
+
+ap_url   = next(l['href'] for l in wf['links'] if l.get('type') == 'application/activity+json')
+atom_url = next(l['href'] for l in wf['links'] if 'atom' in l.get('type',''))
+print('AP actor:', ap_url)    # https://pixelfed.social/users/dansup
+print('Atom feed:', atom_url) # https://pixelfed.social/users/dansup.atom
+```
+
+---
+
+## ActivityPub actor profile (unauthenticated)
+
+```python
+import json
+
+actor = json.loads(http_get(
+    "https://pixelfed.social/users/dansup",
+    headers={"Accept": "application/activity+json"}
+))
+# actor keys: @context, id, type, following, followers, inbox, outbox,
+#             preferredUsername, name, summary, url, published, publicKey,
+#             icon, endpoints, manuallyApprovesFollowers, indexable
+print(actor['type'])               # "Person"
+print(actor['preferredUsername'])  # "dansup"
+print(actor['followers'])          # "https://pixelfed.social/users/dansup/followers"
+print(actor['outbox'])             # "https://pixelfed.social/users/dansup/outbox"
+print(actor['icon']['url'])        # avatar URL
+
+# Follower/following counts (summary only — paging not supported on pixelfed.social)
+fol = json.loads(http_get(actor['followers'], headers={"Accept": "application/activity+json"}))
+print(fol['totalItems'])  # 87953
+```
+
+---
+
+## With user OAuth — full Mastodon-compat API
+
+Pixelfed requires full 3-legged OAuth. Client credentials tokens do NOT work for user APIs.
+
+### App registration (one-time)
+
+```python
+import json
+
+app = json.loads(http_get.__func__(  # use requests or urllib.request directly
+    "POST", "https://pixelfed.social/api/v1/apps",
+    data={"client_name": "my-scraper",
+          "redirect_uris": "urn:ietf:wg:oauth:2.0:oob",
+          "scopes": "read"}
+))
+CLIENT_ID     = app['client_id']
+CLIENT_SECRET = app['client_secret']
+```
+
+Or use curl:
+```bash
+curl -s -X POST https://pixelfed.social/api/v1/apps \
+  -d "client_name=my-scraper&redirect_uris=urn:ietf:wg:oauth:2.0:oob&scopes=read"
+# => {"id":"...","client_id":"...","client_secret":"..."}
+```
+
+Then direct the user to:
+```
+https://pixelfed.social/oauth/authorize?client_id=CLIENT_ID&redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&scope=read
+```
+
+Exchange the code:
+```python
+import json
+
+token_resp = json.loads(...)  # POST /oauth/token with grant_type=authorization_code
+ACCESS_TOKEN = token_resp['access_token']
+```
+
+### Using the token
+
+```python
+import json
+
+headers = {"Authorization": f"Bearer {ACCESS_TOKEN}"}
+
+# Public timeline (media-only by default on Pixelfed; includes text posts too)
+posts = json.loads(http_get(
+    "https://pixelfed.social/api/v1/timelines/public?limit=20",
+    headers=headers
+))
+
+# Hashtag timeline
+posts = json.loads(http_get(
+    "https://pixelfed.social/api/v1/timelines/tag/photography?limit=20",
+    headers=headers
+))
+
+# Account posts by numeric ID
+statuses = json.loads(http_get(
+    "https://pixelfed.social/api/v1/accounts/2/statuses?limit=20",
+    headers=headers
+))
+
+# Pagination (cursor-based using max_id)
+next_page = json.loads(http_get(
+    f"https://pixelfed.social/api/v1/accounts/2/statuses?limit=20&max_id={statuses[-1]['id']}",
+    headers=headers
+))
+```
+
+### Mastodon-compat status fields when using the API (with auth)
+
+```python
+# Each status object:
+{
+    'id':                  '948948726609726866',  # snowflake string
+    'created_at':          '2026-04-12T14:23:27.000000Z',
+    'content':             '<p>Caption text with <a ...>#hashtags</a></p>',  # HTML
+    'visibility':          'public',   # 'public' | 'unlisted' | 'private' | 'direct'
+    'sensitive':           False,
+    'spoiler_text':        '',         # always empty — Pixelfed has no content warnings
+    'language':            None,       # always None on pixelfed.social
+    'poll':                None,       # always None — Pixelfed has no polls
+    'card':                None,       # always None — no link preview cards
+    'in_reply_to_id':      None,       # set if it's a comment
+    'reblog':              None,       # repost object or None
+    'replies_count':       4,
+    'reblogs_count':       12,
+    'favourites_count':    89,
+    'uri':                 'https://pixelfed.social/p/dansup/948948726609726866',
+    'url':                 'https://pixelfed.social/p/dansup/948948726609726866',
+    'account':             {...},      # account object
+    'tags':                [{'name': 'dogsofpixelfed', 'url': '...'}],
+    'emojis':              [],
+    'media_attachments':   [...]       # see below
+}
+
+# media_attachments item (Mastodon-compat shape, auth path):
+{
+    'id':          '12345',
+    'type':        'image',       # 'image' | 'video' | 'gifv'
+    'url':         'https://pxscdn.com/...',
+    'preview_url': 'https://pxscdn.com/...',   # smaller preview
+    'remote_url':  None,
+    'description': 'Alt text string',   # same as AP attachment['name']
+    'blurhash':    'UXN]tl...',
+    'meta': {
+        'original': {'width': 1013, 'height': 1350, 'size': '1013x1350', 'aspect': 0.75},
+        'small':    {'width': 400, 'height': 533, ...},
+        'focus':    {'x': 0.0, 'y': 0.0}   # focalPoint
+    }
+}
+```
+
+---
+
+## Gotchas
+
+### Nearly every API endpoint requires user auth
+Unlike Mastodon, Pixelfed (0.12.x) requires a real user OAuth token for essentially all data endpoints — including the public timeline, hashtag timelines, trends, and account statuses. The instance redirects unauthenticated API requests to `/login` (HTML) or returns `{"error":"Unauthenticated."}`.
+
+### Client credentials tokens are rejected
+`POST /oauth/token` with `grant_type=client_credentials` succeeds and returns a JWT, but that token is rejected with `Unauthenticated.` on all user-facing API endpoints. Only 3-legged OAuth (authorization_code flow) produces a working token.
+
+### The public API surface without auth is tiny
+Only four endpoints work without auth: `/api/v1/instance`, `/api/v1/accounts/lookup`, `/api/v1/custom_emojis`, and `/.well-known/webfinger`. Everything else needs a token.
+
+### ActivityPub and Atom are the only unauthenticated post sources
+Use `/users/{username}.atom` for a quick list of the last 10 post URLs + first image. Use `Accept: application/activity+json` on individual post URLs (`/p/{username}/{id}`) for full album data. The outbox endpoint (`/users/{username}/outbox`) only returns `{"type":"OrderedCollection","totalItems":N}` — paging it returns the same empty summary.
+
+### Atom feed has no pagination
+`/users/{username}.atom?page=2` ignores the param and always returns the same last 10 entries. To get older posts you need user-authenticated API access.
+
+### Posts are photo-only (almost)
+Pixelfed enforces at least one media attachment on most post types. The `media_attachments` array is never empty on a real Pixelfed post. `spoiler_text`, `poll`, and `card` are always null/empty — these Mastodon features don't exist in Pixelfed.
+
+### Hashtag href normalization
+In ActivityPub `tag` objects, `name` preserves original casing (`'#DogsOfPixelFed'`) but `href` is always lowercased (`'.../discover/tags/dogsofpixelfed'`). Don't compare them directly.
+
+### Media CDN vs instance storage
+Profile avatars and headers are served from `pixelfed.social/storage/...`. Post media is on `pxscdn.com/...`. Both URLs are direct (no auth, no token needed) and link to permanent media files.
+
+### Album limit is 20
+Config exposes `album_limit: 20` — a single post can have up to 20 attachments. The AP `attachment` array reflects this (tested: 1–3 attachments confirmed; 20 is the ceiling).
+
+### `id` is a snowflake string, not an integer
+All IDs (account, post, attachment) are 64-bit snowflake integers returned as JSON strings. Don't cast to `int` for sorting — string lexicographic order works correctly for snowflakes of the same bit-width.
+
+### No `/api/v1/directory` or `/api/v1/statuses/{id}` without auth
+Neither endpoint exists or is accessible unauthenticated. Use AP (`/p/{user}/{id}` with `Accept: application/activity+json`) for individual post lookup.
+
+### `/api/v2/discover/posts/trending` returns 404
+This endpoint is documented in some Pixelfed sources but is not deployed on pixelfed.social. Use `/api/v1/trends` (auth required) instead.
+
+### SPA pages are Vue apps — no SSR data
+Pages like `/discover/tags/photography` render via Vue.js after login. The HTML returned to unauthenticated clients is a blank shell with config JSON only (`window.App = {...}`). No post data is embedded.


### PR DESCRIPTION
## Summary
- Bandcamp: data-tralbum HTML attr has full album JSON; dig_deeper POST API for discovery; artist root URL may redirect to signup (use /music); stream URLs expire ~24h
- Pixelfed: auth wall much stricter than Mastodon; client_credentials tokens rejected; ActivityPub + Atom is best unauth path; /api/v2/discover/posts/trending returns 404
- PeerTube: SepiaSearch caps at 10K results; streaming URLs absent in list responses (must fetch detail); always fetch from canonical host instance; HLS vs WebTorrent coexist
- Nominatim: format=jsonv2 uses category vs class; /reverse returns error dict while /search returns []; boundingbox is [S,N,W,E] order; place_rank reference table
- Overpass: error responses are HTML at HTTP 200; out body on ways gives no lat/lon (use out center); rate model is 2 concurrent slots not 2/s; FR mirror more reliable

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new domain skill guides for Bandcamp, Pixelfed, PeerTube, Nominatim, and Overpass with HTTP-only examples, edge cases, and rate/response nuances to make scraping reliable and fast.

- **New Features**
  - Bandcamp: extract full album/track data from `data-tralbum`, use artist `/music`, discovery via `POST /api/hub/2/dig_deeper`, note 24h stream URL TTL and cover URL patterns.
  - Pixelfed: unauth path via ActivityPub (`/p/{user}/{id}`) and Atom (`/users/{user}.atom`); most `api/v1` endpoints require user OAuth; `client_credentials` tokens are rejected; media fields and CDN (`pxscdn.com`) documented.
  - PeerTube: federated search via SepiaSearch (10k cap), instance feeds with `sort` (`-trending`, `-views`), fetch details from canonical host to get `streamingPlaylists` (HLS/WebTorrent), plus comments and captions endpoints.
  - Nominatim: use `format=jsonv2` and a descriptive `User-Agent`, handle `/search` `[]` vs `/reverse` `{"error": ...}`, understand `boundingbox` order `[south,north,west,east]`, `place_rank` reference, and enforce 1 req/s.
  - Overpass: POST QL queries to `interpreter`, guard against HTML error bodies (HTTP 200), use `out center`/`out geom` for ways, bbox `(south,west,north,east)`, 2 concurrent slot rate model, and prefer the FR mirror.

<sup>Written for commit aa3c59dc5d67593316262268d6a51782bd1245dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

