### PR TITLE
Add domain skills: World Bank, REST Countries, NASA, Wayback Machine, arXiv bulk

### DIFF
--- a/domain-skills/arxiv-bulk/scraping.md
+++ b/domain-skills/arxiv-bulk/scraping.md
@@ -1,0 +1,333 @@
+# arXiv Bulk Harvest + Semantic Scholar — OAI-PMH & Citation Enrichment
+
+Companion to `domain-skills/arxiv/scraping.md`. Use the **arxiv** skill for search-and-fetch workflows. Use **this skill** when you need:
+
+- Bulk-harvesting all papers in a subject area or date window (OAI-PMH)
+- Citation counts, influential-citation scores, and cross-database IDs (Semantic Scholar)
+- Per-paper version history and submitter info (`arXivRaw` metadata)
+
+No API key required for either endpoint. Both return JSON or XML over plain HTTP.
+
+---
+
+## OAI-PMH bulk harvest
+
+### Endpoint (confirmed 2026-04-19)
+
+```
+https://oaipmh.arxiv.org/oai
+```
+
+`https://export.arxiv.org/oai2` is the old URL — it 301-redirects to the new one. Use the new URL directly to avoid the extra round-trip.
+
+### Harvest all cs papers from a date window
+
+```python
+import xml.etree.ElementTree as ET
+from helpers import http_get
+
+OAI_NS = {
+    'oai': 'http://www.openarchives.org/OAI/2.0/',
+    'arXiv': 'http://arxiv.org/OAI/arXiv/',
+}
+
+def fetch_oai_page(url):
+    """Fetch one OAI-PMH page; return (records_xml_list, next_token_or_None)."""
+    xml = http_get(url)
+    root = ET.fromstring(xml)
+    records = root.findall('.//oai:record', OAI_NS)
+    token_el = root.find('.//oai:resumptionToken', OAI_NS)
+    token = token_el.text if token_el is not None and token_el.text else None
+    return records, token
+
+def parse_arxiv_record(rec):
+    """Extract fields from one <record> element (metadataPrefix=arXiv)."""
+    header = rec.find('oai:header', OAI_NS)
+    meta   = rec.find('.//arXiv:arXiv', OAI_NS)
+    if meta is None:
+        return None   # deleted record (header has status="deleted")
+    authors_el = meta.findall('arXiv:authors/arXiv:author', OAI_NS)
+    authors = []
+    for a in authors_el:
+        fn = (a.findtext('arXiv:forenames', namespaces=OAI_NS) or '').strip()
+        ln = (a.findtext('arXiv:keyname',   namespaces=OAI_NS) or '').strip()
+        authors.append(f"{fn} {ln}".strip())
+    return {
+        'id':           meta.findtext('arXiv:id', namespaces=OAI_NS),
+        'datestamp':    header.findtext('oai:datestamp', namespaces=OAI_NS),
+        'created':      meta.findtext('arXiv:created',  namespaces=OAI_NS),
+        'updated':      meta.findtext('arXiv:updated',  namespaces=OAI_NS),
+        'title':        (meta.findtext('arXiv:title',    namespaces=OAI_NS) or '').strip(),
+        'authors':      authors,
+        'categories':   (meta.findtext('arXiv:categories', namespaces=OAI_NS) or '').split(),
+        'abstract':     (meta.findtext('arXiv:abstract',   namespaces=OAI_NS) or '').strip(),
+        'doi':          meta.findtext('arXiv:doi',         namespaces=OAI_NS),
+        'journal_ref':  meta.findtext('arXiv:journal-ref', namespaces=OAI_NS),
+        'license':      meta.findtext('arXiv:license',     namespaces=OAI_NS),
+    }
+
+# --- Main harvest loop ---
+import time
+
+BASE = 'https://oaipmh.arxiv.org/oai'
+first_url = (
+    f"{BASE}?verb=ListRecords"
+    f"&metadataPrefix=arXiv"
+    f"&set=cs"
+    f"&from=2024-01-01"
+    f"&until=2024-01-02"
+)
+
+papers = []
+url = first_url
+while url:
+    records, token = fetch_oai_page(url)
+    for rec in records:
+        p = parse_arxiv_record(rec)
+        if p:
+            papers.append(p)
+    print(f"  fetched {len(records)} records, total so far: {len(papers)}")
+    if token:
+        url = f"{BASE}?verb=ListRecords&resumptionToken={token}"
+        time.sleep(5)   # OAI-PMH policy: >=5s between pages
+    else:
+        url = None
+
+print(f"Done. {len(papers)} papers harvested.")
+# Confirmed output for cs, 2024-01-01 to 2024-01-02:
+# fetched 44 records, total so far: 44
+# Done. 44 papers harvested.
+# For 2024-01-01 to 2024-01-07 (cs): multiple pages, resumptionToken issued when >~200 records
+```
+
+### Available verbs
+
+| Verb | Purpose | Key params |
+|---|---|---|
+| `Identify` | Repository info, earliest datestamp (`2005-09-16`) | — |
+| `ListSets` | All harvestable sets (see table below) | — |
+| `ListMetadataFormats` | `oai_dc`, `arXiv`, `arXivOld`, `arXivRaw` | — |
+| `ListRecords` | Bulk harvest with date/set filter | `metadataPrefix`, `set`, `from`, `until` |
+| `GetRecord` | Single record by OAI identifier | `identifier`, `metadataPrefix` |
+
+### Top-level sets (confirmed)
+
+| setSpec | Name |
+|---|---|
+| `cs` | Computer Science (all) |
+| `cs:cs` | Computer Science (subset notation — same scope) |
+| `math` | Mathematics |
+| `physics` | Physics |
+| `stat` | Statistics |
+| `eess` | Electrical Engineering and Systems Science |
+| `econ` | Economics |
+| `q-bio` | Quantitative Biology |
+| `q-fin` | Quantitative Finance |
+
+Subset sets use `topic:topic:SUBCATEGORY` notation, e.g. `cs:cs:LG` for Machine Learning. List all with `verb=ListSets`.
+
+### Available metadata formats
+
+- `arXiv` — rich: id, created/updated dates, authors (keyname + forenames separately), categories, abstract, doi, journal-ref, license. **Use this.**
+- `arXivRaw` — adds `<submitter>`, per-version history (`<version version="v1">` with date and file size), author list as flat string. Use when you need version history.
+- `oai_dc` — Dublin Core, minimal. Skip unless you need cross-system compatibility.
+- `arXivOld` — legacy format pre-2007. Skip.
+
+### GetRecord + arXivRaw (version history)
+
+```python
+import xml.etree.ElementTree as ET
+from helpers import http_get
+
+RAW_NS = {
+    'oai': 'http://www.openarchives.org/OAI/2.0/',
+    'raw': 'http://arxiv.org/OAI/arXivRaw/',
+}
+
+xml = http_get(
+    "https://oaipmh.arxiv.org/oai"
+    "?verb=GetRecord"
+    "&metadataPrefix=arXivRaw"
+    "&identifier=oai:arXiv.org:1706.03762"
+)
+root = ET.fromstring(xml)
+meta = root.find('.//raw:arXivRaw', RAW_NS)
+
+title     = meta.findtext('raw:title',     namespaces=RAW_NS)
+submitter = meta.findtext('raw:submitter', namespaces=RAW_NS)
+versions  = meta.findall('raw:version',    RAW_NS)
+for v in versions:
+    print(v.get('version'), v.findtext('raw:date', namespaces=RAW_NS))
+# Confirmed output for 1706.03762 ("Attention Is All You Need"):
+# v1 Mon, 12 Jun 2017 17:57:34 GMT
+# v2 Mon, 19 Jun 2017 16:49:45 GMT
+# ...
+# v7 Wed, 02 Aug 2023 00:41:18 GMT
+# submitter: Llion Jones
+```
+
+---
+
+## Semantic Scholar — citation enrichment for arXiv papers
+
+No API key required (unauthenticated: 1 req/s, 5000 req/day). With a free key the limit rises to 100 req/s.
+
+Base URL: `https://api.semanticscholar.org/graph/v1/`
+
+### Single paper lookup by arXiv ID
+
+```python
+import json
+from helpers import http_get
+
+paper = json.loads(http_get(
+    "https://api.semanticscholar.org/graph/v1/paper/arXiv:1706.03762"
+    "?fields=title,year,venue,publicationDate,citationCount,"
+    "influentialCitationCount,authors,abstract,externalIds"
+))
+print(paper['title'])                    # "Attention is All you Need"
+print(paper['citationCount'])            # 173155  (confirmed 2026-04-19)
+print(paper['influentialCitationCount']) # 19629
+print(paper['venue'])                    # "Neural Information Processing Systems"
+print(paper['externalIds']['ArXiv'])     # "1706.03762"
+print(paper['externalIds']['DOI'])       # missing if no DOI
+for a in paper['authors']:
+    print(a['name'], a['authorId'])
+```
+
+The ID format `arXiv:NNNN.NNNNN` is accepted directly — no conversion needed.
+
+### Batch lookup (up to 500 IDs per POST)
+
+```python
+import json
+from helpers import http_get
+import urllib.request
+
+ids = ["arXiv:1706.03762", "arXiv:1810.04805", "arXiv:2005.14165"]
+fields = "paperId,externalIds,title,year,citationCount,influentialCitationCount"
+
+body = json.dumps({"ids": ids}).encode()
+req = urllib.request.Request(
+    f"https://api.semanticscholar.org/graph/v1/paper/batch?fields={fields}",
+    data=body,
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    results = json.loads(r.read())
+
+for p in results:
+    print(p['externalIds'].get('ArXiv'), p['citationCount'], p['title'][:50])
+# Confirmed output (2026-04-19):
+# 1706.03762  173155  Attention is All you Need
+# 1810.04805  113138  BERT: Pre-training of Deep Bidirectional Tran...
+# 2005.14165  (varies)  Language Models are Few-Shot Learners
+```
+
+Note: `helpers.http_get` only does GET. For POST use `urllib.request.Request` directly as above.
+
+### Paper search
+
+```python
+import json
+from helpers import http_get
+
+results = json.loads(http_get(
+    "https://api.semanticscholar.org/graph/v1/paper/search"
+    "?query=large+language+model"
+    "&fields=paperId,externalIds,title,year,citationCount"
+    "&limit=5"
+))
+total = results['total']   # e.g. 3473582 for "large language model"
+for p in results['data']:
+    arxiv_id = p['externalIds'].get('ArXiv', 'no-arxiv')
+    print(arxiv_id, p['year'], p['citationCount'], p['title'][:50])
+# next page: use offset=5, offset=10, etc.
+```
+
+### Available fields (pass as comma-separated `fields=` query param)
+
+| Field | Type | Notes |
+|---|---|---|
+| `paperId` | str | Semantic Scholar internal ID |
+| `externalIds` | dict | Keys: `ArXiv`, `DOI`, `DBLP`, `MAG`, `ACL`, `CorpusId` |
+| `title` | str | |
+| `abstract` | str | |
+| `year` | int | Publication year |
+| `publicationDate` | str | `YYYY-MM-DD` |
+| `venue` | str | Conference/journal name |
+| `citationCount` | int | Total citations |
+| `influentialCitationCount` | int | Citations deemed highly influential |
+| `authors` | list | Each: `{authorId, name}` |
+| `references` | list | List of paper objects (needs own `fields`) |
+| `citations` | list | Citing papers (needs own `fields`) |
+| `openAccessPdf` | dict | `{url, status, license}` |
+
+---
+
+## Downloading PDFs
+
+Direct PDF download — no auth, no redirect for versionless URLs (returns 200 + PDF body directly).
+
+```python
+import urllib.request
+
+def download_pdf(arxiv_id, dest_path, version=None):
+    """
+    arxiv_id: bare ID like '1706.03762' or versioned '1706.03762v7'
+    version:  if given, appended as 'v{version}' — ignored if arxiv_id already has version
+    dest_path: where to save, e.g. '/tmp/paper.pdf'
+    """
+    if 'v' not in arxiv_id.split('.')[-1] and version:
+        arxiv_id = f"{arxiv_id}v{version}"
+    url = f"https://arxiv.org/pdf/{arxiv_id}"
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        with open(dest_path, 'wb') as f:
+            f.write(r.read())
+    print(f"Saved {r.headers.get('content-length', '?')} bytes to {dest_path}")
+
+download_pdf('1706.03762', '/tmp/attention.pdf')
+# Confirmed: saves 2215244 bytes, filename hint in header: '1706.03762v7.pdf'
+# Versionless URL resolves to latest version server-side (no redirect, 200 direct)
+```
+
+---
+
+## Gotchas
+
+- **OAI-PMH endpoint moved.** `https://export.arxiv.org/oai2` 301-redirects to `https://oaipmh.arxiv.org/oai`. Use the new URL. `helpers.http_get` (which uses `urllib`) does NOT follow redirects — you'll get an empty string or error. Either use `urllib.request.urlopen` with `follow_redirects` logic, or just use the canonical URL directly.
+
+- **OAI-PMH rate limit: 5 seconds between pages.** The protocol requires a `Retry-After` interval. The server embeds an `expirationDate` on the resumptionToken. Violating the rate limit causes the token to be invalidated and the harvest fails silently. Always `time.sleep(5)` between pages.
+
+- **Resumption token is opaque but URL-encoded.** The token looks like `verb%3DListRecords%26...%26skip%3D247`. Pass it verbatim as `&resumptionToken=<token>` — do not URL-encode it again.
+
+- **`datestamp` in OAI-PMH is last-modified date, not submission date.** A paper submitted in 2008 can appear in a 2024 harvest window if it was revised then. The `<created>` and `<updated>` fields inside `<arXiv>` metadata are the actual submission/revision dates.
+
+- **Deleted records have no `<metadata>` element.** The `<header>` will carry `status="deleted"`. Always check `meta is None` after `find('.//arXiv:arXiv', ...)`.
+
+- **Author structure differs between OAI-PMH formats.** In `arXiv` metadata, authors are structured: `<author><keyname>Vaswani</keyname><forenames>Ashish</forenames></author>`. In `arXivRaw`, they're a flat comma-separated string: `Ashish Vaswani, Noam Shazeer, ...`. In the Atom API, it's `<name>Ashish Vaswani</name>` (first-last order). Pick the source that matches your downstream use.
+
+- **Semantic Scholar 429 under unauthenticated bursts.** The unauthenticated limit is ~1 req/s. Rapid parallel calls return `{"code": "429"}`. Add `time.sleep(1)` between single lookups or use the batch POST endpoint (up to 500 IDs, single request) to stay under the limit. The batch endpoint itself counts as 1 request.
+
+- **Semantic Scholar `externalIds` may lack `ArXiv` key.** Not all papers have an arXiv preprint. When enriching an arXiv list with S2 data, always use `.get('ArXiv')` not `['ArXiv']`.
+
+- **Atom API rate limit: 1 request per 3 seconds for sustained crawls.** The API returns HTTP 429 `"Rate exceeded."` on rapid-fire requests. The OAI-PMH endpoint is designed for bulk and is more tolerant, but still requires the 5s sleep between resumption pages.
+
+- **OAI-PMH `set` param uses colon-separated hierarchy, not dot.** The Atom API uses `cat:cs.LG`; OAI-PMH uses `set=cs:cs:LG`. Using `set=cs.LG` returns zero results.
+
+- **`http_get` in helpers.py does NOT follow HTTP redirects.** If you must use it with the old OAI URL, you'll get an empty body. Either update the URL to the canonical one or use `urllib.request.urlopen` with a redirect handler.
+
+---
+
+## How this complements the existing arxiv skill
+
+| Task | Use |
+|---|---|
+| Search by keyword, author, or category | `arxiv` skill — Atom API |
+| Fetch 1–2000 specific papers by ID | `arxiv` skill — `id_list` batch |
+| Harvest all papers in a subject over a date range | **this skill** — OAI-PMH |
+| Get citation counts / influential citations | **this skill** — Semantic Scholar |
+| Get per-version history and submitter name | **this skill** — OAI-PMH `arXivRaw` |
+| Download a PDF | either skill (same URL structure) |

--- a/domain-skills/nasa/scraping.md
+++ b/domain-skills/nasa/scraping.md
@@ -1,0 +1,339 @@
+# NASA APIs — Scraping & Data Extraction
+
+`https://api.nasa.gov` — open NASA data APIs. **Never use the browser.** All endpoints return JSON via `http_get`. DEMO_KEY works for low-volume use; register for a free personal key at https://api.nasa.gov/ to raise limits.
+
+## Do this first
+
+**All `api.nasa.gov` endpoints share the same rate-limit pool under DEMO_KEY. EPIC and Exoplanet Archive are on separate domains with no rate limit.**
+
+```python
+import json
+from helpers import http_get
+
+# Simplest call: today's Astronomy Picture of the Day
+apod = json.loads(http_get("https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY"))
+print(apod['date'], apod['title'], apod['media_type'])
+# Confirmed output (2026-04-18): 2026-04-18 PanSTARRS and Planets image
+```
+
+Use DEMO_KEY for exploration. Switch to a personal key for any bulk work — DEMO_KEY hits its limit at ~10 req/hour/IP (daily budget around 50; `retry-after` header will show ~22 hours when exhausted).
+
+## Rate limits
+
+| Key type | Limit | Resets |
+|---|---|---|
+| `DEMO_KEY` | 10 req/hour, ~50/day per IP | Hourly window; daily hard stop with `retry-after` ~22h |
+| Personal key (free) | 1,000 req/hour | Hourly window |
+
+Rate limit headers on every `api.nasa.gov` response:
+- `X-Ratelimit-Limit` — your current window limit (e.g. `10`)
+- `X-Ratelimit-Remaining` — calls left this window
+- `Retry-After` — seconds until next window (only on 429)
+
+**EPIC (`epic.gsfc.nasa.gov`) and Exoplanet Archive (`exoplanetarchive.ipac.caltech.edu`) share no rate-limit pool with `api.nasa.gov`.**
+
+## Common workflows
+
+### APOD — single day
+
+```python
+import json
+from helpers import http_get
+
+apod = json.loads(http_get("https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY"))
+print(apod['date'])        # '2026-04-18'
+print(apod['title'])       # 'PanSTARRS and Planets'
+print(apod['media_type'])  # 'image' or 'video'
+print(apod['url'])         # full-res or YouTube embed URL
+print(apod['hdurl'])       # HD image URL (absent when media_type='video')
+print(apod.get('copyright'))  # None if public domain
+# Confirmed output (2026-04-18):
+# url:   https://apod.nasa.gov/apod/image/2604/PanstarrsPlanetsPerrotLab1024.jpg
+# hdurl: https://apod.nasa.gov/apod/image/2604/PanstarrsPlanetsPerrot.jpg
+# copyright: Luc Perrot
+```
+
+### APOD — date range (array response)
+
+```python
+import json
+from helpers import http_get
+
+apods = json.loads(http_get(
+    "https://api.nasa.gov/planetary/apod"
+    "?start_date=2024-01-01&end_date=2024-01-07&api_key=DEMO_KEY"
+))
+# Returns a list of 7 dicts — same schema as single-day response
+for a in apods:
+    print(a['date'], a['media_type'], a['title'][:50])
+# Confirmed output (7 items):
+# 2024-01-01 image NGC 1232: A Grand Design Spiral Galaxy
+# 2024-01-02 image Rocket Transits Rippling Moon
+# 2024-01-03 image A SAR Arc from New Zealand
+# 2024-01-04 image Zeta Oph: Runaway Star
+# 2024-01-05 image Trapezium: At the Heart of Orion
+# 2024-01-06 video The Snows of Churyumov-Gerasimenko
+# 2024-01-07 image The Cat's Eye Nebula in Optical and X-ray
+```
+
+Optional params: `date=YYYY-MM-DD` (specific day), `count=N` (N random entries), `thumbs=true` (include `thumbnail_url` for video entries).
+
+### APOD — random sample
+
+```python
+import json
+from helpers import http_get
+
+apods = json.loads(http_get(
+    "https://api.nasa.gov/planetary/apod?count=5&api_key=DEMO_KEY"
+))
+for a in apods:
+    print(a['date'], a['title'][:40])
+# Returns 5 random APOD entries — dates can be any day since 1995-06-16
+```
+
+### NEO — Near Earth Objects feed
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    "https://api.nasa.gov/neo/rest/v1/feed"
+    "?start_date=2024-01-01&end_date=2024-01-02&api_key=DEMO_KEY"
+))
+print(data['element_count'])   # 32 (total NEOs across both days)
+neos = data['near_earth_objects']  # dict keyed by date string
+for date, objects in sorted(neos.items()):
+    for neo in objects:
+        ca = neo['close_approach_data'][0]
+        print(
+            neo['name'],
+            'hazardous:', neo['is_potentially_hazardous_asteroid'],
+            'miss km:', ca['miss_distance']['kilometers'][:12],
+            'vel kph:', ca['relative_velocity']['kilometers_per_hour'][:10]
+        )
+# Confirmed output (2 days, 32 total NEOs):
+# 415949 (2001 XY10) hazardous: False miss km: 50452409.34 vel kph: 57205.8951
+# (22+ more objects per day)
+```
+
+NEO object fields:
+- `id`, `name`, `nasa_jpl_url` — identity
+- `estimated_diameter` — dict with `kilometers`, `meters`, `miles`, `feet` sub-dicts, each with `min`/`max`
+- `is_potentially_hazardous_asteroid` — bool
+- `close_approach_data[0]` — `close_approach_date`, `miss_distance` (au/lunar/km/mi), `relative_velocity` (km/s, km/h, mph), `orbiting_body`
+
+Date range is capped at **7 days per request**. For longer ranges, paginate with `start_date` / `end_date` in 7-day steps. `links.next` in the response gives the next 7-day window URL.
+
+### NEO — single asteroid lookup
+
+```python
+import json
+from helpers import http_get
+
+# Asteroid ID comes from the feed's `id` field
+neo = json.loads(http_get(
+    "https://api.nasa.gov/neo/rest/v1/neo/2415949?api_key=DEMO_KEY"
+))
+print(neo['name'])
+print(neo['orbital_data']['orbit_class']['orbit_class_description'])
+# Full orbital history + all close approaches are in `close_approach_data` (long list)
+```
+
+### Mars Rover photos — Curiosity by sol
+
+```python
+import json
+from helpers import http_get
+
+# sol = Martian solar day since landing
+data = json.loads(http_get(
+    "https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos"
+    "?sol=1000&api_key=DEMO_KEY"
+))
+photos = data['photos']
+print(f"Photos on sol 1000: {len(photos)}")
+p = photos[0]
+print(p['earth_date'])          # '2015-05-30'
+print(p['img_src'])             # direct JPEG URL
+print(p['camera']['name'])      # 'FHAZ'
+print(p['camera']['full_name']) # 'Front Hazard Avoidance Camera'
+print(p['rover']['name'])       # 'Curiosity'
+print(p['rover']['status'])     # 'active'
+print(p['rover']['max_sol'])    # highest sol with photos
+
+# Filter by camera
+data = json.loads(http_get(
+    "https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos"
+    "?sol=1000&camera=navcam&api_key=DEMO_KEY"
+))
+```
+
+Available cameras for Curiosity: `fhaz`, `rhaz`, `mast`, `chemcam`, `mahli`, `mardi`, `navcam`. Other rovers: `opportunity`, `spirit`, `perseverance`.
+
+Use `latest_photos` to get the most recent available:
+```python
+data = json.loads(http_get(
+    "https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/latest_photos"
+    "?api_key=DEMO_KEY"
+))
+photos = data['latest_photos']
+```
+
+Add `&page=N` for pagination (25 photos/page by default).
+
+### EPIC — Earth Polychromatic Imaging Camera
+
+EPIC images are served from `epic.gsfc.nasa.gov` — **no `api_key` required, no rate limit.**
+
+```python
+import json
+from helpers import http_get
+
+# Latest available images (natural color)
+images = json.loads(http_get("https://epic.gsfc.nasa.gov/api/natural"))
+print(f"Latest batch: {len(images)} images")  # Confirmed: 4 images on 2026-04-18
+
+img = images[0]
+print(img['identifier'])               # '20260416162050'
+print(img['image'])                    # 'epic_1b_20260416162050'
+print(img['date'])                     # '2026-04-16 16:16:01'
+print(img['centroid_coordinates'])     # {'lat': 13.25, 'lon': -75.59}
+
+# Construct PNG URL from image name + date
+date_str = img['date'].split(' ')[0]   # '2026-04-16'
+year, month, day = date_str.split('-')
+png_url = f"https://epic.gsfc.nasa.gov/archive/natural/{year}/{month}/{day}/png/{img['image']}.png"
+jpg_thumb = f"https://epic.gsfc.nasa.gov/archive/natural/{year}/{month}/{day}/thumbs/{img['image']}.jpg"
+print(png_url)
+# Confirmed: https://epic.gsfc.nasa.gov/archive/natural/2026/04/16/png/epic_1b_20260416162050.png
+```
+
+```python
+# Images for a specific date
+images = json.loads(http_get("https://epic.gsfc.nasa.gov/api/natural/date/2024-01-15"))
+print(len(images))   # 14 images on 2024-01-15
+
+# Enhanced (color-corrected) images — same API, different path
+enhanced = json.loads(http_get("https://epic.gsfc.nasa.gov/api/enhanced/date/2024-01-15"))
+# Enhanced image URL pattern uses 'enhanced' and 'epic_RGB_' prefix:
+img = enhanced[0]
+date_str = img['date'].split(' ')[0]
+year, month, day = date_str.split('-')
+url = f"https://epic.gsfc.nasa.gov/archive/enhanced/{year}/{month}/{day}/png/{img['image']}.png"
+# e.g. .../archive/enhanced/2024/01/15/png/epic_RGB_20240115005515.png
+
+# All available dates
+all_dates = json.loads(http_get("https://epic.gsfc.nasa.gov/api/natural/all"))
+print(f"Available dates: {len(all_dates)}")  # 3477 dates (2015-06-13 to present)
+print(all_dates[0])   # {'date': '2026-04-16'}  (newest first)
+print(all_dates[-1])  # {'date': '2015-06-13'}  (oldest)
+```
+
+### Exoplanet Archive — TAP/ADQL queries
+
+No API key or rate limit. SQL-like ADQL queries over the full archive.
+
+```python
+import json
+from helpers import http_get
+
+# Short-period planets with known radii
+planets = json.loads(http_get(
+    "https://exoplanetarchive.ipac.caltech.edu/TAP/sync"
+    "?query=select+pl_name,hostname,pl_orbper+from+ps+where+pl_orbper+%3C+10"
+    "&format=json"
+))
+print(f"Rows: {len(planets)}")      # 17675 (table 'ps' includes duplicate measurements)
+print(planets[0])
+# {'pl_name': 'GJ 1214 b', 'hostname': 'GJ 1214', 'pl_orbper': 1.58040482}
+```
+
+```python
+# Use 'pscomppars' for one row per planet (composite best-estimate params)
+planets = json.loads(http_get(
+    "https://exoplanetarchive.ipac.caltech.edu/TAP/sync"
+    "?query=select+pl_name,hostname,disc_year,discoverymethod,pl_orbper,pl_rade,pl_masse,pl_eqt,sy_dist"
+    "+from+pscomppars+where+disc_year+%3E+2020+and+pl_rade+is+not+null"
+    "+order+by+disc_year+desc"
+    "&format=json&maxrec=5"
+))
+for p in planets:
+    print(p['pl_name'], p['disc_year'], p['discoverymethod'], f"r={p['pl_rade']}Re")
+# Confirmed output:
+# KMT-2024-BLG-1870L b 2026 Microlensing r=13.8Re
+# LHS 1903 b 2026 Transit r=1.382Re
+# TOI-375 d 2026 Radial Velocity r=13.6Re
+```
+
+Key tables:
+- `ps` — all measurements per planet (multiple rows per planet, all sources)
+- `pscomppars` — one row per confirmed planet (best composite parameters)
+
+Key columns: `pl_name`, `hostname`, `disc_year`, `discoverymethod`, `pl_orbper` (orbital period, days), `pl_rade` (radius in Earth radii), `pl_masse` (mass in Earth masses), `pl_eqt` (equilibrium temp K), `sy_dist` (distance in parsec).
+
+URL-encode operators: `<` = `%3C`, `>` = `%3E`, spaces = `+`.
+
+## URL reference
+
+### api.nasa.gov endpoints
+
+| Endpoint | URL pattern |
+|---|---|
+| APOD today | `https://api.nasa.gov/planetary/apod?api_key=KEY` |
+| APOD by date | `...&date=YYYY-MM-DD` |
+| APOD range | `...&start_date=YYYY-MM-DD&end_date=YYYY-MM-DD` |
+| APOD random N | `...&count=N` |
+| NEO feed | `https://api.nasa.gov/neo/rest/v1/feed?start_date=...&end_date=...&api_key=KEY` |
+| NEO by ID | `https://api.nasa.gov/neo/rest/v1/neo/{id}?api_key=KEY` |
+| Mars photos by sol | `https://api.nasa.gov/mars-photos/api/v1/rovers/{rover}/photos?sol=N&api_key=KEY` |
+| Mars photos by date | `...?earth_date=YYYY-MM-DD&api_key=KEY` |
+| Mars latest | `https://api.nasa.gov/mars-photos/api/v1/rovers/{rover}/latest_photos?api_key=KEY` |
+
+### EPIC (epic.gsfc.nasa.gov — no key, no rate limit)
+
+| Endpoint | URL |
+|---|---|
+| Latest natural images | `https://epic.gsfc.nasa.gov/api/natural` |
+| Natural by date | `https://epic.gsfc.nasa.gov/api/natural/date/YYYY-MM-DD` |
+| Enhanced latest | `https://epic.gsfc.nasa.gov/api/enhanced` |
+| Enhanced by date | `https://epic.gsfc.nasa.gov/api/enhanced/date/YYYY-MM-DD` |
+| All available dates | `https://epic.gsfc.nasa.gov/api/natural/all` |
+| PNG image | `https://epic.gsfc.nasa.gov/archive/natural/YYYY/MM/DD/png/{image}.png` |
+| Thumbnail (JPEG) | `https://epic.gsfc.nasa.gov/archive/natural/YYYY/MM/DD/thumbs/{image}.jpg` |
+| Enhanced PNG | `https://epic.gsfc.nasa.gov/archive/enhanced/YYYY/MM/DD/png/{image}.png` |
+
+### Exoplanet Archive (no key, no rate limit)
+
+```
+https://exoplanetarchive.ipac.caltech.edu/TAP/sync?query=<ADQL>&format=json&maxrec=<N>
+```
+
+## Gotchas
+
+- **DEMO_KEY limit is effectively 10/hour per IP, not 30** — The `X-Ratelimit-Limit` header shows `10` in practice. When the daily budget (~50 req) is exhausted, the `retry-after` header is set to ~80,000 seconds (about 22 hours). Register a free personal key at https://api.nasa.gov/ to get 1,000/hour.
+
+- **All `api.nasa.gov` paths share one rate-limit pool** — APOD, NEO, Mars Rover, and all other `api.nasa.gov` paths draw from the same DEMO_KEY bucket. Calling any one of them depletes the limit for all others.
+
+- **EPIC and Exoplanet Archive are fully free** — `epic.gsfc.nasa.gov` returns no rate-limit headers and is not throttled. `exoplanetarchive.ipac.caltech.edu/TAP/sync` is similarly unrestricted. Use these freely without fear of exhausting DEMO_KEY.
+
+- **NEO date range max is 7 days** — Requests spanning more than 7 days return HTTP 400. Paginate with 7-day windows and use `links.next` from the response to get the next URL.
+
+- **APOD earliest date is 1995-06-16** — Requesting `date` before `1995-06-16` returns HTTP 400 with an error message. No upper date bound other than today.
+
+- **APOD `hdurl` is absent for video entries** — When `media_type` is `video`, the response has `url` (a YouTube embed URL) but no `hdurl`. Always check `media_type` before accessing `hdurl`.
+
+- **Mars Rover `sol` vs `earth_date`** — Both are valid filter params. `sol` is the Martian solar day since rover landing. `earth_date` uses `YYYY-MM-DD`. You cannot mix them in one request.
+
+- **Mars Rover pagination defaults to 25 photos/page** — Large sols (Curiosity sol 1000 has many photos) require `&page=2`, `&page=3`, etc. There is no total count in the response; keep paginating until you get an empty `photos` list.
+
+- **EPIC image name encodes type in the prefix** — Natural images use `epic_1b_` prefix; enhanced color-corrected images use `epic_RGB_` prefix. The API returns the correct filename in `img['image']`; don't guess the prefix.
+
+- **EPIC `/api/natural/all` returns newest-first** — The list of 3,477+ available dates starts from today and goes back to 2015-06-13. Not all days have images (gaps during spacecraft maintenance).
+
+- **Exoplanet `ps` table has multiple rows per planet** — Different publications report different measurements for the same planet. Use `pscomppars` for one-row-per-planet composite parameters. `ps` is useful when you need all reported values or want to filter by specific reference.
+
+- **Exoplanet null values come back as `None` in JSON** — Many fields like `pl_masse` are `null` for planets without mass measurements. Always guard with `if row['pl_masse'] is not None`.
+
+- **`http_get` in helpers.py uses stdlib `urllib`** — On some macOS Python 3.11 installs, SSL certificate verification fails (`CERTIFICATE_VERIFY_FAILED`). If you hit this, run `curl` via `subprocess` as a fallback, or install certifi and patch the default SSL context. The harness's browser CDP connection is not affected; only `http_get` is.

--- a/domain-skills/rest-countries/scraping.md
+++ b/domain-skills/rest-countries/scraping.md
@@ -1,0 +1,233 @@
+# REST Countries — Scraping & Data Extraction
+
+`https://restcountries.com` — open JSON API for country data. **Never use the browser.** All data is reachable via `http_get`. No auth required, no API key.
+
+## Do this first
+
+**Fetch all 250 countries in one call with a field filter — almost always the fastest approach.**
+
+```python
+import json
+from helpers import http_get
+
+data = http_get("https://restcountries.com/v3.1/all?fields=name,cca2,capital,population,area,region")
+countries = json.loads(data)
+# countries is a list of 250 dicts — confirmed 2026-04-18
+
+for c in countries:
+    name       = c["name"]["common"]          # "Germany"
+    official   = c["name"]["official"]        # "Federal Republic of Germany"
+    code       = c["cca2"]                    # "DE"
+    capital    = c["capital"][0] if c.get("capital") else None   # list — may be empty
+    population = c["population"]              # 83491249
+    area       = c["area"]                    # 357114.0 (km²)
+    region     = c["region"]                  # "Europe"
+    print(code, name, population)
+# Confirmed output (first result varies — API returns unsorted):
+# CI Ivory Coast 31719275
+```
+
+Use the `?fields=` query param to limit response size — essential when fetching all 250.
+
+## Common workflows
+
+### Lookup a single country by code (ISO 3166-1 alpha-2 or alpha-3)
+
+```python
+import json
+from helpers import http_get
+
+# Single code — returns a list (one element)
+data = http_get("https://restcountries.com/v3.1/alpha/DE")
+country = json.loads(data)[0]
+
+# But: /alpha/CODE?fields=... returns a plain dict, not a list — watch for this
+data2 = http_get("https://restcountries.com/v3.1/alpha/DE?fields=name,cca2,currencies,languages,flags")
+country2 = json.loads(data2)          # dict, NOT list
+
+name       = country2["name"]["common"]                             # "Germany"
+currencies = country2["currencies"]                                 # {"EUR": {"name": "euro", "symbol": "€"}}
+currency_codes = list(currencies.keys())                            # ["EUR"]
+currency_name  = currencies["EUR"]["name"]                          # "euro"
+languages  = country2["languages"]                                  # {"deu": "German"}
+lang_names = list(languages.values())                               # ["German"]
+flag_png   = country2["flags"]["png"]                               # "https://flagcdn.com/w320/de.png"
+flag_svg   = country2["flags"]["svg"]                               # "https://flagcdn.com/de.svg"
+flag_alt   = country2["flags"]["alt"]                               # description text
+
+print(name, currency_codes, lang_names)
+# Confirmed: Germany ['EUR'] ['German']
+```
+
+### Batch lookup — multiple codes in one call
+
+Use `/alpha?codes=` for fetching a known list of countries — always returns a list.
+
+```python
+import json
+from helpers import http_get
+
+codes = ["US", "GB", "FR", "DE", "JP", "CN", "IN", "BR", "AU", "CA"]
+data = http_get(f"https://restcountries.com/v3.1/alpha?codes={','.join(codes)}&fields=name,cca2,population")
+countries = json.loads(data)
+# Returns list, order NOT guaranteed to match input order
+for c in countries:
+    print(c["cca2"], c["name"]["common"], c["population"])
+# Confirmed: 10 results, returned in arbitrary order
+```
+
+### Search by name
+
+```python
+import json
+from helpers import http_get
+
+# Partial match (default) — may return multiple results
+data = http_get("https://restcountries.com/v3.1/name/united")
+results = json.loads(data)
+# Returns 7 countries: United States, UK, UAE, Tanzania, Mexico, ...
+
+# Exact match — use fullText=true with the full common or official name
+data2 = http_get("https://restcountries.com/v3.1/name/united%20kingdom?fullText=true")
+results2 = json.loads(data2)
+# Returns exactly 1 result: United Kingdom
+print(results2[0]["name"]["common"])  # United Kingdom
+```
+
+### Filter by region
+
+```python
+import json
+from helpers import http_get
+
+data = http_get("https://restcountries.com/v3.1/region/europe?fields=name,cca2,population")
+countries = json.loads(data)
+# 53 European countries — confirmed
+
+# Sort by population
+ranked = sorted(countries, key=lambda x: x["population"], reverse=True)
+for c in ranked[:5]:
+    print(c["cca2"], c["name"]["common"], f"{c['population']:,}")
+# Confirmed top 5: RU Russia, DE Germany, FR France, GB United Kingdom, IT Italy
+```
+
+Valid region values: `africa`, `americas`, `asia`, `europe`, `oceania`, `antarctic`
+
+### Filter by subregion
+
+```python
+import json
+from helpers import http_get
+
+data = http_get("https://restcountries.com/v3.1/subregion/Western%20Europe?fields=name,cca2")
+countries = json.loads(data)
+print([c["cca2"] for c in countries])
+# Confirmed: ['FR', 'NL', 'MC', 'DE', 'BE', 'LI', 'CH', 'LU']
+```
+
+### Filter by language
+
+```python
+import json
+from helpers import http_get
+
+data = http_get("https://restcountries.com/v3.1/lang/arabic")
+countries = json.loads(data)
+print(f"Arabic-speaking countries: {len(countries)}")
+# Confirmed: 25 countries
+
+# Language param is the language name (English), not the ISO 639-3 code
+# Works: arabic, french, spanish, english, portuguese, german, russian, chinese
+```
+
+### Filter by currency
+
+```python
+import json
+from helpers import http_get
+
+data = http_get("https://restcountries.com/v3.1/currency/EUR")
+countries = json.loads(data)
+print(f"EUR countries: {len(countries)}")  # Confirmed: 36
+names = [c["name"]["common"] for c in countries]
+print(names[:5])
+
+# Use ISO 4217 currency code (uppercase)
+```
+
+### Filter by capital city
+
+```python
+import json
+from helpers import http_get
+
+data = http_get("https://restcountries.com/v3.1/capital/berlin?fields=name,cca2,capital")
+result = json.loads(data)
+print(result[0]["name"]["common"], result[0]["capital"])
+# Confirmed: Germany ['Berlin']
+# Capital param is case-insensitive
+```
+
+### Full country detail — all fields
+
+```python
+import json
+from helpers import http_get
+
+data = http_get("https://restcountries.com/v3.1/alpha/US")
+c = json.loads(data)[0]
+
+# Available top-level keys (confirmed for US/DE):
+# name, tld, cca2, ccn3, cca3, cioc, independent, status, unMember,
+# currencies, idd, capital, altSpellings, region, subregion, languages,
+# translations, latlng, landlocked, borders, area, demonyms, flag (emoji),
+# maps, population, gini, fifa, car, timezones, continents, flags,
+# coatOfArms, startOfWeek, capitalInfo, postalCode
+
+print(c["idd"])          # {"root": "+1", "suffixes": ["201", "202", ...]}
+print(c["car"]["side"])  # "right" or "left"
+print(c["gini"])         # {"2018": 41.4}  — year keyed, may be absent
+print(c["timezones"])    # list of UTC offset strings
+print(c["borders"])      # list of cca3 codes for bordering countries
+print(c["latlng"])       # [lat, lng] of geographic center
+```
+
+## URL reference
+
+| Endpoint | Pattern | Notes |
+|---|---|---|
+| All countries | `/v3.1/all` | Always add `?fields=` |
+| By code | `/v3.1/alpha/{code}` | cca2 or cca3; single code → list (no fields) or dict (with fields) |
+| By codes | `/v3.1/alpha?codes=DE,FR,JP` | Always returns list |
+| By name | `/v3.1/name/{name}` | Partial; add `?fullText=true` for exact match |
+| By region | `/v3.1/region/{region}` | africa, americas, asia, europe, oceania, antarctic |
+| By subregion | `/v3.1/subregion/{subregion}` | URL-encode spaces as `%20` |
+| By language | `/v3.1/lang/{language}` | English language name |
+| By currency | `/v3.1/currency/{code}` | ISO 4217 (EUR, USD, GBP) |
+| By capital | `/v3.1/capital/{city}` | Case-insensitive |
+
+All endpoints accept `?fields=field1,field2,...` to limit response payload.
+
+## Gotchas
+
+- **`name` is a nested object, not a string.** Use `c["name"]["common"]` for the familiar English name, `c["name"]["official"]` for the full official name. `nativeName` is a dict keyed by ISO 639-3 language code.
+
+- **`/alpha/CODE` return type depends on whether `?fields=` is present.** Without `?fields=`, returns a list (one element). With `?fields=...`, returns a plain dict. Use `json.loads(data)[0]` for the no-fields case, `json.loads(data)` for the fields case. Using `/alpha?codes=CODE` always returns a list regardless.
+
+- **`currencies` is a dict keyed by ISO 4217 code, not a list.** `c["currencies"]["EUR"]["name"]` → `"euro"`, `c["currencies"]["EUR"]["symbol"]` → `"€"`. A country can have multiple currencies — iterate `currencies.items()`.
+
+- **`languages` is a dict keyed by ISO 639-3 code.** `c["languages"]["deu"]` → `"German"`. Use `list(c["languages"].values())` for a simple list of language names.
+
+- **`capital` is a list and may be empty.** Some territories (Antarctica, Bouvet Island, Macau, Heard Island) have no capital — `c.get("capital")` returns `[]`, not `None`. Guard with `c["capital"][0] if c.get("capital") else None`. South Africa has 3 capitals.
+
+- **`gini` is a dict keyed by year string, may be absent entirely.** `c["gini"]` → `{"2016": 31.9}`. Many small countries or territories have no gini data — always check `c.get("gini")`.
+
+- **`borders` uses cca3 codes, not cca2.** `c["borders"]` → `["AUT", "BEL", ...]`. Cross-reference with another `/alpha?codes=` call to resolve to names.
+
+- **`translations` covers ~45 languages.** Each entry: `c["translations"]["deu"]` → `{"official": "Bundesrepublik Deutschland", "common": "Deutschland"}`. Useful for multilingual apps.
+
+- **No rate limit headers, no documented rate limit.** In practice the API handles rapid sequential calls fine. For bulk crawling hundreds of per-country requests, add a short sleep (`time.sleep(0.5)`) between calls to be polite.
+
+- **404 returns JSON, not HTML.** `{"message": "Not Found", "status": 404}`. Wrap calls in try/except and check for this pattern when handling user-supplied country names or codes.
+
+- **`?fields=` is the key performance lever.** The full all-countries payload without field filtering is ~1.5 MB. With `?fields=name,cca2,population` it drops to ~50 KB. Always filter when you don't need all fields.

--- a/domain-skills/wayback-machine/scraping.md
+++ b/domain-skills/wayback-machine/scraping.md
@@ -1,0 +1,306 @@
+# Wayback Machine — CDX API & Snapshot Retrieval
+
+`https://web.archive.org` — all public data, no auth or API key required. Everything here is pure `http_get` — no browser needed.
+
+> **NOTE:** A comprehensive Internet Archive skill (covering CDX, item metadata, and search) already exists at `domain-skills/archive-org/scraping.md`. This file is a focused, CDX-first quick-reference for Wayback Machine snapshot work specifically.
+
+## Start here: CDX API
+
+The CDX (Capture/Crawl Index) API is the single fastest way to query the Wayback Machine. It returns structured JSON and supports filtering, collapsing, pagination, and nearest-date lookups.
+
+```python
+import json
+
+# Find all snapshots of a URL — the minimal starting query
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com&output=json&limit=10"
+    "&fl=timestamp,original,statuscode,mimetype,length",
+    timeout=40.0   # CDX is slow — never use less than 40s
+)
+rows = json.loads(r)
+# rows[0] is ALWAYS the header row — slice rows[1:] for data
+for ts, orig, status, mime, length in rows[1:]:
+    print(f"https://web.archive.org/web/{ts}/{orig}  [{status}]")
+```
+
+**All CDX values are strings**, even numeric ones (`status='200'`, `length='4821'`). Cast explicitly with `int()` / `float()`.
+
+---
+
+## Core CDX patterns
+
+### Nearest snapshot to a target date
+
+```python
+import json
+
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com&output=json&limit=1"
+    "&fl=timestamp,original,statuscode"
+    "&closest=20230601120000&sort=closest",
+    timeout=60.0
+)
+rows = json.loads(r)
+ts, orig, status = rows[1]   # rows[0] is header
+snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+# Timestamp format: 14-digit YYYYMMDDHHMMSS
+# Prefix shorthand: '20230601' (day), '202306' (month), '2023' (year)
+```
+
+### One snapshot per month (collapsed)
+
+```python
+import json
+
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com&output=json"
+    "&collapse=timestamp:6"   # :6 = one per YYYYMM
+    "&from=20220101&to=20230101"
+    "&fl=timestamp,original,statuscode",
+    timeout=60.0
+)
+rows = json.loads(r)
+for ts, orig, status in rows[1:]:
+    print(f"{ts[:4]}-{ts[4:6]}  https://web.archive.org/web/{ts}/{orig}")
+
+# collapse=timestamp:N — collapse by first N timestamp digits:
+#   :4 = one per year
+#   :6 = one per month   (most common)
+#   :8 = one per day
+#   :10 = one per hour
+# Keeps the FIRST capture of each period — not the last.
+```
+
+### All pages under a domain or path
+
+```python
+import json
+
+# matchType=prefix — all URLs starting with the given path
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com/blog/&matchType=prefix&output=json"
+    "&limit=20&fl=timestamp,original,statuscode"
+    "&filter=statuscode:200",   # only successful captures
+    timeout=60.0
+)
+rows = json.loads(r)
+for row in rows[1:]:
+    print(row)
+
+# matchType options:
+#   exact   (default) — this URL only
+#   prefix  — URL + all subpaths
+#   host    — all subdomains of the host
+#   domain  — host + all subdomains (broadest)
+```
+
+### Filter by status code or MIME type
+
+```python
+import json
+
+# Only successful HTML captures — combine multiple filters
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com&output=json"
+    "&filter=statuscode:200"
+    "&filter=mimetype:text/html"
+    "&fl=timestamp,original,length"
+    "&limit=10",
+    timeout=40.0
+)
+rows = json.loads(r)
+
+# filter= uses regex. Examples:
+#   &filter=statuscode:200          exact match
+#   &filter=!statuscode:200         negation (all non-200)
+#   &filter=statuscode:[23]..       2xx and 3xx only
+#   &filter=mimetype:text/html      HTML only
+#   &filter=original:.*\\.pdf       URLs ending in .pdf
+# Multiple &filter= params are ANDed together.
+```
+
+### CDX field reference
+
+| Field | Description | Example value |
+|---|---|---|
+| `urlkey` | SURT-format URL (reversed domain) | `com,example)/` |
+| `timestamp` | Capture time, 14-digit `YYYYMMDDHHMMSS` | `20230601114925` |
+| `original` | Original crawled URL (includes port if non-standard) | `https://example.com/` |
+| `mimetype` | Content-Type at crawl time | `text/html` |
+| `statuscode` | HTTP status at crawl time (string) | `200` |
+| `digest` | SHA-1 of body, base32-encoded | `I4YBMQ6PHPWE2TD6TIXNWHZB6MXRNTSR` |
+| `length` | Content-length in bytes (string) | `4821` |
+
+Default `fl=` when omitted: all 7 fields above in that order.
+
+---
+
+## Availability API (DO NOT USE as primary)
+
+```python
+import json
+
+# WARNING: This API is BROKEN — returns empty archived_snapshots
+# for URLs that ARE in the archive. Confirmed broken 2026-04-18.
+# Use CDX with ?sort=closest&limit=1 instead (see above).
+
+# Left here for reference only — do not rely on it:
+r = http_get(
+    "https://archive.org/wayback/available"
+    "?url=example.com&timestamp=20240101",
+    timeout=20.0
+)
+data = json.loads(r)
+# Returns: {"url": "example.com", "archived_snapshots": {}}
+# Even for well-archived URLs. Do not trust empty results.
+
+# CORRECT replacement:
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com&output=json&limit=1"
+    "&fl=timestamp,original,statuscode"
+    "&closest=20240101000000&sort=closest",
+    timeout=60.0
+)
+rows = json.loads(r)
+if len(rows) > 1:
+    ts, orig, status = rows[1]
+    snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+```
+
+---
+
+## Paginate large result sets
+
+```python
+import json
+from urllib.parse import quote
+
+def cdx_all_snapshots(url, fl="timestamp,original,statuscode", page_size=500):
+    """Yield all CDX rows for a URL, page by page."""
+    base = (
+        "https://web.archive.org/cdx/search/cdx"
+        f"?url={quote(url, safe='')}&output=json"
+        f"&fl={fl}&limit={page_size}&showResumeKey=true"
+    )
+    resume_key = None
+    while True:
+        endpoint = base if resume_key is None else f"{base}&resumeKey={quote(resume_key)}"
+        rows = json.loads(http_get(endpoint, timeout=60.0))
+        # With showResumeKey=true, last two rows are [] and ['<key>']
+        has_resume = len(rows) >= 2 and rows[-2] == [] and rows[-1] != []
+        data_rows = rows[1:-2] if has_resume else rows[1:]
+        for row in data_rows:
+            yield row
+        if not has_resume:
+            break
+        resume_key = rows[-1][0]
+
+for ts, orig, status in cdx_all_snapshots("example.com"):
+    snap_url = f"https://web.archive.org/web/{ts}/{orig}"
+    # process...
+```
+
+---
+
+## Retrieve the archived page
+
+```python
+# Direct snapshot URL: /web/{14-digit-timestamp}/{original-url}
+snap_url = "https://web.archive.org/web/20230601114925/https://example.com/"
+content = http_get(snap_url, timeout=30.0)
+# Returns archived HTML with Wayback toolbar injected inside:
+# <!-- BEGIN WAYBACK TOOLBAR INSERT --> ... <!-- END WAYBACK TOOLBAR INSERT -->
+# Strip those comments + their contents if you want the original HTML.
+
+# Canonical form for "get latest available" — use 14 zeros:
+latest = "https://web.archive.org/web/20240101000000*/example.com"
+# The * suffix returns a calendar page (HTML), not the archived page itself.
+# Use CDX to find the real timestamp, then fetch the direct URL.
+```
+
+---
+
+## Advanced CDX: deduplicate by content digest
+
+```python
+import json
+
+# Find only snapshots where the content CHANGED — dedup by SHA-1 digest
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com&output=json"
+    "&collapse=digest"           # one capture per unique body hash
+    "&fl=timestamp,original,digest,length"
+    "&filter=statuscode:200",
+    timeout=60.0
+)
+rows = json.loads(r)
+# rows[1:] are unique content versions across all time
+# Useful for detecting when a page actually changed, vs. being re-crawled identically
+```
+
+---
+
+## CDX summary/count query
+
+```python
+import json
+
+# showNumPages=true returns total page count, not records
+# Use for estimating result size before a full fetch
+r = http_get(
+    "https://web.archive.org/cdx/search/cdx"
+    "?url=example.com&matchType=prefix"
+    "&showNumPages=true",
+    timeout=30.0
+)
+page_count = int(r.strip())   # returns plain integer, not JSON
+# 1 page ~ 150,000 records by default
+# Combine with &page=N for manual page-based pagination:
+# ?url=...&output=json&page=0, ?url=...&output=json&page=1, etc.
+```
+
+---
+
+## Rate limits & timeouts
+
+| API | Typical latency | Safe timeout | Notes |
+|---|---|---|---|
+| CDX search | 5–40s | 60s | Intermittently slow; retry on timeout |
+| Snapshot fetch (`/web/`) | 2–10s | 30s | Reliable |
+| Metadata (`/metadata/`) | <1s | 20s | Fast, stable |
+| Advanced search | <1s | 20s | Fast, stable |
+
+No API key required. No documented rate limit. Be respectful: add `time.sleep(1)` between CDX calls in loops. 3 rapid sequential CDX calls (~10s) complete fine; 10+ rapid calls produce timeouts.
+
+---
+
+## Gotchas
+
+- **CDX is slow — always set `timeout=60.0` for CDX calls.** 40s minimum, 60s recommended. Metadata and search APIs are fine at 20s. CDX slowness is server-side and unpredictable.
+
+- **Availability API (`/wayback/available`) is broken.** Returns `{"archived_snapshots": {}}` even for URLs with thousands of captures. Tested 2026-04-18 — do not use. Replacement: CDX with `?sort=closest&limit=1`.
+
+- **`rows[0]` is always the header when `output=json`.** Always slice `rows[1:]` for data. Forgetting this causes silent type errors because you're destructuring column names, not values.
+
+- **`output=json` must be explicit.** Omitting it returns space-separated text. There is no default JSON mode.
+
+- **All CDX values are strings.** `statuscode='200'` not `200`, `length='4821'` not `4821`. Cast: `int(row[4])`, `int(row[6])`.
+
+- **`original` preserves non-standard ports.** Old crawls captured `http://www.example.com:80/` — the `:80` is part of the `original` field. Build playback URLs verbatim: `f"https://web.archive.org/web/{ts}/{orig}"` works correctly with the port.
+
+- **`from=` / `to=` timestamps are exclusive at the boundary.** `to=20231231` means `to=20231231000000` — it excludes captures from Dec 31 itself. Use `to=20240101` to include all of 2023.
+
+- **`collapse=timestamp:6` keeps the FIRST capture of each period.** Not the most recent. Reverse the result set or filter client-side if you need the last.
+
+- **CDX `matchType=domain` can return millions of rows for popular sites.** Always add `&limit=` or `&showNumPages=true` first to estimate size.
+
+- **`showResumeKey=true` appends two sentinel rows.** The second-to-last row is `[]` (empty separator), the last row is `['<resume_key_string>']`. Slice `rows[1:-2]` for data rows when a resume key is present.
+
+- **Wayback toolbar is injected into every archived HTML page.** The injection is wrapped in `<!-- BEGIN WAYBACK TOOLBAR INSERT -->` / `<!-- END WAYBACK TOOLBAR INSERT -->` comments. Strip them if you need original HTML fidelity.

--- a/domain-skills/world-bank/scraping.md
+++ b/domain-skills/world-bank/scraping.md
@@ -1,0 +1,356 @@
+# World Bank Open Data — Scraping & Data Extraction
+
+`https://api.worldbank.org/v2` — free REST API for global development indicators. No API key, no auth, no browser needed. All data via `http_get`.
+
+## Do this first
+
+**Every response is a 2-element JSON array: `[metadata, data]`.** The metadata element is always at index 0 (pagination info); the data array is at index 1. This is the single biggest gotcha — `json.loads(raw)` gives you a list, not a dict.
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get("https://api.worldbank.org/v2/country/US/indicator/NY.GDP.MKTP.CD?format=json")
+d = json.loads(raw)
+meta = d[0]   # {"page": 1, "pages": 2, "per_page": 50, "total": 66, ...}
+rows = d[1]   # list of data records
+```
+
+Always append `?format=json` — default response is XML.
+
+## Common workflows
+
+### Single country, single indicator
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get("https://api.worldbank.org/v2/country/US/indicator/NY.GDP.MKTP.CD?format=json")
+d = json.loads(raw)
+meta, rows = d[0], d[1]
+
+for r in rows:
+    if r["value"] is not None:   # recent years often have null values
+        print(r["date"], r["value"])
+# Confirmed output (2026-04-18):
+# 2024 28750956130731.2
+# 2023 27292170793214.4
+# 2022 25604848907611.0
+# ...
+```
+
+### Most recent N values (`mrv` param)
+
+`mrv` (most recent values) skips null years and returns the N most recent non-provisional points.
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get(
+    "https://api.worldbank.org/v2/country/US/indicator/NY.GDP.MKTP.CD"
+    "?format=json&mrv=5"
+)
+d = json.loads(raw)
+for r in d[1]:
+    print(r["date"], r["value"])
+# Confirmed output (2026-04-18):
+# 2024 28750956130731.2
+# 2023 27292170793214.4
+# 2022 25604848907611.0
+# 2021 23315080560000.0
+# 2020 21060473613000.0
+```
+
+### Multiple countries, date range
+
+Semicolon-delimit country codes in the URL path. Use `date=YYYY:YYYY` for a range.
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get(
+    "https://api.worldbank.org/v2/country/US;CN;GB/indicator/SP.POP.TOTL"
+    "?format=json&date=2000:2023&per_page=100"
+)
+d = json.loads(raw)
+meta, rows = d[0], d[1]
+print(f"Total records: {meta['total']}, pages: {meta['pages']}")
+
+for r in rows:
+    print(r["country"]["value"], r["date"], r["value"])
+# Confirmed: returns 8 records per page (50 default), date range honored exactly
+# Countries: ['China', 'United States', 'United Kingdom']
+# Dates: ['2000', '2001', ..., '2023']
+```
+
+### All countries, latest value only
+
+Use `mrv=1` with `per_page=1000` to get all 266 countries in a single call.
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get(
+    "https://api.worldbank.org/v2/country/all/indicator/NY.GDP.PCAP.CD"
+    "?format=json&mrv=1&per_page=1000"
+)
+d = json.loads(raw)
+meta, rows = d[0], d[1]
+print(f"Countries returned: {len(rows)}")  # 266 (includes aggregates)
+
+# Filter out regional aggregates — they have no iso2Code or have aggregate ids
+countries_only = [r for r in rows if len(r["country"]["id"]) == 2]
+for r in sorted(countries_only, key=lambda x: -(x["value"] or 0))[:5]:
+    print(r["country"]["value"], r["date"], f"${r['value']:,.0f}")
+# Confirmed output (2026-04-18):
+# Luxembourg 2024 $135,605
+# Norway 2024 $105,056
+# ...
+```
+
+### Full pagination (fetch all pages)
+
+```python
+from helpers import http_get
+import json
+
+def fetch_all_pages(base_url):
+    """Fetch all pages of a World Bank API endpoint."""
+    all_rows = []
+    page = 1
+    while True:
+        url = f"{base_url}&page={page}" if "?" in base_url else f"{base_url}?page={page}"
+        d = json.loads(http_get(url))
+        meta, rows = d[0], d[1]
+        all_rows.extend(rows)
+        if page >= meta["pages"]:
+            break
+        page += 1
+    return all_rows
+
+# Example: all US GDP data (66 years, 2 pages)
+rows = fetch_all_pages(
+    "https://api.worldbank.org/v2/country/US/indicator/NY.GDP.MKTP.CD"
+    "?format=json&per_page=50"
+)
+print(f"Total rows: {len(rows)}")  # 66
+non_null = [(r["date"], r["value"]) for r in rows if r["value"] is not None]
+print(f"Non-null: {len(non_null)}, range: {non_null[-1][0]}–{non_null[0][0]}")
+```
+
+### Indicators list (discover available indicators)
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get("https://api.worldbank.org/v2/indicator?format=json&per_page=50")
+d = json.loads(raw)
+meta = d[0]
+print(f"Total indicators: {meta['total']}, pages: {meta['pages']}")
+# Confirmed: 29,511 indicators across 591 pages
+
+for ind in d[1][:3]:
+    print(ind["id"], "-", ind["name"])
+# 1.0.HCount.1.90usd - Poverty Headcount ($1.90 a day)
+# ...
+```
+
+### Indicators by topic
+
+```python
+from helpers import http_get
+import json
+
+# Topic 3 = Economy & Growth
+raw = http_get("https://api.worldbank.org/v2/topic/3/indicator?format=json&per_page=50")
+d = json.loads(raw)
+print(f"Economy & Growth indicators: {d[0]['total']}")  # 306
+
+for ind in d[1][:5]:
+    print(ind["id"], "-", ind["name"])
+```
+
+### Country metadata
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get("https://api.worldbank.org/v2/country/US?format=json")
+d = json.loads(raw)
+c = d[1][0]
+print(c["name"], c["capitalCity"], c["region"]["value"], c["incomeLevel"]["value"])
+# United States  Washington D.C.  North America  High income
+
+# Filter countries by income level
+raw = http_get("https://api.worldbank.org/v2/country?format=json&incomeLevel=LIC&per_page=300")
+d = json.loads(raw)
+print(f"Low-income countries: {d[0]['total']}")  # 25
+```
+
+### Topics list
+
+```python
+from helpers import http_get
+import json
+
+raw = http_get("https://api.worldbank.org/v2/topics?format=json")
+d = json.loads(raw)
+for t in d[1]:
+    print(t["id"], t["value"])
+# 1  Agriculture & Rural Development
+# 2  Aid Effectiveness
+# 3  Economy & Growth
+# ... (21 topics total)
+```
+
+### Parallel fetch for multiple indicators (ThreadPoolExecutor)
+
+```python
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+import json
+
+INDICATORS = {
+    "NY.GDP.MKTP.CD": "GDP (current US$)",
+    "SP.POP.TOTL": "Population",
+    "NY.GDP.PCAP.CD": "GDP per capita",
+}
+
+def fetch_indicator(ind_id):
+    url = (
+        f"https://api.worldbank.org/v2/country/US/indicator/{ind_id}"
+        f"?format=json&mrv=5"
+    )
+    d = json.loads(http_get(url))
+    return ind_id, d[1]
+
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = dict(ex.map(lambda i: fetch_indicator(i), INDICATORS))
+
+for ind_id, rows in results.items():
+    latest = next((r for r in rows if r["value"] is not None), None)
+    if latest:
+        print(f"{INDICATORS[ind_id]}: {latest['date']} = {latest['value']:,.2f}")
+```
+
+## URL reference
+
+### Base URL
+
+```
+https://api.worldbank.org/v2
+```
+
+HTTP redirects to HTTPS (302). Always use HTTPS directly.
+
+### Endpoint patterns
+
+| Endpoint | Description |
+|---|---|
+| `/country/{code}/indicator/{id}` | Single country + indicator time series |
+| `/country/{c1};{c2};{c3}/indicator/{id}` | Multi-country (semicolon-delimited) |
+| `/country/all/indicator/{id}` | All countries |
+| `/country/{code}` | Country metadata |
+| `/country` | All countries metadata (filterable) |
+| `/indicator` | All indicators list |
+| `/indicator/{id}` | Single indicator metadata |
+| `/topic/{id}/indicator` | Indicators for a topic |
+| `/topics` | All topics |
+
+### Query parameters
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `format` | `json`, `xml` (default) | Always set `format=json` |
+| `per_page` | integer, default 50, max 1000 | Higher is faster for bulk |
+| `page` | integer, default 1 | For paginating results |
+| `date` | `2020`, `2000:2023` | Single year or colon-separated range |
+| `mrv` | integer | N most recent non-null values |
+| `gapfill` | `Y` | Forward-fill nulls when used with `mrv` |
+| `incomeLevel` | `LIC`, `MIC`, `HIC`, `LMC`, `UMC` | Filter countries by income |
+| `region` | `EAS`, `ECS`, `LAC`, `MEA`, `NAC`, `SAS`, `SSF` | Filter countries by region |
+
+### Common indicator IDs (confirmed working, 2026-04-18)
+
+| ID | Name |
+|---|---|
+| `NY.GDP.MKTP.CD` | GDP (current US$) |
+| `NY.GDP.PCAP.CD` | GDP per capita (current US$) |
+| `SP.POP.TOTL` | Population, total |
+| `SL.UEM.TOTL.ZS` | Unemployment (% of labor force) |
+| `FP.CPI.TOTL.ZG` | Inflation, consumer prices (%) |
+| `NE.EXP.GNFS.ZS` | Exports of goods and services (% of GDP) |
+| `SP.DYN.LE00.IN` | Life expectancy at birth |
+| `SE.ADT.LITR.ZS` | Literacy rate, adult total (%) |
+| `EG.USE.PCAP.KG.OE` | Energy use per capita (kg of oil equiv.) |
+
+Find more: `https://api.worldbank.org/v2/indicator?format=json&per_page=50&page=N`
+
+### Country codes (ISO2)
+
+Standard ISO 3166-1 alpha-2 codes: `US`, `CN`, `GB`, `DE`, `JP`, `IN`, `BR`, etc.
+Special: `all` for all countries.
+
+## Response structure
+
+Every endpoint returns a 2-element array:
+
+```json
+[
+  {
+    "page": 1,
+    "pages": 2,
+    "per_page": 50,
+    "total": 66,
+    "sourceid": "2",
+    "lastupdated": "2026-04-08"
+  },
+  [
+    {
+      "indicator": {"id": "NY.GDP.MKTP.CD", "value": "GDP (current US$)"},
+      "country": {"id": "US", "value": "United States"},
+      "countryiso3code": "USA",
+      "date": "2024",
+      "value": 28750956130731.2,
+      "unit": "",
+      "obs_status": "",
+      "decimal": 0
+    },
+    ...
+  ]
+]
+```
+
+Country metadata endpoint returns same 2-element shape but with country objects (not indicator rows) at index 1.
+
+## Gotchas
+
+- **Response is always a 2-element array, not a dict.** `d = json.loads(raw)` gives a list. `d[0]` is pagination metadata, `d[1]` is the data list. Accessing `d["page"]` raises `TypeError`. This is the most common mistake.
+
+- **`value` can be null.** Recent years (e.g. 2025) and data-sparse countries frequently have `null` values. Always check `if r["value"] is not None` before using. Use `mrv=N` to skip nulls automatically.
+
+- **Always append `?format=json`.** The default response format is XML. Without `format=json`, you get an XML string that fails `json.loads`.
+
+- **`all/indicator/{id}` includes regional aggregates.** The "all countries" endpoint returns 266 entries including aggregated regions like "Africa Eastern and Southern" (`id: "ZH"`). Filter to real countries with `len(r["country"]["id"]) == 2` (ISO2 codes are always 2 chars; aggregate codes are 2-3 chars but with non-standard values).
+
+- **Semicolons in URL path, not query string.** Multi-country requests use `country/US;CN;GB/indicator/...` not `?countries=US,CN,GB`. Commas do not work.
+
+- **HTTP 302 redirects HTTP to HTTPS.** Always use `https://` directly to avoid an extra round trip.
+
+- **`per_page` in metadata is sometimes a string, sometimes an integer.** The API returns `"per_page": "50"` (string) for some endpoints and `"per_page": 50` (int) for others. Don't compare with `==` without casting: `int(meta["per_page"])`.
+
+- **Invalid country codes return an error object, not a 2-element array.** A bad code gives `[{"message": [{"id": "120", "key": "Invalid value", ...}]}]` — a 1-element list with an error dict. Check `if isinstance(d[0], dict) and "message" in d[0]` before accessing `d[1]`.
+
+- **`mrv` + `gapfill=Y` forward-fills the latest value into future years.** If 2024 is the latest data point and `mrv=3`, `gapfill=Y` returns 2025 (the current year) with the 2024 value copied in. Useful for "current" lookups, but the filled date is misleading.
+
+- **No rate limit documented, but 3 req/s sustained is safe.** The API handles bursts (parallel ThreadPoolExecutor with `max_workers=3`) without issue. For crawling thousands of indicators, add `time.sleep(0.5)` between pages.
+
+- **`date` range returns records newest-first.** Results within a date range are sorted descending by year. If you need ascending order, sort after fetching: `sorted(rows, key=lambda r: r["date"])`.
+
+- **Indicator IDs are case-sensitive.** `ny.gdp.mktp.cd` returns an error; use the uppercase dot-separated form `NY.GDP.MKTP.CD`.


### PR DESCRIPTION
## Summary
- World Bank: always 2-element array [metadata, data]; per_page is int for indicators but string for catalog; mrv skips nulls; semicolons for multi-country paths; gapfill=Y misleads on date field
- REST Countries: /alpha/DE returns list but /alpha/DE?fields=... returns dict; currencies is dict keyed by ISO code; capital is a list (can be empty); borders use cca3 codes
- NASA: DEMO_KEY limit is 10/hr (not 30 as advertised); APOD/NEO/Mars share one rate-limit pool; EPIC and Exoplanet Archive are free with no key; NEO capped at 7 days per request
- Wayback Machine (CDX): Availability API unreliable (use CDX nearest-date instead); collapse=digest for dedup; showNumPages for estimation; page-based pagination via resumeKey
- arXiv bulk: OAI-PMH endpoint migrated to oaipmh.arxiv.org; 5s sleep between pages required; http_get no-redirect issue with old URL; S2 /paper/search 429s fast without key

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five domain-skill guides for World Bank, REST Countries, NASA, Wayback Machine (CDX), and arXiv bulk with Semantic Scholar. Focuses on correct endpoints, rate limits, and pagination with copy‑paste examples and gotchas.

- **New Features**
  - World Bank: documents the 2‑element `[metadata, data]` JSON shape, `?format=json`, semicolon multi-country paths, `mrv` skipping nulls, and `gapfill=Y` caveats.
  - REST Countries: clarifies `/alpha/DE` list vs `/alpha/DE?fields=...` dict, `currencies` as a dict, `capital` as a list, `borders` using `cca3`, and batch `alpha?codes=`.
  - NASA: corrects `DEMO_KEY` to ~10/hour shared across `api.nasa.gov` (APOD/NEO/Mars), notes EPIC and Exoplanet Archive are keyless and unthrottled, and NEO’s 7‑day request cap.
  - Wayback Machine: replaces unreliable Availability API with CDX `closest` lookups, shows pagination with `showResumeKey`, dedup via `collapse=digest`, and recommends 60s CDX timeouts.
  - arXiv bulk: switches OAI-PMH to `https://oaipmh.arxiv.org/oai`, enforces 5s between pages, shows `arXivRaw` for version history, Semantic Scholar enrichment, and notes redirect pitfalls with simple `http_get`.

<sup>Written for commit 57ad39b709220145f18eeceb5f28d0eac42b0163. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

