### PR TITLE
Add domain skills: BLS, Food Data, PoetryDB, Fandom APIs, GitHub GraphQL

### DIFF
--- a/domain-skills/bls/scraping.md
+++ b/domain-skills/bls/scraping.md
@@ -1,0 +1,341 @@
+# U.S. Bureau of Labor Statistics (BLS) API — Data Extraction
+
+`https://api.bls.gov/publicAPI/v2` — public U.S. economic statistics. **No browser needed.** All data is reachable via `http_get` or Python's `urllib`. No API key required for basic access; a free registered key unlocks higher limits and extra features.
+
+## Do this first
+
+**Use the POST multi-series endpoint — it fetches up to 50 series in one call and supports year-range filtering.**
+
+```python
+import json, urllib.request
+
+def bls_post(series_ids, start_year, end_year, api_key=None):
+    """Fetch one or more BLS series via POST. No API key = 25 req/day (IP-shared)."""
+    payload = {"seriesid": series_ids, "startyear": str(start_year), "endyear": str(end_year)}
+    if api_key:
+        payload["registrationkey"] = api_key
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        "https://api.bls.gov/publicAPI/v2/timeseries/data/",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+data = bls_post(["LNS14000000", "CUUR0000SA0"], 2020, 2024)
+# Always check status first — limit exhaustion returns status='REQUEST_NOT_PROCESSED'
+assert data["status"] == "REQUEST_SUCCEEDED", data["message"]
+
+for series in data["Results"]["series"]:
+    sid = series["seriesID"]
+    for obs in series["data"][:3]:
+        print(sid, obs["year"], obs["period"], obs["periodName"], obs["value"])
+# LNS14000000  2024  M12  December   4.1
+# LNS14000000  2024  M11  November   4.2
+# CUUR0000SA0  2024  M12  December   314.175
+```
+
+Data is returned newest-first. Iterate in reverse (`series["data"][::-1]`) for chronological order.
+
+## Rate limits
+
+| Tier | Requests/day | Series/query | Year range | Extra fields |
+|---|---|---|---|---|
+| Unregistered | 25 (shared per IP) | 25 | 3 years max | No |
+| Registered (free key) | 500 | 50 | 20 years | catalog, calculations |
+
+Register at: `https://data.bls.gov/registrationEngine/` (instant, free, email only).
+
+The unregistered 25-req/day limit is **per IP address** — shared across all users on the same network. Hit the limit and every call returns `REQUEST_NOT_PROCESSED`. Recovery resets at midnight ET.
+
+## Response shape
+
+```python
+{
+    "status": "REQUEST_SUCCEEDED",  # or "REQUEST_NOT_PROCESSED" / "REQUEST_FAILED"
+    "responseTime": 118,            # ms
+    "message": [],                  # list of strings; non-empty on errors/warnings
+    "Results": {
+        "series": [
+            {
+                "seriesID": "LNS14000000",
+                "data": [
+                    {
+                        "year": "2024",
+                        "period": "M12",         # M01-M12, Q01-Q04, A01, S01-S02
+                        "periodName": "December",
+                        "value": "4.1",          # ALWAYS a string — cast to float
+                        "footnotes": [{"code": "P", "text": "Preliminary."}]
+                        # With api_key: also "calculations": {"net_changes": {...}, "pct_changes": {...}}
+                    },
+                    ...
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Common workflows
+
+### Single series — GET (no POST needed for one series)
+
+```python
+import json, urllib.request
+
+url = "https://api.bls.gov/publicAPI/v2/timeseries/data/LNS14000000"
+with urllib.request.urlopen(url, timeout=20) as r:
+    data = json.loads(r.read())
+
+series = data["Results"]["series"][0]
+latest = series["data"][0]  # newest first
+print(f"Unemployment rate: {latest['value']}% ({latest['periodName']} {latest['year']})")
+# Unemployment rate: 4.1% (December 2024)
+```
+
+### Multi-series fetch and flatten to records
+
+```python
+import json, urllib.request
+
+def bls_fetch(series_ids, start_year, end_year, api_key=None):
+    payload = {"seriesid": series_ids, "startyear": str(start_year), "endyear": str(end_year)}
+    if api_key:
+        payload["registrationkey"] = api_key
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        "https://api.bls.gov/publicAPI/v2/timeseries/data/",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        resp = json.loads(r.read())
+    if resp["status"] != "REQUEST_SUCCEEDED":
+        raise RuntimeError(resp["message"])
+    records = []
+    for series in resp["Results"]["series"]:
+        sid = series["seriesID"]
+        for obs in series["data"]:
+            records.append({
+                "series_id": sid,
+                "year": int(obs["year"]),
+                "period": obs["period"],
+                "period_name": obs["periodName"],
+                "value": float(obs["value"]),
+                "preliminary": any(f.get("code") == "P" for f in obs.get("footnotes", []) if f),
+            })
+    return records
+
+records = bls_fetch(["LNS14000000", "CUUR0000SA0"], 2022, 2024)
+print(len(records))  # e.g. 72 (2 series × 36 monthly observations)
+```
+
+### Monthly time-series: convert period to date
+
+```python
+import datetime
+
+def period_to_date(year: int, period: str) -> datetime.date:
+    """Convert BLS year+period to a date. M01='Jan 1', Q01='Jan 1', A01='Jan 1'."""
+    if period.startswith("M"):
+        month = int(period[1:])
+        return datetime.date(year, month, 1)
+    elif period.startswith("Q"):
+        quarter = int(period[1:])
+        month = (quarter - 1) * 3 + 1
+        return datetime.date(year, month, 1)
+    elif period.startswith("A"):
+        return datetime.date(year, 1, 1)
+    elif period.startswith("S"):
+        half = int(period[1:])
+        month = 1 if half == 1 else 7
+        return datetime.date(year, month, 1)
+    return datetime.date(year, 1, 1)
+
+for rec in sorted(records, key=lambda r: (r["year"], r["period"])):
+    dt = period_to_date(rec["year"], rec["period"])
+    print(dt, rec["series_id"], rec["value"])
+```
+
+### Fetch 20 years of data (requires API key)
+
+```python
+import json, urllib.request
+
+API_KEY = "your_key_here"  # from https://data.bls.gov/registrationEngine/
+
+payload = {
+    "seriesid": ["LNS14000000"],
+    "startyear": "2005",
+    "endyear": "2024",
+    "registrationkey": API_KEY,
+    "catalog": True,          # adds series metadata (title, survey, etc.)
+    "calculations": True,     # adds net_changes and pct_changes per observation
+    "annualaverage": True,    # adds annual average (period="M13") where available
+}
+body = json.dumps(payload).encode()
+req = urllib.request.Request(
+    "https://api.bls.gov/publicAPI/v2/timeseries/data/",
+    data=body,
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(req, timeout=30) as r:
+    data = json.loads(r.read())
+
+series = data["Results"]["series"][0]
+# With catalog=True: series["catalog"] dict with survey name, measure, area, etc.
+print(series.get("catalog", {}))
+# With calculations=True: each obs has "calculations" sub-dict
+obs = series["data"][0]
+print(obs.get("calculations", {}))
+# {'net_changes': {'1': '-0.1', '3': '0.2', '6': '-0.2', '12': '0.4'},
+#  'pct_changes': {'1': '-2.4', '3': '5.0', '6': '-4.8', '12': '10.8'}}
+```
+
+`calculations` keys `'1'`, `'3'`, `'6'`, `'12'` are 1-month, 3-month, 6-month, 12-month changes. Values are strings — cast to float.
+
+### Parallel fetch for independent year ranges (stays within 500/day limit)
+
+```python
+import json, urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+API_KEY = "your_key_here"
+
+def fetch_chunk(args):
+    series_ids, start, end = args
+    payload = {
+        "seriesid": series_ids,
+        "startyear": str(start),
+        "endyear": str(end),
+        "registrationkey": API_KEY,
+    }
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        "https://api.bls.gov/publicAPI/v2/timeseries/data/",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read())
+
+# Split 40 years into two 20-year chunks (v2 max is 20 years per call)
+chunks = [
+    (["LNS14000000", "CUUR0000SA0"], 1985, 2004),
+    (["LNS14000000", "CUUR0000SA0"], 2005, 2024),
+]
+with ThreadPoolExecutor(max_workers=2) as ex:
+    results = list(ex.map(fetch_chunk, chunks))
+```
+
+## Popular series IDs
+
+### Employment & Unemployment (BLS Current Population Survey)
+
+| Series ID | Description | Frequency |
+|---|---|---|
+| `LNS14000000` | Unemployment rate, seasonally adjusted | Monthly |
+| `LNS11000000` | Civilian labor force level | Monthly |
+| `LNS12000000` | Employment level | Monthly |
+| `LNS13000000` | Unemployed persons | Monthly |
+| `LAUCN040010000000006` | Arizona unemployment rate (county-level LAUS) | Monthly |
+
+### Nonfarm Payrolls (CES / Establishment Survey)
+
+| Series ID | Description | Frequency |
+|---|---|---|
+| `CES0000000001` | Total nonfarm employment, seasonally adjusted | Monthly |
+| `CES0500000001` | Total private employment | Monthly |
+| `CES1000000001` | Mining and logging | Monthly |
+| `CES2000000001` | Construction | Monthly |
+| `CES3000000001` | Manufacturing | Monthly |
+| `CES6000000001` | Professional and business services | Monthly |
+| `CES7000000001` | Leisure and hospitality | Monthly |
+
+### Inflation / Consumer Price Index (CPI-U)
+
+| Series ID | Description | Frequency |
+|---|---|---|
+| `CUUR0000SA0` | CPI-U, All items, not seasonally adjusted | Monthly |
+| `CUSR0000SA0` | CPI-U, All items, seasonally adjusted | Monthly |
+| `CUUR0000SA0L1E` | CPI-U, All items less food and energy (core) | Monthly |
+| `CUUR0000SAF1` | CPI-U, Food | Monthly |
+| `CUUR0000SA0E` | CPI-U, Energy | Monthly |
+
+### Producer Price Index (PPI)
+
+| Series ID | Description | Frequency |
+|---|---|---|
+| `PPIACO` | PPI, All commodities | Monthly |
+| `WPSSOP3000` | PPI, Finished goods | Monthly |
+
+### Productivity & Costs
+
+| Series ID | Description | Frequency |
+|---|---|---|
+| `PRS85006092` | Nonfarm business productivity, % change | Quarterly |
+| `PRS85006112` | Nonfarm business unit labor costs, % change | Quarterly |
+
+### Average Wages
+
+| Series ID | Description | Frequency |
+|---|---|---|
+| `CES0500000003` | Average hourly earnings, all private, SA | Monthly |
+| `CES0500000008` | Average weekly hours, all private, SA | Monthly |
+
+## Series ID structure
+
+BLS series IDs encode all query dimensions. Pattern: `PREFIX + region + measure + adjustment + ...`
+
+```
+LNS 14 000000 0  →  Local Area Unemployment Stats, Unemployment Rate, National, Seasonally Adj
+CES 000 0000 001 →  Current Employment Statistics, Total Nonfarm, All Employees
+CUU R0000 SA0   →  CPI-U, US city average, Not Seasonally Adjusted, All Items
+```
+
+Find series IDs using BLS Data Finder: `https://www.bls.gov/data/`
+
+## Period codes
+
+| Period | Meaning |
+|---|---|
+| `M01` – `M12` | January – December (monthly data) |
+| `M13` | Annual average (only with `annualaverage=True` and API key) |
+| `Q01` – `Q04` | Q1–Q4 (quarterly data, e.g. productivity) |
+| `A01` | Annual (yearly data) |
+| `S01` / `S02` | Semi-annual (H1 / H2) |
+
+The `periodName` field gives the human-readable label: `"January"`, `"1st Quarter"`, `"Annual"`, etc.
+
+## Gotchas
+
+- **`value` is always a string** — `obs["value"]` is `"4.1"`, not `4.1`. Always cast: `float(obs["value"])`. Occasional values are `"-"` for suppressed data; guard with `obs["value"] != "-"` before casting.
+
+- **Data is newest-first** — `series["data"][0]` is the most recent observation. Use `series["data"][::-1]` or `sorted(..., key=lambda o: (o["year"], o["period"]))` for chronological order.
+
+- **Unregistered limit is shared per IP** — 25 queries/day is not per-user; it applies to all traffic from the same public IP. In a shared environment (office, cloud NAT) this exhausts quickly. Register a free key to get 500/day tied to your email.
+
+- **Unregistered is limited to 3 years** — A call with `startyear=2000&endyear=2024` without a key silently truncates to the last 3 years. You won't get an error — you just get fewer rows. Always use a key for long time ranges.
+
+- **`REQUEST_NOT_PROCESSED` means rate limited** — Check `data["status"]` before processing. When limited, `data["Results"]` is `{}` or `[]`, causing a `KeyError` if you skip the check.
+
+- **POST body must be `application/json`** — The Content-Type header is required. Without it the server returns a 400 or processes the request as a form (ignoring `seriesid`).
+
+- **No SSL certificate on some Python installs** — macOS Python 3.11+ may fail with `CERTIFICATE_VERIFY_FAILED` against `api.bls.gov`. Fix: `ssl._create_default_https_context = ssl._create_unverified_context` (dev only), or install `certifi` and pass `context=ssl.create_default_context(cafile=certifi.where())`.
+
+- **Preliminary data footnote** — The most recent 1-2 observations are often marked preliminary (`footnotes[].code == "P"`). They will be revised in subsequent releases. Track the `"P"` footnote if revision-awareness matters.
+
+- **`calculations` keys are strings `'1'`/`'3'`/`'6'`/`'12'`** — Not integers. Access as `obs["calculations"]["net_changes"]["12"]` and cast to float. Only present when `calculations=True` is passed in the POST body (requires API key).
+
+- **`catalog` requires API key** — Passing `catalog=True` without a `registrationkey` is silently ignored. The `series["catalog"]` key won't appear in the response.
+
+- **Quarterly series use Q-periods, not M-periods** — Productivity (`PRS...`) and some GDP-linked series use `Q01`–`Q04`. Mixing monthly and quarterly series in one POST call works fine — each series has its own period codes.
+
+- **Max 20 years per call, max 50 series per call (with key)** — To retrieve more than 20 years, split into chunks and make multiple calls. To fetch more than 50 series, batch them. Without a key the limits are 3 years / 25 series.
+
+- **Annual averages are a separate period** — `M13` (annual average) only appears when `annualaverage=True` is set in the POST body and you have an API key. Do not confuse `A01` (an actual annual-frequency series) with `M13` (the annual average of a monthly series).

--- a/domain-skills/fandom-apis/scraping.md
+++ b/domain-skills/fandom-apis/scraping.md
@@ -1,0 +1,407 @@
+# Fandom / Fictional Universe APIs — Data Extraction
+
+Public REST (and GraphQL) APIs for Rick and Morty, Star Wars, Pokémon, and Harry Potter. **No auth, no browser needed.** All data is reachable via `http_get`. Confirmed working 2026-04-18.
+
+## Do this first: pick your universe
+
+| Universe | Base URL | Best approach | Latency |
+|---|---|---|---|
+| Rick and Morty | `https://rickandmortyapi.com/api/` | REST or GraphQL | ~100ms |
+| Star Wars | `https://swapi.info/api/` | REST, bulk list | ~150ms |
+| Pokémon | `https://pokeapi.co/api/v2/` | REST, by name or id | ~100ms |
+| Harry Potter | `https://hp-api.onrender.com/api/` | REST, list then filter | ~300ms |
+
+**Never use a browser for any of these.** All responses are plain JSON, no JS rendering required.
+
+---
+
+## Rick and Morty (`rickandmortyapi.com`)
+
+826 characters, 51 episodes, 126 locations. Supports both REST and GraphQL.
+
+### REST: list with filters and pagination
+
+```python
+import json
+from helpers import http_get
+
+# All characters — 20 per page, 42 pages total
+data = json.loads(http_get("https://rickandmortyapi.com/api/character"))
+# data['info'] = {'count': 826, 'pages': 42, 'next': '...?page=2', 'prev': None}
+# data['results'] = list of 20 character dicts
+
+# Filter: status, species, gender, name, type
+data = json.loads(http_get(
+    "https://rickandmortyapi.com/api/character?status=alive&species=Human&name=Rick"
+))
+# data['info']['count'] = 22  (alive human Ricks)
+# data['results'][0] = {'id': 1, 'name': 'Rick Sanchez', 'status': 'Alive', ...}
+
+# Paginate
+page2 = json.loads(http_get("https://rickandmortyapi.com/api/character?page=2"))
+# Or follow data['info']['next'] directly
+```
+
+Character fields: `id`, `name`, `status` (Alive/Dead/unknown), `species`, `type`, `gender`, `origin` (dict with name+url), `location` (dict), `image` (JPEG URL), `episode` (list of episode URLs), `url`, `created`
+
+### REST: batch fetch by ID (comma-separated — returns list, not paginated dict)
+
+```python
+import json
+from helpers import http_get
+
+# Batch: returns a plain list, NOT the {info, results} wrapper
+chars = json.loads(http_get("https://rickandmortyapi.com/api/character/1,2,3"))
+# [{'id': 1, 'name': 'Rick Sanchez', ...}, {'id': 2, 'name': 'Morty Smith', ...}, ...]
+
+# Same works for episodes and locations
+eps = json.loads(http_get("https://rickandmortyapi.com/api/episode/1,2,3"))
+# [{'id': 1, 'name': 'Pilot', 'episode': 'S01E01', 'air_date': 'December 2, 2013',
+#   'characters': ['https://.../character/1', ...], ...}, ...]
+```
+
+### REST: episodes and locations
+
+```python
+import json
+from helpers import http_get
+
+# Episodes: 51 total, 3 pages
+eps = json.loads(http_get("https://rickandmortyapi.com/api/episode"))
+# ep fields: id, name, air_date, episode (e.g. 'S01E01'), characters (list of URLs), url, created
+
+# Filter by episode code (partial match)
+s1 = json.loads(http_get("https://rickandmortyapi.com/api/episode?episode=S01"))
+# s1['info']['count'] = 11
+
+# Locations: 126 total, 7 pages
+locs = json.loads(http_get("https://rickandmortyapi.com/api/location"))
+# loc fields: id, name, type, dimension, residents (list of character URLs), url, created
+```
+
+### GraphQL endpoint
+
+```python
+import json, urllib.request
+
+query = """{
+  characters(filter: {status: "Alive", species: "Human"}) {
+    info { count }
+    results { id name status species gender }
+  }
+}"""
+body = json.dumps({"query": query}).encode()
+req = urllib.request.Request(
+    "https://rickandmortyapi.com/graphql",
+    data=body,
+    headers={"Content-Type": "application/json", "Accept": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    resp = json.loads(r.read())
+# resp['data']['characters']['info']['count'] = 245
+# resp['data']['characters']['results'] = list of {id, name, status, species, gender}
+
+# Filter episodes by season
+query2 = '{ episodes(filter: {episode: "S01"}) { info { count } results { id name episode air_date } } }'
+```
+
+GraphQL also supports `locations` with `filter: {name, type, dimension}`. Use REST for bulk; use GraphQL when you need specific filtered subsets without pagination loops.
+
+### Fetch all characters (paginate to completion)
+
+```python
+import json
+from helpers import http_get
+
+all_chars = []
+url = "https://rickandmortyapi.com/api/character"
+while url:
+    data = json.loads(http_get(url))
+    all_chars.extend(data["results"])
+    url = data["info"]["next"]  # None on last page
+# len(all_chars) == 826  (confirmed 2026-04-18)
+```
+
+---
+
+## Star Wars — SWAPI (`swapi.info`)
+
+Use `swapi.info` (faster unofficial clone) for bulk reads. Fall back to `swapi.dev` for `?search=` filtering. `swapi.info` list endpoints return the full array in one call — no pagination needed.
+
+```python
+import json
+from helpers import http_get
+
+# swapi.info: single call returns ALL 82 people (no pagination)
+people = json.loads(http_get("https://swapi.info/api/people/"))
+# people = list of 82 dicts, each: name, height, mass, hair_color, skin_color,
+#   eye_color, birth_year, gender, homeworld (URL), films (list of URLs),
+#   species, vehicles, starships, created, edited, url
+
+# Single resource by ID (no trailing slash required on swapi.info)
+luke = json.loads(http_get("https://swapi.info/api/people/1"))
+# luke['name'] = 'Luke Skywalker', luke['birth_year'] = '19BBY'
+
+# Available resources on swapi.info
+root = json.loads(http_get("https://swapi.info/api/"))
+# root keys: ['films', 'people', 'planets', 'species', 'vehicles', 'starships']
+
+films = json.loads(http_get("https://swapi.info/api/films/"))      # 6 films
+ships = json.loads(http_get("https://swapi.info/api/starships/"))  # 36 starships
+```
+
+**Film fields:** `title`, `episode_id`, `opening_crawl`, `director`, `producer`, `release_date`, `characters` (list of URLs), `planets`, `starships`, `vehicles`, `species`
+
+### Search (use swapi.dev for this — swapi.info ignores `?search=`)
+
+```python
+import json
+from helpers import http_get
+
+# swapi.dev supports ?search= but is slower (~700-900ms per call)
+results = json.loads(http_get("https://swapi.dev/api/people/?search=luke"))
+# results['count'] = 1
+# results['results'][0]['name'] = 'Luke Skywalker'
+# Paginates with results['next'] URL (10 items per page)
+
+# swapi.info ignores ?search= — returns all 82 people regardless
+# For client-side search on swapi.info:
+people = json.loads(http_get("https://swapi.info/api/people/"))
+luke = next(p for p in people if "luke" in p["name"].lower())
+```
+
+### Resolve URLs to data
+
+All related resources (homeworld, films, starships) are returned as URL strings. Resolve them with `http_get`:
+
+```python
+import json
+from helpers import http_get
+
+luke = json.loads(http_get("https://swapi.info/api/people/1"))
+homeworld = json.loads(http_get(luke["homeworld"]))
+# homeworld['name'] = 'Tatooine', homeworld['climate'] = 'arid',
+# homeworld['terrain'] = 'desert', homeworld['population'] = '200000'
+
+# Bulk resolve with ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
+with ThreadPoolExecutor(max_workers=5) as ex:
+    film_data = list(ex.map(lambda u: json.loads(http_get(u)), luke["films"]))
+```
+
+---
+
+## Pokémon (`pokeapi.co`)
+
+1350 Pokémon. Free, no auth. Supports name or numeric ID in all endpoints.
+
+### Fetch a Pokémon
+
+```python
+import json
+from helpers import http_get
+
+# By name or ID — both work
+p = json.loads(http_get("https://pokeapi.co/api/v2/pokemon/pikachu"))
+# or: http_get("https://pokeapi.co/api/v2/pokemon/25")
+
+print(p["id"])           # 25
+print(p["name"])         # pikachu
+print(p["height"])       # 4  (decimetres)
+print(p["weight"])       # 60 (hectograms)
+print(p["base_experience"])  # 112
+print([t["type"]["name"] for t in p["types"]])       # ['electric']
+print([a["ability"]["name"] for a in p["abilities"]]) # ['static', 'lightning-rod']
+print({s["stat"]["name"]: s["base_stat"] for s in p["stats"]})
+# {'hp': 35, 'attack': 55, 'defense': 40, 'special-attack': 50, 'special-defense': 50, 'speed': 90}
+print(p["sprites"]["front_default"])
+# 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png'
+```
+
+### List with pagination
+
+```python
+import json
+from helpers import http_get
+
+# Default: 20 per page, offset=0
+data = json.loads(http_get("https://pokeapi.co/api/v2/pokemon?limit=20&offset=0"))
+# data['count'] = 1350 (total)
+# data['next'] = 'https://pokeapi.co/api/v2/pokemon?offset=20&limit=20'
+# data['results'] = [{'name': 'bulbasaur', 'url': 'https://pokeapi.co/api/v2/pokemon/1/'}, ...]
+
+# Fetch ALL at once (no server-side cap enforced)
+all_pokemon = json.loads(http_get("https://pokeapi.co/api/v2/pokemon?limit=100000&offset=0"))
+# all_pokemon['results'] length == 1350  (~150ms, confirmed 2026-04-18)
+names = [p["name"] for p in all_pokemon["results"]]
+```
+
+### Species, evolution chain, type
+
+```python
+import json
+from helpers import http_get
+
+# Species: lore, capture rate, generation, Pokédex flavor text
+species = json.loads(http_get("https://pokeapi.co/api/v2/pokemon-species/pikachu"))
+# species['capture_rate'] = 190
+# species['is_legendary'] = False
+# species['generation']['name'] = 'generation-i'
+# species['evolution_chain']['url'] = 'https://pokeapi.co/api/v2/evolution-chain/10/'
+en_text = next(
+    e["flavor_text"] for e in species["flavor_text_entries"]
+    if e["language"]["name"] == "en"
+)
+
+# Evolution chain
+evo_url = species["evolution_chain"]["url"]
+evo = json.loads(http_get(evo_url))
+# evo['chain']['species']['name'] = 'pichu'
+# evo['chain']['evolves_to'][0]['species']['name'] = 'pikachu'
+# evo['chain']['evolves_to'][0]['evolves_to'][0]['species']['name'] = 'raichu'
+
+# All Pokémon of a type
+electric = json.loads(http_get("https://pokeapi.co/api/v2/type/electric"))
+# electric['pokemon'] = list of 114 dicts, each {'pokemon': {'name': '...', 'url': '...'}, 'slot': 1}
+names = [p["pokemon"]["name"] for p in electric["pokemon"]]
+
+# Move details
+move = json.loads(http_get("https://pokeapi.co/api/v2/move/thunderbolt"))
+# move['power'] = 90, move['pp'] = 15, move['accuracy'] = 100
+# move['type']['name'] = 'electric', move['damage_class']['name'] = 'special'
+
+# Ability details
+ability = json.loads(http_get("https://pokeapi.co/api/v2/ability/overgrow"))
+effect = next(e["effect"] for e in ability["effect_entries"] if e["language"]["name"] == "en")
+# 'When this Pokémon has 1/3 or less of its HP remaining, its grass-type moves inflict 1.5×...'
+```
+
+### Parallel bulk fetch
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+def fetch_pokemon(name):
+    d = json.loads(http_get(f"https://pokeapi.co/api/v2/pokemon/{name}"))
+    return {
+        "name": d["name"],
+        "id": d["id"],
+        "types": [t["type"]["name"] for t in d["types"]],
+        "stats": {s["stat"]["name"]: s["base_stat"] for s in d["stats"]},
+    }
+
+names = ["bulbasaur", "charmander", "squirtle", "pikachu", "mewtwo"]
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_pokemon, names))
+# Confirmed: 5 Pokémon in ~0.15s  (2026-04-18)
+```
+
+### Other resource endpoints
+
+| Endpoint | Example | Notes |
+|---|---|---|
+| `/api/v2/ability/{name}` | `overgrow` | Effect, Pokémon that have it |
+| `/api/v2/move/{name}` | `thunderbolt` | Power, PP, accuracy, type |
+| `/api/v2/type/{name}` | `electric` | All Pokémon of that type, damage relations |
+| `/api/v2/generation/{id}` | `1` | All 151 species in Gen I |
+| `/api/v2/berry/{name}` | `cheri` | Firmness, natural gift type |
+| `/api/v2/evolution-chain/{id}` | `10` | Full evolution tree |
+| `/api/v2/item/{name}` | `poke-ball` | Item details |
+
+---
+
+## Harry Potter (`hp-api.onrender.com`)
+
+437 characters, 77 spells. No auth. No search/filter params — fetch all and filter client-side.
+
+### Characters
+
+```python
+import json
+from helpers import http_get
+
+# All 437 characters in one call
+chars = json.loads(http_get("https://hp-api.onrender.com/api/characters"))
+# Each dict: id (UUID), name, alternate_names (list), species, gender, house,
+#   dateOfBirth ('31-07-1980'), yearOfBirth (int), wizard (bool), ancestry,
+#   eyeColour, hairColour, wand {wood, core, length}, patronus,
+#   hogwartsStudent (bool), hogwartsStaff (bool), actor, alternate_actors,
+#   alive (bool), image (URL or '')
+
+# Filter client-side
+alive = [c for c in chars if c["alive"]]           # 307
+dead  = [c for c in chars if not c["alive"]]        # 130
+wizards = [c for c in chars if c["wizard"]]
+gryff   = [c for c in chars if c["house"] == "Gryffindor"]
+
+# By house (server-side filter — faster if you only need one house)
+g = json.loads(http_get("https://hp-api.onrender.com/api/characters/house/gryffindor"))  # 47
+s = json.loads(http_get("https://hp-api.onrender.com/api/characters/house/slytherin"))   # 46
+h = json.loads(http_get("https://hp-api.onrender.com/api/characters/house/hufflepuff"))  # 19
+r = json.loads(http_get("https://hp-api.onrender.com/api/characters/house/ravenclaw"))   # 23
+
+# Students only / Staff only
+students = json.loads(http_get("https://hp-api.onrender.com/api/characters/students"))  # 103
+staff    = json.loads(http_get("https://hp-api.onrender.com/api/characters/staff"))     # 25
+
+# Individual character by UUID — returns a list (always wrap with [0])
+char = json.loads(http_get("https://hp-api.onrender.com/api/character/9e3f7ce4-b9a7-4244-b709-dae5c1f1d4a8"))[0]
+# char['name'] = 'Harry Potter'
+```
+
+### Spells
+
+```python
+import json
+from helpers import http_get
+
+spells = json.loads(http_get("https://hp-api.onrender.com/api/spells"))
+# 77 spells, each: id (UUID), name, description
+# Example: {'id': 'c76a2922-...', 'name': 'Aberto', 'description': 'Opens locked doors'}
+```
+
+### HP API endpoints summary
+
+| Endpoint | Returns |
+|---|---|
+| `/api/characters` | All 437 characters |
+| `/api/characters/students` | 103 Hogwarts students |
+| `/api/characters/staff` | 25 Hogwarts staff |
+| `/api/characters/house/{house}` | House members (gryffindor/slytherin/hufflepuff/ravenclaw) |
+| `/api/character/{uuid}` | Single character as a 1-element list |
+| `/api/spells` | All 77 spells |
+
+---
+
+## Gotchas
+
+- **Rick and Morty batch ID returns a list, not the paginated wrapper.** `/api/character/1,2,3` returns `[{...}, {...}, {...}]` directly. `/api/character` returns `{info: {...}, results: [...]}`. Check `isinstance(data, list)` if you handle both paths.
+
+- **Rick and Morty GraphQL is POST to `/graphql`, not `/api/graphql`.** Endpoint is `https://rickandmortyapi.com/graphql`. The REST base is `https://rickandmortyapi.com/api/`. Don't mix them.
+
+- **`swapi.info` ignores `?search=`.** The unofficial clone returns all 82 people regardless of the search parameter. Use `swapi.dev` if you need server-side name filtering (costs ~700-900ms vs. 150ms). Alternatively fetch all from `swapi.info` and filter client-side with `next(p for p in people if keyword in p["name"].lower())`.
+
+- **`swapi.info` URLs have no trailing slash for single resources.** `/api/people/1` works; `/api/people/1/` also works. List endpoints like `/api/people/` require the trailing slash or you get a redirect.
+
+- **SWAPI related fields are URL strings, not nested objects.** `luke["homeworld"]` is `"https://swapi.info/api/planets/1"`, not a dict. You must make a separate `http_get` call to resolve it. Use `ThreadPoolExecutor` to parallelize resolution of multiple related URLs.
+
+- **SWAPI `height` and `mass` are strings, not numbers.** Values like `"172"`, `"77"`, `"unknown"`. Always cast with `int(p["height"])` inside a try/except.
+
+- **PokeAPI `height` is decimetres, `weight` is hectograms.** Pikachu: `height=4` (0.4m), `weight=60` (6.0kg). Divide by 10 for metric SI units.
+
+- **PokeAPI `flavor_text` contains control characters.** The Pokédex entry strings include `\n`, `\x0c` (form feed), and `\u00ad` (soft hyphen). Clean with `text.replace("\n", " ").replace("\x0c", " ").replace("\u00ad", "")`.
+
+- **PokeAPI has no search endpoint.** There is no `?search=` or `?name=` parameter. Fetch by exact name (`/pokemon/pikachu`) or numeric ID (`/pokemon/25`). For fuzzy search, fetch the full name list with `?limit=100000` (one call, ~150ms) and filter locally.
+
+- **HP API `/api/character/{uuid}` returns a list, not an object.** The single-character endpoint wraps the result in `[{...}]`. Always index with `[0]`.
+
+- **HP API has no search or filter params.** No `?name=`, `?alive=`, `?house=`. The only server-side filtering is by house and by student/staff role. Everything else requires fetching all 437 characters and filtering in Python.
+
+- **HP API is hosted on Render free tier — cold starts.** First request after idle may take 15-30 seconds. If you get a timeout, retry once. Subsequent calls respond in ~300ms.
+
+- **Rick and Morty character `episode` field is a list of episode URLs, not IDs.** To get episode IDs, parse the URL: `ep_id = url.split('/')[-1]`. Or fetch the episodes endpoint and join on character URLs.
+
+- **`pokeapi.co` has implicit rate limiting.** Responses include `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers (not accessible via `http_get`'s raw urllib). For bulk crawls, cap `ThreadPoolExecutor` at `max_workers=10` and add `time.sleep(0.05)` between batches of 50+.

--- a/domain-skills/food-data/scraping.md
+++ b/domain-skills/food-data/scraping.md
@@ -1,0 +1,296 @@
+# Food Data — Scraping & Nutrition Lookup
+
+Two free APIs cover almost every food data use case:
+
+| API | Best for | Auth | Rate limit |
+|-----|----------|------|------------|
+| **USDA FoodData Central** (`api.nal.usda.gov/fdc`) | Authoritative nutrient data (USDA Foundation/SR Legacy), ingredient search | Free key (register at `fdc.nal.usda.gov`) or `DEMO_KEY` | `DEMO_KEY`: 30 req/hr, 50 req/day. Free key: 1,000 req/hr |
+| **Open Food Facts** (`world.openfoodfacts.org`) | Packaged products by barcode, nutriscore, nova group, ingredients | None | ~100 req/min (no auth) |
+
+**Use Open Food Facts for packaged products (barcode known).** Use USDA FDC for raw/whole foods and precise nutrient values. Never use the browser for either — both are pure JSON REST APIs.
+
+---
+
+## USDA FoodData Central
+
+### Search foods
+
+```python
+import json
+from helpers import http_get
+
+# GET search — supports query string params
+result = json.loads(http_get(
+    "https://api.nal.usda.gov/fdc/v1/foods/search"
+    "?query=chicken+breast"
+    "&dataType=Foundation"   # Foundation | SR+Legacy | Branded | Survey+%28FNDDS%29
+    "&pageSize=5"
+    "&api_key=DEMO_KEY"      # replace with your free key for production
+))
+
+print("totalHits:", result["totalHits"])   # 437 for "chicken breast"
+for food in result["foods"][:2]:
+    print(f"  fdcId={food['fdcId']} dataType={food['dataType']} desc={food['description']}")
+    for n in food.get("foodNutrients", [])[:4]:
+        print(f"    {n['nutrientName']}: {n.get('value','?')} {n['unitName']}")
+# Confirmed output (2026-04-18):
+# totalHits: 437
+#   fdcId=171515 dataType=SR Legacy desc=Chicken breast tenders, breaded, uncooked
+#     Galactose: 0.0 G
+#     Fiber, total dietary: 1.1 G
+#   fdcId=2646170 dataType=Foundation desc=Chicken, breast, boneless, skinless, raw
+#     Iron, Fe: 0.354 MG
+#     Protein: 20.787 G
+```
+
+### POST search (filter by specific nutrients)
+
+```python
+import json
+from helpers import http_get
+import urllib.request
+
+body = json.dumps({
+    "query": "banana",
+    "dataType": ["Foundation"],
+    "pageSize": 3,
+    "nutrients": [1003, 1004, 1005, 1008]  # Protein, Fat, Carbs, Energy
+}).encode()
+req = urllib.request.Request(
+    "https://api.nal.usda.gov/fdc/v1/foods/search?api_key=DEMO_KEY",
+    data=body,
+    headers={"Content-Type": "application/json"},
+    method="POST"
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    result = json.loads(r.read())
+
+for food in result["foods"][:2]:
+    print(f"{food['description']} (fdcId={food['fdcId']})")
+    for n in food.get("foodNutrients", []):
+        print(f"  {n['nutrientName']}: {n.get('value','?')} {n['unitName']}")
+# Confirmed (2026-04-18):
+# Bananas, overripe, raw (fdcId=1105073)
+#   Protein: 0.73 G  |  Total lipid (fat): 0.22 G
+#   Carbohydrate, by difference: 20.1 G  |  Energy: 85.0 KCAL
+```
+
+### Fetch single food by fdcId
+
+```python
+import json
+from helpers import http_get
+
+food = json.loads(http_get(
+    "https://api.nal.usda.gov/fdc/v1/food/2262074?api_key=DEMO_KEY"
+))
+print(food["description"])   # Almond butter, creamy
+print(food["dataType"])       # Foundation
+
+for n in food["foodNutrients"][:6]:
+    nut = n["nutrient"]
+    print(f"  id={nut['id']} {nut['name']}: {n.get('amount','?')} {nut['unitName']}")
+# id=1051 Water: 1.751 g
+# id=1003 Protein: 20.787 g
+# id=1004 Total lipid (fat): 53.04 g
+# id=1008 Energy: 645.456 kcal
+```
+
+### List foods (paginate all)
+
+```python
+import json
+from helpers import http_get
+
+page = json.loads(http_get(
+    "https://api.nal.usda.gov/fdc/v1/foods/list"
+    "?dataType=Foundation"
+    "&pageSize=20"
+    "&pageNumber=1"
+    "&api_key=DEMO_KEY"
+))
+for food in page[:3]:
+    print(f"{food['fdcId']}: {food['description']} ({food['dataType']})")
+# 2262074: Almond butter, creamy (Foundation)
+# 2257045: Almond milk, unsweetened, plain, refrigerated (Foundation)
+# 2747652: Anchovies, canned in olive oil, with salt, drained (Foundation)
+```
+
+### Key nutrient IDs
+
+| ID | Nutrient | Unit |
+|----|---------|------|
+| 1003 | Protein | g |
+| 1004 | Total lipid (fat) | g |
+| 1005 | Carbohydrate, by difference | g |
+| 1008 | Energy | kcal |
+| 1051 | Water | g |
+| 1079 | Fiber, total dietary | g |
+| 2000 | Sugars, Total | g |
+| 1087 | Calcium, Ca | mg |
+| 1089 | Iron, Fe | mg |
+| 1090 | Magnesium, Mg | mg |
+| 1092 | Potassium, K | mg |
+| 1093 | Sodium, Na | mg |
+
+### dataType values
+
+| dataType | Description |
+|----------|-------------|
+| `Foundation` | USDA reference foods — most accurate nutrient profiles |
+| `SR Legacy` | Standard Reference (legacy, broad coverage) |
+| `Survey (FNDDS)` | USDA dietary survey foods |
+| `Branded` | 400K+ CPG branded products (less consistent nutrients) |
+
+Use `Foundation` or `SR Legacy` for reliable nutrient data. Use `Branded` if you need real product SKUs.
+
+---
+
+## Open Food Facts (packaged products, no auth)
+
+### Barcode lookup (most reliable endpoint)
+
+```python
+import json
+from helpers import http_get
+
+# v2 barcode lookup — pass ?fields= to trim response (product JSON is often very large)
+product = json.loads(http_get(
+    "https://world.openfoodfacts.org/api/v2/product/3017620422003.json"
+    # barcode above = Nutella
+))
+
+p = product["product"]
+n = p.get("nutriments", {})
+
+print(p.get("product_name"))       # Nutella
+print(p.get("brands"))             # Ferrero
+print(p.get("nutriscore_grade"))   # e  (a/b/c/d/e — best to worst)
+print(p.get("nova_group"))         # 4  (1=unprocessed .. 4=ultra-processed)
+print(p.get("serving_size"))       # 15 g
+print(p.get("quantity"))           # 400 g
+
+# Nutriments are per 100g (key suffix _100g) or per serving (_serving)
+print(n.get("energy-kcal_100g"))   # 539
+print(n.get("proteins_100g"))      # 6.3
+print(n.get("carbohydrates_100g")) # 57.5
+print(n.get("fat_100g"))           # 30.9
+print(n.get("fiber_100g"))         # 0
+print(n.get("sugars_100g"))        # 56.3
+print(n.get("salt_100g"))          # 0.107
+# Confirmed (2026-04-18) — status=1 means product found, status=0 means not found
+```
+
+### Product lookup with field selection (faster for bulk)
+
+```python
+import json
+from helpers import http_get
+
+# Request only the fields you need — saves bandwidth on large product records
+product = json.loads(http_get(
+    "https://world.openfoodfacts.org/api/v2/product/0048151623426.json"
+    "?fields=code,product_name,brands,nutriscore_grade,nova_group,nutriments,serving_size,categories_tags"
+))
+p = product["product"]
+# categories_tags is a list like ['en:snacks', 'en:cookies']
+print(p.get("categories_tags", [])[:3])
+```
+
+### Text search (use sparingly — endpoint is unstable)
+
+```python
+import json
+from helpers import http_get
+
+# The CGI search endpoint works but returns an HTML error page if OFF servers are under load.
+# Always check that the response starts with '{' before parsing.
+raw = http_get(
+    "https://world.openfoodfacts.org/cgi/search.pl"
+    "?search_terms=greek+yogurt"
+    "&action=process"
+    "&json=1"
+    "&page_size=5"
+    "&fields=code,product_name,brands,nutriscore_grade,nutriments"
+)
+if not raw.strip().startswith("{"):
+    raise RuntimeError("OFF search returned non-JSON (server under load — retry or use barcode lookup)")
+
+result = json.loads(raw)
+print("count:", result.get("count"))
+for p in result.get("products", [])[:3]:
+    print(f"  {p.get('code')} {p.get('product_name','?')} [{p.get('nutriscore_grade','?')}]")
+```
+
+### Key Open Food Facts fields
+
+| Field | Description |
+|-------|-------------|
+| `product_name` | Product name |
+| `brands` | Brand name(s) |
+| `quantity` | Package size (e.g. `"400 g"`) |
+| `serving_size` | Serving size string |
+| `nutriscore_grade` | `a`–`e` (nutritional quality) |
+| `nova_group` | `1`–`4` (processing level) |
+| `categories_tags` | List of `en:category-name` tags |
+| `ingredients_text` | Ingredients list as string |
+| `allergens_tags` | List of `en:allergen` tags |
+| `nutriments` | Dict with `_100g` and `_serving` suffixes |
+| `image_front_url` | Front-of-pack image URL |
+
+Nutriment keys use hyphens: `energy-kcal_100g`, `saturated-fat_100g`, `trans-fat_100g`.
+
+---
+
+## Bulk fetch pattern (multiple foods)
+
+```python
+import json, time
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+FDC_KEY = "DEMO_KEY"  # replace with real key for production
+
+def fetch_fdc(fdc_id):
+    url = f"https://api.nal.usda.gov/fdc/v1/food/{fdc_id}?api_key={FDC_KEY}"
+    try:
+        return json.loads(http_get(url))
+    except Exception as e:
+        return {"error": str(e), "fdcId": fdc_id}
+
+# With DEMO_KEY: do NOT parallelize — rate limit is 30 req/hr.
+# With a real free key (1,000 req/hr): safe to use ThreadPoolExecutor(max_workers=4)
+fdc_ids = [2262074, 1750340, 1105073]  # almond butter, apple (fuji), banana
+results = []
+for fdc_id in fdc_ids:
+    results.append(fetch_fdc(fdc_id))
+    time.sleep(2)  # conservative — with real key drop to time.sleep(0.1)
+
+for r in results:
+    if "error" not in r:
+        print(r["description"], r.get("dataType"))
+```
+
+---
+
+## Gotchas
+
+- **DEMO_KEY has a very tight rate limit: 30 requests/hour and 50/day per IP.** It hits `OVER_RATE_LIMIT` fast in any loop. Register a free key at `fdc.nal.usda.gov/api-guide.html` for real work (1,000 req/hr). Error response looks like `{"error": {"code": "OVER_RATE_LIMIT", "message": "..."}}` — always check `"error" in result` before accessing `result["foods"]`.
+
+- **`format=abridged` strips nutrient names.** Using `?format=abridged` in the food detail endpoint returns `id=None, name=None` for every nutrient — the names are gone. Use the default (no `format` param) to get `nutrient.id`, `nutrient.name`, and `nutrient.unitName`.
+
+- **POST search nutrient filter is additive, not exclusive.** When you pass `"nutrients": [1003, 1004]` to the POST body, the response only returns those nutrient values in `foodNutrients` — it does NOT filter to foods that have those nutrients. All foods still match; you just get a trimmed nutrient list back.
+
+- **`dataType` URL encoding:** In GET queries, multi-value dataType must use comma separation or repeated params — `dataType=Foundation,SR+Legacy` works. Branded data has wildly inconsistent nutrient coverage; stick to `Foundation` or `SR Legacy` for nutrition queries.
+
+- **Open Food Facts barcode lookup is reliable; text search is not.** The `/api/v2/product/{barcode}.json` endpoint is stable. The CGI search endpoint (`/cgi/search.pl`) returns a raw HTML error page (`<!DOCTYPE html>`) instead of JSON when their servers are overloaded — check `raw.strip().startswith("{")` before parsing.
+
+- **Open Food Facts nutriment keys use hyphens, not underscores.** The key is `energy-kcal_100g`, not `energy_kcal_100g`. Missing nutrients are absent from the dict (don't default to 0) — always use `.get(key)` with a fallback.
+
+- **`status=0` in Open Food Facts means product not found**, not an error. `product["status"] == 0` returns `{"status": 0, "status_verbose": "product not found"}`. Check status before accessing `product["product"]`.
+
+- **Open Food Facts product JSON can be very large** (10–50 KB for well-documented products). Use `?fields=` to request only the fields you need when doing bulk lookups.
+
+- **USDA Foundation foods have the most complete nutrient profiles** — they include 100+ nutrients with analytical measurements. SR Legacy is broad but older. Branded foods often have only the 12 label-required nutrients.
+
+- **USDA fdcId is stable across API versions** — the same fdcId resolves to the same food permanently. Safe to cache and store for future lookups.

--- a/domain-skills/github-graphql/scraping.md
+++ b/domain-skills/github-graphql/scraping.md
@@ -1,0 +1,586 @@
+# GitHub GraphQL API v4 — Scraping & Data Extraction
+
+`https://api.github.com/graphql` — GitHub's GraphQL API. **Requires a token for every call** — `graphql.limit` is 0 for unauthenticated requests (confirmed 2026-04-18). All data is available over a single `POST` with no browser needed.
+
+## Do this first
+
+**Always check for a token before anything else. Every GraphQL call fails without one.**
+
+```python
+import os, json, urllib.request, ssl
+
+token = os.environ.get('GITHUB_TOKEN', '')
+if not token:
+    raise RuntimeError("GITHUB_TOKEN not set — GitHub GraphQL requires authentication")
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+HEADERS = {
+    "Authorization": f"bearer {token}",
+    "Content-Type": "application/json",
+    "User-Agent": "Mozilla/5.0",
+    "X-Github-Next-Global-ID": "1",   # opt-in to new global Node IDs
+}
+
+def gql(query, variables=None):
+    """Execute a GraphQL query. Returns parsed response dict."""
+    body = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(GRAPHQL_URL, data=body, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = json.loads(r.read().decode())
+    if "errors" in data:
+        raise RuntimeError(data["errors"])
+    return data["data"]
+```
+
+**When to use GraphQL v4 over REST v3:**
+- Fetch multiple related objects in a single round-trip (e.g., repo + issues + PRs + labels)
+- Need nested data (PR reviews, review comments, timeline events)
+- Need exact field control (no over-fetching)
+- Pagination with cursors (cleaner than REST `Link` headers)
+- Repository contributions, project boards, discussions
+- Real-time rate limit cost inspection via `rateLimit` field
+
+**When to stick with REST v3 (see `github/scraping.md`):**
+- Simple single-object fetches (repo metadata, user profile)
+- No token available
+- Trending page (browser only)
+- Bulk file content via `raw.githubusercontent.com`
+
+---
+
+## Rate limits
+
+GraphQL uses a **point-based** system, not a request count:
+
+| Account type | Points/hour |
+|---|---|
+| Authenticated user | 5,000 |
+| GitHub App (installation) | 15,000 |
+| Unauthenticated | 0 (blocked) |
+
+**Points per query = nodes requested** (approximately). A query returning 1 object costs 1 point; returning 100 items in a connection costs ~100 points. Add `rateLimit` to any query to inspect cost and remaining budget:
+
+```python
+RATE_LIMIT_FRAGMENT = """
+rateLimit {
+  cost
+  remaining
+  resetAt
+  limit
+  used
+  nodeCount
+}
+"""
+```
+
+Check rate limit without consuming points:
+
+```python
+data = gql("""
+{
+  rateLimit {
+    limit
+    remaining
+    resetAt
+    used
+  }
+}
+""")
+print(data['rateLimit'])
+# {'limit': 5000, 'remaining': 4987, 'resetAt': '2026-04-18T15:00:00Z', 'used': 13}
+```
+
+---
+
+## Common workflows
+
+### Repo metadata + stats (single call)
+
+```python
+data = gql("""
+query RepoInfo($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    nameWithOwner
+    description
+    stargazerCount
+    forkCount
+    watcherCount: watchers { totalCount }
+    openIssues: issues(states: OPEN) { totalCount }
+    openPRs: pullRequests(states: OPEN) { totalCount }
+    diskUsage
+    isPrivate
+    isFork
+    isArchived
+    defaultBranchRef { name }
+    primaryLanguage { name }
+    licenseInfo { name spdxId }
+    createdAt
+    pushedAt
+    url
+    homepageUrl
+    topics: repositoryTopics(first: 10) {
+      nodes { topic { name } }
+    }
+  }
+  rateLimit { cost remaining }
+}
+""", {"owner": "browser-use", "name": "browser-use"})
+
+repo = data['repository']
+print(repo['stargazerCount'], repo['forkCount'])
+print([n['topic']['name'] for n in repo['topics']['nodes']])
+# Expected: stargazerCount=88400+, topics list
+```
+
+### Issues with labels and pagination
+
+```python
+def fetch_issues(owner, name, state="OPEN", first=20, after=None):
+    data = gql("""
+    query Issues($owner: String!, $name: String!, $state: IssueState!, $first: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        issues(states: [$state], first: $first, after: $after, orderBy: {field: CREATED_AT, direction: DESC}) {
+          pageInfo { hasNextPage endCursor }
+          totalCount
+          nodes {
+            number
+            title
+            state
+            createdAt
+            closedAt
+            author { login }
+            labels(first: 10) { nodes { name color } }
+            comments { totalCount }
+            reactions { totalCount }
+            url
+          }
+        }
+      }
+    }
+    """, {"owner": owner, "name": name, "state": state, "first": first, "after": after})
+    return data['repository']['issues']
+
+# Paginate all open issues
+all_issues = []
+cursor = None
+while True:
+    result = fetch_issues("browser-use", "browser-use", after=cursor)
+    all_issues.extend(result['nodes'])
+    if not result['pageInfo']['hasNextPage']:
+        break
+    cursor = result['pageInfo']['endCursor']
+
+print(f"Fetched {len(all_issues)} of {result['totalCount']} issues")
+```
+
+### Pull requests with review status
+
+```python
+data = gql("""
+query PRs($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: [OPEN], first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        state
+        isDraft
+        createdAt
+        mergedAt
+        author { login }
+        headRefName
+        baseRefName
+        additions
+        deletions
+        changedFiles
+        reviewDecision          # APPROVED | REVIEW_REQUIRED | CHANGES_REQUESTED
+        reviews(first: 5) {
+          nodes {
+            author { login }
+            state               # APPROVED | CHANGES_REQUESTED | COMMENTED
+            submittedAt
+            body
+          }
+        }
+        labels(first: 5) { nodes { name } }
+        comments { totalCount }
+        url
+      }
+    }
+  }
+}
+""", {"owner": "browser-use", "name": "browser-use"})
+
+for pr in data['repository']['pullRequests']['nodes']:
+    reviews = [r['state'] for r in pr['reviews']['nodes']]
+    print(pr['number'], pr['reviewDecision'], pr['additions'], pr['deletions'], reviews)
+```
+
+### Repository search
+
+```python
+def search_repos(query_str, first=10, after=None):
+    data = gql("""
+    query SearchRepos($q: String!, $first: Int!, $after: String) {
+      search(query: $q, type: REPOSITORY, first: $first, after: $after) {
+        repositoryCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          ... on Repository {
+            nameWithOwner
+            stargazerCount
+            forkCount
+            description
+            primaryLanguage { name }
+            updatedAt
+            url
+          }
+        }
+      }
+      rateLimit { cost remaining }
+    }
+    """, {"q": query_str, "first": first, "after": after})
+    return data
+
+result = search_repos("browser automation language:python stars:>500 sort:stars")
+for repo in result['search']['nodes']:
+    print(repo['nameWithOwner'], repo['stargazerCount'])
+print("Query cost:", result['rateLimit']['cost'])
+
+# Search query modifiers:
+# language:python  stars:>100  forks:>50  pushed:>2025-01-01
+# sort:stars  sort:forks  sort:updated  sort:interactions
+# is:public  is:private  archived:false
+# topic:machine-learning  license:mit
+```
+
+### User/org profile and contributions
+
+```python
+data = gql("""
+query UserProfile($login: String!) {
+  user(login: $login) {
+    login
+    name
+    email
+    bio
+    company
+    location
+    websiteUrl
+    twitterUsername
+    followers { totalCount }
+    following { totalCount }
+    repositories(ownerAffiliations: OWNER) { totalCount }
+    contributionsCollection {
+      totalCommitContributions
+      totalIssueContributions
+      totalPullRequestContributions
+      totalPullRequestReviewContributions
+      restrictedContributionsCount
+    }
+    sponsorshipsAsMaintainer { totalCount }
+    createdAt
+  }
+}
+""", {"login": "torvalds"})
+
+user = data['user']
+contribs = user['contributionsCollection']
+print(user['name'], user['followers']['totalCount'])
+print("Commits:", contribs['totalCommitContributions'])
+print("PRs:", contribs['totalPullRequestContributions'])
+```
+
+### Commit history
+
+```python
+data = gql("""
+query Commits($owner: String!, $name: String!, $branch: String!) {
+  repository(owner: $owner, name: $name) {
+    ref(qualifiedName: $branch) {
+      target {
+        ... on Commit {
+          history(first: 20) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              oid
+              messageHeadline
+              message
+              committedDate
+              additions
+              deletions
+              changedFilesIfAvailable
+              author {
+                name
+                email
+                user { login }
+              }
+              committer {
+                name
+                email
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""", {"owner": "browser-use", "name": "browser-use", "branch": "main"})
+
+history = data['repository']['ref']['target']['history']
+for commit in history['nodes']:
+    print(commit['oid'][:8], commit['committedDate'][:10], commit['messageHeadline'])
+    print(f"  +{commit['additions']} -{commit['deletions']}")
+```
+
+### Repository stargazers (who starred)
+
+```python
+def fetch_stargazers(owner, name, first=100, after=None):
+    data = gql("""
+    query Stargazers($owner: String!, $name: String!, $first: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        stargazers(first: $first, after: $after, orderBy: {field: STARRED_AT, direction: DESC}) {
+          pageInfo { hasNextPage endCursor }
+          totalCount
+          edges {
+            starredAt
+            node {
+              login
+              name
+              followers { totalCount }
+              company
+              location
+            }
+          }
+        }
+      }
+    }
+    """, {"owner": owner, "name": name, "first": first, "after": after})
+    return data['repository']['stargazers']
+
+result = fetch_stargazers("browser-use", "browser-use")
+print("Total stars:", result['totalCount'])
+for edge in result['edges'][:5]:
+    print(edge['starredAt'][:10], edge['node']['login'], edge['node']['followers']['totalCount'])
+# Returns most recent stargazers first
+```
+
+### Fetch multiple repos in one query (batch)
+
+```python
+# Use aliases to fetch multiple repos in a single round-trip
+data = gql("""
+{
+  repo1: repository(owner: "browser-use", name: "browser-use") {
+    stargazerCount forkCount pushedAt
+  }
+  repo2: repository(owner: "microsoft", name: "playwright") {
+    stargazerCount forkCount pushedAt
+  }
+  repo3: repository(owner: "puppeteer", name: "puppeteer") {
+    stargazerCount forkCount pushedAt
+  }
+  rateLimit { cost remaining }
+}
+""")
+
+for key in ["repo1", "repo2", "repo3"]:
+    r = data[key]
+    print(key, r['stargazerCount'], r['forkCount'])
+print("Total cost:", data['rateLimit']['cost'])
+# One query, one HTTP call, cost = 3 points (one per repo)
+```
+
+### Discussions (GitHub Discussions API)
+
+```python
+data = gql("""
+query Discussions($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    discussions(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+      totalCount
+      nodes {
+        number
+        title
+        createdAt
+        author { login }
+        category { name emoji }
+        upvoteCount
+        comments { totalCount }
+        answerChosenAt
+        answer { body author { login } }
+        url
+      }
+    }
+  }
+}
+""", {"owner": "browser-use", "name": "browser-use"})
+
+for d in data['repository']['discussions']['nodes']:
+    answered = "ANSWERED" if d['answer'] else "open"
+    print(d['number'], answered, d['category']['name'], d['title'][:50])
+```
+
+### Labels for a repository
+
+```python
+data = gql("""
+query Labels($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    labels(first: 50) {
+      nodes { name color description issues { totalCount } }
+    }
+  }
+}
+""", {"owner": "browser-use", "name": "browser-use"})
+
+for label in data['repository']['labels']['nodes']:
+    print(f"#{label['color']} {label['name']}: {label['issues']['totalCount']} issues")
+```
+
+### Org members and repos
+
+```python
+data = gql("""
+query OrgInfo($org: String!) {
+  organization(login: $org) {
+    name
+    description
+    membersWithRole { totalCount }
+    repositories(first: 10, orderBy: {field: STARGAZERS, direction: DESC}) {
+      totalCount
+      nodes {
+        nameWithOwner
+        stargazerCount
+        primaryLanguage { name }
+        isPrivate
+      }
+    }
+    teams(first: 5) {
+      totalCount
+      nodes { name slug members { totalCount } }
+    }
+  }
+}
+""", {"org": "browser-use"})
+
+org = data['organization']
+print(org['name'], "Members:", org['membersWithRole']['totalCount'])
+for repo in org['repositories']['nodes']:
+    print(" ", repo['nameWithOwner'], repo['stargazerCount'])
+```
+
+---
+
+## Pagination pattern
+
+GraphQL uses cursor-based pagination via `pageInfo`:
+
+```python
+def paginate_all(query_fn, extract_fn, max_pages=50):
+    """Generic paginator. query_fn(after) -> raw data. extract_fn(data) -> (nodes, pageInfo)."""
+    all_nodes = []
+    cursor = None
+    for _ in range(max_pages):
+        data = query_fn(after=cursor)
+        nodes, page_info = extract_fn(data)
+        all_nodes.extend(nodes)
+        if not page_info['hasNextPage']:
+            break
+        cursor = page_info['endCursor']
+    return all_nodes
+
+# Example: all open issues
+issues = paginate_all(
+    query_fn=lambda after: gql("""
+        query($owner:String!,$name:String!,$after:String){
+          repository(owner:$owner, name:$name){
+            issues(states:OPEN, first:100, after:$after){
+              pageInfo{hasNextPage endCursor}
+              nodes{number title createdAt}
+            }
+          }
+        }
+    """, {"owner": "browser-use", "name": "browser-use", "after": after}),
+    extract_fn=lambda d: (
+        d['repository']['issues']['nodes'],
+        d['repository']['issues']['pageInfo']
+    )
+)
+```
+
+Key pagination rules:
+- Max `first:` value is **100** for most connections (some allow 100+)
+- `after:` takes the `endCursor` string from the previous response
+- `before:` / `last:` paginate backwards
+- Never use `offset` — GraphQL connections are cursor-only
+
+---
+
+## Introspection (explore the schema)
+
+```python
+# List all top-level query fields
+data = gql("""
+{
+  __schema {
+    queryType { fields { name description } }
+  }
+}
+""")
+for f in data['__schema']['queryType']['fields']:
+    print(f['name'], '-', f['description'][:60] if f['description'] else '')
+
+# Inspect a specific type
+data = gql("""
+{
+  __type(name: "Repository") {
+    fields {
+      name
+      description
+      type { name kind ofType { name kind } }
+    }
+  }
+}
+""")
+for f in data['__type']['fields'][:20]:
+    print(f['name'], f['type'])
+```
+
+---
+
+## Gotchas
+
+- **GraphQL requires auth — no anonymous access.** Unlike REST (60 req/hr unauthenticated), `graphql.limit = 0` without a token. Every call returns HTTP 403. Confirmed 2026-04-18 via `https://api.github.com/rate_limit` → `"graphql": {"limit": 0}`.
+
+- **`bearer` not `Bearer` or `token`** — The `Authorization` header value must be `bearer {token}` (lowercase `bearer`). GitHub's REST API accepts `Bearer` (capital B) but for GraphQL, `bearer` is the documented form. Both work in practice but match the docs.
+
+- **Point cost ≠ request count** — `rateLimit.cost` is charged per call regardless of whether the query returns data. A query for a nonexistent repo still costs 1 point. Always add `rateLimit { cost remaining }` to debug expensive queries.
+
+- **Connections have a max `first:` of 100** — Most connections (`issues`, `pullRequests`, `stargazers`, etc.) reject `first: 101+` with a validation error: `"first" argument must not exceed 100`. Use pagination for large sets.
+
+- **`... on TypeName` fragments required for union/interface fields** — `search()` returns `SearchResultItemConnection` where nodes are a union. Without `... on Repository { ... }`, `nodes` returns empty objects. Same applies to `ref.target` (`... on Commit { ... }`), timeline items, and actor unions.
+
+- **Inline fragments do NOT merge with sibling fields** — If a node is `... on Commit` it will not expose `... on Tree` fields. Only one fragment matches per node.
+
+- **Null vs missing field** — GraphQL returns `null` for nullable fields that have no value (e.g. `closedAt` on an open issue, `email` when hidden). Missing non-nullable fields cause an error at query compile time, not runtime.
+
+- **`author` can be null for deleted accounts** — On commits, issues, and PRs, `author { login }` returns `null` if the account was deleted. Always guard: `commit.get('author') or {}`.
+
+- **`changedFilesIfAvailable` vs `changedFiles`** — Old `changedFiles` field on `Commit` is deprecated; use `changedFilesIfAvailable` which returns `null` for very large diffs (GitHub doesn't compute diff stats for commits touching >1000 files).
+
+- **Search rate limit is separate from GraphQL** — The `search()` query type has an internal abuse limit of ~30 search queries/minute in addition to the 5000 point/hr pool. Space search calls out if running many in a loop.
+
+- **`contributionsCollection` defaults to the current year** — Without `from`/`to` arguments it returns contributions for the past year from the calling date. Specify `contributionsCollection(from: "2025-01-01T00:00:00Z", to: "2025-12-31T23:59:59Z")` for a specific year.
+
+- **Private repo fields require appropriate scopes** — Token needs `repo` scope for private content. With only `public_repo`, private repos return `null` or are omitted from results, not an error.
+
+- **Variables must match declared types exactly** — A query declaring `$first: Int!` will error if you pass `first: "20"` (a string). Always pass Python `int`, not `str`, for `Int` variables.
+
+- **`X-Github-Next-Global-ID: 1` header** — GitHub is migrating to new-format node IDs. Add this header to get the new format proactively. Without it, some IDs returned are legacy format. Doesn't affect query results.
+
+- **Errors array vs HTTP error codes** — GraphQL always returns HTTP 200 even for partial errors. Check `data.get('errors')` — it can co-exist with `data.get('data')` for partial success (some fields returned, some errored). The `gql()` helper above raises on any errors; adjust if you want partial results.
+
+- **Rate limit resets hourly, not per-minute** — The `resetAt` timestamp is always ~1 hour from first use. There's no per-minute sub-limit for non-search GraphQL queries. If you hit 0 remaining, wait until `resetAt`.

--- a/domain-skills/poetrydb/scraping.md
+++ b/domain-skills/poetrydb/scraping.md
@@ -1,0 +1,238 @@
+# PoetryDB — Scraping & Data Extraction
+
+`https://poetrydb.org` — free REST API with 3 010 poems from 129 public-domain authors. No auth, no rate limits documented, no browser needed. All responses are JSON (always — even the `.text` suffix returns `application/json`).
+
+**Note on Gutenberg poetry**: If you need the full text of a poetry collection as a single file (e.g., all of Whitman's *Leaves of Grass* as one document), see the Gutenberg skill — it covers fetching full ebooks. Use PoetryDB when you need individual poems, author listings, line counts, or text-search within poetry.
+
+## Do this first
+
+**One call gives you all poems for an author — no pagination, no auth.**
+
+```python
+import json, urllib.parse
+from helpers import http_get
+
+# Get all Emily Dickinson poems
+poems = json.loads(http_get('https://poetrydb.org/author/Emily%20Dickinson'))
+# poems = list of 362 dicts, each with: title, author, lines (list[str]), linecount (str)
+
+for p in poems:
+    print(p['title'], '-', p['linecount'], 'lines')
+    print('\n'.join(p['lines'][:4]))
+    print()
+```
+
+## Common workflows
+
+### List all authors
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get('https://poetrydb.org/author'))
+authors = data['authors']   # list of 129 strings, exact names
+# ['Adam Lindsay Gordon', 'Alan Seeger', 'Alexander Pope', ..., 'William Shakespeare']
+print(len(authors))  # 129
+```
+
+### List all titles
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get('https://poetrydb.org/title'))
+titles = data['titles']     # list of 3010 strings
+print(len(titles))          # 3010
+```
+
+### Fetch a poem by exact title
+
+```python
+import json
+from helpers import http_get
+
+poems = json.loads(http_get('https://poetrydb.org/title/Ozymandias'))
+# Returns a list — usually 1 item, may be more for shared titles
+p = poems[0]
+print(p['title'])           # Ozymandias
+print(p['author'])          # Percy Bysshe Shelley
+print(p['linecount'])       # '14'  ← always a string, not int
+print('\n'.join(p['lines']))
+# I met a traveller from an antique land
+# Who said: Two vast and trunkless legs of stone
+# ...
+```
+
+### Search by line content
+
+```python
+import json
+from helpers import http_get
+
+# Exact substring match within any line of any poem
+poems = json.loads(http_get('https://poetrydb.org/lines/Shall%20I%20compare%20thee'))
+print(len(poems))           # 1
+print(poems[0]['title'])    # Sonnet 18: Shall I compare thee to a summer's day?
+print(poems[0]['author'])   # William Shakespeare
+```
+
+### Get sonnets (14-line poems)
+
+```python
+import json
+from helpers import http_get
+
+sonnets = json.loads(http_get('https://poetrydb.org/linecount/14'))
+print(len(sonnets))         # 450
+# Each item has: title, author, lines, linecount
+print(sonnets[0]['title'])  # On the Death of Robert Browning
+print(sonnets[0]['author']) # Algernon Charles Swinburne
+```
+
+### Random poems
+
+```python
+import json
+from helpers import http_get
+
+# Get N random poems in one call
+poems = json.loads(http_get('https://poetrydb.org/random/5'))
+for p in poems:
+    print(f"{p['title']} — {p['author']} ({p['linecount']} lines)")
+# Sonnet 132: Thine eyes I love...  — William Shakespeare (14 lines)
+# THE ARSENAL AT SPRINGFIELD        — Henry Wadsworth Longfellow (48 lines)
+# ...
+```
+
+### Combined field search (AND logic)
+
+Combine up to two search fields with comma-separated names and semicolon-separated values. All fields must match.
+
+```python
+import json
+from helpers import http_get
+
+# Emily Dickinson poems with exactly 4 lines
+poems = json.loads(http_get('https://poetrydb.org/author,linecount/Emily%20Dickinson;4'))
+print(len(poems))   # 33
+
+# Shakespeare's Sonnet 18 (exact title match + author)
+poems = json.loads(http_get(
+    'https://poetrydb.org/author,title/William%20Shakespeare;Sonnet%2018'
+))
+print(poems[0]['title'])    # Sonnet 18: Shall I compare thee to a summer's day?
+```
+
+### Select output fields (reduce payload)
+
+Add a third path segment with a comma-separated field list to return only those fields.
+
+```python
+import json
+from helpers import http_get
+
+# Just titles for all Dickinson poems — much smaller payload
+titles = json.loads(http_get('https://poetrydb.org/author/Emily%20Dickinson/title'))
+# [{'title': 'Not at Home to Callers'}, {'title': 'After! When the Hills do'}, ...]
+print(len(titles))          # 362
+
+# Title + linecount for all 14-line poems
+items = json.loads(http_get('https://poetrydb.org/linecount/14/title,author'))
+# [{'title': 'On the Death of Robert Browning', 'author': 'Algernon Charles Swinburne'}, ...]
+```
+
+Available output fields: `title`, `author`, `lines`, `linecount`
+
+### Bulk download all poems (parallel by author)
+
+```python
+import json, urllib.parse
+from helpers import http_get
+from concurrent.futures import ThreadPoolExecutor
+
+def fetch_author(author):
+    url = f"https://poetrydb.org/author/{urllib.parse.quote(author)}"
+    r = json.loads(http_get(url))
+    return r if isinstance(r, list) else []
+
+authors = json.loads(http_get('https://poetrydb.org/author'))['authors']
+# 129 authors — safe to fetch all in parallel at max_workers=10
+with ThreadPoolExecutor(max_workers=10) as ex:
+    all_poems = []
+    for batch in ex.map(fetch_author, authors):
+        all_poems.extend(batch)
+
+print(len(all_poems))   # 3010
+```
+
+## URL schema
+
+```
+https://poetrydb.org/{input_field}/{search_term}[/{output_fields}][.json]
+```
+
+| Pattern | Example | What it returns |
+|---|---|---|
+| `/author` | `/author` | `{"authors": [...]}` — all 129 author names |
+| `/title` | `/title` | `{"titles": [...]}` — all 3010 titles |
+| `/author/{name}` | `/author/Emily%20Dickinson` | All poems by that author (exact match, case-sensitive) |
+| `/title/{title}` | `/title/Ozymandias` | Poems with that exact title |
+| `/lines/{text}` | `/lines/I%20met%20a%20traveller` | Poems containing that substring in any line |
+| `/linecount/{n}` | `/linecount/14` | All poems with exactly N lines |
+| `/random/{n}` | `/random/5` | N random poems |
+| `/f1,f2/{v1};{v2}` | `/author,linecount/Dickinson;14` | AND search across two fields |
+| `/{search}/{term}/{fields}` | `/author/Dickinson/title,linecount` | Return only the named fields |
+
+## Response schema
+
+Every poem is the same shape:
+
+```json
+{
+  "title": "Ozymandias",
+  "author": "Percy Bysshe Shelley",
+  "lines": [
+    "I met a traveller from an antique land",
+    "Who said: Two vast and trunkless legs of stone",
+    "..."
+  ],
+  "linecount": "14"
+}
+```
+
+Author/title list endpoints return a single-key dict:
+
+```json
+{"authors": ["Adam Lindsay Gordon", "Alan Seeger", ...]}
+{"titles": [" Thoughts On The Works Of Providence", "\"All Is Vanity...\"", ...]}
+```
+
+Error response (status stays 200, body is JSON):
+
+```json
+{"status": 404, "reason": "Not found"}
+```
+
+## Gotchas
+
+- **`linecount` is always a string, not an integer.** `p['linecount']` returns `'14'`, not `14`. Use `int(p['linecount'])` if you need numeric comparison.
+
+- **Author names are exact and case-sensitive.** `Shakespeare` matches `William Shakespeare` (substring match seems to work for the author path), but `shakespeare` (lowercase) returns 404. Use the name exactly as it appears in the `/author` list. Always URL-encode spaces as `%20`.
+
+- **The `/title/` endpoint is exact-match only.** `https://poetrydb.org/title/Because%20I` returns 404 even though "Because I could not stop for Death" exists. You must supply the full title exactly as listed in `/title`. The `:abs` suffix works for some title searches but inconsistently — avoid relying on it.
+
+- **Combined search uses semicolons as separators, not commas.** URL: `/author,linecount/Emily%20Dickinson;4` — the comma separates field names, the semicolon separates values. Swapping them gives 404.
+
+- **`.text` and `.json` output suffixes both return `application/json`.** The `.text` suffix does NOT return a plain text poem — it still returns the standard JSON array. Always parse with `json.loads()` regardless of suffix.
+
+- **Empty lines in poems are real array entries.** `p['lines']` may contain `''` (empty string) to represent stanza breaks. Filter with `[l for l in p['lines'] if l]` if you only want the text lines.
+
+- **`status` in error responses is a string, not an int.** The 404 body is `{"status": "404", ...}` in some endpoints and `{"status": 404, ...}` in others — always check with `isinstance(data, list)` rather than parsing the status field.
+
+- **No pagination — all results returned at once.** A call for `linecount/14` returns all 450 sonnets in a single response. No `page`, `limit`, or `offset` parameters exist.
+
+- **Max random poems per call is not documented.** In practice, `random/100` and higher work fine. No hard cap was observed.
+
+- **The `poemcount` input field is not listable.** `GET /poemcount` returns a 405 error. Only `author` and `title` support the bare list call.


### PR DESCRIPTION
## Summary
- BLS: value field is always a string; period codes M01-M12/Q01-Q04/A01; unregistered limit 25/day (IP-shared); REQUEST_NOT_PROCESSED means rate-limited; catalog/calculations require API key
- Food Data: USDA DEMO_KEY hits rate limit fast (30/hr, 50/day); Open Food Facts barcode lookup is stable; CGI search endpoint returns HTML under load; nutriment keys use hyphens; status=0 means not found
- PoetryDB: linecount is always a string not int; /title/ is exact-match only; .text suffix still returns JSON; combined search uses comma for fields, semicolon for values; no pagination
- Fandom APIs: Rick and Morty REST + GraphQL; swapi.info returns full arrays (no pagination); swapi.dev has search; PokeAPI height/weight in dm/hg; HP API cold-starts on Render free tier
- GitHub GraphQL: requires Bearer token (no anonymous access); 5000 point/hour system; first: 100 max per query; HTTP 200 always even for errors; inline fragments for union types

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five domain-skill guides with runnable examples and gotchas for BLS, Food Data (USDA + Open Food Facts), PoetryDB, fandom APIs, and GitHub GraphQL. This expands our scraping playbook and speeds up reliable data extraction.

- **New Features**
  - BLS: multi-series POST with period codes; `value` is string; unregistered 25/day; 20-year ranges and `catalog`/`calculations` require a key.
  - Food Data: USDA FDC search/detail and OFF barcode lookup; DEMO_KEY hits limits fast; OFF `status=0` = not found; nutriment keys use hyphens.
  - PoetryDB: author/title/linecount queries and combined filters; `linecount` is string; `.text` still JSON; no pagination.
  - Fandom APIs: Rick and Morty REST+GraphQL; `swapi.info` bulk lists (no search), `swapi.dev` for `?search=`; PokeAPI units in dm/hg; HP API cold-starts.
  - GitHub GraphQL: token required; 5k points/hour; `first: 100` max; HTTP 200 even on errors; use inline fragments for unions; examples for issues, PRs, search, pagination.

<sup>Written for commit 60dde5602c0c8e76aa55a751ba0b672e3b48e8e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

