### PR TITLE
Add domain skills: CryptoCompare, Open-Meteo, Fun APIs, Cover Art Archive, Wikipedia REST

### DIFF
--- a/domain-skills/cover-art-archive/scraping.md
+++ b/domain-skills/cover-art-archive/scraping.md
@@ -1,0 +1,248 @@
+# Cover Art Archive — Scraping & Data Extraction
+
+`https://coverartarchive.org` — album artwork database linked to MusicBrainz. **Never use the browser.** All data is reachable via HTTP. No API key required.
+
+## Do this first
+
+**Use subprocess curl (not `http_get`) to avoid SSL certificate errors on macOS Python 3.11.** The CAA API always redirects (`307`) to `archive.org` — pass `-L` to follow.
+
+```python
+import subprocess, json
+
+def caa_get(url):
+    """Fetch a CAA URL, following redirects. Returns parsed JSON or None (on 404)."""
+    result = subprocess.run(
+        ['curl', '-sL', url],
+        capture_output=True, text=True, timeout=20
+    )
+    if not result.stdout.strip():
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+# Get all cover art for a release (MusicBrainz Release MBID)
+data = caa_get('https://coverartarchive.org/release/76df3287-6cda-33eb-8e9a-044b5e15ffdd')
+# Confirmed output (2026-04-18): {'images': [...6 items...], 'release': 'https://musicbrainz.org/...'}
+```
+
+You need the **Release MBID** (not Release Group MBID) for the most reliable results. Use the MusicBrainz API to look up MBIDs by artist/album name.
+
+## Common workflows
+
+### Get front cover art for a release
+
+```python
+import subprocess, json
+
+def caa_get(url):
+    result = subprocess.run(['curl', '-sL', url], capture_output=True, text=True, timeout=20)
+    if not result.stdout.strip():
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+# OK Computer (UK original pressing)
+MBID = '76df3287-6cda-33eb-8e9a-044b5e15ffdd'
+data = caa_get(f'https://coverartarchive.org/release/{MBID}')
+
+if data is None:
+    print('No cover art found for this release')
+else:
+    images = data['images']
+    front = next((img for img in images if img.get('front')), None)
+    if front:
+        print('Full image:', front['image'])
+        print('250px thumb:', front['thumbnails']['250'])
+        print('500px thumb:', front['thumbnails']['500'])
+        print('1200px thumb:', front['thumbnails']['1200'])
+        print('Types:', front['types'])
+        print('Approved:', front['approved'])
+        print('Image ID:', front['id'])
+# Confirmed output (2026-04-18):
+# Full image:    http://coverartarchive.org/release/76df3287-.../829521842.jpg
+# 250px thumb:   http://coverartarchive.org/release/76df3287-.../829521842-250.jpg
+# 500px thumb:   http://coverartarchive.org/release/76df3287-.../829521842-500.jpg
+# 1200px thumb:  http://coverartarchive.org/release/76df3287-.../829521842-1200.jpg
+# Types: ['Front']
+# Approved: True
+# Image ID: 829521842
+```
+
+### Get all images with their types
+
+```python
+data = caa_get(f'https://coverartarchive.org/release/{MBID}')
+if data:
+    for img in data['images']:
+        print(
+            f"ID={img['id']}",
+            f"front={img['front']}",
+            f"back={img['back']}",
+            f"types={img['types']}",
+            f"approved={img['approved']}"
+        )
+# Confirmed output for OK Computer (UK):
+# ID=829521842   front=True  back=False  types=['Front']           approved=True
+# ID=24546038908 front=False back=False  types=['Front', 'Booklet'] approved=True
+# ID=24546039829 front=False back=False  types=['Booklet']          approved=True
+# ID=24546040945 front=False back=False  types=['Booklet']          approved=True
+# ID=5769317885  front=False back=True   types=['Back']             approved=True
+# ID=5769316809  front=False back=False  types=['Medium']           approved=True
+```
+
+Known image types: `Front`, `Back`, `Booklet`, `Medium`, `Tray`, `Spine`, `Obi`, `Sticker`, `Liner`, `Poster`, `Watermark`, `Raw/Unedited`, `Matrix/Runout`, `Top`, `Bottom`, `Other`.
+
+### Release-group cover art (canonical front cover across all releases)
+
+```python
+# Returns images from one specific release chosen as canonical for the group.
+# The 'release' field tells you which release was selected.
+# Dark Side of the Moon release group
+data = caa_get('https://coverartarchive.org/release-group/f5093c06-23e3-404f-aeaa-40f72885ee3a')
+if data:
+    print('Canonical release:', data['release'])
+    front = next((i for i in data['images'] if i.get('front')), None)
+    print('Front thumb 500:', front['thumbnails']['500'] if front else None)
+# Confirmed output (2026-04-18):
+# Canonical release: https://musicbrainz.org/release/956fbc58-362d-43b8-b880-3779e0508559
+# Front thumb 500:   http://coverartarchive.org/release/956fbc58-.../34025419985-500.jpg
+```
+
+### Direct front/back shortcut URLs (redirect straight to image bytes)
+
+```python
+import subprocess
+
+# These URLs redirect (307) to the actual JPEG — no JSON parsing needed.
+MBID = '76df3287-6cda-33eb-8e9a-044b5e15ffdd'
+
+# Download full-resolution front cover
+result = subprocess.run(
+    ['curl', '-sL', f'https://coverartarchive.org/release/{MBID}/front'],
+    capture_output=True, timeout=30
+)
+jpeg_bytes = result.stdout  # raw JPEG bytes — 76KB for OK Computer front cover
+
+# Thumbnail shortcuts: /front-250, /front-500, /front-1200, /back-250, /back-500, /back-1200
+result = subprocess.run(
+    ['curl', '-sL', f'https://coverartarchive.org/release/{MBID}/front-500'],
+    capture_output=True, timeout=30
+)
+thumb_bytes = result.stdout
+
+# Save to file
+with open('/tmp/cover.jpg', 'wb') as f:
+    f.write(result.stdout)
+```
+
+### Parallel fetch for multiple releases
+
+```python
+import subprocess, json
+from concurrent.futures import ThreadPoolExecutor
+
+def get_front_thumb(mbid, size=500):
+    """Return (mbid, thumbnail_url_or_None)."""
+    result = subprocess.run(
+        ['curl', '-sL', f'https://coverartarchive.org/release/{mbid}'],
+        capture_output=True, text=True, timeout=20
+    )
+    if not result.stdout.strip():
+        return mbid, None
+    try:
+        data = json.loads(result.stdout)
+        front = next((i for i in data['images'] if i.get('front')), None)
+        return mbid, front['thumbnails'].get(str(size)) if front else None
+    except Exception:
+        return mbid, None
+
+mbids = [
+    '76df3287-6cda-33eb-8e9a-044b5e15ffdd',  # OK Computer (UK)
+    '956fbc58-362d-43b8-b880-3779e0508559',  # Dark Side of the Moon
+]
+with ThreadPoolExecutor(max_workers=4) as ex:
+    results = list(ex.map(get_front_thumb, mbids))
+
+for mbid, url in results:
+    print(mbid, url)
+# Confirmed working (2026-04-18): both returned 500px thumbnail URLs
+# max_workers=4 is safe; don't exceed 8 for continuous crawling
+```
+
+## URL reference
+
+### API endpoints
+
+| Endpoint | Method | Returns |
+|---|---|---|
+| `https://coverartarchive.org/release/{mbid}` | GET | JSON index of all images for a release |
+| `https://coverartarchive.org/release-group/{mbid}` | GET | JSON index from the canonical release of a group |
+| `https://coverartarchive.org/release/{mbid}/front` | GET | Redirects to full-res front cover JPEG |
+| `https://coverartarchive.org/release/{mbid}/back` | GET | Redirects to full-res back cover JPEG |
+| `https://coverartarchive.org/release/{mbid}/front-250` | GET | Redirects to 250px front thumbnail |
+| `https://coverartarchive.org/release/{mbid}/front-500` | GET | Redirects to 500px front thumbnail |
+| `https://coverartarchive.org/release/{mbid}/front-1200` | GET | Redirects to 1200px front thumbnail |
+| `https://coverartarchive.org/release/{mbid}/{image_id}.jpg` | GET | Redirects to full-res specific image |
+| `https://coverartarchive.org/release/{mbid}/{image_id}-250.jpg` | GET | Redirects to 250px thumbnail |
+| `https://coverartarchive.org/release/{mbid}/{image_id}-500.jpg` | GET | Redirects to 500px thumbnail |
+| `https://coverartarchive.org/release/{mbid}/{image_id}-1200.jpg` | GET | Redirects to 1200px thumbnail |
+
+### Redirect chain
+
+Every CAA URL redirects — always pass `-L` to curl or use an HTTP client that follows redirects:
+
+1. `coverartarchive.org/release/{mbid}` → `307` → `archive.org/download/mbid-{mbid}/index.json` → `200` (JSON)
+2. `coverartarchive.org/release/{mbid}/front` → `307` → `archive.org/download/mbid-{mbid}/mbid-{mbid}-{id}.jpg` → `302` → CDN URL → `200` (JPEG)
+3. Thumbnail URLs in the JSON response use `http://` not `https://`, but both work.
+
+### JSON response structure
+
+```python
+{
+    "images": [
+        {
+            "id": 829521842,          # numeric image ID
+            "image": "http://coverartarchive.org/release/{mbid}/829521842.jpg",  # full-res
+            "thumbnails": {
+                "250":   "http://coverartarchive.org/release/{mbid}/829521842-250.jpg",
+                "500":   "http://coverartarchive.org/release/{mbid}/829521842-500.jpg",
+                "1200":  "http://coverartarchive.org/release/{mbid}/829521842-1200.jpg",
+                "small": "...829521842-250.jpg",   # alias for 250
+                "large": "...829521842-500.jpg",   # alias for 500
+            },
+            "types": ["Front"],       # list of type strings
+            "front": True,            # bool — is this the designated front cover?
+            "back": False,            # bool — is this the designated back cover?
+            "approved": True,         # bool — approved by MusicBrainz editors
+            "comment": "",            # optional editor comment
+            "edit": 17462565          # MusicBrainz edit ID that added this image
+        },
+        # ... more images
+    ],
+    "release": "https://musicbrainz.org/release/{mbid}"  # canonical MB release URL
+}
+```
+
+## Gotchas
+
+- **`http_get` from helpers.py fails on macOS Python 3.11** — `urllib` SSL certificate verification fails (`CERTIFICATE_VERIFY_FAILED`) on this platform. Use `subprocess.run(['curl', '-sL', ...])` instead. Alternatively, patch SSL: `ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE`.
+
+- **Always pass `-L` to curl** — CAA never returns data directly; it always redirects (`307`). Without `-L`, you get 87 bytes of plain text: `See: https://archive.org/download/mbid-.../index.json`.
+
+- **404 means no cover art uploaded, not a bad MBID** — A valid MBID with no art returns HTTP 404 and `<p>No cover art found for release {mbid}</p>`. Many releases on MusicBrainz have no associated cover art.
+
+- **Release MBID vs Release Group MBID are different** — The release-group endpoint (`/release-group/{mbid}`) accepts a different type of MBID and returns images from whichever release the CAA chose as canonical for that group. The canonical release is identified by the `release` field in the response. When you need a specific edition's artwork (e.g., the Japanese pressing vs the UK pressing), use the individual release MBID.
+
+- **The `front` and `back` boolean fields are independent of the `types` list** — An image can have `front: True` and `types: ['Front', 'Booklet']`. The boolean flags indicate which image is the *designated* front/back for the `/front` and `/back` shortcuts. Use `img.get('front')` to find the one image that serves the `/front` shortcut.
+
+- **`small` and `large` are aliases, not unique sizes** — `thumbnails['small']` == `thumbnails['250']`; `thumbnails['large']` == `thumbnails['500']`. Only `250`, `500`, and `1200` are actual distinct sizes.
+
+- **Image URLs in the JSON use `http://` not `https://**` — The `image` and `thumbnails` fields return `http://coverartarchive.org/...` URLs. Substitute `https://` or use as-is; the server accepts both.
+
+- **No rate limit headers are returned** — CAA does not send `X-Ratelimit-*` headers. In practice, rapid bursts of 8–10 requests complete without throttling. For bulk crawling of hundreds of releases, add `time.sleep(1)` between batches to be safe.
+
+- **Not all image IDs have all thumbnail sizes** — If a very old or small image was uploaded before thumbnail generation was added, the `250` or `1200` key may be missing from `thumbnails`. Always use `.get('250')` rather than `['250']` and fall back to `image` (the full-res URL) if needed.

--- a/domain-skills/cryptocompare/scraping.md
+++ b/domain-skills/cryptocompare/scraping.md
@@ -1,0 +1,430 @@
+# CryptoCompare — Data Extraction
+
+`https://min-api.cryptocompare.com` — free-tier REST API, no API key needed for the endpoints documented here. Pure JSON, no browser required.
+
+## Do this first
+
+**Use `http_get` directly — no browser, no parsing, structured JSON.**
+
+```python
+import json
+data = json.loads(http_get("https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"))
+print(data['USD'])   # 75576.61
+```
+
+**No API key needed for price, OHLCV, top-coins, exchanges, and pairs endpoints.** Confirmed 50+ rapid sequential calls with no rate-limit errors — no delay needed between calls on the free tier.
+
+**Symbols are uppercase** (`BTC`, `ETH`, `SOL`), unlike CoinGecko which uses kebab-case IDs.
+
+## Rate limits (confirmed live)
+
+- **Free tier**: no observed throttling after 50+ rapid sequential calls — no `Retry-After`, no 429s
+- **Response body `RateLimit`**: always `{}` (empty) on free-tier calls — not used for counting
+- **Cache**: responses include `cache-control: public, max-age=10` — safe to hammer
+- No `time.sleep()` needed between calls (unlike CoinGecko which hard-limits at ~3/min)
+
+## Endpoints that require API key (return `{"Response":"Error","Message":"You need a valid auth key..."}`)
+
+- `/data/social/coin/latest` — Reddit/Twitter/GitHub stats
+- `/data/blockchain/histo/day` — on-chain metrics (hashrate, difficulty, tx count)
+- `/data/news/` and `/data/v2/news/` — crypto news articles
+- `/data/ob/l2/snapshot` — order book data
+
+**The above return HTTP 200 but with an error body** — no exception is raised. Always check `d.get('Response') == 'Error'` if you're unsure.
+
+## Common workflows
+
+### Simple price (one coin, multiple target currencies)
+
+```python
+import json
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/price"
+    "?fsym=BTC&tsyms=USD,EUR,GBP,ETH,BNB"
+))
+print(data)
+# {'USD': 75576.61, 'EUR': 64259.31, 'GBP': 55903.09, 'ETH': 32.23, 'BNB': 120.34}
+```
+
+`fsym` = from symbol (single coin). `tsyms` = comma-separated target currencies (fiat or crypto).
+
+### Multi-coin prices (batch lookup)
+
+```python
+import json
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/pricemulti"
+    "?fsyms=BTC,ETH,SOL,BNB,XRP&tsyms=USD,EUR,BTC"
+))
+for coin, prices in data.items():
+    print(f"{coin}: ${prices['USD']:,.2f} | {prices['EUR']:,.2f} EUR | {prices['BTC']:.6f} BTC")
+# BTC: $75,576.33 | 64,259.31 EUR | 1.000000 BTC
+# ETH: $2,344.78  | 1,993.43 EUR  | 0.031040 BTC
+# SOL: $85.71     | 72.86 EUR     | 0.001134 BTC
+```
+
+### Full price details (OHLCV + market cap + supply)
+
+```python
+import json
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/pricemultifull"
+    "?fsyms=BTC,ETH&tsyms=USD"
+))
+raw = data['RAW']['BTC']['USD']   # raw numeric values
+disp = data['DISPLAY']['BTC']['USD']  # pre-formatted strings (e.g. "$ 75,585.8")
+
+print(f"Price:          ${raw['PRICE']:,.2f}")
+print(f"24h Change:     {raw['CHANGEPCT24HOUR']:+.2f}%  (${raw['CHANGE24HOUR']:+,.2f})")
+print(f"24h High/Low:   ${raw['HIGH24HOUR']:,.2f} / ${raw['LOW24HOUR']:,.2f}")
+print(f"Day High/Low:   ${raw['HIGHDAY']:,.2f} / ${raw['LOWDAY']:,.2f}")
+print(f"Hour OHLC:      O={raw['OPENHOUR']:,.2f} H={raw['HIGHHOUR']:,.2f} L={raw['LOWHOUR']:,.2f}")
+print(f"Volume 24h:     {raw['VOLUME24HOUR']:,.4f} BTC (${raw['VOLUME24HOURTO']/1e9:.2f}B)")
+print(f"Market Cap:     ${raw['MKTCAP']/1e9:.1f}B")
+print(f"Supply:         {raw['CIRCULATINGSUPPLY']:,.0f} BTC")
+print(f"Last exchange:  {raw['LASTMARKET']}")
+print(f"Image URL:      https://www.cryptocompare.com{raw['IMAGEURL']}")
+# Formatted version (no math needed):
+print(f"Price (display):{disp['PRICE']}")   # "$ 75,585.8"
+print(f"MCap (display): {disp['MKTCAP']}")  # "$ 1,513.06 B"
+```
+
+All `RAW` fields (confirmed live):
+`TYPE, MARKET, FROMSYMBOL, TOSYMBOL, FLAGS, LASTMARKET, MEDIAN, TOPTIERVOLUME24HOUR, TOPTIERVOLUME24HOURTO, LASTTRADEID, PRICE, LASTUPDATE, LASTVOLUME, LASTVOLUMETO, VOLUMEHOUR, VOLUMEHOURTO, OPENHOUR, HIGHHOUR, LOWHOUR, VOLUMEDAY, VOLUMEDAYTO, OPENDAY, HIGHDAY, LOWDAY, VOLUME24HOUR, VOLUME24HOURTO, OPEN24HOUR, HIGH24HOUR, LOW24HOUR, CHANGE24HOUR, CHANGEPCT24HOUR, CHANGEDAY, CHANGEPCTDAY, CHANGEHOUR, CHANGEPCTHOUR, CONVERSIONTYPE, CONVERSIONSYMBOL, CONVERSIONLASTUPDATE, SUPPLY, MKTCAP, MKTCAPPENALTY, CIRCULATINGSUPPLY, CIRCULATINGSUPPLYMKTCAP, TOTALVOLUME24H, TOTALVOLUME24HTO, TOTALTOPTIERVOLUME24H, TOTALTOPTIERVOLUME24HTO, IMAGEURL`
+
+`DISPLAY` mirrors all fields but as pre-formatted strings (e.g. `"$ 75,585.8"`, `"$ 1,513.06 B"`).
+
+### Historical OHLCV — daily candles
+
+```python
+import json, datetime
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v2/histoday"
+    "?fsym=BTC&tsym=USD&limit=7"   # limit = number of candles returned
+))
+candles = data['Data']['Data']     # list of dicts
+
+for c in candles:
+    dt = datetime.datetime.fromtimestamp(c['time'], tz=datetime.timezone.utc).strftime('%Y-%m-%d')
+    print(f"{dt}: O={c['open']:,.0f} H={c['high']:,.0f} L={c['low']:,.0f} C={c['close']:,.0f} "
+          f"Vol={c['volumefrom']:,.2f} {c['volumeto']:,.0f} USD")
+# 2026-04-12: O=79,770 H=83,458 L=79,770 C=82,622 Vol=24,540.70
+# ...
+
+# Fields per candle: time, high, low, open, volumefrom, volumeto, close, conversionType, conversionSymbol
+```
+
+**`toTs` parameter** — fetch historical candles ending at a specific Unix timestamp:
+```python
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v2/histoday"
+    "?fsym=BTC&tsym=USD&limit=5&toTs=1700000000"   # Nov 14, 2023
+))
+# Returns 5 daily candles ending 2023-11-14 at BTC ~$35,551
+```
+
+**`aggregate` parameter** — group candles into weekly or other intervals:
+```python
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v2/histoday"
+    "?fsym=BTC&tsym=USD&limit=4&aggregate=7"   # weekly candles
+))
+# Returns 4 weekly OHLCV candles
+# 2026-03-26: O=71,305 H=71,410 L=64,960 C=68,108 Vol=183,253.59 BTC
+```
+
+**Exchange-specific OHLCV** — add `&e=Coinbase` or `&e=Kraken` (uses CCCAGG aggregate by default):
+```python
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v2/histoday"
+    "?fsym=BTC&tsym=USD&limit=5&e=Coinbase"
+))
+# Returns Coinbase-specific OHLCV only
+```
+
+### Historical OHLCV — hourly candles
+
+```python
+import json, datetime
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v2/histohour"
+    "?fsym=ETH&tsym=USD&limit=24"   # last 24 hours
+))
+candles = data['Data']['Data']
+meta = data['Data']
+print(f"TimeFrom: {meta['TimeFrom']}  TimeTo: {meta['TimeTo']}")
+print(f"Entries: {len(candles)}")
+
+e = candles[-1]
+dt = datetime.datetime.fromtimestamp(e['time'], tz=datetime.timezone.utc).strftime('%Y-%m-%d %H:%M')
+print(f"Latest: {dt}  C={e['close']:,.2f}")
+```
+
+Same fields as daily: `time, open, high, low, close, volumefrom, volumeto, conversionType, conversionSymbol`
+
+Exchange-specific hourly (confirmed working for Coinbase):
+```python
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v2/histohour"
+    "?fsym=BTC&tsym=USD&limit=5&e=Coinbase"
+))
+# Coinbase-specific volume and OHLC
+```
+
+### Historical OHLCV — minute candles
+
+```python
+import json, datetime
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v2/histominute"
+    "?fsym=BTC&tsym=USD&limit=60"   # last 60 minutes
+))
+candles = data['Data']['Data']
+print(f"Entries: {len(candles)}")   # 61 entries (includes the current partial minute)
+
+e = candles[-1]
+dt = datetime.datetime.fromtimestamp(e['time'], tz=datetime.timezone.utc).strftime('%Y-%m-%d %H:%M')
+print(f"{dt}: O={e['open']:,.2f} C={e['close']:,.2f}")
+# 2026-04-19 01:42: O=75,571.67 C=75,571.74
+```
+
+Minute data is free (confirmed working — earlier `Error` test was a fluke). Max `limit` per call is not enforced strictly but use 1440 or less for reasonable responses.
+
+### Top coins by market cap
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/top/mktcapfull"
+    "?limit=10&tsym=USD"   # limit max 100
+))
+for item in data['Data']:
+    info = item['CoinInfo']
+    raw  = item['RAW']['USD']
+    print(
+        f"{info['Name']:6} {info['FullName']:20} "
+        f"${raw['PRICE']:>12,.2f}  "
+        f"MCap=${raw['MKTCAP']/1e9:.1f}B  "
+        f"Vol24h={raw['VOLUME24HOUR']:,.0f}"
+    )
+# BTC    Bitcoin              $   75,604.86  MCap=$1513.4B  Vol24h=10,846
+# ETH    Ethereum             $    2,346.16  MCap=$283.2B   Vol24h=171,815
+
+# CoinInfo keys per item:
+# Id, Name, FullName, Internal, ImageUrl, Url, Algorithm, ProofType,
+# Rating, NetHashesPerSecond, BlockNumber, BlockTime, BlockReward,
+# AssetLaunchDate, MaxSupply, Type, DocumentType
+```
+
+The `RAW` and `DISPLAY` sections are identical to `pricemultifull` (same full field set).
+
+### Top coins by volume (top-tier exchanges only)
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/top/totaltoptiervolfull"
+    "?limit=10&tsym=USD"
+))
+for item in data['Data']:
+    info = item['CoinInfo']
+    raw  = item.get('RAW', {}).get('USD', {})
+    print(f"{info['Name']:6} ${raw.get('PRICE',0):>10,.2f}  Top-tier Vol24h={raw.get('TOPTIERVOLUME24HOUR',0):,.0f}")
+# BTC    $   75,604.86  Top-tier Vol24h=10,882
+# ETH    $    2,346.16  Top-tier Vol24h=174,036
+# USDC   $        1.00  Top-tier Vol24h=304,987,042
+```
+
+### Top trading pairs for a coin
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/top/pairs"
+    "?fsym=BTC&limit=10"
+))
+for p in data['Data']:
+    print(
+        f"{p['fromSymbol']}/{p['toSymbol']:6}  "
+        f"Exchange: {p['exchange']:15}  "
+        f"Vol24h: {p['volume24h']:>15,.2f}  "
+        f"Price: {p['price']:,.4f}  "
+        f"Grade: {p['exchangeGrade']}"
+    )
+# BTC/USDC   Exchange: CCCAGG          Vol24h:   7,000.73  Price: 75,591.5000  Grade: -
+# BTC/BTC    Exchange: CCCAGG          Vol24h:   ...
+
+# Pair fields: exchange, fromSymbol, toSymbol, volume24h, volume24hTo,
+#              price, lastUpdateTs, exchangeGradePoints, exchangeGrade
+```
+
+The `exchange=CCCAGG` is the CryptoCompare aggregate market — covers all tracked exchanges combined.
+
+### Top exchanges for a specific coin pair
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/top/exchanges/full"
+    "?fsym=BTC&tsym=USD&limit=10"
+))
+d = data['Data']
+agg = d['AggregatedData']
+print(f"Aggregate: ${agg['PRICE']:,.2f}  Vol24h={agg['VOLUME24HOUR']:,.2f} BTC")
+
+for ex in d['Exchanges']:
+    print(f"  {ex['MARKET']:15} ${ex['PRICE']:>12,.2f}  Vol:{ex['VOLUME24HOUR']:>10,.2f}")
+# Coinbase        $   75,590.00  Vol:  4,103.16
+# cryptodotcom    $   75,595.80  Vol:  3,362.08
+# Kraken          $   75,573.60  Vol:    860.20
+
+# Exchange fields: TYPE, MARKET, FROMSYMBOL, TOSYMBOL, PRICE,
+#   VOLUME24HOUR, VOLUME24HOURTO, HIGH24HOUR, LOW24HOUR,
+#   CHANGE24HOUR, CHANGEPCT24HOUR, OPEN24HOUR, HIGHDAY, LOWDAY (etc.)
+```
+
+### Exchange metadata list
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/exchanges/general"
+))
+exchanges = data['Data']   # dict keyed by numeric exchange ID strings
+print(f"Exchanges: {len(exchanges)}")   # 304 as of April 2026
+
+# Find by name
+for ex_id, ex in exchanges.items():
+    if ex.get('Name') == 'Binance':
+        print(f"ID: {ex_id}")
+        print(f"Country: {ex.get('Country')}")       # Cayman Islands
+        print(f"Grade: {ex.get('Grade')}")             # AA
+        print(f"24h Vol: {ex.get('TOTALVOLUME24H')}")  # {'BTC': 91508.68}
+        print(f"CentralizationType: {ex.get('CentralizationType')}")
+        break
+
+# Exchange fields: Id, Name, Url, LogoUrl, ItemType, CentralizationType,
+#   InternalName, GradePoints, Grade, GradePointsSplit, AffiliateURL,
+#   Country, OrderBook, Trades, Description, FullAddress, Fees,
+#   DepositMethods, WithdrawalMethods, Sponsored, Recommended, Rating,
+#   SortOrder, TOTALVOLUME24H, DISPLAYTOTALVOLUME24H
+```
+
+### All trading pairs on an exchange
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/v4/all/exchanges"
+    "?tsym=USD&e=Binance"
+))
+exchanges = data['Data']['exchanges']
+binance = exchanges.get('Binance', {})
+print(f"Active: {binance.get('isActive')}")       # True
+print(f"TopTier: {binance.get('isTopTier')}")     # True
+pairs = binance.get('pairs', {})
+print(f"Pairs count: {len(pairs)}")               # 437
+
+# Each pair key is a coin symbol; value maps to quote currencies with history timestamps
+for base_sym in list(pairs.keys())[:3]:
+    quotes = list(pairs[base_sym]['tsyms'].keys())
+    print(f"  {base_sym} -> {quotes}")
+# BTC -> ['USDT', 'JPY', 'MXN', 'IDR', ...]
+
+# Each tsym entry has: histo_minute_start_ts, histo_minute_start,
+#   histo_minute_end_ts, histo_minute_end, isActive
+```
+
+### Coin list and metadata
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/all/coinlist"
+))
+coins = data['Data']   # dict keyed by ticker symbol (e.g. 'BTC', 'ETH')
+print(f"Total coins: {len(coins)}")   # 19,331 as of April 2026
+
+btc = coins['BTC']
+print(f"Id:            {btc['Id']}")           # 1182  ← needed for social/blockchain endpoints
+print(f"Name:          {btc['CoinName']}")     # Bitcoin
+print(f"Algorithm:     {btc['Algorithm']}")    # SHA-256
+print(f"ProofType:     {btc['ProofType']}")    # PoW
+print(f"IsTrading:     {btc['IsTrading']}")    # True
+print(f"ImageUrl:      https://www.cryptocompare.com{btc['ImageUrl']}")
+
+# Fields: Id, Url, ImageUrl, ContentCreatedOn, Name, Symbol, CoinName,
+#   FullName, Description, AssetTokenStatus, Algorithm, ProofType,
+#   SortOrder, Sponsored, Taxonomy, Rating, IsTrading
+```
+
+**Use `coins[sym]['Id']` to get the numeric coin ID** needed for social/blockchain auth-required endpoints.
+
+### Coin general info (supply + image URL, no auth)
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://min-api.cryptocompare.com/data/coin/generalinfo"
+    "?fsyms=BTC,ETH,SOL&tsym=USD"
+))
+for item in data['Data']:
+    ci   = item['CoinInfo']
+    conv = item['ConversionInfo']
+    print(f"{ci['Name']:5} Id={ci['Id']:7} {ci['FullName']:20} Supply={conv.get('Supply', 'N/A')}")
+    print(f"       Image: https://www.cryptocompare.com{ci['ImageUrl']}")
+# BTC   Id=1182    Bitcoin              Supply=20017787
+# ETH   Id=7605    Ethereum             Supply=120690548.46
+```
+
+`ConversionInfo` also has: `Conversion, ConversionSymbol, CurrencyFrom, CurrencyTo, Market, Supply, MktCap`
+
+## Symbol conventions
+
+| Aspect | CoinGecko | CryptoCompare |
+|--------|-----------|---------------|
+| Format | kebab-case ID (`bitcoin`) | uppercase ticker (`BTC`) |
+| Uniqueness | IDs are unique | Symbols may collide (rare) |
+| Lookup | `/coins/list` needed | Use symbol directly |
+| Unknown coin | Returns `{}` silently | Returns `{}` or `Error` response |
+
+Symbols used in `fsym`/`fsyms` are case-insensitive in practice but always use uppercase to be safe: `BTC`, `ETH`, `SOL`, `XRP`, `BNB`, `DOGE`, `ADA`, `AVAX`, `DOT`.
+
+## Supported quote currencies (`tsyms`)
+
+Works with any major fiat or crypto: `USD`, `EUR`, `GBP`, `JPY`, `AUD`, `CAD`, `CHF`, `CNY`, `KRW`, `BRL`, `INR`, `MXN` (fiat) and `BTC`, `ETH`, `BNB`, `USDT`, `USDC` (crypto). More obscure pairs may silently return `{}`.
+
+## Gotchas
+
+- **No auth needed, but errors still return HTTP 200** — auth-required endpoints return `{"Response":"Error","Message":"You need a valid auth key..."}` with HTTP 200. No exception is raised by `http_get`. Always check `d.get('Response') == 'Error'` before reading data from untested endpoints.
+
+- **`pricemultifull` returns both `RAW` and `DISPLAY`** — `RAW` is numeric, `DISPLAY` is pre-formatted strings with currency symbols (e.g. `"$ 75,585.8"`). Use `RAW` for computation, `DISPLAY` for printing directly.
+
+- **`IMAGEURL` is a relative path** — `raw['IMAGEURL']` returns `/media/37746251/btc.png`. Prepend `https://www.cryptocompare.com` to get the full URL. Confirmed working (HTTP 200).
+
+- **`histoday`/`histohour` `limit` is the number of candles, not days back** — `limit=7` returns 8 candles (the current partial period + 7 complete ones). The array has `limit + 1` entries.
+
+- **`toTs` timestamp is inclusive** — `toTs=1700000000` returns candles ending on or before that Unix timestamp. The last candle's `time` will be `<= toTs`.
+
+- **`aggregate=7` gives weekly candles from daily endpoint** — multiply the base interval (day) by `aggregate`. `aggregate=4` on `histohour` gives 4-hour candles.
+
+- **`e=Coinbase` works for exchange-specific OHLCV** — adds the `&e=ExchangeName` param to `histoday`/`histohour`/`histominute`. Valid exchange names must match CryptoCompare's internal names (use `/data/exchanges/general` to find them: Binance, Kraken, Coinbase, Bitfinex, etc.).
+
+- **`data/v4/all/exchanges` keyed by exchange name, `data/exchanges/general` keyed by numeric ID** — inconsistent. The v4 endpoint uses the exchange's display name (e.g. `'Binance'`) as key; the general endpoint uses a numeric ID string (e.g. `'283442'`). To match them, filter the general endpoint by `ex['Name'] == 'Binance'`.
+
+- **Top coins `limit` max is 100** — `limit=250` for `top/mktcapfull` silently returns 100. Use pagination with `page=2` etc. if you need more.
+
+- **`histominute` max lookback is ~7 days** — requesting more than ~10,080 minutes worth of data returns what's available (may be fewer entries than requested).
+
+- **CCCAGG is the default aggregate market** — all price/volume data from `pricemulti`, `pricemultifull`, and `histoday` uses CryptoCompare's volume-weighted aggregate across all tracked exchanges unless you specify `&e=ExchangeName`. `TOTALVOLUME24H` in `pricemultifull` reflects the sum across all markets; `VOLUME24HOUR` reflects the top-tier aggregate.

--- a/domain-skills/fun-apis/scraping.md
+++ b/domain-skills/fun-apis/scraping.md
@@ -1,0 +1,422 @@
+# Fun / Random Public APIs — Data Extraction
+
+No-auth, no-browser APIs great for testing, demos, and data generation. All work with `http_get`. Confirmed 2026-04-18.
+
+| API | Base URL | Auth | Rate limit |
+|-----|----------|------|------------|
+| The Cat API | `https://api.thecatapi.com/v1` | None (or optional key) | ~10 req/min anon |
+| Dog CEO | `https://dog.ceo/api` | None | None documented |
+| Random User | `https://randomuser.me/api` | None | None documented |
+| JokeAPI | `https://v2.jokeapi.dev/joke` | None | 120 req/min |
+| ZenQuotes | `https://zenquotes.io/api` | None | ~5 req/30s |
+| Open Trivia DB | `https://opentdb.com/api.php` | None | ~5 req/5s |
+
+---
+
+## Animals
+
+### Cat API — random images
+
+```python
+import json
+from helpers import http_get
+
+# 5 random cat images (no API key needed)
+cats = json.loads(http_get("https://api.thecatapi.com/v1/images/search?limit=5"))
+for cat in cats:
+    print(cat["url"], cat["width"], "x", cat["height"])
+# Confirmed keys: id (str), url, width (int), height (int)
+# Confirmed: ?limit=5 returns UP TO 10 without an API key (limit param ignored anon — returns ~10)
+
+# Filter to JPG/PNG only (no GIFs)
+cats = json.loads(http_get("https://api.thecatapi.com/v1/images/search?limit=5&mime_types=jpg,png"))
+```
+
+### Cat API — images with breed data
+
+```python
+import json
+from helpers import http_get
+
+# Returns images that have breed metadata attached
+cats = json.loads(http_get("https://api.thecatapi.com/v1/images/search?limit=3&has_breeds=1"))
+for cat in cats:
+    if cat.get("breeds"):
+        b = cat["breeds"][0]
+        print(b["name"], b["origin"], b["temperament"])
+        print(f"  Intelligence: {b['intelligence']}/5, Energy: {b['energy_level']}/5")
+        print(f"  Life span: {b['life_span']} years")
+```
+
+### Cat API — full breed catalog (67 breeds)
+
+```python
+import json
+from helpers import http_get
+
+breeds = json.loads(http_get("https://api.thecatapi.com/v1/breeds"))
+# Returns list of 67 breed dicts — confirmed 2026-04-18
+for b in breeds[:3]:
+    print(b["id"], b["name"])
+    # b keys: id, name, origin, temperament, description, life_span
+    #         adaptability, affection_level, child_friendly, dog_friendly,
+    #         energy_level, grooming, health_issues, intelligence,
+    #         shedding_level, social_needs, stranger_friendly, vocalisation
+    #         hypoallergenic, indoor, lap, natural, rare, rex
+    #         wikipedia_url, reference_image_id
+
+# Get image for a breed using reference_image_id
+breed = breeds[0]
+img_url = f"https://cdn2.thecatapi.com/images/{breed['reference_image_id']}.jpg"
+```
+
+### Dog CEO — random images
+
+```python
+import json
+from helpers import http_get
+
+# Single random dog image
+dog = json.loads(http_get("https://dog.ceo/api/breeds/image/random"))
+print(dog["message"])   # "https://images.dog.ceo/breeds/husky/n02110185_8860.jpg"
+print(dog["status"])    # "success"
+
+# Multiple random images (any breed), up to 50
+dogs = json.loads(http_get("https://dog.ceo/api/breeds/image/random/10"))
+for url in dogs["message"]:
+    print(url)
+# message is a list of URLs when requesting multiple
+```
+
+### Dog CEO — breed-specific images
+
+```python
+import json
+from helpers import http_get
+
+# Random image from a specific breed
+lab = json.loads(http_get("https://dog.ceo/api/breed/labrador/images/random/5"))
+print(lab["message"])    # list of 5 URLs
+
+# Sub-breed (breed/sub-breed)
+french = json.loads(http_get("https://dog.ceo/api/breed/bulldog/french/images/random"))
+print(french["message"]) # single URL string
+
+# List all sub-breeds for a breed
+subs = json.loads(http_get("https://dog.ceo/api/breed/bulldog/list"))
+print(subs["message"])   # ["boston", "english", "french"]
+
+# Full breed list — dict where key=breed, value=list of sub-breeds (empty list if none)
+all_breeds = json.loads(http_get("https://dog.ceo/api/breeds/list/all"))
+breeds = all_breeds["message"]   # {"affenpinscher": [], "african": ["wild"], "bulldog": ["boston","english","french"], ...}
+print(list(breeds.items())[:3])
+```
+
+Confirmed breed name format: `"bulldog/french"` → URL path is `/breed/bulldog/french/...`. Breed names are all lowercase.
+
+---
+
+## Random User Data
+
+### randomuser.me — generate test personas
+
+```python
+import json
+from helpers import http_get
+
+# 5 random US users
+data = json.loads(http_get("https://randomuser.me/api/?results=5&nat=us"))
+for u in data["results"]:
+    name = f"{u['name']['title']} {u['name']['first']} {u['name']['last']}"
+    print(name, u["email"], u["phone"])
+    print(f"  DOB: {u['dob']['date'][:10]}, age {u['dob']['age']}")
+    print(f"  City: {u['location']['city']}, {u['location']['state']}")
+    print(f"  Avatar: {u['picture']['large']}")
+    # login: uuid, username, password, salt, md5, sha1, sha256
+    # id: {"name": "SSN", "value": "576-49-7178"}
+```
+
+### Filter fields and nationality
+
+```python
+import json
+from helpers import http_get
+
+# Only fetch the fields you need — much smaller response
+data = json.loads(http_get(
+    "https://randomuser.me/api/"
+    "?results=10&nat=gb,fr,de&inc=name,email,nat,dob,picture"
+))
+for u in data["results"]:
+    print(u["nat"], u["name"]["first"], u["name"]["last"], u["email"])
+# info.seed is returned — reuse for reproducibility
+
+# Reproducible results with a seed
+data = json.loads(http_get("https://randomuser.me/api/?results=5&seed=abc123&nat=us"))
+# Same seed always returns same users — good for test fixtures
+```
+
+Available nationalities: `au, br, ca, ch, de, dk, es, fi, fr, gb, ie, in, ir, mx, nl, no, nz, rs, tr, ua, us`
+
+Available `inc` fields: `gender, name, location, email, login, dob, registered, phone, cell, id, picture, nat`
+
+---
+
+## Jokes
+
+### JokeAPI — single joke
+
+```python
+import json
+from helpers import http_get
+
+# Safe single joke from any category
+joke = json.loads(http_get("https://v2.jokeapi.dev/joke/Any?safe-mode"))
+
+if joke["type"] == "twopart":
+    print(joke["setup"])
+    print(joke["delivery"])
+else:  # type == "single"
+    print(joke["joke"])
+
+# Metadata always present:
+# joke["category"]    — "Programming", "Misc", "Pun", "Dark", "Spooky", "Christmas"
+# joke["id"]          — int, unique per joke
+# joke["flags"]       — {"nsfw": bool, "religious": bool, "political": bool,
+#                        "racist": bool, "sexist": bool, "explicit": bool}
+# joke["lang"]        — "en"
+# joke["safe"]        — True when ?safe-mode used
+# joke["error"]       — False on success
+```
+
+### JokeAPI — batch and filter
+
+```python
+import json
+from helpers import http_get
+
+# Up to 10 jokes at once, multiple categories
+data = json.loads(http_get(
+    "https://v2.jokeapi.dev/joke/Programming,Pun?safe-mode&amount=5"
+))
+# When amount > 1: data["jokes"] is a list, data["amount"] = count returned
+# When amount = 1: joke is a flat dict (no "jokes" key)
+for j in data["jokes"]:
+    text = j["setup"] + " / " + j["delivery"] if j["type"] == "twopart" else j["joke"]
+    print(f"[{j['category']}] {text}")
+
+# Blacklist specific flags (comma-separated)
+joke = json.loads(http_get(
+    "https://v2.jokeapi.dev/joke/Any?blacklistFlags=nsfw,political,sexist"
+))
+```
+
+Valid categories (case-insensitive): `Any, Misc, Programming, Dark, Pun, Spooky, Christmas`
+
+---
+
+## Quotes
+
+### ZenQuotes — single or batch
+
+```python
+import json
+from helpers import http_get
+
+# Single random quote
+data = json.loads(http_get("https://zenquotes.io/api/random"))
+quote = data[0]          # always a list, even for single
+print(quote["q"])        # "Don't be afraid that you do not know something..."
+print(quote["a"])        # "Zen Proverb"
+# quote["h"] — pre-formatted HTML <blockquote>
+# quote["c"] — character count (only in /quotes batch endpoint)
+
+# Today's quote of the day (stable for 24h — good for caching)
+data = json.loads(http_get("https://zenquotes.io/api/today"))
+print(data[0]["q"], "—", data[0]["a"])
+
+# Batch: 50 quotes at once — more efficient than repeated single calls
+batch = json.loads(http_get("https://zenquotes.io/api/quotes"))
+print(f"Got {len(batch)} quotes")
+for q in batch[:3]:
+    print(q["q"], "—", q["a"], f"({q['c']} chars)")
+```
+
+Rate limit: ~5 requests per 30 seconds for the `/random` endpoint. Use `/quotes` (50 at once) then shuffle locally to avoid hitting limits.
+
+---
+
+## Trivia
+
+### Open Trivia DB — fetch questions
+
+```python
+import json, html
+from helpers import http_get
+
+# 5 multiple-choice questions (any category)
+data = json.loads(http_get("https://opentdb.com/api.php?amount=5&type=multiple"))
+# response_code 0 = success, 1 = no results, 2 = invalid param,
+#               3 = token not found, 4 = token empty (all questions exhausted)
+assert data["response_code"] == 0
+
+for q in data["results"]:
+    question = html.unescape(q["question"])   # CRITICAL: questions use HTML entities
+    correct  = html.unescape(q["correct_answer"])
+    wrong    = [html.unescape(a) for a in q["incorrect_answers"]]
+    print(f"[{q['difficulty']}] {question}")
+    print(f"  Answer: {correct}")
+    # q keys: type, difficulty, category, question, correct_answer, incorrect_answers
+```
+
+### Filter by category and difficulty
+
+```python
+import json, html, random
+from helpers import http_get
+
+# Category 18 = Science: Computers, difficulty = easy, type = multiple
+data = json.loads(http_get(
+    "https://opentdb.com/api.php?amount=10&category=18&difficulty=easy&type=multiple"
+))
+
+for q in data["results"]:
+    question = html.unescape(q["question"])
+    # Shuffle answers for display
+    answers = [html.unescape(a) for a in q["incorrect_answers"]] + [html.unescape(q["correct_answer"])]
+    random.shuffle(answers)
+    print(question)
+    for i, a in enumerate(answers, 1):
+        print(f"  {i}. {a}")
+
+# True/False questions (type=boolean — returns "True"/"False" strings)
+data = json.loads(http_get(
+    "https://opentdb.com/api.php?amount=5&category=9&difficulty=easy&type=boolean"
+))
+for q in data["results"]:
+    print(html.unescape(q["question"]))
+    print(f"  Answer: {q['correct_answer']}")  # "True" or "False"
+```
+
+### Session token (no question repeats)
+
+```python
+import json
+from helpers import http_get
+
+# Get a session token — valid 6 hours, guarantees no repeats until all questions served
+tok = json.loads(http_get("https://opentdb.com/api_token.php?command=request"))
+token = tok["token"]   # long hex string
+
+# Pass token with every question request
+data = json.loads(http_get(
+    f"https://opentdb.com/api.php?amount=5&type=multiple&token={token}"
+))
+# When all questions in category exhausted: response_code=4 — reset with:
+# http_get(f"https://opentdb.com/api_token.php?command=reset&token={token}")
+```
+
+### Category reference
+
+```python
+import json
+from helpers import http_get
+
+categories = json.loads(http_get("https://opentdb.com/api_category.php"))
+for c in categories["trivia_categories"]:
+    print(c["id"], c["name"])
+# 9 General Knowledge | 10 Books | 11 Film | 12 Music | 14 Television
+# 15 Video Games | 17 Science & Nature | 18 Science: Computers | 19 Science: Mathematics
+# 20 Mythology | 21 Sports | 22 Geography | 23 History | 24 Politics
+# 25 Art | 26 Celebrities | 27 Animals | 28 Vehicles | 32 Cartoons
+```
+
+---
+
+## Combined: build a demo dataset
+
+```python
+import json, html, random
+from helpers import http_get
+
+def get_cat_image():
+    cats = json.loads(http_get("https://api.thecatapi.com/v1/images/search?limit=1&mime_types=jpg,png"))
+    return cats[0]["url"]
+
+def get_dog_image(breed=None):
+    if breed:
+        url = f"https://dog.ceo/api/breed/{breed}/images/random"
+    else:
+        url = "https://dog.ceo/api/breeds/image/random"
+    return json.loads(http_get(url))["message"]
+
+def get_random_user(nat="us"):
+    data = json.loads(http_get(
+        f"https://randomuser.me/api/?results=1&nat={nat}&inc=name,email,picture,dob"
+    ))
+    u = data["results"][0]
+    return {
+        "name": f"{u['name']['first']} {u['name']['last']}",
+        "email": u["email"],
+        "age": u["dob"]["age"],
+        "avatar": u["picture"]["thumbnail"],
+    }
+
+def get_joke():
+    j = json.loads(http_get("https://v2.jokeapi.dev/joke/Programming,Pun?safe-mode"))
+    if j["type"] == "twopart":
+        return f"{j['setup']} / {j['delivery']}"
+    return j["joke"]
+
+def get_trivia(category=18, difficulty="easy"):
+    data = json.loads(http_get(
+        f"https://opentdb.com/api.php?amount=1&category={category}&difficulty={difficulty}&type=multiple"
+    ))
+    if data["response_code"] != 0:
+        return None
+    q = data["results"][0]
+    return {
+        "question": html.unescape(q["question"]),
+        "correct": html.unescape(q["correct_answer"]),
+        "wrong": [html.unescape(a) for a in q["incorrect_answers"]],
+        "difficulty": q["difficulty"],
+    }
+
+# Example usage
+user = get_random_user()
+print(f"User: {user['name']} ({user['email']}, age {user['age']})")
+print(f"Joke: {get_joke()}")
+q = get_trivia()
+if q:
+    print(f"Trivia [{q['difficulty']}]: {q['question']} -> {q['correct']}")
+```
+
+---
+
+## Gotchas
+
+**Cat API `?limit=` param is silently ignored for anonymous requests.** Without an API key the response returns up to ~10 images regardless of `limit`. Register for a free key at `https://thecatapi.com` and pass `x-api-key: YOUR_KEY` header to get true `limit` control and higher-quality images.
+
+**Cat API `has_breeds=1` often returns images with empty `breeds` list anyway.** The filter is best-effort — always guard with `if cat.get("breeds")`.
+
+**Dog CEO `message` is a string for single-image endpoints, list for multi-image.** `/breeds/image/random` → string; `/breeds/image/random/5` → list. Don't assume type.
+
+**Dog CEO breed path uses hyphens for sub-breeds:** `/breed/bulldog-french` does NOT work — correct is `/breed/bulldog/french`.
+
+**JokeAPI response shape differs between `amount=1` and `amount>1`.** Single joke: flat dict with `joke["setup"]` or `joke["joke"]`. Multiple: `data["jokes"]` is a list. Always check `amount` param or test for the `"jokes"` key.
+
+**JokeAPI categories are specific strings, not freeform.** Valid: `Any, Misc, Programming, Dark, Pun, Spooky, Christmas`. Anything else returns error code 106. `Science` is NOT a valid category (confirmed error in testing).
+
+**OpenTDB questions use HTML entities.** `&quot;`, `&amp;`, `&#039;` appear in raw strings. Always pass through `html.unescape()` before display.
+
+**OpenTDB `response_code=1` means "no results for your filters"**, not an HTTP error. Happens when category + difficulty combination has fewer questions than your `amount` — reduce `amount` or remove `difficulty`.
+
+**OpenTDB rate limit is ~5 requests per 5 seconds.** Exceeding it returns HTTP 429. Add `time.sleep(1)` between calls in loops. Use session tokens + batch `amount=50` to minimize round trips.
+
+**ZenQuotes `/random` rate-limits aggressively (~5 req/30s).** For bulk use, call `/quotes` once (returns 50 quotes) and shuffle locally. `/today` is stable for 24h and not rate-limited.
+
+**randomuser.me `nat` codes are lowercase 2-letter country codes**, not language codes. `nat=us` for American names, `nat=gb` for British, `nat=fr` for French, etc.
+
+**quotable.io (`api.quotable.io`) is offline** as of 2026-04-18. Use ZenQuotes instead.
+
+**loripsum.net is offline** as of 2026-04-18. For Lorem Ipsum, generate with Python's `lorem` package or use `https://loremipsum.io/api/` if you need a live endpoint.

--- a/domain-skills/open-meteo/scraping.md
+++ b/domain-skills/open-meteo/scraping.md
@@ -1,0 +1,486 @@
+# Open-Meteo — Complete API Reference
+
+Free weather data with no API key. Four subdomain APIs tested: **forecast**, **historical archive**, **air quality**, **marine**. All return JSON via `http_get` — no browser needed.
+
+## Quick reference
+
+| Need | Endpoint | Notes |
+|------|----------|-------|
+| Current conditions + forecast | `api.open-meteo.com/v1/forecast` | Up to 16 days out |
+| Historical data (back to 1940) | `archive-api.open-meteo.com/v1/archive` | `start_date` + `end_date` required |
+| Air quality / AQI | `air-quality-api.open-meteo.com/v1/air-quality` | PM2.5, PM10, AQI, gases |
+| Ocean waves | `marine-api.open-meteo.com/v1/marine` | Coastal coords may return nulls — use open-ocean |
+| City name → lat/lon | `geocoding-api.open-meteo.com/v1/search` | Free, no key |
+
+---
+
+## Step 0: city name → coordinates
+
+Required for all other calls unless you already have lat/lon.
+
+```python
+import json
+
+geo = json.loads(http_get(
+    "https://geocoding-api.open-meteo.com/v1/search?name=Tokyo&count=1"
+))
+loc = geo['results'][0]
+lat = loc['latitude']    # 35.6895
+lon = loc['longitude']   # 139.69171
+tz  = loc['timezone']    # 'Asia/Tokyo'
+
+# Also available:
+# loc['elevation']     44.0 (metres)
+# loc['country']       'Japan'
+# loc['country_code']  'JP'
+# loc['admin1']        'Tokyo' (state/province)
+# loc['population']    9733276
+```
+
+Always pass `count=1` and take `results[0]`. Returns `{}` (no `results` key) for unknown names.
+
+---
+
+## Current forecast (simplest call)
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://api.open-meteo.com/v1/forecast"
+    "?latitude=40.71&longitude=-74.01"
+    "&current=temperature_2m,wind_speed_10m,precipitation"
+    "&timezone=America/New_York"
+))
+
+cur   = data['current']        # dict
+units = data['current_units']  # dict
+
+# Confirmed live values (2026-04-18, New York):
+# cur['time']           '2026-04-18T21:30'   (local ISO8601)
+# cur['interval']       900                  (update cadence, seconds)
+# cur['temperature_2m'] 9.9                  (°C)
+# cur['wind_speed_10m'] 14.1                 (km/h)
+# cur['precipitation']  0.0                  (mm)
+
+print(cur['temperature_2m'], units['temperature_2m'])  # 9.9 °C
+```
+
+### Extended current — recommended
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+    f"precipitation,weathercode,wind_speed_10m,wind_direction_10m,"
+    f"wind_gusts_10m,uv_index,surface_pressure,cloud_cover"
+    f"&timezone={tz}"
+))
+
+cur = data['current']
+# All available current variables and their units:
+# temperature_2m          °C      apparent_temperature   °C
+# relative_humidity_2m    %       precipitation          mm
+# weathercode             wmo code int                   (see WMO table below)
+# wind_speed_10m          km/h    wind_direction_10m     °
+# wind_gusts_10m          km/h    uv_index               (unitless)
+# surface_pressure        hPa     cloud_cover            %
+# is_day                  1 or 0
+```
+
+### Hourly forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&hourly=temperature_2m,precipitation_probability,precipitation,"
+    f"weathercode,cloud_cover,visibility,wind_speed_10m,wind_gusts_10m"
+    f"&forecast_days=3&timezone={tz}"
+))
+
+hourly = data['hourly']   # dict of parallel arrays
+units  = data['hourly_units']
+# hourly['time']  — ISO8601 strings, one per hour: '2026-04-18T00:00', ...
+# 3 forecast days → 72 entries. forecast_days max = 16.
+
+for i, t in enumerate(hourly['time'][:24]):  # first day
+    print(t,
+          hourly['temperature_2m'][i],             # °C
+          hourly['precipitation_probability'][i],   # %
+          hourly['wind_speed_10m'][i])              # km/h
+
+# Note: visibility is in metres (not km). Divide by 1000 for km.
+# Units confirmed: visibility → 'm'
+```
+
+### Daily forecast
+
+```python
+data = json.loads(http_get(
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={lat}&longitude={lon}"
+    f"&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,"
+    f"precipitation_probability_max,wind_speed_10m_max,weathercode,"
+    f"sunrise,sunset,uv_index_max"
+    f"&forecast_days=7&timezone={tz}"
+))
+
+daily = data['daily']
+units = data['daily_units']
+for i, date in enumerate(daily['time']):
+    print(date,
+          daily['temperature_2m_max'][i], '/', daily['temperature_2m_min'][i],
+          f"pop={daily['precipitation_probability_max'][i]}%",
+          f"precip={daily['precipitation_sum'][i]}mm",
+          daily['sunrise'][i], daily['sunset'][i])
+# sunrise/sunset are full ISO8601 datetimes: '2026-04-18T06:29'
+```
+
+---
+
+## Historical weather (archive API)
+
+Different subdomain. Requires `start_date` and `end_date` in `YYYY-MM-DD` format.
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://archive-api.open-meteo.com/v1/archive"
+    "?latitude=40.71&longitude=-74.01"
+    "&start_date=2024-01-01&end_date=2024-01-07"
+    "&daily=temperature_2m_max,temperature_2m_min,precipitation_sum"
+    "&timezone=America/New_York"
+))
+
+daily = data['daily']
+# daily['time']               ['2024-01-01', '2024-01-02', ...]
+# daily['temperature_2m_max'] [7.7, 5.7, 7.7, ...]   °C
+# daily['temperature_2m_min'] [...]                   °C
+# daily['precipitation_sum']  [0.0, 0.0, 0.0, ...]   mm
+
+for i, date in enumerate(daily['time']):
+    print(date, daily['temperature_2m_max'][i], daily['temperature_2m_min'][i], daily['precipitation_sum'][i])
+```
+
+### Full daily variable list (all confirmed units)
+
+```python
+data = json.loads(http_get(
+    f"https://archive-api.open-meteo.com/v1/archive"
+    f"?latitude={lat}&longitude={lon}"
+    f"&start_date=2024-06-01&end_date=2024-06-30"
+    f"&daily=temperature_2m_max,temperature_2m_min,temperature_2m_mean,"
+    f"apparent_temperature_max,apparent_temperature_min,"
+    f"precipitation_sum,rain_sum,snowfall_sum,precipitation_hours,"
+    f"wind_speed_10m_max,wind_gusts_10m_max,wind_direction_10m_dominant,"
+    f"shortwave_radiation_sum,et0_fao_evapotranspiration,"
+    f"weathercode,sunrise,sunset"
+    f"&timezone={tz}"
+))
+
+# Confirmed daily units (live test, 2026-04-18):
+# temperature_2m_max/min/mean         °C
+# apparent_temperature_max/min        °C
+# precipitation_sum                   mm
+# rain_sum                            mm
+# snowfall_sum                        cm   (NOTE: cm not mm)
+# precipitation_hours                 h
+# wind_speed_10m_max                  km/h
+# wind_gusts_10m_max                  km/h
+# wind_direction_10m_dominant         °
+# shortwave_radiation_sum             MJ/m²
+# et0_fao_evapotranspiration          mm   (reference evapotranspiration)
+# weathercode                         wmo code
+# sunrise / sunset                    iso8601 local datetime
+```
+
+### Hourly historical variables (all confirmed units)
+
+```python
+data = json.loads(http_get(
+    f"https://archive-api.open-meteo.com/v1/archive"
+    f"?latitude={lat}&longitude={lon}"
+    f"&start_date=2024-06-01&end_date=2024-06-07"
+    f"&hourly=temperature_2m,relative_humidity_2m,dewpoint_2m,"
+    f"apparent_temperature,precipitation,rain,snowfall,snow_depth,"
+    f"weathercode,surface_pressure,cloud_cover,visibility,"
+    f"wind_speed_10m,wind_direction_10m,wind_gusts_10m,"
+    f"soil_temperature_0_to_7cm,soil_moisture_0_to_7cm"
+    f"&timezone={tz}"
+))
+
+hourly = data['hourly']
+# Confirmed hourly units (live test, 2026-04-18):
+# temperature_2m              °C      relative_humidity_2m  %
+# dewpoint_2m                 °C      apparent_temperature  °C
+# precipitation               mm      rain                  mm
+# snowfall                    cm      snow_depth            m
+# weathercode                 wmo code surface_pressure     hPa
+# cloud_cover                 %       visibility            'undefined' (metres in practice)
+# wind_speed_10m              km/h    wind_direction_10m    °
+# wind_gusts_10m              km/h
+# soil_temperature_0_to_7cm   °C
+# soil_moisture_0_to_7cm      m³/m³
+
+# NOTE: visibility returns None for many historical hourly entries (sparse coverage)
+```
+
+### Data range
+
+- Goes back to **1940** for most locations. Precipitation before ~1950 may have `None` entries.
+- Goes up to **yesterday** (sometimes same-day). Future dates for archive return data up to the most recently available day without error.
+
+```python
+# Checking data availability (1940 confirmed live):
+data = json.loads(http_get(
+    "https://archive-api.open-meteo.com/v1/archive"
+    "?latitude=40.71&longitude=-74.01"
+    "&start_date=1940-01-01&end_date=1940-01-03"
+    "&daily=temperature_2m_max,precipitation_sum&timezone=UTC"
+))
+# Returns: {'time': ['1940-01-01', '1940-01-02', '1940-01-03'],
+#           'temperature_2m_max': [-1.7, -1.4, 0.3],
+#           'precipitation_sum': [None, 0.0, 0.0]}   ← None is normal pre-1950
+```
+
+---
+
+## Air quality API
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://air-quality-api.open-meteo.com/v1/air-quality"
+    "?latitude=40.71&longitude=-74.01"
+    "&current=pm10,pm2_5,us_aqi,european_aqi,"
+    "carbon_monoxide,nitrogen_dioxide,ozone"
+    "&timezone=America/New_York"
+))
+
+cur = data['current']
+# Confirmed live values (2026-04-18, New York):
+# cur['time']             '2026-04-18T21:00'
+# cur['interval']         3600               (1-hour update cadence)
+# cur['pm10']             11.5   μg/m³
+# cur['pm2_5']            10.1   μg/m³
+# cur['us_aqi']           48     USAQI
+# cur['european_aqi']     29     EAQI
+# cur['carbon_monoxide']  195.0  μg/m³
+# cur['nitrogen_dioxide'] 20.7   μg/m³
+# cur['ozone']            72.0   μg/m³
+
+print(f"AQI (US): {cur['us_aqi']} — PM2.5: {cur['pm2_5']} μg/m³")
+```
+
+### Air quality AQI thresholds (US)
+
+```python
+AQI_LEVELS = [
+    (50,  "Good"),
+    (100, "Moderate"),
+    (150, "Unhealthy for Sensitive Groups"),
+    (200, "Unhealthy"),
+    (300, "Very Unhealthy"),
+    (500, "Hazardous"),
+]
+
+def aqi_label(aqi):
+    for threshold, label in AQI_LEVELS:
+        if aqi <= threshold:
+            return label
+    return "Hazardous"
+```
+
+### Hourly air quality forecast
+
+```python
+data = json.loads(http_get(
+    f"https://air-quality-api.open-meteo.com/v1/air-quality"
+    f"?latitude={lat}&longitude={lon}"
+    f"&hourly=pm10,pm2_5,us_aqi,european_aqi"
+    f"&forecast_days=3&timezone={tz}"
+))
+
+hourly = data['hourly']
+# hourly['time']           ISO8601 strings, one per hour
+# hourly['pm10']           μg/m³
+# hourly['pm2_5']          μg/m³
+# hourly['us_aqi']         USAQI integer
+# hourly['european_aqi']   EAQI integer
+```
+
+---
+
+## Marine API
+
+Use open-ocean or coastal coordinates. Shallow nearshore or landlocked coordinates may return `None` for all wave variables.
+
+```python
+import json
+
+# Atlantic open ocean (confirmed non-null values)
+data = json.loads(http_get(
+    "https://marine-api.open-meteo.com/v1/marine"
+    "?latitude=35.0&longitude=-60.0"
+    "&hourly=wave_height,wave_direction,wave_period,"
+    "wind_wave_height,swell_wave_height"
+    "&daily=wave_height_max,wave_direction_dominant,wind_wave_height_max"
+    "&timezone=UTC"
+))
+
+hourly = data['hourly']
+daily  = data['daily']
+
+# Confirmed units (live test, 2026-04-18):
+# wave_height            m    wave_direction         °
+# wave_period            s    wind_wave_height       m
+# swell_wave_height      m
+
+# Daily:
+# wave_height_max        m    wave_direction_dominant °
+# wind_wave_height_max   m
+
+for i, t in enumerate(hourly['time'][:6]):
+    print(t,
+          f"wave={hourly['wave_height'][i]}m",
+          f"dir={hourly['wave_direction'][i]}°",
+          f"period={hourly['wave_period'][i]}s")
+
+# Confirmed live (Atlantic 35°N, 60°W):
+# 2026-04-19T00:00 wave=1.3m dir=None° period=9.66s
+```
+
+---
+
+## Unit overrides (all APIs)
+
+Server-side conversion — just add query params:
+
+```
+&temperature_unit=fahrenheit    # default: celsius
+&windspeed_unit=mph             # default: kmh  (also: ms, kn)
+&precipitation_unit=inch        # default: mm
+&wind_speed_unit=mph            # alias for windspeed_unit (both work)
+```
+
+---
+
+## WMO weather code table
+
+Used by `weathercode` in forecast and archive hourly/daily.
+
+```python
+WMO_CODES = {
+    0: "Clear sky",
+    1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+    45: "Fog", 48: "Icy fog",
+    51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+    61: "Slight rain", 63: "Moderate rain", 65: "Heavy rain",
+    71: "Slight snow", 73: "Moderate snow", 75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight showers", 81: "Moderate showers", 82: "Violent showers",
+    85: "Slight snow showers", 86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with slight hail", 99: "Thunderstorm with heavy hail",
+}
+
+def wmo_desc(code):
+    return WMO_CODES.get(code, f"Unknown ({code})")
+```
+
+---
+
+## End-to-end pattern: city → climate summary
+
+```python
+import json
+
+def climate_summary(city: str, year: int = 2024) -> dict:
+    """Monthly averages for a full year using the historical archive."""
+    # 1. Geocode
+    geo = json.loads(http_get(
+        f"https://geocoding-api.open-meteo.com/v1/search?name={city.replace(' ', '+')}&count=1"
+    ))
+    if not geo.get('results'):
+        raise ValueError(f"City not found: {city}")
+    loc = geo['results'][0]
+    lat, lon, tz = loc['latitude'], loc['longitude'], loc['timezone']
+
+    # 2. Full year of daily data
+    data = json.loads(http_get(
+        f"https://archive-api.open-meteo.com/v1/archive"
+        f"?latitude={lat}&longitude={lon}"
+        f"&start_date={year}-01-01&end_date={year}-12-31"
+        f"&daily=temperature_2m_max,temperature_2m_min,precipitation_sum"
+        f"&timezone={tz}"
+    ))
+
+    # 3. Aggregate by month
+    daily = data['daily']
+    from collections import defaultdict
+    months = defaultdict(lambda: {'tmax': [], 'tmin': [], 'precip': []})
+    for i, date in enumerate(daily['time']):
+        m = date[5:7]  # '01'..'12'
+        if daily['temperature_2m_max'][i] is not None:
+            months[m]['tmax'].append(daily['temperature_2m_max'][i])
+        if daily['temperature_2m_min'][i] is not None:
+            months[m]['tmin'].append(daily['temperature_2m_min'][i])
+        if daily['precipitation_sum'][i] is not None:
+            months[m]['precip'].append(daily['precipitation_sum'][i])
+
+    result = {}
+    for m, vals in sorted(months.items()):
+        result[m] = {
+            'avg_tmax': round(sum(vals['tmax']) / len(vals['tmax']), 1) if vals['tmax'] else None,
+            'avg_tmin': round(sum(vals['tmin']) / len(vals['tmin']), 1) if vals['tmin'] else None,
+            'total_precip_mm': round(sum(vals['precip']), 1) if vals['precip'] else None,
+        }
+    return {'city': loc['name'], 'country': loc.get('country'), 'year': year, 'months': result}
+
+summary = climate_summary("London", 2024)
+for month, stats in summary['months'].items():
+    print(f"{month}: {stats['avg_tmax']}°C / {stats['avg_tmin']}°C  {stats['total_precip_mm']}mm")
+```
+
+Total: 2 API calls (~1.4 s combined).
+
+---
+
+## Gotchas
+
+**Always pass `&timezone={tz}`.** Without it, the API uses GMT. Daily buckets (max/min, sunrise) shift to UTC boundaries — daily highs for New York in summer will be attributed to the wrong day. Hourly timestamps will also be UTC, not local.
+
+**`wind_speed_10m` (forecast) vs `wind_speed_10m_max` (daily).** The current and hourly variable is `wind_speed_10m`; the daily aggregate is `wind_speed_10m_max`. Using `wind_speed_10m` in a `&daily=` request returns an HTTP 400.
+
+**`snowfall_sum` is in centimetres, not millimetres.** All other precipitation variables (`precipitation_sum`, `rain_sum`) are in mm. The `snowfall` hourly variable is also cm.
+
+**`visibility` unit is listed as `'undefined'`** in the hourly_units dict (confirmed live). The actual values are in metres — divide by 1000 for km. The archive historical visibility is sparse (many `None` entries).
+
+**Marine API returns `None` for nearshore/landlocked coordinates.** Use open-ocean coordinates (e.g. 35°N 60°W for the Atlantic). Coastal points like `51.5°N, 0.0°E` (London) may return all nulls despite being near the coast.
+
+**HTTP 400 on bad params — error body is gzip-compressed.** The `http_get` helper raises `urllib.error.HTTPError` on 4xx. To read the reason:
+```python
+import urllib.error, gzip
+try:
+    data = json.loads(http_get(bad_url))
+except urllib.error.HTTPError as e:
+    body = e.read()
+    if e.headers.get("Content-Encoding") == "gzip":
+        body = gzip.decompress(body)
+    print(json.loads(body)['reason'])
+    # e.g. "Latitude must be in range of -90 to 90°. Given: 999.0."
+```
+
+**Geocoding returns `{}` (no `results` key) for unknown names** — not an error, not an empty list. Guard with `geo.get('results')`.
+
+**Rate limit: 10,000 requests/day (free tier).** Geocoding and forecast/archive count separately. No rate-limit headers are returned on success — track usage yourself.
+
+**`forecast_days` max is 16 for the forecast API.** Requesting more raises HTTP 400. Default is 7.
+
+**Archive API max date range is not documented but is very large** — a full year (366 days) works fine in a single call. There is no documented per-call row limit.
+
+**`data['elevation']` is the terrain elevation at the requested coordinates (metres), not related to any weather variable.** Useful to confirm the geocoded point is sensible (e.g. a mountain vs a city).

--- a/domain-skills/wikipedia-rest/scraping.md
+++ b/domain-skills/wikipedia-rest/scraping.md
@@ -1,0 +1,301 @@
+# Wikipedia REST API (`en.wikipedia.org/api/rest_v1`)
+
+Supplemental skill for the **Wikimedia REST API v1** — a clean JSON/HTML API
+distinct from the older MediaWiki action API (`/w/api.php`).  Use this API
+for page summaries, media lists, featured feeds, and random pages.  Use the
+action API for full-text search (see gotchas below).
+
+Base URL: `https://en.wikipedia.org/api/rest_v1/`
+
+---
+
+## Critical: User-Agent required
+
+Wikipedia's CDN (Varnish) returns **403** for requests without a descriptive
+User-Agent.  Always set one:
+
+```python
+WIKI_UA = "MyBot/1.0 (your-contact@example.com)"
+```
+
+Pass it as a header in every request.  The `http_get()` helper in
+`helpers.py` sets `Mozilla/5.0` by default — override it for Wikipedia.
+
+---
+
+## 1. Page Summary (simplest, most useful)
+
+Returns title, short description, first-paragraph extract, thumbnail, and
+content URLs.  **Start here** for any "look up a Wikipedia article" task.
+
+```python
+import json
+from helpers import http_get
+
+def wiki_summary(title: str) -> dict:
+    """Fetch summary for a Wikipedia page title.
+    Title may use spaces or underscores — both work.
+    Returns dict with: title, description, extract, extract_html, thumbnail,
+    content_urls, type ('standard' | 'disambiguation' | 'no-extract').
+    """
+    url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{title}"
+    raw = http_get(url, headers={"User-Agent": WIKI_UA})
+    return json.loads(raw)
+
+# Example
+data = wiki_summary("Python_(programming_language)")
+print(data["title"])        # Python (programming language)
+print(data["description"])  # General-purpose programming language
+print(data["extract"])      # Python is a high-level, general-purpose...
+print(data["thumbnail"]["source"])  # https://upload.wikimedia.org/...
+```
+
+**Check `data["type"]` before trusting the extract:**
+- `"standard"` — normal article with extract
+- `"disambiguation"` — multiple meanings; extract is unreliable, pick a
+  specific title instead (e.g. `"Python_(programming_language)"`)
+- `"no-extract"` — article exists but has no lead section
+
+---
+
+## 2. Random Page Summary
+
+Returns a 303 redirect to a random article summary.  `urllib` (used by
+`http_get`) follows this automatically.
+
+```python
+def wiki_random() -> dict:
+    raw = http_get(
+        "https://en.wikipedia.org/api/rest_v1/page/random/summary",
+        headers={"User-Agent": WIKI_UA},
+    )
+    return json.loads(raw)
+
+article = wiki_random()
+print(article["title"], "|", article["extract"][:120])
+```
+
+---
+
+## 3. Page HTML (full article)
+
+Returns the full article as Parsoid HTML.  Large pages can be >1 MB.
+
+```python
+def wiki_html(title: str) -> str:
+    """Returns raw HTML string of the full article."""
+    return http_get(
+        f"https://en.wikipedia.org/api/rest_v1/page/html/{title}",
+        headers={"User-Agent": WIKI_UA},
+    )
+
+html = wiki_html("Python_(programming_language)")
+# Parse with BeautifulSoup or extract text sections as needed
+```
+
+Tip: For structured section extraction, prefer `page/mobile-html/{title}` —
+it returns cleaner HTML designed for programmatic consumption.
+
+---
+
+## 4. Media List
+
+Returns all images and media files used in an article.
+
+```python
+def wiki_media(title: str) -> list[dict]:
+    """Returns list of media items: title, type, srcset, caption."""
+    raw = http_get(
+        f"https://en.wikipedia.org/api/rest_v1/page/media-list/{title}",
+        headers={"User-Agent": WIKI_UA},
+    )
+    return json.loads(raw)["items"]
+
+items = wiki_media("Python_(programming_language)")
+for item in items:
+    print(item["type"], item["title"])
+    if "srcset" in item:
+        print("  2x src:", item["srcset"][-1]["src"])
+    if "caption" in item:
+        print("  caption:", item["caption"].get("text", ""))
+```
+
+Each item has:
+- `type` — `"image"` or `"video"` or `"audio"`
+- `title` — File namespace title (e.g. `"File:Python-logo-notext.svg"`)
+- `leadImage` — bool, true if it's the article's lead/thumbnail image
+- `srcset` — list of `{src, scale}` dicts (scale = `"1x"`, `"2x"`)
+- `caption` — optional `{html, text}` dict
+
+---
+
+## 5. Page Revision / Metadata
+
+Returns edit history metadata for the current revision.
+
+```python
+def wiki_revision(title: str) -> dict:
+    """Returns revision metadata: rev, timestamp, user_text, comment, tags."""
+    raw = http_get(
+        f"https://en.wikipedia.org/api/rest_v1/page/title/{title}",
+        headers={"User-Agent": WIKI_UA},
+    )
+    items = json.loads(raw)["items"]
+    return items[0] if items else {}
+
+rev = wiki_revision("Python_(programming_language)")
+print(rev["rev"], rev["timestamp"], rev["user_text"])
+```
+
+---
+
+## 6. Featured Content Feed
+
+Returns today's (or any past date's) featured article, most-read articles,
+picture of the day, and on-this-day events.
+
+```python
+def wiki_featured(year: int, month: int, day: int) -> dict:
+    """
+    Returns dict with keys:
+      tfa        — today's featured article (summary-shaped)
+      mostread   — {date, articles: [summary + views + rank]}
+      image      — picture of the day {title, thumbnail, description}
+      onthisday  — list of {year, text, pages: [...]}
+    """
+    url = f"https://en.wikipedia.org/api/rest_v1/feed/featured/{year}/{month:02d}/{day:02d}"
+    raw = http_get(url, headers={"User-Agent": WIKI_UA})
+    return json.loads(raw)
+
+feed = wiki_featured(2024, 1, 15)
+print("Featured:", feed["tfa"]["title"])
+print("Top article:", feed["mostread"]["articles"][0]["title"])
+print("On this day:", feed["onthisday"][0]["year"], feed["onthisday"][0]["text"][:80])
+```
+
+---
+
+## 7. On This Day
+
+Returns historical events, births, or deaths for a given month/day.
+
+```python
+def wiki_onthisday(month: int, day: int, kind: str = "events") -> list[dict]:
+    """
+    kind options: events | births | deaths | holidays | selected
+    Each item: {year, text, pages: [summary-shaped articles]}
+    """
+    url = f"https://en.wikipedia.org/api/rest_v1/feed/onthisday/{kind}/{month:02d}/{day:02d}"
+    raw = http_get(url, headers={"User-Agent": WIKI_UA})
+    return json.loads(raw)[kind]
+
+events = wiki_onthisday(1, 15, "births")
+for e in events[:5]:
+    print(e["year"], e["text"])
+```
+
+---
+
+## 8. Bulk: Multiple Summaries
+
+`http_get` is synchronous — for fetching many pages, use a thread pool:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import json
+from helpers import http_get
+
+def fetch_summary(title):
+    try:
+        raw = http_get(
+            f"https://en.wikipedia.org/api/rest_v1/page/summary/{title}",
+            headers={"User-Agent": WIKI_UA},
+        )
+        return json.loads(raw)
+    except Exception as e:
+        return {"title": title, "error": str(e)}
+
+titles = ["Python_(programming_language)", "Rust_(programming_language)", "Go_(programming_language)"]
+with ThreadPoolExecutor(max_workers=5) as pool:
+    results = list(pool.map(fetch_summary, titles))
+
+for r in results:
+    print(r["title"], "|", r.get("description", r.get("error")))
+```
+
+---
+
+## Gotchas
+
+### Title encoding
+- Spaces and underscores are **equivalent** in titles — both work in the URL.
+- URL-encode special characters: `%27` for apostrophe, `%28`/`%29` for
+  parentheses (though most HTTP clients do this automatically).
+- Always use the **canonical title** from `data["titles"]["canonical"]` when
+  chaining calls (e.g., using a summary result to build the next URL).
+
+### Disambiguation pages
+- `data["type"] == "disambiguation"` means the title is ambiguous.
+- The extract will be a short list of meanings, not a real article lead.
+- Append `_(topic)` to the title (e.g., `"Python_(programming_language)"`) to
+  reach the specific article.
+
+### Redirects (303)
+- `page/random/summary` returns HTTP 303 → a specific article URL.
+- `urllib.request.urlopen` (used by `http_get`) **follows redirects
+  automatically** — no special handling needed.
+
+### `related` endpoint: not available
+- `page/related/{title}` returns **404** ("route not found") as of 2024.
+- Use the MediaWiki action API for related-article discovery instead (see
+  "Search" below).
+
+### `mobile-sections` endpoint: not available
+- `/page/mobile-sections/{title}` is **no longer served** by the REST v1
+  gateway — returns 403/404.
+- Use `/page/mobile-html/{title}` for a structured HTML alternative, or
+  `/page/summary/{title}` for the lead section.
+
+### Full-text search: use the action API
+The REST v1 API has **no search endpoint**.  For search, use:
+
+```python
+def wiki_search(query: str, limit: int = 5) -> list[dict]:
+    """Uses MediaWiki action API — separate from REST v1."""
+    import urllib.parse
+    params = urllib.parse.urlencode({
+        "action": "query",
+        "list": "search",
+        "srsearch": query,
+        "srlimit": limit,
+        "format": "json",
+    })
+    raw = http_get(
+        f"https://en.wikipedia.org/w/api.php?{params}",
+        headers={"User-Agent": WIKI_UA},
+    )
+    return json.loads(raw)["query"]["search"]
+
+results = wiki_search("python programming language")
+for r in results:
+    print(r["title"], "|", r["snippet"][:80])
+# → Python (programming language) | Python is a high-level...
+```
+
+### Rate limits and caching
+- Wikipedia REST responses are heavily cached (CDN).  Repeated identical
+  requests are essentially free.
+- For novel requests, stay under ~50 req/s per the Wikimedia policy.
+- `featured` feed is cached per-day; re-requesting the same date is instant.
+
+### 404 for missing pages
+- Non-existent titles return `{"status": 404, "type": "Internal error"}`.
+- Check `"status" in data` or wrap in try/except before accessing `data["title"]`.
+
+```python
+data = wiki_summary("ZZZNOTAPAGE12345")
+if data.get("status") == 404:
+    print("Page not found")
+else:
+    print(data["title"])
+```


### PR DESCRIPTION
## Summary
- CryptoCompare: no rate limiting observed (unlike CoinGecko); auth-required endpoints return HTTP 200 with error JSON body (must check Response field); IMAGEURL is relative path; 19K+ coins in coinlist
- Open-Meteo: historical back to 1940; snowfall is cm while precipitation is mm; marine API returns all-null for nearshore coords; error body is gzip-compressed; wind_speed naming differs between current/hourly vs daily
- Fun APIs: Cat API ignores limit param anon; Dog CEO message type differs between single vs multi; JokeAPI Science is not a valid category; OpenTDB has HTML entities in all text; loripsum.net and quotable.io are dead
- Cover Art Archive: http_get fails with SSL on macOS (use curl -sL); front/back booleans independent of types list; image URLs use http:// (both work); 404 = no art uploaded
- Wikipedia REST: page/related returns 404 (removed); page/mobile-sections decommissioned; search requires action API not REST; User-Agent required (403 without)

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new domain-skill guides with runnable examples for CryptoCompare, Open‑Meteo, Fun APIs, Cover Art Archive, and Wikipedia REST to support fast, reliable data pulls with clear gotchas and edge-case handling.

- **New Features**
  - CryptoCompare: free price/OHLC/pairs/exchange endpoints; auth-only endpoints return HTTP 200 with `{"Response":"Error"}`; `IMAGEURL` is relative; 19k+ coins.
  - Open‑Meteo: forecast, air quality, marine, and archive (back to 1940); snowfall in cm (not mm); visibility in metres; marine nearshore may return nulls; gzip-compressed error bodies.
  - Fun APIs: Cat API ignores `limit` without key; Dog CEO single vs multi `message` shape; OpenTDB uses HTML entities; JokeAPI categories fixed; `quotable.io` and `loripsum.net` noted as down.
  - Cover Art Archive: use `curl -sL` to follow redirects and avoid macOS SSL issues; `/front`/`/back` shortcuts; image URLs may be `http://`; 404 means no art uploaded.
  - Wikipedia REST: User-Agent required (403 without); `page/related` and `mobile-sections` removed; use MediaWiki action API for search.

<sup>Written for commit 0d45d1baa11b1ec30be649ee33d8a983478dc4b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

