### PR TITLE
Add domain skills: US Census, TMDB, WorldTimeAPI, PubChem, GeoNames

### DIFF
--- a/domain-skills/geonames/scraping.md
+++ b/domain-skills/geonames/scraping.md
@@ -1,0 +1,390 @@
+# GeoNames — Scraping & Data Extraction
+
+`geonames.org` — geographic names database covering 11 million place names, postal codes, countries, timezones, and admin divisions. **Two access paths: free bulk TSV downloads (no key) or JSON API (requires free registered username).**
+
+## Which approach to use
+
+| Need | Use |
+|------|-----|
+| One-off lookup (place name, postal code, timezone) | API with registered username |
+| Bulk data for a country or all cities | Bulk TSV downloads — no key, no rate limit |
+| Offline / embedded use | Bulk downloads |
+
+The `demo` username is **exhausted** (20,000 daily credit cap shared across all demo users). Always register a free account at `https://www.geonames.org/login` and use your own username. Registration is instant and free.
+
+---
+
+## Path A — Bulk TSV downloads (no API key, no rate limit)
+
+All files at `https://download.geonames.org/export/dump/` are open (CC-BY 4.0), updated daily, served as gzip-compressed zip archives. **Use `http_get` with the Content-Encoding header handled automatically by the helper.**
+
+### Download and parse a single country's places
+
+```python
+import io, zipfile, csv
+from helpers import http_get
+
+# Download country zip — two-letter ISO code
+raw = http_get("https://download.geonames.org/export/dump/US.zip")
+# http_get decompresses gzip transfer encoding; zip archive is still intact
+z = zipfile.ZipFile(io.BytesIO(raw.encode("latin-1")))
+
+# File inside zip is named XX.txt (same as the country code)
+COLS = [
+    "geonameid", "name", "asciiname", "alternatenames",
+    "latitude", "longitude", "feature_class", "feature_code",
+    "country_code", "cc2", "admin1_code", "admin2_code",
+    "admin3_code", "admin4_code", "population", "elevation",
+    "dem", "timezone", "modification_date",
+]
+
+with z.open("US.txt") as f:
+    reader = csv.DictReader(
+        io.TextIOWrapper(f, encoding="utf-8"),
+        fieldnames=COLS,
+        delimiter="\t",
+    )
+    for row in reader:
+        if row["feature_class"] == "P" and int(row["population"] or 0) > 100_000:
+            print(row["name"], row["population"], row["timezone"])
+            # New York City 8336817 America/New_York
+            # Los Angeles 3979576 America/Los_Angeles
+            # Chicago 2720546 America/Chicago
+
+# feature_class == "P"  → populated places
+# feature_class == "A"  → administrative division
+# feature_class == "H"  → hydrographic (rivers, lakes)
+# feature_class == "T"  → mountain, hill, rock
+# feature_class == "S"  → spot / building / farm
+```
+
+### Pre-filtered city files (faster — no parsing full country dump)
+
+```python
+import io, zipfile, csv
+from helpers import http_get
+
+# Four sizes available:
+#   cities500.zip   ~185,000 cities (pop > 500)
+#   cities1000.zip  ~130,000 cities (pop > 1000)
+#   cities5000.zip   ~50,000 cities (pop > 5000)
+#   cities15000.zip  ~25,000 cities (pop > 15000 or capital)
+
+raw = http_get("https://download.geonames.org/export/dump/cities15000.zip")
+z = zipfile.ZipFile(io.BytesIO(raw.encode("latin-1")))
+
+COLS = [
+    "geonameid", "name", "asciiname", "alternatenames",
+    "latitude", "longitude", "feature_class", "feature_code",
+    "country_code", "cc2", "admin1_code", "admin2_code",
+    "admin3_code", "admin4_code", "population", "elevation",
+    "dem", "timezone", "modification_date",
+]
+
+cities = []
+with z.open("cities15000.txt") as f:
+    reader = csv.DictReader(
+        io.TextIOWrapper(f, encoding="utf-8"),
+        fieldnames=COLS,
+        delimiter="\t",
+    )
+    for row in reader:
+        cities.append({
+            "id":          int(row["geonameid"]),
+            "name":        row["name"],
+            "lat":         float(row["latitude"]),
+            "lon":         float(row["longitude"]),
+            "country":     row["country_code"],
+            "population":  int(row["population"] or 0),
+            "timezone":    row["timezone"],
+            "feature":     row["feature_code"],  # PPLC=capital, PPL=city, PPLA=admin center
+        })
+
+# Confirmed: 26,817 cities in cities15000.txt (2026-04-18)
+print(len(cities))   # 26817
+print(cities[0])
+# {'id': 3040051, 'name': 'les Escaldes', 'lat': 42.50729, 'lon': 1.53414,
+#  'country': 'AD', 'population': 15853, 'timezone': 'Europe/Andorra', 'feature': 'PPLA'}
+```
+
+### Country metadata (no zip — plain TSV, skip comment lines)
+
+```python
+import csv, io
+from helpers import http_get
+
+raw = http_get("https://download.geonames.org/export/dump/countryInfo.txt")
+COLS = [
+    "iso", "iso3", "iso_numeric", "fips", "country", "capital",
+    "area_sqkm", "population", "continent", "tld", "currency_code",
+    "currency_name", "phone", "postal_format", "postal_regex",
+    "languages", "geonameid", "neighbours", "fips_equiv",
+]
+
+countries = []
+for line in raw.splitlines():
+    if line.startswith("#") or not line.strip():
+        continue
+    row = dict(zip(COLS, line.split("\t")))
+    countries.append(row)
+
+# Lookup by ISO code
+by_iso = {c["iso"]: c for c in countries}
+us = by_iso["US"]
+print(us["country"], us["capital"], us["population"])
+# United States Washington 327167434
+print(us["languages"])    # en-US,es-US,haw,fr
+print(us["neighbours"])   # CA,MX,CU
+# Confirmed output (2026-04-18)
+```
+
+### Postal codes — country-specific or all countries
+
+```python
+import io, zipfile, csv
+from helpers import http_get
+
+# Single country: https://download.geonames.org/export/zip/US.zip
+# All countries:  https://download.geonames.org/export/zip/allCountries.zip (~28 MB)
+
+POSTAL_COLS = [
+    "country_code", "postal_code", "place_name",
+    "admin_name1", "admin_code1",
+    "admin_name2", "admin_code2",
+    "admin_name3", "admin_code3",
+    "latitude", "longitude", "accuracy",
+]
+
+raw = http_get("https://download.geonames.org/export/zip/US.zip")
+z = zipfile.ZipFile(io.BytesIO(raw.encode("latin-1")))
+
+with z.open("US.txt") as f:
+    reader = csv.DictReader(
+        io.TextIOWrapper(f, encoding="utf-8"),
+        fieldnames=POSTAL_COLS,
+        delimiter="\t",
+    )
+    by_zip = {row["postal_code"]: row for row in reader}
+
+row = by_zip["10001"]
+print(row["place_name"], row["admin_name1"], row["latitude"], row["longitude"])
+# New York City New York 40.7484 -73.9967
+# Confirmed output (2026-04-18)
+```
+
+### Admin1 (state/province) reference table
+
+```python
+from helpers import http_get
+
+raw = http_get("https://download.geonames.org/export/dump/admin1CodesASCII.txt")
+# Format: "US.NY\tNew York\tNew York\t5128638"
+admin1 = {}
+for line in raw.splitlines():
+    if not line.strip():
+        continue
+    code, name, ascii_name, geoname_id = line.split("\t")
+    admin1[code] = {"name": name, "ascii": ascii_name, "id": geoname_id}
+
+print(admin1["US.NY"])   # {'name': 'New York', 'ascii': 'New York', 'id': '5128638'}
+print(admin1["GB.ENG"])  # {'name': 'England', 'ascii': 'England', 'id': '6269131'}
+# Confirmed (2026-04-18)
+```
+
+---
+
+## Path B — JSON API (requires registered username)
+
+Register free at `https://www.geonames.org/login`. You get 20,000 credits/day. Each call costs 1–4 credits depending on endpoint.
+
+All API endpoints use `http_get` — fully static JSON responses, no browser needed.
+
+```python
+USERNAME = "your_geonames_username"   # set once, reuse everywhere
+```
+
+### Search for places by name
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    f"http://api.geonames.org/searchJSON"
+    f"?q=New+York&maxRows=5&username={USERNAME}"
+))
+# data['totalResultsCount']  — total matches
+# data['geonames']           — list of place dicts
+
+for place in data["geonames"]:
+    print(place["name"], place["countryCode"], place["lat"], place["lng"], place["population"])
+# New York City US 40.71427 -74.00597 8336817
+# New York US 43.00035 -75.49990 19274244   (the state)
+# Confirmed structure — status 18 (demo exhausted) when tested; structure from API docs
+```
+
+### Postal code lookup
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    f"http://api.geonames.org/postalCodeSearchJSON"
+    f"?postalcode=10001&country=US&username={USERNAME}"
+))
+result = data["postalCodes"][0]
+print(result["placeName"], result["lat"], result["lng"])
+# New York City 40.74844 -73.99656
+```
+
+### Reverse geocode — nearest place to lat/lon
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    f"http://api.geonames.org/findNearbyPlaceNameJSON"
+    f"?lat=40.71&lng=-74.01&username={USERNAME}"
+))
+place = data["geonames"][0]
+print(place["name"], place["adminName1"], place["distance"])
+# Manhattan New York 0.57   (distance in km)
+```
+
+### Timezone for lat/lon
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    f"http://api.geonames.org/timezoneJSON"
+    f"?lat=40.71&lng=-74.01&username={USERNAME}"
+))
+print(data["timezoneId"])   # America/New_York
+print(data["gmtOffset"])    # -5
+print(data["dstOffset"])    # -4
+```
+
+### Country info
+
+```python
+import json
+from helpers import http_get
+
+data = json.loads(http_get(
+    f"http://api.geonames.org/countryInfoJSON"
+    f"?country=US&username={USERNAME}"
+))
+info = data["geonames"][0]
+print(info["countryName"], info["capital"], info["population"])
+# United States Washington 327167434
+```
+
+---
+
+## Parallel bulk download with ThreadPoolExecutor
+
+```python
+import io, zipfile, csv
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+POSTAL_COLS = [
+    "country_code", "postal_code", "place_name",
+    "admin_name1", "admin_code1", "admin_name2", "admin_code2",
+    "admin_name3", "admin_code3", "latitude", "longitude", "accuracy",
+]
+
+def fetch_postal(cc):
+    """Fetch and parse postal codes for a two-letter country code."""
+    try:
+        raw = http_get(f"https://download.geonames.org/export/zip/{cc}.zip")
+        z = zipfile.ZipFile(io.BytesIO(raw.encode("latin-1")))
+        with z.open(f"{cc}.txt") as f:
+            reader = csv.DictReader(
+                io.TextIOWrapper(f, encoding="utf-8"),
+                fieldnames=POSTAL_COLS,
+                delimiter="\t",
+            )
+            return list(reader)
+    except Exception:
+        return []
+
+countries = ["US", "GB", "DE", "FR", "CA"]
+with ThreadPoolExecutor(max_workers=3) as ex:
+    results = dict(zip(countries, ex.map(fetch_postal, countries)))
+
+for cc, rows in results.items():
+    print(cc, len(rows), "postal codes")
+# US 41483
+# GB 2673
+# DE 16476
+# FR 51542
+# CA 1645
+```
+
+---
+
+## API endpoint reference
+
+| Endpoint | Purpose | Key params |
+|----------|---------|-----------|
+| `/searchJSON` | Search by name | `q`, `country`, `featureClass`, `maxRows` |
+| `/postalCodeSearchJSON` | Postal code lookup | `postalcode`, `country` |
+| `/findNearbyPlaceNameJSON` | Reverse geocode | `lat`, `lng`, `radius` |
+| `/timezoneJSON` | Timezone for coords | `lat`, `lng` |
+| `/countryInfoJSON` | Country metadata | `country` |
+| `/getJSON` | Lookup by geonameid | `geonameId` |
+| `/findNearbyJSON` | Features near coords | `lat`, `lng`, `featureClass`, `featureCode` |
+
+All endpoints: `http://api.geonames.org/<endpoint>?..&username=<u>`
+
+---
+
+## Bulk download file reference
+
+| URL | Contents | Size | Key |
+|-----|---------|------|-----|
+| `.../dump/XX.zip` | All features for country XX | varies | none |
+| `.../dump/allCountries.zip` | All features worldwide | 399 MB | none |
+| `.../dump/cities500.zip` | Cities pop > 500 (~185k) | 13 MB | none |
+| `.../dump/cities1000.zip` | Cities pop > 1000 (~130k) | 10 MB | none |
+| `.../dump/cities5000.zip` | Cities pop > 5000 (~50k) | 5.3 MB | none |
+| `.../dump/cities15000.zip` | Cities pop > 15000 (~25k) | 3.1 MB | none |
+| `.../dump/countryInfo.txt` | Country metadata (plain TSV) | 31 KB | none |
+| `.../dump/admin1CodesASCII.txt` | State/province names | 148 KB | none |
+| `.../dump/admin2Codes.txt` | County/district names | 2.3 MB | none |
+| `.../dump/timeZones.txt` | Timezone offsets per country | small | none |
+| `.../zip/XX.zip` | Postal codes for country XX | varies | none |
+| `.../zip/allCountries.zip` | All postal codes worldwide | ~28 MB | none |
+
+---
+
+## Gotchas
+
+**`demo` username is always exhausted.** The shared `demo` account hits its 20,000-credit daily cap within minutes. It returns `{"status": {"message": "the daily limit of 20000 credits for demo has been exceeded...", "value": 18}}` — not an HTTP error, just a JSON status body. For any real work, register a free personal account.
+
+**API errors come back as HTTP 200 with a `status` key.** There is no HTTP 4xx/5xx for auth errors or quota exhaustion. Always check `if "status" in data` before accessing `data["geonames"]` or `data["postalCodes"]`.
+
+**`http_get` returns a `str`, not `bytes`.** The bulk zip files are binary. The workaround is `raw.encode("latin-1")` before passing to `zipfile.ZipFile` — latin-1 is a lossless round-trip for arbitrary bytes through Python's str layer.
+
+**`csv.DictReader` with `fieldnames` skips no header.** The TSV files have no header row — pass `fieldnames=COLS` explicitly. Without it, the first data row becomes the header and is silently lost.
+
+**`population` and `elevation` fields can be empty strings.** Always guard: `int(row["population"] or 0)`. Elevation is frequently empty for small places.
+
+**`alternatenames` column is a long comma-separated string, not a list.** It includes transliterations in many scripts (Arabic, Chinese, Cyrillic, etc.) and can be several KB per row. Split with `row["alternatenames"].split(",")` if you need individual names.
+
+**Country zip files include a `readme.txt` entry.** When iterating `zipfile.namelist()`, skip `readme.txt`; only `XX.txt` contains data.
+
+**Postal code zips for CA, NL, GB only contain the first part of the code.** Full Canadian postal codes are in `CA_full.csv.zip` (different filename and CSV not TSV format). Full UK codes are in `GB_full.csv.zip`.
+
+**`accuracy` field in postal codes is 1–6.** `1` = estimated from neighboring codes; `4` = matched to geonameid; `6` = centroid of addresses. Many non-US/non-EU postal codes are `1` — treat lat/lng as approximate (±5 km).
+
+**Admin1 codes are FIPS, not ISO for most countries.** Exceptions: US, CH, BE, ME use ISO codes. `US.NY` is New York (ISO), but most countries use FIPS subdivision codes which differ from ISO 3166-2.
+
+**`feature_code` distinguishes capital from city.** `PPLC` = national capital, `PPLA` = first-order admin center (state capital), `PPLA2`/`PPLA3` = smaller admin centers, `PPL` = populated place. Filter by `feature_code` to get only capitals.
+
+**Rate limit for the API is per username, not per IP.** Each free account gets 20,000 credits/day; credit cost varies (search = 1, nearby = 1, hierarchy = 4). Exceeding returns status value `18` in the JSON body — no HTTP error is raised.

--- a/domain-skills/pubchem/scraping.md
+++ b/domain-skills/pubchem/scraping.md
@@ -1,0 +1,308 @@
+# PubChem — Scraping & Data Extraction
+
+`https://pubchem.ncbi.nlm.nih.gov` — NIH's free chemical compound database. **Never use the browser for PubChem.** All data is reachable via `http_get` against the PUG REST API. No API key required.
+
+## Do this first
+
+**Use the PUG REST API for any compound lookup — one call, JSON response, no auth.**
+
+```python
+import json
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+
+data = json.loads(http_get(f"{BASE}/compound/name/aspirin/property/MolecularFormula,MolecularWeight,IUPACName,IsomericSMILES,InChIKey,XLogP,TPSA,HBondDonorCount,HBondAcceptorCount,RotatableBondCount,HeavyAtomCount,Complexity,Charge/JSON"))
+props = data["PropertyTable"]["Properties"][0]
+# {'CID': 2244, 'MolecularFormula': 'C9H8O4', 'MolecularWeight': '180.16',
+#  'SMILES': 'CC(=O)OC1=CC=CC=C1C(=O)O', 'InChIKey': 'BSYNRYMUTXBXSQ-UHFFFAOYSA-N',
+#  'IUPACName': '2-acetyloxybenzoic acid', 'XLogP': 1.2, 'TPSA': 63.6,
+#  'HBondDonorCount': 1, 'HBondAcceptorCount': 4, 'RotatableBondCount': 3,
+#  'HeavyAtomCount': 13, 'Complexity': 212, 'Charge': 0}
+```
+
+Prefer the properties endpoint over the full compound JSON — it is faster and returns a clean flat dict instead of a deeply nested structure.
+
+## Common workflows
+
+### Lookup by name → get CID and properties
+
+```python
+import json
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+PROPS = "MolecularFormula,MolecularWeight,IUPACName,IsomericSMILES,InChIKey,XLogP,ExactMass,TPSA,HBondDonorCount,HBondAcceptorCount,RotatableBondCount,HeavyAtomCount,Complexity,Charge"
+
+def get_compound(name):
+    url = f"{BASE}/compound/name/{name}/property/{PROPS}/JSON"
+    try:
+        data = json.loads(http_get(url))
+        return data["PropertyTable"]["Properties"][0]
+    except Exception:
+        return None  # 404 if name not found
+
+compound = get_compound("aspirin")
+print(compound["CID"], compound["MolecularFormula"], compound["MolecularWeight"])
+# Confirmed output (2026-04-18):
+# 2244 C9H8O4 180.16
+```
+
+### Lookup by CID → properties
+
+```python
+import json
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+PROPS = "MolecularFormula,MolecularWeight,IUPACName,IsomericSMILES,InChIKey,XLogP,ExactMass,TPSA,HBondDonorCount,HBondAcceptorCount,RotatableBondCount,HeavyAtomCount,Complexity,Charge"
+
+data = json.loads(http_get(f"{BASE}/compound/cid/2244/property/{PROPS}/JSON"))
+props = data["PropertyTable"]["Properties"][0]
+print(props["IUPACName"], props["XLogP"])
+# Confirmed output:
+# 2-acetyloxybenzoic acid 1.2
+```
+
+### Batch CID fetch — multiple compounds in one call
+
+Comma-separate CIDs for a single round-trip. Faster than sequential calls.
+
+```python
+import json
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+PROPS = "MolecularFormula,MolecularWeight,IUPACName,IsomericSMILES"
+
+cids = [2244, 2519, 5090]  # aspirin, caffeine, rofecoxib
+url = f"{BASE}/compound/cid/{','.join(str(c) for c in cids)}/property/{PROPS}/JSON"
+data = json.loads(http_get(url))
+for p in data["PropertyTable"]["Properties"]:
+    print(p["CID"], p["MolecularFormula"], p["IUPACName"][:40])
+# Confirmed output:
+# 2244 C9H8O4 2-acetyloxybenzoic acid
+# 2519 C8H10N4O2 1,3,7-trimethylpurine-2,6-dione
+# 5090 C17H14O4S 3-(4-methylsulfonylphenyl)-4-phenyl-2H-furan-5-one
+```
+
+### Resolve name to CID (ambiguous names return all matching CIDs)
+
+```python
+import json
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+
+data = json.loads(http_get(f"{BASE}/compound/name/caffeine/cids/JSON"))
+cids = data["IdentifierList"]["CID"]
+print("CIDs:", cids)
+# Confirmed output:
+# CIDs: [2519]
+
+# Ambiguous names (common names that map to multiple compounds) return multiple CIDs:
+# e.g. "glucose" → [5793], "morphine" → [5288826], etc.
+# For common drug names, typically returns a single canonical CID
+```
+
+### Synonyms
+
+```python
+import json
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+
+data = json.loads(http_get(f"{BASE}/compound/name/aspirin/synonyms/JSON"))
+info = data["InformationList"]["Information"][0]
+cid = info["CID"]
+synonyms = info.get("Synonym", [])
+print(f"CID {cid} has {len(synonyms)} synonyms")
+print("First 5:", synonyms[:5])
+# Confirmed output:
+# CID 2244 has 695 synonyms
+# First 5: ['aspirin', 'ACETYLSALICYLIC ACID', '50-78-2', '2-Acetoxybenzoic acid', '2-(Acetyloxy)benzoic acid']
+# Synonyms include: IUPAC names, CAS numbers, trade names, common names
+```
+
+### Description / bioactivity summary
+
+```python
+import json
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+
+data = json.loads(http_get(f"{BASE}/compound/cid/2244/description/JSON"))
+infos = data["InformationList"]["Information"]
+for info in infos:
+    title = info.get("Title", "")
+    desc = info.get("Description", "")
+    if desc:
+        print(f"[{title}] {desc[:200]}")
+# Returns compound descriptions from multiple sources (MeSH, NLM, etc.)
+# Confirmed: 3 description records for aspirin
+```
+
+### Structure image URL (PNG)
+
+```python
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+
+# Construct the PNG URL directly — no http_get needed, just use the URL in <img> or download
+cid = 2244
+img_url = f"{BASE}/compound/cid/{cid}/PNG"
+# Returns a 300x300 PNG of the 2D structure
+# Confirmed: content-type image/png, HTTP 200
+
+# Can also look up by name:
+img_url_by_name = f"{BASE}/compound/name/aspirin/PNG"
+
+# Customize size:
+img_url_large = f"{BASE}/compound/cid/{cid}/PNG?image_size=500x500"
+```
+
+### Structure data file (SDF) — for cheminformatics tools
+
+```python
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+
+sdf = http_get(f"{BASE}/compound/cid/2244/SDF")
+# Returns V2000 SDF format with atom coordinates, bonds, and properties
+# First line is the CID, usable directly with RDKit, OpenBabel, etc.
+```
+
+### Parallel batch fetch (ThreadPoolExecutor)
+
+Use for large lists of CIDs or names. Respect the 5 req/s guideline.
+
+```python
+import json, time
+from concurrent.futures import ThreadPoolExecutor
+from helpers import http_get
+
+BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+PROPS = "MolecularFormula,MolecularWeight,IUPACName,IsomericSMILES,InChIKey"
+
+def fetch_by_name(name):
+    try:
+        url = f"{BASE}/compound/name/{name}/property/{PROPS}/JSON"
+        data = json.loads(http_get(url))
+        return data["PropertyTable"]["Properties"][0]
+    except Exception:
+        return {"name": name, "error": "not found"}
+
+names = ["aspirin", "ibuprofen", "caffeine", "paracetamol", "morphine"]
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_by_name, names))
+for r in results:
+    if "error" not in r:
+        print(r["CID"], r["MolecularFormula"], r["IUPACName"][:40])
+# Keep max_workers <= 5 to stay within the 5 req/s rate limit
+```
+
+## URL patterns
+
+```
+# Compound by name
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/property/{props}/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/cids/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/synonyms/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/PNG
+
+# Compound by CID (batch: comma-separate CIDs)
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{cid}/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{cid}/property/{props}/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{cid}/synonyms/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{cid}/description/JSON
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{cid}/SDF
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{cid}/PNG
+
+# Compound by InChIKey
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/inchikey/{inchikey}/property/{props}/JSON
+
+# Compound by SMILES
+https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/{smiles}/property/{props}/JSON
+```
+
+## Available property keys
+
+Pass any comma-separated subset to the `/property/{props}/JSON` endpoint:
+
+| Key | Type | Description |
+|---|---|---|
+| `MolecularFormula` | string | e.g. `C9H8O4` |
+| `MolecularWeight` | string | e.g. `"180.16"` (g/mol) |
+| `IUPACName` | string | Preferred IUPAC name |
+| `IsomericSMILES` | string | Isomeric SMILES (key is `SMILES` in response) |
+| `CanonicalSMILES` | string | Canonical SMILES (key is `ConnectivitySMILES` in response) |
+| `InChI` | string | Standard InChI |
+| `InChIKey` | string | Standard InChIKey (27-char hash) |
+| `XLogP` | float | Octanol/water partition coefficient |
+| `ExactMass` | string | Monoisotopic exact mass |
+| `MonoisotopicMass` | string | Same as ExactMass |
+| `TPSA` | float | Topological polar surface area (A²) |
+| `Complexity` | int | Molecular complexity score |
+| `Charge` | int | Net formal charge |
+| `HBondDonorCount` | int | Hydrogen bond donor count |
+| `HBondAcceptorCount` | int | Hydrogen bond acceptor count |
+| `RotatableBondCount` | int | Rotatable bond count |
+| `HeavyAtomCount` | int | Non-hydrogen atom count |
+| `CovalentUnitCount` | int | Number of covalent units (1 for most drugs) |
+
+## Response shape reference
+
+Properties endpoint returns a flat dict per compound — the easiest format to use:
+
+```python
+# GET /compound/name/aspirin/property/MolecularFormula,MolecularWeight,IUPACName,IsomericSMILES,InChIKey,XLogP,TPSA,HBondDonorCount,HBondAcceptorCount,RotatableBondCount,HeavyAtomCount,Complexity,Charge/JSON
+{
+  "PropertyTable": {
+    "Properties": [
+      {
+        "CID": 2244,
+        "MolecularFormula": "C9H8O4",
+        "MolecularWeight": "180.16",
+        "SMILES": "CC(=O)OC1=CC=CC=C1C(=O)O",          # IsomericSMILES
+        "InChIKey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+        "IUPACName": "2-acetyloxybenzoic acid",
+        "XLogP": 1.2,
+        "TPSA": 63.6,
+        "HBondDonorCount": 1,
+        "HBondAcceptorCount": 4,
+        "RotatableBondCount": 3,
+        "HeavyAtomCount": 13,
+        "Complexity": 212,
+        "Charge": 0
+      }
+    ]
+  }
+}
+```
+
+Full compound JSON (`/compound/name/{name}/JSON`) returns a deeply nested `PC_Compounds` array with `props` list — only use it if you need fields not available in the properties endpoint (e.g. stereochemistry atom details, bond tables).
+
+## Gotchas
+
+- **Never use the browser for PubChem.** The PUG REST API covers everything: structure, properties, synonyms, images, SDF, descriptions. `http_get` is sufficient for all data retrieval.
+
+- **`IsomericSMILES` is returned as `SMILES` in the response dict**, not `IsomericSMILES`. Similarly, `CanonicalSMILES` is returned as `ConnectivitySMILES`. Always access `props["SMILES"]`, not `props["IsomericSMILES"]`.
+
+- **404 returns a JSON fault, not an HTML error page.** `{"Fault": {"Code": "PUGREST.NotFound", "Message": "No CID found", ...}}`. Wrap `http_get` in a try/except — the 404 status itself raises an exception in `urllib`.
+
+- **Name lookup is case-insensitive but whitespace-sensitive.** `aspirin`, `Aspirin`, `ASPIRIN` all work. URL-encode spaces in multi-word names: `acetylsalicylic+acid` or `acetylsalicylic%20acid`.
+
+- **Rate limit: 5 requests/second.** The API returns an `x-throttling-control` header indicating Green/Yellow/Red status. At Green (normal load), bursts of 5 concurrent requests are safe. For sustained bulk fetching use `ThreadPoolExecutor(max_workers=5)` and stay under 5 req/s. No explicit backoff header is returned — the server just slows down or returns HTTP 503.
+
+- **Batch CID lookup via comma-separated list is the fastest approach for known CIDs.** A single call with 50 CIDs is much faster than 50 sequential calls. Keep batch size under 200 CIDs to avoid request timeouts.
+
+- **`MolecularWeight` is a string, not a float.** The API returns `"180.16"` (string). Cast with `float(props["MolecularWeight"])` if you need arithmetic.
+
+- **Common names map to exactly one CID; ambiguous names may return multiple CIDs** from the `/cids/` endpoint. Use `/cids/` first if you need to verify uniqueness, then fetch properties by CID.
+
+- **InChIKey lookup works for exact structure matching.** If you have an InChIKey from another source, use `/compound/inchikey/{key}/property/.../JSON` to get PubChem data without going through name resolution.
+
+- **SMILES lookup is supported but must be URL-encoded.** Special SMILES characters like `=`, `#`, `(`, `)` must be percent-encoded. Prefer InChIKey for exact structure lookup — it is a safe URL-friendly hash.

--- a/domain-skills/tmdb/scraping.md
+++ b/domain-skills/tmdb/scraping.md
@@ -1,0 +1,334 @@
+# TMDB — Data Extraction
+
+`https://api.themoviedb.org/3` — The Movie Database REST API. **Requires a free API key** on every request. No bypass exists.
+
+---
+
+## API key setup
+
+Free keys are available at `https://www.themoviedb.org/settings/api` after signing up (no credit card).
+Store as `TMDB_API_KEY` in `.env`.
+
+```python
+import os, json
+KEY = os.environ.get('TMDB_API_KEY')
+if not KEY:
+    raise RuntimeError("Set TMDB_API_KEY in .env — get one free at https://www.themoviedb.org/settings/api")
+```
+
+All examples below assume `KEY` is set. Append `&api_key={KEY}` to every v3 URL.
+
+---
+
+## Approach: Direct REST API with `http_get`
+
+Pure JSON — no browser, no HTML parsing. All responses are structured dicts.
+
+### Movie search (simplest entry point)
+
+```python
+import json, os
+from helpers import http_get
+
+KEY = os.environ['TMDB_API_KEY']
+
+results = json.loads(http_get(
+    f"https://api.themoviedb.org/3/search/movie?query=inception&api_key={KEY}"
+))
+# results['total_results']  -> 14
+# results['total_pages']    -> 1
+# results['page']           -> 1
+# results['results']        -> list of movie objects
+
+for m in results['results'][:3]:
+    print(f"{m['title']} ({m['release_date'][:4]}) id={m['id']} rating={m['vote_average']}")
+# Inception (2010) id=27205 rating=8.369
+```
+
+Movie object fields in search results:
+`id`, `title`, `original_title`, `overview`, `release_date` (YYYY-MM-DD),
+`vote_average` (0–10), `vote_count`, `popularity`, `poster_path`, `backdrop_path`,
+`genre_ids` (list of ints), `adult`, `video`, `original_language`
+
+### Movie details (full metadata by ID)
+
+```python
+# Inception = id 27205
+movie = json.loads(http_get(
+    f"https://api.themoviedb.org/3/movie/27205?api_key={KEY}"
+))
+print(movie['title'])           # Inception
+print(movie['runtime'])         # 148  (minutes)
+print(movie['revenue'])         # 825532764
+print(movie['budget'])          # 160000000
+print(movie['status'])          # Released
+print(movie['tagline'])         # Your mind is the scene of the crime.
+print(movie['imdb_id'])         # tt1375666
+print(movie['homepage'])        # https://www.warnerbros.com/movies/inception
+
+# Genres (full objects, not just IDs):
+print([g['name'] for g in movie['genres']])
+# ['Action', 'Science Fiction', 'Adventure']
+
+# Production companies:
+print([c['name'] for c in movie['production_companies']])
+# ['Legendary Pictures', 'Syncopy', 'Warner Bros. Pictures']
+
+# Spoken languages:
+print([l['english_name'] for l in movie['spoken_languages']])
+# ['English', 'French', 'Japanese', 'Swahili']
+```
+
+Extra fields in detail (vs search): `runtime`, `budget`, `revenue`, `status`, `tagline`,
+`imdb_id`, `homepage`, `genres` (full objects), `production_companies`, `production_countries`,
+`spoken_languages`, `belongs_to_collection`
+
+### Append `append_to_response` for credits, videos, keywords in one call
+
+```python
+# Fetch movie + credits + videos in a single API call
+movie = json.loads(http_get(
+    f"https://api.themoviedb.org/3/movie/27205"
+    f"?api_key={KEY}&append_to_response=credits,videos,keywords,release_dates"
+))
+
+# Credits
+cast = movie['credits']['cast'][:5]
+for actor in cast:
+    print(f"{actor['name']} as {actor['character']} (order={actor['order']})")
+# Leonardo DiCaprio as Cobb (order=0)
+# Joseph Gordon-Levitt as Arthur (order=1)
+
+crew = [p for p in movie['credits']['crew'] if p['job'] == 'Director']
+print(crew[0]['name'])  # Christopher Nolan
+
+# Trailers
+trailers = [v for v in movie['videos']['results'] if v['type'] == 'Trailer' and v['site'] == 'YouTube']
+print(f"https://www.youtube.com/watch?v={trailers[0]['key']}")
+
+# Keywords
+print([k['name'] for k in movie['keywords']['keywords'][:5]])
+# ['dream', 'spy', 'paris', 'subconscious', 'theft']
+```
+
+### Popular movies
+
+```python
+popular = json.loads(http_get(
+    f"https://api.themoviedb.org/3/movie/popular?api_key={KEY}&page=1"
+))
+# popular['results'] -> 20 movies per page, sorted by TMDB popularity score
+# popular['total_pages'] -> total pages available
+
+for m in popular['results'][:5]:
+    print(f"#{popular['results'].index(m)+1} {m['title']} popularity={m['popularity']:.1f}")
+```
+
+Other list endpoints (same shape, 20 results/page):
+- `/movie/top_rated` — highest `vote_average` with enough votes
+- `/movie/now_playing` — currently in theaters (includes `dates.minimum`/`dates.maximum`)
+- `/movie/upcoming` — releasing soon
+
+### TV search
+
+```python
+results = json.loads(http_get(
+    f"https://api.themoviedb.org/3/search/tv?query=breaking+bad&api_key={KEY}"
+))
+show = results['results'][0]
+print(show['name'], show['id'], show['first_air_date'])
+# Breaking Bad 1396 2008-01-20
+
+# TV detail by ID
+tv = json.loads(http_get(f"https://api.themoviedb.org/3/tv/1396?api_key={KEY}"))
+print(tv['number_of_seasons'])   # 5
+print(tv['number_of_episodes'])  # 62
+print(tv['status'])              # Ended
+print(tv['networks'][0]['name']) # AMC
+
+# Season detail
+s1 = json.loads(http_get(f"https://api.themoviedb.org/3/tv/1396/season/1?api_key={KEY}"))
+print(len(s1['episodes']))           # 7
+print(s1['episodes'][0]['name'])     # Pilot
+print(s1['episodes'][0]['runtime'])  # 58
+```
+
+TV show fields: `id`, `name`, `original_name`, `overview`, `first_air_date`, `last_air_date`,
+`status`, `type`, `vote_average`, `vote_count`, `popularity`, `number_of_seasons`,
+`number_of_episodes`, `episode_run_time`, `networks`, `genres`, `created_by`, `languages`,
+`origin_country`, `poster_path`, `backdrop_path`, `in_production`, `seasons`
+
+### Person / actor lookup
+
+```python
+# Search by name
+results = json.loads(http_get(
+    f"https://api.themoviedb.org/3/search/person?query=christopher+nolan&api_key={KEY}"
+))
+person = results['results'][0]
+print(person['id'], person['name'], person['known_for_department'])
+# 525 Christopher Nolan Directing
+
+# Person detail
+p = json.loads(http_get(f"https://api.themoviedb.org/3/person/525?api_key={KEY}"))
+print(p['birthday'])      # 1970-07-30
+print(p['place_of_birth']) # Westminster, London, England, UK
+print(p['biography'][:120])
+
+# Combined credits (movies + TV)
+credits = json.loads(http_get(
+    f"https://api.themoviedb.org/3/person/525/combined_credits?api_key={KEY}"
+))
+# credits['cast']  -> roles they acted in
+# credits['crew']  -> roles they directed/wrote/produced
+directed = [c for c in credits['crew'] if c['job'] == 'Director']
+for d in sorted(directed, key=lambda x: x.get('release_date',''), reverse=True)[:5]:
+    title = d.get('title') or d.get('name')
+    print(f"{title} ({d.get('release_date','')[:4]})")
+# Oppenheimer (2023), Tenet (2020), Dunkirk (2017), Interstellar (2014), The Dark Knight Rises (2012)
+```
+
+### Configuration — image base URLs
+
+Call this once and cache. Needed to build full image URLs.
+
+```python
+config = json.loads(http_get(
+    f"https://api.themoviedb.org/3/configuration?api_key={KEY}"
+))
+img = config['images']
+base_url    = img['secure_base_url']   # 'https://image.tmdb.org/t/p/'
+poster_sizes = img['poster_sizes']     # ['w92','w154','w185','w342','w500','w780','original']
+backdrop_sizes = img['backdrop_sizes'] # ['w300','w780','w1280','original']
+profile_sizes = img['profile_sizes']   # ['w45','w185','h632','original']
+```
+
+### Image URL construction
+
+```python
+def poster_url(poster_path, size='w500'):
+    """Build full poster URL from TMDB poster_path field."""
+    if not poster_path:
+        return None
+    return f"https://image.tmdb.org/t/p/{size}{poster_path}"
+
+def backdrop_url(backdrop_path, size='w1280'):
+    if not backdrop_path:
+        return None
+    return f"https://image.tmdb.org/t/p/{size}{backdrop_path}"
+
+# Usage
+movie = json.loads(http_get(f"https://api.themoviedb.org/3/movie/27205?api_key={KEY}"))
+print(poster_url(movie['poster_path']))
+# https://image.tmdb.org/t/p/w500/ljsZTbVsrQSqZgWeep2B1QiDKuh.jpg
+print(backdrop_url(movie['backdrop_path'], size='w1280'))
+# https://image.tmdb.org/t/p/w1280/s3TBrRGB1iav7gFOCNx3H31MoES.jpg
+```
+
+Size options by type:
+- **Poster**: `w92`, `w154`, `w185`, `w342`, `w500`, `w780`, `original`
+- **Backdrop**: `w300`, `w780`, `w1280`, `original`
+- **Profile**: `w45`, `w185`, `h632`, `original`
+- **Logo**: `w45`, `w92`, `w154`, `w185`, `w300`, `w500`, `original`
+
+### Genre list (ID → name mapping)
+
+```python
+genres = json.loads(http_get(
+    f"https://api.themoviedb.org/3/genre/movie/list?api_key={KEY}"
+))
+genre_map = {g['id']: g['name'] for g in genres['genres']}
+# {28: 'Action', 12: 'Adventure', 16: 'Animation', 35: 'Comedy', ...}
+
+# For TV genres:
+tv_genres = json.loads(http_get(
+    f"https://api.themoviedb.org/3/genre/tv/list?api_key={KEY}"
+))
+```
+
+### Discover — filtered listing
+
+```python
+# Top-rated sci-fi movies from 2020+
+discover = json.loads(http_get(
+    f"https://api.themoviedb.org/3/discover/movie"
+    f"?api_key={KEY}"
+    f"&with_genres=878"          # 878 = Science Fiction
+    f"&primary_release_date.gte=2020-01-01"
+    f"&sort_by=vote_average.desc"
+    f"&vote_count.gte=200"       # require enough votes for meaningful average
+    f"&page=1"
+))
+for m in discover['results'][:5]:
+    print(f"{m['title']} ({m['release_date'][:4]}) {m['vote_average']:.1f}")
+```
+
+`sort_by` options: `popularity.desc`, `popularity.asc`, `release_date.desc`,
+`release_date.asc`, `vote_average.desc`, `vote_average.asc`, `revenue.desc`, `revenue.asc`
+
+### Bulk / concurrent fetching
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+movie_ids = [27205, 157336, 49026, 155, 372058]  # Inception, Interstellar, TDKR, Batman Begins, Your Name
+
+def fetch_movie(mid):
+    try:
+        return json.loads(http_get(
+            f"https://api.themoviedb.org/3/movie/{mid}"
+            f"?api_key={KEY}&append_to_response=credits"
+        ))
+    except Exception as e:
+        return {'id': mid, 'error': str(e)}
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    movies = list(ex.map(fetch_movie, movie_ids))
+# ~5 movies in ~1.5s at max_workers=5 — reliable at this concurrency
+```
+
+### Pagination
+
+```python
+def get_all_popular(max_pages=5):
+    movies = []
+    for page in range(1, max_pages + 1):
+        data = json.loads(http_get(
+            f"https://api.themoviedb.org/3/movie/popular?api_key={KEY}&page={page}"
+        ))
+        movies.extend(data['results'])
+        if page >= data['total_pages']:
+            break
+    return movies
+# 20 movies per page; max page=500 per TMDB docs
+```
+
+---
+
+## Gotchas
+
+- **API key required on every request** — HTTP 401 without it. Even `?api_key=` (empty) returns 401. Free keys don't expire and have no stated rate limit for read operations, but TMDB asks for fair use (<50 calls/sec).
+
+- **`poster_path` and `backdrop_path` can be `None`** — Common for obscure titles, older films, or recently added entries. Always guard: `poster_url(m['poster_path']) if m['poster_path'] else None`.
+
+- **Image paths start with `/`** — `poster_path` is `'/ljsZTbVsrQSqZgWeep2B1QiDKuh.jpg'`. The base URL already ends with `/`, so concatenate directly: `base_url + size + poster_path` (not `base_url + size + '/' + poster_path`).
+
+- **`vote_average` is meaningless with low `vote_count`** — A film with 3 votes and a 9.0 average means nothing. Always filter with `vote_count.gte=100` (or 200) when sorting by rating in Discover.
+
+- **Search returns `genre_ids` (ints), details return `genres` (objects)** — Search results give `[28, 878]`; use the genre map from `/genre/movie/list` to resolve names. Detail endpoints give `[{'id': 28, 'name': 'Action'}, ...]` directly.
+
+- **`release_date` is empty string `''` for unreleased films** — Not `None`. Guard with `m.get('release_date') or 'TBD'` before slicing `[:4]`.
+
+- **`append_to_response` is a single API call** — Requesting `credits,videos,keywords` together costs 1 API call, not 3. Use it for any time you need multiple sub-resources for the same movie/show.
+
+- **TV uses `name` / `first_air_date`, movies use `title` / `release_date`** — Search results from `/search/multi` mix both; check `media_type` field (`'movie'` or `'tv'`) to pick the right field.
+
+- **Person `combined_credits` mixes movies and TV** — Each entry has a `media_type` field (`'movie'` or `'tv'`). Movie entries use `title`/`release_date`; TV entries use `name`/`first_air_date`.
+
+- **`/search/multi` searches movies, TV, and people in one call** — Useful when you don't know the type: `?query=nolan&api_key={KEY}`. Returns `media_type` on each result.
+
+- **External IDs** — Find TMDB ID from an IMDb ID: `/find/tt1375666?external_source=imdb_id&api_key={KEY}`. Returns `{'movie_results': [...], 'tv_results': [...], ...}`.
+
+- **Rate limit: ~40 requests/10 seconds** — TMDB enforces ~40 req/10s per IP. At `max_workers=5` with typical response times this stays safe. For aggressive bulk scraping (hundreds of IDs), add `time.sleep(0.25)` between batches or use `ThreadPoolExecutor(max_workers=10)` with caution.
+
+- **Language / region params** — Append `&language=en-US` (default) or `&region=US` to localize results. `popular` and `now_playing` respect `region` to filter by theatrical release country.

--- a/domain-skills/us-census/scraping.md
+++ b/domain-skills/us-census/scraping.md
@@ -1,0 +1,386 @@
+# U.S. Census Bureau API — Data Extraction
+
+`https://api.census.gov/data` — official U.S. demographic, economic, and housing statistics. **No browser needed.** All endpoints return JSON via `http_get`. **No API key required** for most use; a free key removes a daily rate cap.
+
+## Do this first
+
+**Fetch all states — no key needed, works immediately.**
+
+```python
+import json
+
+# All-state population, median income, and median age (2022 ACS 5-year estimates)
+raw = http_get(
+    "https://api.census.gov/data/2022/acs/acs5"
+    "?get=NAME,B01003_001E,B19013_001E,B01002_001E"
+    "&for=state:*"
+)
+data = json.loads(raw)
+
+# First row is always the header
+headers = data[0]   # ['NAME', 'B01003_001E', 'B19013_001E', 'B01002_001E', 'state']
+rows    = data[1:]  # [['Alabama', '5028092', '59609', '39.3', '01'], ...]
+
+records = [dict(zip(headers, row)) for row in rows]
+for r in records[:3]:
+    print(r['NAME'], 'pop:', r['B01003_001E'], 'median_income:', r['B19013_001E'])
+# Alabama pop: 5028092 median_income: 59609
+# Alaska  pop: 734821  median_income: 86370
+# Arizona pop: 7172282 median_income: 73450
+```
+
+All values are returned as **strings** — cast to `int()` or `float()` as needed.
+
+---
+
+## Response format
+
+Every endpoint returns a 2-D JSON array. Row 0 = column headers. Rows 1..N = data.
+
+```python
+data = json.loads(raw)
+headers = data[0]          # ['NAME', 'B01003_001E', 'state']
+rows    = data[1:]         # [['Alabama', '5028092', '01'], ...]
+
+# Convert to list of dicts
+records = [dict(zip(headers, row)) for row in rows]
+
+# Or convert to a DataFrame (if pandas available)
+# import pandas as pd
+# df = pd.DataFrame(data[1:], columns=data[0])
+```
+
+The geographic FIPS code columns (e.g. `state`, `county`, `tract`) are always appended to the right of the requested variables.
+
+---
+
+## Geographic hierarchy
+
+Supported `for=` targets (from coarsest to finest):
+
+| Geography | `for=` clause | `in=` filter needed? |
+|---|---|---|
+| Nation | `us:1` | No |
+| State | `state:*` or `state:06` | No |
+| County | `county:*` | Optional `in=state:XX` |
+| Congressional district | `congressional+district:*` | `in=state:XX` |
+| Place (city/town) | `place:*` | `in=state:XX` |
+| ZCTA (ZIP code area) | `zip+code+tabulation+area:94102` | No |
+| Census tract | `tract:*` | `in=state:XX&in=county:YYY` |
+| Block group | `block+group:*` | `in=state:XX&in=county:YYY&in=tract:ZZZZZZ` |
+
+```python
+# County-level: all counties in California (state FIPS 06)
+raw = http_get(
+    "https://api.census.gov/data/2022/acs/acs5"
+    "?get=NAME,B01003_001E,B19013_001E"
+    "&for=county:*&in=state:06"
+)
+data = json.loads(raw)
+# headers: ['NAME', 'B01003_001E', 'B19013_001E', 'state', 'county']
+# 58 counties
+
+# ZCTA (ZIP code area)
+raw = http_get(
+    "https://api.census.gov/data/2022/acs/acs5"
+    "?get=NAME,B01003_001E"
+    "&for=zip+code+tabulation+area:94102"
+)
+# headers: ['NAME', 'B01003_001E', 'zip code tabulation area']
+
+# Census tract (requires state + county in 'in' clause)
+raw = http_get(
+    "https://api.census.gov/data/2022/acs/acs5"
+    "?get=NAME,B01003_001E"
+    "&for=tract:*&in=state:06&in=county:001"
+)
+# Alameda County tracts — 379 tracts
+
+# Block group (requires state + county + tract)
+raw = http_get(
+    "https://api.census.gov/data/2022/acs/acs5"
+    "?get=NAME,B01003_001E"
+    "&for=block+group:*&in=state:06&in=county:001&in=tract:400100"
+)
+```
+
+---
+
+## Datasets (survey × year)
+
+### ACS 5-Year (most common — full geographic coverage)
+
+```
+https://api.census.gov/data/{year}/acs/acs5?get=...
+```
+
+Available years: 2009 – 2024. Covers all geographies down to block group.
+
+### ACS 1-Year (faster updates, fewer geographies)
+
+```
+https://api.census.gov/data/{year}/acs/acs1?get=...
+```
+
+Available years: 2005 – 2022. Only covers areas with population > 65,000. ACS1 has ~42 counties in California vs ~58 for ACS5.
+
+### Decennial Census (exact counts, not estimates)
+
+```
+https://api.census.gov/data/2020/dec/pl?get=NAME,P1_001N&for=state:*
+# Also: 2010, 2000, 1990
+```
+
+Decennial variables use `P` prefix instead of `B`.
+
+### County Business Patterns (employment + establishments)
+
+```
+https://api.census.gov/data/2021/cbp?get=NAME,ESTAB,EMP,PAYANN&for=state:*&NAICS2017=72
+# NAICS2017=72 = Accommodation and Food Services
+```
+
+### List all 1,776+ available datasets
+
+```python
+raw = http_get("https://api.census.gov/data.json")
+catalog = json.loads(raw)
+for d in catalog['dataset'][:10]:
+    print(d['c_vintage'], d['c_dataset'], d['title'][:60])
+```
+
+---
+
+## Common variable codes (ACS)
+
+Variables follow the pattern `B{group}_{sequence}E` (E = Estimate, M = Margin of Error).
+
+### Demographics
+
+| Variable | Description |
+|---|---|
+| `B01003_001E` | Total population |
+| `B01002_001E` | Median age |
+| `B02001_002E` | White alone |
+| `B02001_003E` | Black or African American alone |
+| `B02001_004E` | American Indian and Alaska Native alone |
+| `B02001_005E` | Asian alone |
+| `B02001_006E` | Native Hawaiian and Other Pacific Islander alone |
+| `B02001_007E` | Some other race alone |
+| `B03001_003E` | Hispanic or Latino (any race) |
+| `B05001_006E` | Not a U.S. citizen |
+
+### Income & Poverty
+
+| Variable | Description |
+|---|---|
+| `B19013_001E` | Median household income (past 12 months) |
+| `B19025_001E` | Aggregate household income |
+| `B17001_002E` | Population below poverty level |
+| `B19001_001E` | Total households (income distribution base) |
+
+### Housing
+
+| Variable | Description |
+|---|---|
+| `B25001_001E` | Total housing units |
+| `B25003_002E` | Owner-occupied housing units |
+| `B25003_003E` | Renter-occupied housing units |
+| `B25035_001E` | Median year structure built |
+| `B25064_001E` | Median gross rent |
+| `B25071_001E` | Median gross rent as % of household income |
+| `B25077_001E` | Median home value |
+
+### Education
+
+| Variable | Description |
+|---|---|
+| `B15003_022E` | Population 25+: Bachelor's degree |
+| `B15003_023E` | Population 25+: Master's degree |
+| `B15003_025E` | Population 25+: Doctorate degree |
+| `B14001_002E` | School enrollment: nursery/preschool |
+| `B14001_007E` | School enrollment: undergraduate college |
+
+### Employment
+
+| Variable | Description |
+|---|---|
+| `B23025_004E` | Civilian labor force: employed |
+| `B23025_005E` | Civilian labor force: unemployed |
+| `B08303_001E` | Travel time to work: total |
+| `B08006_017E` | Means of transport: public transit |
+| `B08006_019E` | Means of transport: worked from home |
+
+### Look up any variable
+
+```python
+raw = http_get("https://api.census.gov/data/2022/acs/acs5/variables.json")
+variables = json.loads(raw)['variables']
+print(len(variables))  # 28,193 variables for ACS 2022
+
+# Look up a specific code
+v = variables['B19013_001E']
+print(v['label'])   # Estimate!!Median household income...
+print(v['group'])   # B19013
+
+# Search by label keyword
+matches = [(k, v['label']) for k, v in variables.items()
+           if 'median' in v.get('label', '').lower() and k.endswith('001E')]
+for code, label in matches[:5]:
+    print(code, ':', label)
+```
+
+---
+
+## State FIPS codes (partial)
+
+```
+01=Alabama  02=Alaska   04=Arizona  05=Arkansas 06=California
+08=Colorado 09=Connecticut 10=Delaware 11=DC  12=Florida
+13=Georgia  15=Hawaii   16=Idaho    17=Illinois 18=Indiana
+19=Iowa     20=Kansas   21=Kentucky 22=Louisiana 23=Maine
+36=New York 48=Texas    51=Virginia 53=Washington 72=Puerto Rico
+```
+
+Note: FIPS codes skip numbers (03, 07, 11 = DC, etc.). Use `for=state:*` to enumerate all.
+
+---
+
+## End-to-end pattern: multi-county population table
+
+```python
+import json
+
+def census_get(year, dataset, variables, geo_for, geo_in=None, api_key=None):
+    """Fetch Census data, return list of dicts. All values are strings."""
+    params = f"get=NAME,{','.join(variables)}&for={geo_for}"
+    if geo_in:
+        params += f"&in={geo_in}"
+    if api_key:
+        params += f"&key={api_key}"
+    url = f"https://api.census.gov/data/{year}/{dataset}?{params}"
+    raw = http_get(url)
+    data = json.loads(raw)
+    headers = data[0]
+    return [dict(zip(headers, row)) for row in data[1:]]
+
+# All counties in Texas
+records = census_get(
+    year=2022,
+    dataset="acs/acs5",
+    variables=["B01003_001E", "B19013_001E", "B25077_001E"],
+    geo_for="county:*",
+    geo_in="state:48",
+)
+
+# Sort by population descending
+records.sort(key=lambda r: int(r['B01003_001E']), reverse=True)
+
+for r in records[:5]:
+    pop     = int(r['B01003_001E'])
+    income  = int(r['B19013_001E']) if r['B19013_001E'] != '-666666666' else None
+    home_val= int(r['B25077_001E']) if r['B25077_001E'] != '-666666666' else None
+    print(f"{r['NAME']}: pop={pop:,}  income=${income:,}  home=${home_val:,}")
+# Harris County, Texas:     pop=4,731,145  income=$62,474  home=$225,500
+# Dallas County, Texas:     pop=2,618,148  income=$60,085  home=$238,700
+# Tarrant County, Texas:    pop=2,117,665  income=$72,826  home=$255,600
+```
+
+---
+
+## Rate limits & API key
+
+- **Without key**: 500 requests/day (per IP). Sufficient for most scripting tasks.
+- **With free key**: Higher limit (undocumented, ~1,000+/day). Required for heavy batch use.
+
+Get a free key at `https://api.census.gov/data/key_signup.html` (instant, email only).
+
+Add `&key=YOUR_KEY` to any query URL:
+```python
+url = "https://api.census.gov/data/2022/acs/acs5?get=NAME,B01003_001E&for=state:*&key=YOUR_KEY"
+```
+
+---
+
+## Parallel bulk fetch (all counties nationwide)
+
+```python
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+# All 50 states (FIPS 01-56, non-contiguous)
+STATE_FIPS = [
+    '01','02','04','05','06','08','09','10','11','12','13','15','16','17','18',
+    '19','20','21','22','23','24','25','26','27','28','29','30','31','32','33',
+    '34','35','36','37','38','39','40','41','42','44','45','46','47','48','49',
+    '50','51','53','54','55','56'
+]
+
+def fetch_state_counties(fips):
+    raw = http_get(
+        f"https://api.census.gov/data/2022/acs/acs5"
+        f"?get=NAME,B01003_001E,B19013_001E,B25077_001E"
+        f"&for=county:*&in=state:{fips}"
+    )
+    data = json.loads(raw)
+    headers = data[0]
+    return [dict(zip(headers, row)) for row in data[1:]]
+
+with ThreadPoolExecutor(max_workers=5) as ex:
+    results = list(ex.map(fetch_state_counties, STATE_FIPS))
+
+all_counties = [rec for state in results for rec in state]
+print(len(all_counties))  # ~3,200 counties
+```
+
+---
+
+## Gotchas
+
+**All values are strings.** `row['B01003_001E']` is `'5028092'`, not `5028092`. Always cast: `int(r['B01003_001E'])` or `float(r['B01002_001E'])`.
+
+**Special sentinel values signal missing/suppressed data — never cast them blindly.**
+
+| Sentinel | Meaning |
+|---|---|
+| `-666666666` | Not applicable (geography doesn't have this variable) |
+| `-555555555` | Not available (estimate unavailable for this area) |
+| `-333333333` | Unreliable estimate (sampling error too large) |
+| `-222222222` | Doesn't apply / data withheld |
+
+Always guard:
+```python
+val = r['B19013_001E']
+income = int(val) if int(val) > 0 else None
+```
+
+**First row is always headers.** `data[0]` is `['NAME', 'B01003_001E', 'state']`. `data[1:]` is the actual records. Forgetting this causes every `int()` cast to fail.
+
+**Variable limit: 49 per request** (plus `NAME` = 50 columns total). Requesting 50+ variables returns HTTP 400 with no message body. Batch into chunks of 49:
+```python
+CHUNK = 49
+for i in range(0, len(all_vars), CHUNK):
+    chunk = all_vars[i:i+CHUNK]
+    raw = http_get(f"...?get=NAME,{','.join(chunk)}&for=...")
+```
+
+**ACS1 only covers large geographies.** The 1-year estimates skip counties and tracts below ~65,000 population. Use ACS5 for complete county/tract/block-group coverage.
+
+**Geographic FIPS codes are appended to the right**, not necessarily where you expect. When you request `?get=NAME,B01003_001E&for=county:*&in=state:06`, the response headers are `['NAME','B01003_001E','state','county']` — the geo columns (`state`, `county`) are always last. Use `dict(zip(headers, row))` rather than positional indexing.
+
+**`E` = Estimate, `M` = Margin of Error.** Variable `B01003_001E` is the estimate; `B01003_001M` is its 90% margin of error. State-level `_001M` often returns `-555555555` (unreliable at that aggregate level). For subnational geographies, the MOE is meaningful.
+
+**SSL certificate failure on macOS Python 3.11+.** The `http_get` helper in `helpers.py` may raise `CERTIFICATE_VERIFY_FAILED`. Fix for development:
+```python
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+```
+Or install `certifi` and pass its CA bundle.
+
+**Invalid API key returns empty body (HTTP 400), not a JSON error.** If you pass `&key=BADKEY`, the server returns HTTP 400 with an empty body — `json.loads(raw)` raises `JSONDecodeError`. Omit the key entirely if you don't have a valid one; keyless access works fine.
+
+**`for=all counties` is not valid syntax.** Use `for=county:*` (with an asterisk), not `for=county:all`.
+
+**Decennial variables differ from ACS.** Decennial 2020 uses `P1_001N` for total population (not `B01003_001E`). The two surveys have separate variable namespaces.
+
+**Year is "vintage" — specifies which survey edition, not the data collection year.** `2022/acs/acs5` refers to the 5-year estimates ending in 2022 (covering 2018–2022).

--- a/domain-skills/worldtime/scraping.md
+++ b/domain-skills/worldtime/scraping.md
@@ -1,0 +1,442 @@
+# World Time APIs — Current Time & Timezone Data
+
+No-browser, JSON-over-HTTP APIs for current time, UTC offsets, and DST detection. All work with `http_get`. Confirmed live 2026-04-18.
+
+| API | Base URL | Auth | IANA zones | Rate limit |
+|-----|----------|------|------------|------------|
+| WorldTimeAPI | `worldtimeapi.org` | None | ~400 | ~1 req/s (informal) |
+| TimeAPI.io | `timeapi.io` | None | 597 | None documented |
+| WorldClockAPI | `worldclockapi.com` | None | ~10 fixed codes | None documented |
+| TimezoneDB | `api.timezonedb.com` | Free API key | 400+ | 1 req/s free tier |
+
+**Status as of 2026-04-18:** WorldTimeAPI (`worldtimeapi.org`) is currently returning TLS/connection resets on both HTTP and HTTPS — the API is unreachable. Use **TimeAPI.io** as the primary no-key alternative; it supports the same IANA zone names and returns richer DST data.
+
+---
+
+## WorldTimeAPI (when available)
+
+WorldTimeAPI is the canonical reference; the endpoints below match its documented spec. If it comes back online, the HTTP (not HTTPS) endpoint was historically more reliable on some client stacks.
+
+### Documented response shape
+
+```python
+import json
+
+# GET http://worldtimeapi.org/api/timezone/America/New_York
+# Returns:
+{
+    "abbreviation": "EDT",           # current timezone abbreviation
+    "client_ip": "1.2.3.4",
+    "datetime": "2024-06-15T10:23:45.123456-04:00",  # ISO8601 with offset
+    "day_of_week": 6,               # 0=Sunday … 6=Saturday
+    "day_of_year": 167,
+    "dst": True,                    # DST currently active?
+    "dst_from": "2024-03-10T07:00:00+00:00",  # DST start (UTC), null if no DST
+    "dst_offset": 3600,             # DST offset in seconds (0 if no DST)
+    "dst_until": "2024-11-03T06:00:00+00:00", # DST end (UTC), null if no DST
+    "raw_offset": -18000,           # standard UTC offset in seconds (no DST)
+    "timezone": "America/New_York",
+    "unixtime": 1718447025,
+    "utc_datetime": "2024-06-15T14:23:45.123456+00:00",
+    "utc_offset": "-04:00",         # current UTC offset string (includes DST)
+    "week_number": 24
+}
+```
+
+### List all available timezones
+
+```python
+import json
+
+# GET http://worldtimeapi.org/api/timezone
+zones = json.loads(http_get("http://worldtimeapi.org/api/timezone"))
+# Returns a flat list of IANA strings:
+# ["Africa/Abidjan", "Africa/Accra", ..., "UTC"]
+print(len(zones))   # ~400 zones
+
+# Filter to US zones:
+us_zones = [z for z in zones if z.startswith("America/")]
+```
+
+### By caller IP (auto-detect timezone)
+
+```python
+import json
+
+data = json.loads(http_get("http://worldtimeapi.org/api/ip"))
+# Returns same shape as /api/timezone/{zone}
+# timezone field reflects IP geolocation — not reliable inside cloud/VPN
+print(data["timezone"])     # e.g. "America/New_York"
+print(data["utc_offset"])   # e.g. "-04:00"
+```
+
+---
+
+## TimeAPI.io (confirmed working, no key)
+
+Drop-in replacement for WorldTimeAPI. Uses full IANA zone names. 597 supported zones.
+
+### Current time in a zone
+
+```python
+import json
+
+data = json.loads(http_get(
+    "https://timeapi.io/api/Time/current/zone?timeZone=America/New_York"
+))
+
+# Confirmed live response (2026-04-18):
+# data["year"]          2026
+# data["month"]         4
+# data["day"]           18
+# data["hour"]          21
+# data["minute"]        49
+# data["seconds"]       42
+# data["milliSeconds"]  630
+# data["dateTime"]      "2026-04-18T21:49:42.6309083"
+# data["date"]          "04/18/2026"
+# data["time"]          "21:49"
+# data["timeZone"]      "America/New_York"
+# data["dayOfWeek"]     "Saturday"
+# data["dstActive"]     True
+
+print(data["dateTime"], data["timeZone"])
+print("DST active:", data["dstActive"])
+```
+
+### Timezone info with UTC offsets and DST window
+
+```python
+import json
+
+info = json.loads(http_get(
+    "https://timeapi.io/api/timezone/zone?timeZone=America/New_York"
+))
+
+# Confirmed live (2026-04-18, during EDT):
+# info["timeZone"]                        "America/New_York"
+# info["currentLocalTime"]                "2026-04-18T21:49:52.4722691"
+# info["currentUtcOffset"]["seconds"]     -14400   # -4 hours (EDT)
+# info["standardUtcOffset"]["seconds"]    -18000   # -5 hours (EST, no DST)
+# info["hasDayLightSaving"]               True
+# info["isDayLightSavingActive"]          True
+# info["dstInterval"]["dstName"]          "EDT"
+# info["dstInterval"]["dstStart"]         "2026-03-08T07:00:00Z"
+# info["dstInterval"]["dstEnd"]           "2026-11-01T06:00:00Z"
+# info["dstInterval"]["dstOffsetToStandardTime"]["seconds"]  3600  # +1 hour
+
+# For a non-DST zone (Tokyo):
+# info["hasDayLightSaving"]              False
+# info["isDayLightSavingActive"]         False
+# info["dstInterval"]                    None
+
+# Extract current UTC offset in hours:
+offset_hours = info["currentUtcOffset"]["seconds"] / 3600
+print(f"UTC{offset_hours:+.0f}")   # UTC-4
+
+# Detect DST:
+is_dst = info["isDayLightSavingActive"]
+
+# DST offset vs standard (seconds):
+dst_shift = info["currentUtcOffset"]["seconds"] - info["standardUtcOffset"]["seconds"]
+# → 3600 when DST active, 0 when not
+```
+
+### DST detection pattern
+
+```python
+import json
+
+def get_utc_offset(zone: str) -> dict:
+    """Returns current and standard UTC offset, DST flag, and DST name."""
+    info = json.loads(http_get(
+        f"https://timeapi.io/api/timezone/zone?timeZone={zone}"
+    ))
+    current_offset_s  = info["currentUtcOffset"]["seconds"]
+    standard_offset_s = info["standardUtcOffset"]["seconds"]
+    dst_active        = info["isDayLightSavingActive"]
+    dst_name          = info["dstInterval"]["dstName"] if dst_active else None
+
+    return {
+        "zone":             zone,
+        "offset_hours":     current_offset_s / 3600,
+        "standard_hours":   standard_offset_s / 3600,
+        "dst_active":       dst_active,
+        "dst_name":         dst_name,
+        "dst_start":        info["dstInterval"]["dstStart"] if dst_active else None,
+        "dst_end":          info["dstInterval"]["dstEnd"]   if dst_active else None,
+    }
+
+# Confirmed live (2026-04-18):
+ny  = get_utc_offset("America/New_York")
+# → {'offset_hours': -4.0, 'standard_hours': -5.0, 'dst_active': True, 'dst_name': 'EDT', ...}
+tok = get_utc_offset("Asia/Tokyo")
+# → {'offset_hours': 9.0, 'standard_hours': 9.0, 'dst_active': False, 'dst_name': None, ...}
+lon = get_utc_offset("Europe/London")
+# → {'offset_hours': 1.0, 'standard_hours': 0.0, 'dst_active': True, 'dst_name': 'BST', ...}
+```
+
+### Convert time between zones
+
+```python
+import json
+
+# POST endpoint — converts a specific datetime from one zone to another
+import urllib.request
+
+body = json.dumps({
+    "fromTimeZone": "America/New_York",
+    "dateTime":     "2026-04-18 12:00:00",
+    "toTimeZone":   "Europe/London",
+    "dstAmbiguity": ""
+}).encode()
+
+req = urllib.request.Request(
+    "https://timeapi.io/api/Conversion/convertTimeZone",
+    data=body,
+    headers={"Content-Type": "application/json"},
+    method="POST"
+)
+with urllib.request.urlopen(req, timeout=20) as r:
+    result = json.loads(r.read())
+
+# Confirmed live (2026-04-18, both in DST):
+# result["fromTimezone"]                       "America/New_York"
+# result["fromDateTime"]                       "2026-04-18T12:00:00"
+# result["toTimeZone"]                         "Europe/London"
+# result["conversionResult"]["dateTime"]       "2026-04-18T17:00:00"
+# result["conversionResult"]["dstActive"]      True
+# result["conversionResult"]["timeZone"]       "Europe/London"
+
+print(result["conversionResult"]["dateTime"])   # "2026-04-18T17:00:00"
+```
+
+### Current time by IP address
+
+```python
+import json
+
+# IP address → timezone → current time
+data = json.loads(http_get(
+    "https://timeapi.io/api/Time/current/ip?ipAddress=8.8.8.8"
+))
+# Confirmed: 8.8.8.8 → America/Los_Angeles
+# Same response shape as /current/zone
+
+print(data["timeZone"])     # "America/Los_Angeles"
+print(data["dateTime"])     # "2026-04-18T18:51:05.5840305"
+print(data["dstActive"])    # True
+```
+
+### List all supported timezones
+
+```python
+import json
+
+zones = json.loads(http_get(
+    "https://timeapi.io/api/timezone/availabletimezones"
+))
+# Returns a flat JSON array of 597 IANA zone strings (confirmed 2026-04-18)
+# ["Africa/Abidjan", "Africa/Accra", ..., "UTC", "W-SU", "WET", "Zulu"]
+
+print(len(zones))   # 597
+us_zones = [z for z in zones if z.startswith("America/")]
+print(us_zones[:5]) # ['America/Adak', 'America/Anchorage', ...]
+```
+
+---
+
+## WorldClockAPI (simple, HTTP only)
+
+Fixed set of ~10 named zones. No IANA names — use only for UTC/EST/PST/etc. shorthand lookups.
+
+### Current time
+
+```python
+import json
+
+# HTTP only — HTTPS not supported
+data = json.loads(http_get("http://worldclockapi.com/api/json/utc/now"))
+
+# Confirmed response (2026-04-18):
+# data["currentDateTime"]       "2026-04-19T01:50Z"   (ISO8601, offset appended for non-UTC)
+# data["utcOffset"]             "00:00:00"             (HH:MM:SS string)
+# data["isDayLightSavingsTime"] False
+# data["dayOfTheWeek"]          "Sunday"
+# data["timeZoneName"]          "UTC"
+# data["currentFileTime"]       134210370220836830     (Windows FILETIME — ignore)
+# data["ordinalDate"]           "2026-109"             (YYYY-DDD)
+# data["serviceResponse"]       None                   (non-null = error message)
+
+print(data["currentDateTime"])          # "2026-04-19T01:50Z"
+print(data["utcOffset"])                # "00:00:00"
+print(data["isDayLightSavingsTime"])    # False
+
+# EST zone — currentDateTime includes offset
+est = json.loads(http_get("http://worldclockapi.com/api/json/est/now"))
+print(est["currentDateTime"])   # "2026-04-18T21:50-04:00"
+print(est["utcOffset"])         # "-04:00:00"
+print(est["isDayLightSavingsTime"])  # True  (confirming EDT is active)
+```
+
+### Confirmed valid zone codes
+
+```python
+# Confirmed working (2026-04-18):
+WORLDCLOCK_ZONES = {
+    "utc":  "UTC",
+    "gmt":  "GMT Standard Time",        # UTC+1 during BST
+    "est":  "Eastern Standard Time",    # UTC-4 during EDT
+    "cst":  "Central Standard Time",    # UTC-5 during CDT
+    "mst":  "Mountain Standard Time",   # UTC-6 during MDT
+    "pst":  "Pacific Standard Time",    # UTC-7 during PDT
+    "cet":  "Central Europe Standard Time",  # UTC+2 during CEST
+    "nst":  "Newfoundland Standard Time",
+}
+
+# Invalid (confirmed errors): jst, ist, bst, aest, hst, akt, sydney
+# Error response: data["serviceResponse"] = "{code} is not a valid Time Zone"
+#                 data["currentDateTime"] = None
+
+for code in WORLDCLOCK_ZONES:
+    data = json.loads(http_get(f"http://worldclockapi.com/api/json/{code}/now"))
+    print(code, data["utcOffset"], data["isDayLightSavingsTime"])
+```
+
+---
+
+## TimezoneDB (free key required)
+
+Register at `https://timezonedb.com` for a free key. 1 req/s on free tier.
+
+### Get timezone info
+
+```python
+import json
+
+API_KEY = "YOUR_KEY"  # register free at timezonedb.com
+
+data = json.loads(http_get(
+    f"https://api.timezonedb.com/v2.1/get-time-zone"
+    f"?key={API_KEY}&format=json&by=zone&zone=America/New_York"
+))
+
+# Response shape (from API docs — key required to verify live):
+# data["status"]          "OK"          (or "FAILED" with error message)
+# data["countryCode"]     "US"
+# data["countryName"]     "United States"
+# data["regionName"]      "New York"
+# data["cityName"]        "New York"
+# data["zoneName"]        "America/New_York"
+# data["abbreviation"]    "EDT"
+# data["gmtOffset"]       -14400        # current UTC offset in seconds
+# data["dst"]             1             # 1=DST active, 0=not
+# data["zoneStart"]       1710054000    # unix timestamp when this offset started
+# data["zoneEnd"]         1730613600    # unix timestamp when this offset ends
+# data["nextAbbreviation"] "EST"
+# data["timestamp"]       1718447025    # current unix time
+# data["formatted"]       "2024-06-15 10:23:45"
+
+if data["status"] == "OK":
+    offset_hours = data["gmtOffset"] / 3600
+    print(f"UTC{offset_hours:+.0f}, DST={bool(data['dst'])}")
+
+# Lookup by lat/lon instead of zone name:
+data = json.loads(http_get(
+    f"https://api.timezonedb.com/v2.1/get-time-zone"
+    f"?key={API_KEY}&format=json&by=position&lat=40.71&lng=-74.01"
+))
+
+# List all zones:
+zones = json.loads(http_get(
+    f"https://api.timezonedb.com/v2.1/list-time-zone"
+    f"?key={API_KEY}&format=json&fields=countryCode,zoneName,gmtOffset"
+))
+# zones["zones"] — list of dicts with countryCode, zoneName, gmtOffset
+```
+
+---
+
+## End-to-end: compare current time across multiple zones
+
+```python
+import json
+
+ZONES = [
+    "America/New_York",
+    "Europe/London",
+    "Europe/Paris",
+    "Asia/Tokyo",
+    "Australia/Sydney",
+    "UTC",
+]
+
+def zone_snapshot(zone: str) -> dict:
+    """Current time + UTC offset + DST for any IANA zone."""
+    data = json.loads(http_get(
+        f"https://timeapi.io/api/Time/current/zone?timeZone={zone}"
+    ))
+    info = json.loads(http_get(
+        f"https://timeapi.io/api/timezone/zone?timeZone={zone}"
+    ))
+    offset_h = info["currentUtcOffset"]["seconds"] / 3600
+    return {
+        "zone":       zone,
+        "datetime":   data["dateTime"][:19],  # trim microseconds
+        "weekday":    data["dayOfWeek"],
+        "utc_offset": f"UTC{offset_h:+.1f}".replace(".0", ""),
+        "dst":        data["dstActive"],
+        "dst_name":   info["dstInterval"]["dstName"] if data["dstActive"] else None,
+    }
+
+for zone in ZONES:
+    snap = zone_snapshot(zone)
+    dst_tag = f" ({snap['dst_name']})" if snap["dst"] else ""
+    print(f"{snap['zone']:25s}  {snap['datetime']}  {snap['utc_offset']}{dst_tag}")
+
+# Example output (2026-04-18):
+# America/New_York           2026-04-18T21:49:42  UTC-4 (EDT)
+# Europe/London              2026-04-19T02:49:51  UTC+1 (BST)
+# Europe/Paris               2026-04-19T03:49:51  UTC+2 (CEST)
+# Asia/Tokyo                 2026-04-19T10:49:51  UTC+9
+# Australia/Sydney           2026-04-19T11:49:51  UTC+10
+# UTC                        2026-04-19T01:49:51  UTC+0
+```
+
+Two API calls per zone (current + timezone info). For bulk, batch the `timezone/zone` calls first.
+
+---
+
+## Gotchas
+
+**WorldTimeAPI is currently down (2026-04-18).** Both HTTP and HTTPS return `Connection reset by peer` at the TLS layer. Use TimeAPI.io instead — it accepts the same IANA zone names and returns equivalent data with additional DST window fields.
+
+**WorldTimeAPI used HTTP, not HTTPS.** Historically the documented base was `http://worldtimeapi.org` (plain HTTP). Calling it with HTTPS caused SSL errors on some clients even when the server was up.
+
+**TimeAPI.io `currentDateTime` has trailing microseconds** — truncate to 19 chars (`[:19]`) for a clean `YYYY-MM-DDTHH:MM:SS` string.
+
+**UTC offset is in seconds, not hours.** `currentUtcOffset["seconds"]` is `-14400` for EDT. Divide by 3600 to get hours. Do NOT use `milliseconds` or `ticks` — they are the same value scaled, not separate fields.
+
+**DST detection: compare `currentUtcOffset` vs `standardUtcOffset`.** If `currentUtcOffset["seconds"] != standardUtcOffset["seconds"]`, DST is active. The `isDayLightSavingActive` field does the same check — prefer it directly.
+
+**`isDayLightSavingActive=True` does NOT mean DST is always active.** Tokyo (`Asia/Tokyo`) returns `hasDayLightSaving=False` and `dstInterval=null`. `isDayLightSavingActive` is always False for zones without DST rules.
+
+**TimeAPI.io returns `"Invalid Timezone"` (a plain string, not JSON object)** for unknown zone names. Wrap in a try/except:
+```python
+try:
+    data = json.loads(http_get(f"https://timeapi.io/api/Time/current/zone?timeZone={zone}"))
+    if isinstance(data, str):
+        raise ValueError(f"Invalid timezone: {zone}")
+except Exception as e:
+    print(f"Error: {e}")
+```
+
+**WorldClockAPI uses HTTP only** — HTTPS is not supported. The zone codes are short abbreviations (`est`, `utc`, `cet`), not IANA names. Many common codes (`jst`, `ist`, `bst`, `aest`) are invalid. Check `data["serviceResponse"]` for errors — `currentDateTime` will be `None` on error.
+
+**WorldClockAPI `isDayLightSavingsTime` is unreliable** — the zone is labelled "Eastern Standard Time" year-round, but during EDT `isDayLightSavingsTime=True` and the offset correctly shows `-04:00`. The name does not update to "Eastern Daylight Time".
+
+**TimezoneDB requires a free API key.** Register at `https://timezonedb.com`. Free tier is capped at 1 request/second; paid tiers allow higher throughput. Always check `data["status"] == "OK"` before reading other fields — invalid keys return `status="FAILED"` with zeroed-out numeric fields (not an HTTP error).
+
+**`raw_offset` (WorldTimeAPI) vs `standardUtcOffset` (TimeAPI.io) are the same concept** — the UTC offset without DST applied. Use `utc_offset` / `currentUtcOffset` for the *current* offset which already incorporates DST.
+
+**Rate limits are informal or undocumented.** WorldTimeAPI historically asked for ~1 req/s. TimeAPI.io has no documented limit but may throttle burst traffic. Add `time.sleep(0.5)` between calls when iterating over many zones.


### PR DESCRIPTION
## Summary
- US Census: no key needed (500/day limit); first row is always headers; all values are strings; max 49 variables per request; suppression sentinels are -666666666/-555555555; geo FIPS always appended at right
- TMDB: free key required; append_to_response for 1-call multi-resource; genre_ids in search vs genres in detail; movie title field vs TV name field; image URLs need base_url + size + path construction
- WorldTimeAPI: currently DOWN (Connection reset); TimeAPI.io is the working alternative (no key); invalid zones return plain string not JSON; WorldClockAPI HTTP-only with limited zone codes
- PubChem: IsomericSMILES returns as SMILES in response; MolecularWeight is a string not float; 404 returns JSON Fault not HTML; batch CIDs in comma-separated path; properties endpoint much simpler than full JSON
- GeoNames: demo username always rate-exhausted; API returns HTTP 200 with status key on errors; bulk TSV downloads at download.geonames.org need no key; http_get returns str so encode latin-1 for zip files

## Test plan
- Verify each skill file has runnable code examples
- Spot-check API endpoints still respond

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five new domain skills with runnable `http_get` examples and concise references for US Census, TMDB, World Time APIs, PubChem, and GeoNames. This expands coverage of public data sources with clear usage, rate limits, and error handling patterns.

- New Features
  - US Census: no key (500/day) or free key; responses are 2‑D arrays of strings; 49‑variable limit; geo FIPS columns appended at right; missing/suppression sentinels noted; examples for states/counties/ZCTAs/tracts and parallel fetching.
  - TMDB: requires `TMDB_API_KEY`; search, detail, and `append_to_response` for 1‑call subresources; `genre_ids` (search) vs `genres` (detail); build image URLs via `https://image.tmdb.org/t/p/{size}{path}`; pagination/discover patterns and safe concurrency.
  - World Time: `worldtimeapi.org` currently down; added `timeapi.io` as no‑key replacement (IANA zones, DST fields, zone conversion, zone listing); `worldclockapi.com` is HTTP‑only with fixed codes; `timezonedb.com` requires a key; guard for invalid zones returning a plain string.
  - PubChem: use PUG REST; prefer `/property` for flat dicts; `IsomericSMILES` returns as `SMILES`; `MolecularWeight` is a string; 404 yields JSON Fault; batch by comma‑separated CIDs; image PNG and SDF endpoints included.
  - GeoNames: bulk TSV downloads need no key; JSON API requires a username (demo is exhausted); API errors come as HTTP 200 with a `status` key; for zip files, encode `http_get` string as latin‑1; examples for cities, postal codes, and admin codes.

<sup>Written for commit 0fab43bb70f3edc315774e0c2fa9af3eb6d22891. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

