### PR TITLE
helpers: use certifi CA bundle for http_get

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -186,10 +186,11 @@ def upload_file(selector, path):
 
 def http_get(url, headers=None, timeout=20.0):
     """Pure HTTP — no browser. Use for static pages / APIs. Wrap in ThreadPoolExecutor for bulk."""
-    import urllib.request, gzip
+    import urllib.request, gzip, ssl, certifi
     h = {"User-Agent": "Mozilla/5.0", "Accept-Encoding": "gzip"}
     if headers: h.update(headers)
-    with urllib.request.urlopen(urllib.request.Request(url, headers=h), timeout=timeout) as r:
+    ctx = ssl.create_default_context(cafile=certifi.where())
+    with urllib.request.urlopen(urllib.request.Request(url, headers=h), timeout=timeout, context=ctx) as r:
         data = r.read()
         if r.headers.get("Content-Encoding") == "gzip": data = gzip.decompress(data)
         return data.decode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "browser-harness>=0.0.1",
     "cdp-use>=1.4.5",
+    "certifi>=2024.2.2",
     "websockets>=16.0",
 ]
 


### PR DESCRIPTION
## Summary

`http_get` called `urllib.request.urlopen` with no explicit SSL context, so it relied on whatever trust store the interpreter shipped with. On python.org's Python 3.11 for macOS the CA keychain is empty until the user runs `Install Certificates.command` — so every HTTPS call raised `CERTIFICATE_VERIFY_FAILED`.

Agents hitting this were writing `domain-skills/` files that either shelled out to `subprocess.run(['curl', '-sL', ...])` (see #88's Cover Art Archive skill) or, worse, suggested `verify=False` / `ssl.CERT_NONE` as a workaround. Fixing the tool removes the motivation.

## Changes

- `helpers.py`: build an `ssl.create_default_context(cafile=certifi.where())` and pass it to `urlopen`. Same approach `requests` / `httpx` use.
- `pyproject.toml`: add `certifi>=2024.2.2` (one tiny PyPA-maintained package; `uv sync` pulled in 2026.2.25 locally).

## Test plan

- [x] `uv sync` succeeds and installs certifi.
- [x] Smoke test: `http_get`-equivalent call to `https://api.github.com/zen` returns 200 under the new SSL context.
- [ ] Verify on a clean python.org macOS install (the trigger case).
- [ ] No regression on Homebrew Python / Linux where `urlopen` already worked.