### PR TITLE
pyproject: pin dependencies and commit uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ version = "0.1.0"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 requires-python = ">=3.11"
 dependencies = [
-    "browser-harness>=0.0.1",
-    "cdp-use>=1.4.5",
-    "websockets>=16.0",
+    "browser-harness==0.0.1",
+    "cdp-use==1.4.5",
+    "websockets==16.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

`pyproject.toml` used `>=` for all three direct dependencies, so a resolver could pull newer minors/patches on any fresh install. Move them to `==` at the currently-resolved versions so bumps have to be explicit and show up in review.

`uv.lock` stays gitignored; transitives float by design.

## Changes

- `pyproject.toml`: `>=` → `==` on `browser-harness`, `cdp-use`, `websockets`.

## Test plan

- [x] `uv sync` on a clean venv resolves and installs successfully with pinned versions.
- [ ] CI passes.