### PR TITLE
remote: paginate list_cloud_profiles; expose profile-use v1.0.4 sync flags

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -160,19 +160,27 @@ def list_cloud_profiles():
     Returns [{id, name, userId, cookieDomains, lastUsedAt}, ...]. `cookieDomains`
     is the array of domain strings the cloud profile has cookies for — use
     `len(cookieDomains)` as a cheap 'how much is logged in' summary. Per-cookie
-    detail on a *local* profile before sync: `profile-use inspect --profile <name>`."""
-    listing = _browser_use("/profiles?pageSize=200", "GET")
-    items = listing.get("items", listing) if isinstance(listing, dict) else listing
-    out = []
-    for p in items:
-        detail = _browser_use(f"/profiles/{p['id']}", "GET")
-        out.append({
-            "id": detail["id"],
-            "name": detail.get("name"),
-            "userId": detail.get("userId"),
-            "cookieDomains": detail.get("cookieDomains") or [],
-            "lastUsedAt": detail.get("lastUsedAt"),
-        })
+    detail on a *local* profile before sync: `profile-use inspect --profile <name>`.
+
+    Paginates through all pages — the API caps `pageSize` at 100."""
+    out, page = [], 1
+    while True:
+        listing = _browser_use(f"/profiles?pageSize=100&pageNumber={page}", "GET")
+        items = listing.get("items") if isinstance(listing, dict) else listing
+        if not items:
+            break
+        for p in items:
+            detail = _browser_use(f"/profiles/{p['id']}", "GET")
+            out.append({
+                "id": detail["id"],
+                "name": detail.get("name"),
+                "userId": detail.get("userId"),
+                "cookieDomains": detail.get("cookieDomains") or [],
+                "lastUsedAt": detail.get("lastUsedAt"),
+            })
+        if isinstance(listing, dict) and len(out) >= listing.get("totalItems", len(out)):
+            break
+        page += 1
     return out
 
 
@@ -224,12 +232,25 @@ def list_local_profiles():
     return json.loads(subprocess.check_output(["profile-use", "list", "--json"], text=True))
 
 
-def sync_local_profile(profile_name, browser=None):
-    """Sync a local profile's cookies into a new cloud profile. Returns the cloud UUID.
+def sync_local_profile(profile_name, browser=None, cloud_profile_id=None,
+                        include_domains=None, exclude_domains=None):
+    """Sync a local profile's cookies to a cloud profile. Returns the cloud UUID.
 
-    Shells out to `profile-use sync --profile <name> [--browser <browser>]`. Every call
-    creates a *new* cloud profile (upstream limitation — see interaction-skills/profile-sync.md).
-    Requires BROWSER_USE_API_KEY and that the target local Chrome profile is closed."""
+    Shells out to `profile-use sync` (v1.0.4+). Requires BROWSER_USE_API_KEY and the
+    target local Chrome profile to be closed (profile-use needs an exclusive lock on
+    the Cookies DB).
+
+    Args:
+      profile_name:       local Chrome profile name (as shown by `list_local_profiles`).
+      browser:            disambiguate when multiple browsers have profiles of the
+                          same name (e.g. "Google Chrome"). Default: any match.
+      cloud_profile_id:   push cookies into this existing cloud profile instead of
+                          creating a new one. Idempotent — call again to refresh
+                          the same profile. Default: create new.
+      include_domains:    only sync cookies for these domains (and subdomains).
+                          Leading dot is optional. Example: ["google.com", "stripe.com"].
+      exclude_domains:    drop cookies for these domains (and subdomains). Applied
+                          before `include_domains` so exclude wins on overlap."""
     import os, re, shutil, subprocess, sys
     if not shutil.which("profile-use"):
         raise RuntimeError("profile-use not installed -- curl -fsSL https://browser-use.com/profile.sh | sh")
@@ -238,9 +259,21 @@ def sync_local_profile(profile_name, browser=None):
     cmd = ["profile-use", "sync", "--profile", profile_name]
     if browser:
         cmd += ["--browser", browser]
+    if cloud_profile_id:
+        cmd += ["--cloud-profile-id", cloud_profile_id]
+    for d in include_domains or []:
+        cmd += ["--domain", d]
+    for d in exclude_domains or []:
+        cmd += ["--exclude-domain", d]
     r = subprocess.run(cmd, text=True, capture_output=True)
     sys.stdout.write(r.stdout)
     sys.stderr.write(r.stderr)
+    if r.returncode != 0:
+        raise RuntimeError(f"profile-use sync failed (exit {r.returncode})")
+    # With --cloud-profile-id the tool prints "♻️ Using existing cloud profile"
+    # instead of "Profile created: <uuid>", so we already know the UUID.
+    if cloud_profile_id:
+        return cloud_profile_id
     m = re.search(r"Profile created:\s+([0-9a-f-]{36})", r.stdout)
     if not m:
         raise RuntimeError(f"profile-use did not report a profile UUID (exit {r.returncode})")

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -19,8 +19,12 @@ list_cloud_profiles()
 list_local_profiles()
 # [{BrowserName, ProfileName, DisplayName, ProfilePath, ...}, ...] — detected on this machine
 
-sync_local_profile(local_profile_name, browser=None)
-# Shells out to `profile-use sync`. Returns the new cloud profile UUID.
+sync_local_profile(local_profile_name, browser=None,
+                   cloud_profile_id=None,      # update an existing cloud profile instead of creating new
+                   include_domains=None,       # only these domains (and subdomains); leading dot optional
+                   exclude_domains=None)       # drop these domains; applied before include
+# Shells out to `profile-use sync`. Returns the cloud profile UUID
+# (the existing one if cloud_profile_id was passed, else the newly-created one).
 
 start_remote_daemon("work", profileName="my-work")   # name→id resolved client-side
 start_remote_daemon("work", profileId="<uuid>")      # or pass UUID directly
@@ -48,9 +52,17 @@ for lp in list_local_profiles():
 → Agent: *"Which local profile?"* → user picks → before syncing, inspect domain-level cookie counts with `profile-use inspect --profile <name>` (or `--verbose` for individual cookies) and report the summary; never dump 500 cookies into chat.
 
 ```python
-# 3. Sync + use. Returns the new cloud UUID.
+# 3. Sync + use. Returns the cloud UUID.
 uuid = sync_local_profile("browser-use.com")
 start_remote_daemon("work", profileId=uuid)
+
+# 3b. Refresh that same cloud profile later (idempotent — no duplicate profiles).
+sync_local_profile("browser-use.com", cloud_profile_id=uuid)
+
+# 3c. Scoped: push *only* Stripe cookies into a dedicated cloud profile.
+sync_local_profile("browser-use.com",
+                   cloud_profile_id=uuid,
+                   include_domains=["stripe.com"])
 ```
 
 ## What actually gets synced
@@ -58,15 +70,6 @@ start_remote_daemon("work", profileId=uuid)
 **Cookies only.** No localStorage, no IndexedDB, no extensions. Enough for session-cookie sites (Google, GitHub, Stripe, most SaaS); not for sites that store auth in localStorage.
 
 Cookies mutated during a remote session only persist on a clean `PATCH /browsers/{id} {"action":"stop"}` — the daemon does this on shutdown when `BU_BROWSER_ID` + `BROWSER_USE_API_KEY` are set (default for remote daemons). Sessions that hit the timeout lose in-session state.
-
-## Upstream limitations
-
-These need a PR to `browser-use/profile-use` — they can't be fixed inside `browser-harness`:
-
-- `profile-use sync` **always creates a new cloud profile.** No flag to update an existing one by UUID or name. Syncing the same local profile twice produces two cloud profiles — delete the old one first (UI or `DELETE /api/v3/profiles/{id}`) if you want one-to-one mapping.
-- `profile-use sync` **uploads every cookie in the local profile.** No `--domain` / `--cookie` filter. For scoped uploads, use a dedicated local Chrome profile containing only what you want synced.
-
-The Browser Use API has no cookie upload/download endpoint — `profile-use` is the only path, so both limitations live upstream.
 
 ## Cloud profile CRUD
 


### PR DESCRIPTION
Two fixes that fell out of testing #84 against a real account.

## 1. `list_cloud_profiles` pagination

The function hit `/profiles?pageSize=200` and got **HTTP 422** back — the API caps `pageSize` at 100. Anyone with more than the default page worth of profiles was silently losing data before that, and anyone tipping past 100 hit the hard error. My own account was at 18 when I found this and climbs with every `sync_local_profile()` call, so it was about to bite.

Now paginates with `pageSize=100` until \`totalItems\` is reached.

## 2. Expose the new `profile-use` v1.0.4 flags

`profile-use` v1.0.4 (this repo's PR #84 + `browser-use/profile-use#6` + `#7`) shipped three flags that finally solve the "upstream limitations" we'd documented in \`interaction-skills/profile-sync.md\`:

- `--cloud-profile-id <uuid>` — refresh an existing cloud profile instead of creating a new one every sync.
- `--domain <d>` (repeatable) — only sync cookies for these domains (and subdomains).
- `--exclude-domain <d>` (repeatable) — drop cookies for these domains.

Wired up as kwargs on `sync_local_profile`:

```python
sync_local_profile("browser-use.com", cloud_profile_id=uuid)                    # refresh existing
sync_local_profile("browser-use.com", include_domains=["stripe.com"])           # scoped sync
sync_local_profile("browser-use.com", cloud_profile_id=uuid,                    # refresh + scope
                   include_domains=["stripe.com"])
```

Edge case: when `cloud_profile_id` is passed, `profile-use` prints \`♻️  Using existing cloud profile\` instead of \`Profile created: <uuid>\` — so the old stdout regex would fail. Short-circuited to return the caller-supplied UUID directly.

## Skill updates

`interaction-skills/profile-sync.md` — drops the entire "Upstream limitations" section (both fixed in v1.0.4) and adds two worked examples under "Chat-driven flow": refresh-same-profile and scoped-by-domain.

## Test plan

End-to-end against my real account:

```
sync_local_profile("browser-use.com", include_domains=["stripe.com"])
  → "Domain filter: 43 → 1 cookies (include=[stripe.com])"
  → cloud profile cookieDomains == ["m.stripe.com"]       ✓ scoped correctly

sync_local_profile("browser-use.com", cloud_profile_id=uuid,
                   include_domains=["stripe.com"])
  → "♻️  Using existing cloud profile"
  → returned UUID matches                                 ✓ idempotent refresh
```

Pagination verified against the 18-profile account (previously silently truncated to 10).

## Requires

`profile-use` v1.0.4+ (install via `curl -fsSL https://browser-use.com/profile.sh | sh`). Older versions will fail loudly on unknown flags — better than silent misbehaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pagination to cloud profile listing and exposes new `profile-use` v1.0.4 sync flags in `sync_local_profile`. Prevents data loss/422s and lets you refresh an existing cloud profile or scope cookies by domain.

- **New Features**
  - `sync_local_profile(..., cloud_profile_id, include_domains, exclude_domains)` maps to `--cloud-profile-id`, `--domain`, `--exclude-domain`; returns the provided UUID when updating an existing profile. Requires `profile-use` v1.0.4+.

- **Bug Fixes**
  - `list_cloud_profiles` now paginates with `pageSize=100` until `totalItems`, fixing truncation beyond the first page and 422 errors.

<sup>Written for commit a4f71abf4bed27df84257fbc42c1224cf1a4be00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

