### PR TITLE
domain-skills: atlas — my.recruitwithatlas.com

### DIFF
--- a/domain-skills/atlas/overview.md
+++ b/domain-skills/atlas/overview.md
@@ -1,0 +1,70 @@
+---
+name: atlas-recruit
+description: Atlas recruitment platform (my.recruitwithatlas.com) — routes, filters, GraphQL bootstrap for authenticated UI probes.
+---
+
+# Atlas — my.recruitwithatlas.com
+
+Gated recruitment SaaS. Auth via Google SSO (WebAuthn/passkey). GraphQL backend at `/graphql` (NextAuth session cookie, `credentials: 'include'` from the tab).
+
+## Routes
+
+| Route | What |
+|---|---|
+| `/home` | Dashboard (default landing after login) |
+| `/sign-in` | Redirect target when unauthenticated |
+| `/business-development/opportunities` | BD opportunities (kanban / list view) |
+| `/business-development/leads` | Leads |
+| `/business-development/prospects` | Prospects |
+| `/business-development/playbook` | Playbook |
+| `/candidates` | Candidate pipeline |
+| `/projects/<id>` | Specific job / project |
+| `/graphql` | Authenticated GraphQL endpoint (POST) |
+
+## Filters in URL
+
+BD opportunities uses `?filters=[JSON]` (URL-encoded). Example "Me" filter:
+
+```json
+[{"id":"opportunity_owner","selectedOptions":[{"id":"<USER_UUID>","title":"Me","excludeFromSearch":false}]}]
+```
+
+Filter IDs seen: `opportunity_owner`, `stage`, `industry`, `segment`, `conversion_probability`.
+
+## Finding your own user UUID
+
+- Apply a filter like "owner = Me" in `/business-development/opportunities`, then read `selectedOptions[0].id` out of the URL `filters=` param.
+- Or: `query { me { id email } }` via the GraphQL endpoint (see below).
+- User UUIDs are tenant-stable; keep them in a local secret store, not in this shared skill.
+
+## Stages (BD funnel)
+
+`Identified` → `Initial Outreach` → `Late Stage` → `Converted` → `Archived`. Seen as tab labels on `/business-development/opportunities`.
+
+## Auth quirks
+
+- Google SSO flows through `accounts.google.com/signin/oauth/id?...` — passkey / WebAuthn only, no password fallback visible.
+- Session state lives in multiple cookies (JWE session + CSRF). Injecting only the JWE into a fresh Chrome profile is **not sufficient** for UI access — you land in a login loop. For UI work: log in once inside a persistent Chrome profile and let all cookies settle. For backend-only GraphQL calls: the `__Secure-authjs.session-token` JWE alone is enough when sent with `cookie: __Secure-authjs.session-token=<jwe>` from an external HTTP client.
+
+## GraphQL endpoint
+
+POST `https://my.recruitwithatlas.com/graphql` using the tab's own cookies:
+
+```python
+js("""
+fetch('/graphql', {
+  method: 'POST',
+  headers: {'Content-Type': 'application/json', 'apollo-require-preflight': 'true'},
+  credentials: 'include',
+  body: JSON.stringify({query: 'query { me { id email } }'})
+}).then(r => r.json()).then(j => JSON.stringify(j))
+""")
+```
+
+This reuses the session cookies of the current tab — no JWE juggling needed when browsing from inside browser-harness.
+
+Known mutations (verified against production schema, April 2026): `opportunityCreate`, `opportunityUpdate`, `companyCreate`, `projectCreate`, `projectUpdate`, `opportunityAddLead`, `createOpportunityNote`. Create mutations return placeholder names; follow with an `opportunityUpdate` / `projectUpdate` to set the final name or description. `opportunityAddLead` side-effects `Project.company` onto `Opportunity.targetCompany` when the opp had none.
+
+## Page titles
+
+The app sets a green-dot emoji prefix on titles: `🟢 Atlas Agency` (sign-in), `🟢 Business development` (BD overview), etc. Useful for `wait_for` conditions — the emoji is consistent across routes.


### PR DESCRIPTION
## Summary

Adds a domain-skill for **Atlas** (my.recruitwithatlas.com), a gated recruitment SaaS with Google SSO + NextAuth session cookies + GraphQL backend.

Captures the durable shape of the site per CONTRIBUTING guidance:

- Route map (`/home`, `/business-development/*`, `/candidates`, `/projects/<id>`, `/graphql`)
- URL `filters=[JSON]` format with a worked "Me" example (user UUID placeholder, not hard-coded)
- How to find your own user UUID (without committing it)
- BD funnel stage labels
- Auth quirks — passkey-only Google SSO; why JWE-only cookie injection into a fresh profile causes a login loop (but works for headless backend GraphQL calls)
- `fetch('/graphql', {credentials: 'include'})` pattern from `js(...)` that reuses the tab's cookies — avoids needing to copy cookies out into an external client when running from browser-harness
- Known GraphQL mutations + the "create returns placeholder, follow with update" side effect
- The consistent green-dot title prefix (`🟢 ...`) as a useful `wait_for` hook

## Test plan

- [x] Verified routes + filter JSON against a live Atlas session
- [x] Verified GraphQL bootstrap from `js(...)` using `credentials: 'include'`
- [x] No user-specific state (UUIDs, tokens, emails) committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Atlas domain-skill that documents routes, URL filters, auth behavior, and a simple GraphQL bootstrap so probes can run authenticated UI and backend calls reliably.

- **New Features**
  - Added `domain-skills/atlas/overview.md` with a route map and BD `filters=[JSON]` example, plus how to find your own user UUID without committing it.
  - Documented Google SSO + NextAuth cookie quirks: UI requires the full cookie set; backend GraphQL can use `__Secure-authjs.session-token` alone.
  - Included a `fetch('/graphql', {credentials: 'include'})` pattern to reuse the tab’s cookies for authenticated queries.
  - Listed key mutations and the create-then-update behavior; noted the green-dot title prefix as a stable `wait_for` hook.

<sup>Written for commit 9d64aad07e3477fc34cd22af4c5ee7701295fb70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

