### PR TITLE
remote: stop_remote_daemon helper, skill updates from sub-agent testing

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -74,6 +74,17 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
 
 
+def stop_remote_daemon(name="remote"):
+    """Stop a remote daemon and its backing Browser Use cloud browser.
+
+    Triggers the daemon's clean shutdown, which PATCHes
+    /browsers/{id} {"action":"stop"} so billing ends and any profile
+    state in the session is persisted. Same implementation as
+    restart_daemon() — this alias just matches the common intent and
+    the symmetry with start_remote_daemon()."""
+    restart_daemon(name)
+
+
 def restart_daemon(name=None):
     """Best-effort daemon restart for setup/debug flows."""
     import signal

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -80,7 +80,7 @@ Cookies mutated during a remote session only persist on a clean `PATCH /browsers
 - UI: https://cloud.browser-use.com/settings?tab=profiles
 - API: `GET /profiles`, `GET/PATCH/DELETE /profiles/{id}` (paths are relative to `BU_API = "https://api.browser-use.com/api/v3"` in `admin.py`). Fields: `id`, `name`, `userId`, `lastUsedAt`, `cookieDomains[]`. `list_cloud_profiles()` wraps this.
 - Name → UUID: `profileName=` on `start_remote_daemon` resolves client-side; no API change needed.
-- Need the UUID for an existing profile? `next(p["id"] for p in list_cloud_profiles() if p["name"] == "<name>")`.
+- Need the UUID for an existing profile? `matches = [p["id"] for p in list_cloud_profiles() if p["name"] == "<name>"]` — then verify `len(matches) == 1` before using it. Profile names are not unique; syncs create duplicates unless you pass `cloud_profile_id=`.
 - Lower-level raw calls: `from admin import _browser_use; _browser_use("/profiles/<id>", "DELETE")`. Pass the path *without* the `/api/v3` prefix — it's already on `BU_API`.
 
 ## Traps

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -28,7 +28,11 @@ sync_local_profile(local_profile_name, browser=None,
 
 start_remote_daemon("work", profileName="my-work")   # name→id resolved client-side
 start_remote_daemon("work", profileId="<uuid>")      # or pass UUID directly
+
+stop_remote_daemon("work")                           # shut the daemon and PATCH the cloud browser to stop — billing ends
 ```
+
+`sync_local_profile` prints `♻️  Using existing cloud profile` when `cloud_profile_id` is accepted, or `📝  Creating remote profile...` → `✓ Profile created: <uuid>` when it creates a new one. Check that line if you want to confirm which path ran.
 
 ## Chat-driven flow (don't guess — ask the user)
 
@@ -74,11 +78,13 @@ Cookies mutated during a remote session only persist on a clean `PATCH /browsers
 ## Cloud profile CRUD
 
 - UI: https://cloud.browser-use.com/settings?tab=profiles
-- API: `GET /api/v3/profiles`, `GET/PATCH/DELETE /api/v3/profiles/{id}`. Fields: `id`, `name`, `userId`, `lastUsedAt`, `cookieDomains[]`. `list_cloud_profiles()` wraps this.
+- API: `GET /profiles`, `GET/PATCH/DELETE /profiles/{id}` (paths are relative to `BU_API = "https://api.browser-use.com/api/v3"` in `admin.py`). Fields: `id`, `name`, `userId`, `lastUsedAt`, `cookieDomains[]`. `list_cloud_profiles()` wraps this.
 - Name → UUID: `profileName=` on `start_remote_daemon` resolves client-side; no API change needed.
+- Need the UUID for an existing profile? `next(p["id"] for p in list_cloud_profiles() if p["name"] == "<name>")`.
+- Lower-level raw calls: `from admin import _browser_use; _browser_use("/profiles/<id>", "DELETE")`. Pass the path *without* the `/api/v3` prefix — it's already on `BU_API`.
 
 ## Traps
 
-- **Close the target Chrome profile before syncing.** `profile-use` reads the `Cookies` SQLite DB, which Chrome holds with an exclusive lock — `sync` hangs otherwise.
 - **Default proxy (`proxyCountryCode="us"`) blocks some destinations** with `ERR_TUNNEL_CONNECTION_FAILED` (e.g. `cloud.browser-use.com` itself). `proxyCountryCode=None` disables the BU proxy; a different country code picks a different exit.
 - **Prefer a dedicated work profile over your personal one.** Especially while testing.
+- **Older than `profile-use` v1.0.5?** Pre-1.0.5 the sync needed the Chrome profile to be closed (exclusive SQLite lock on the `Cookies` DB). v1.0.5+ copies the profile dir to a temp and syncs from the copy — Chrome can stay open.

--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@ from admin import (
     list_local_profiles,
     restart_daemon,
     start_remote_daemon,
+    stop_remote_daemon,
     sync_local_profile,
 )
 from helpers import *


### PR DESCRIPTION
Three fresh sub-agents ran realistic user prompts against the skill:

| Prompt | Verdict |
|---|---|
| \"Start a remote browser with my logged-in data\" | ✅ cookies made it; YouTube avatar CDN rendered |
| \"Stripe-only, no Google\" | ✅ cloud \`cookieDomains = ['m.stripe.com']\`, zero Google leakage |
| \"Refresh existing profile, don't duplicate\" | ✅ \`♻️ Using existing\` fired, profile count 8→8 |

All three completed end-to-end. This PR closes the doc/code seams they surfaced:

## Changes

### `admin.py`

Add \`stop_remote_daemon(name=\"remote\")\`. Sub-agents kept reaching for \`restart_daemon()\` because there was no obvious shutdown helper — the new alias pairs symmetrically with \`start_remote_daemon()\`. Same underlying implementation; the daemon's clean shutdown already PATCHes \`/browsers/{id} {\"action\":\"stop\"}\`, so this is pure naming.

### `run.py`

Pre-import \`stop_remote_daemon\` so it's callable from \`browser-harness <<'PY' ... PY\` without an extra import line.

### `interaction-skills/profile-sync.md`

- **Delete the \"close Chrome before syncing\" trap.** Obsolete on \`profile-use\` v1.0.5+ — the tool copies the profile dir to a temp and syncs from the copy. Two sub-agents verified sync works fine with Chrome open on v1.0.5. Kept a small compatibility note for anyone on older versions.
- **Document the ♻️ / 📝 reuse-vs-create signal.** Agents can now confirm \`cloud_profile_id\` was accepted by checking the \`profile-use\` output rather than diffing profile lists.
- **Clarify API path convention.** Sub-agents copy-pasted \`PATCH /api/v3/browsers/{id}\` from the doc into \`_browser_use()\` calls and hit 404s because \`BU_API\` already includes \`/api/v3\`. Paths are now shown relative, with an explicit note.
- **Add UUID-lookup one-liner.** \`next(p[\"id\"] for p in list_cloud_profiles() if p[\"name\"] == \"...\")\` — sub-agents had to rediscover this.
- **Surface \`stop_remote_daemon\`** in the Python API overview at the top.

## Not in this PR (but surfaced)

- Your account has 1,040 historical active remote browsers. I stopped 5 sub-agent-leftover ones from today's testing (~11 min old). The rest predate this session — not touching without permission.
- Sub-1 reported \`sync_local_profile\` once produced *two* cloud profiles in a single call. Likely cross-talk from three parallel sub-agents syncing the same local profile simultaneously, but worth watching on a future clean run.

## Test

- \`python -c 'import admin, run'\` clean.
- \`browser-harness <<'PY' inspect.signature(stop_remote_daemon) PY\` → \`(name='remote')\`.
- No behaviour change to existing helpers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `stop_remote_daemon` for a clean remote shutdown and updates profile-sync docs to remove outdated steps, fix API path examples, and add a safe UUID lookup pattern.

- **New Features**
  - Added `stop_remote_daemon(name="remote")` as a symmetric helper to `start_remote_daemon()` (alias to `restart_daemon()`); pre-imported in `run.py` for direct use in the harness.
  - Docs: removed the “close Chrome before syncing” trap for `profile-use` v1.0.5+, clarified that API paths are relative to `BU_API`, documented the ♻️/📝 reuse-vs-create signal, added a safe UUID lookup pattern that requires exactly one match (names aren’t unique), included raw `_browser_use` examples, and surfaced `stop_remote_daemon` in the API overview.

<sup>Written for commit 63833f63127745a5d9ae46e987755c08cb594eac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

