### PR TITLE
admin: explain why stop_remote_daemon calls restart_daemon

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -79,14 +79,21 @@ def stop_remote_daemon(name="remote"):
 
     Triggers the daemon's clean shutdown, which PATCHes
     /browsers/{id} {"action":"stop"} so billing ends and any profile
-    state in the session is persisted. Same implementation as
-    restart_daemon() — this alias just matches the common intent and
-    the symmetry with start_remote_daemon()."""
+    state in the session is persisted."""
+    # restart_daemon is misnamed — it only stops the daemon (sends
+    # shutdown, SIGTERMs if needed, unlinks socket+pid). It never
+    # restarts anything on its own; a follow-up `browser-harness`
+    # call would auto-spawn a fresh one via ensure_daemon(). That
+    # "run-it-again-to-restart" workflow is why it was named that way.
     restart_daemon(name)
 
 
 def restart_daemon(name=None):
-    """Best-effort daemon restart for setup/debug flows."""
+    """Best-effort daemon shutdown + socket/pid cleanup.
+
+    Name is historical: callers typically follow this with another
+    `browser-harness` invocation, which auto-spawns a fresh daemon via
+    ensure_daemon(). The function itself only stops."""
     import signal
 
     sock, pid_path = _paths(name)


### PR DESCRIPTION
Follow-up to #96. User flagged the confusing chain \`stop_remote_daemon → restart_daemon → \"actually stops\"\` — correct in behaviour, misleading on the page.

\`restart_daemon\` is a long-standing misnomer. It only stops the daemon (sends shutdown, SIGTERMs if needed, unlinks socket+pid). It never restarts anything on its own — the \"restart\" label came from the typical caller workflow of \`restart_daemon()\` → follow-up \`browser-harness\` invocation → \`ensure_daemon()\` spawns a fresh one. Two-step restart from the *caller's* perspective, pure stop from the function's.

Comment-only change per user request (\"just add a comment\"):
- \`stop_remote_daemon\`: inline comment explains why it dispatches to the oddly-named \`restart_daemon\`.
- \`restart_daemon\`: docstring now leads with what it actually does (\"Best-effort daemon shutdown + socket/pid cleanup\") and keeps a short note on the name's origin.

No behaviour change. A proper rename (e.g. \`restart_daemon\` → \`stop_daemon\` with the old name kept as a deprecated alias) is deferred — user opted out of that for now.

## Known-unfixed-in-this-PR (noted during review)

\`restart_daemon(name=None)\` defaults to stopping the *local* \`default\` daemon (via \`NAME = os.environ.get(\"BU_NAME\", \"default\")\`), while \`start_remote_daemon(name=\"remote\", ...)\` and \`stop_remote_daemon(name=\"remote\")\` default to \`\"remote\"\`. Pre-existing asymmetry, pre-dates this series. If you call \`restart_daemon()\` expecting to stop your remote, you'll stop your local instead. Worth a separate PR if it bites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify why `stop_remote_daemon` calls `restart_daemon` by documenting that `restart_daemon` only stops the daemon and cleans up socket/PID; it never restarts on its own. Comment-only update (inline note in `stop_remote_daemon`, docstring for `restart_daemon`); no behavior change.

<sup>Written for commit a252c89dcd9870929c5119712ce2f8a55096cf10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

