### PR TITLE
Support Windows: TCP loopback fallback for AF_UNIX + UTF-8 stdio

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,9 +1,15 @@
 import json
 import os
 import socket
+import tempfile
 import time
 import urllib.request
 from pathlib import Path
+
+# POSIX: AF_UNIX socket file. Windows: TCP loopback with port written to a
+# sibling .port file (stdlib Python on Windows is built without AF_UNIX).
+_USE_UNIX = hasattr(socket, "AF_UNIX")
+TMPDIR = "/tmp" if _USE_UNIX else tempfile.gettempdir()
 
 
 def _load_env():
@@ -26,11 +32,12 @@ BU_API = "https://api.browser-use.com/api/v3"
 
 def _paths(name):
     n = name or NAME
-    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
+    addr = os.path.join(TMPDIR, f"bu-{n}.sock" if _USE_UNIX else f"bu-{n}.port")
+    return addr, os.path.join(TMPDIR, f"bu-{n}.pid")
 
 
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
+    p = os.path.join(TMPDIR, f"bu-{name or NAME}.log")
     try:
         return Path(p).read_text().strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
@@ -38,13 +45,20 @@ def _log_tail(name):
 
 
 def daemon_alive(name=None):
+    addr = _paths(name)[0]
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(1)
-        s.connect(_paths(name)[0])
+        if _USE_UNIX:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.settimeout(1)
+            s.connect(addr)
+        else:
+            port = int(Path(addr).read_text().strip())
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(1)
+            s.connect(("127.0.0.1", port))
         s.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, ValueError):
         return False
 
 
@@ -71,7 +85,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             break
         time.sleep(0.2)
     msg = _log_tail(name)
-    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {os.path.join(TMPDIR, f'bu-{name or NAME}.log')}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -96,11 +110,17 @@ def restart_daemon(name=None):
     ensure_daemon(). The function itself only stops."""
     import signal
 
-    sock, pid_path = _paths(name)
+    addr, pid_path = _paths(name)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(5)
-        s.connect(sock)
+        if _USE_UNIX:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.settimeout(5)
+            s.connect(addr)
+        else:
+            port = int(Path(addr).read_text().strip())
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(5)
+            s.connect(("127.0.0.1", port))
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
         s.close()
@@ -110,7 +130,10 @@ def restart_daemon(name=None):
         pid = int(open(pid_path).read())
     except (FileNotFoundError, ValueError):
         pid = None
-    if pid:
+    # os.kill(pid, 0) and SIGTERM fallback are POSIX-only; on Windows
+    # os.kill with sig=0 raises OSError unconditionally. The graceful
+    # shutdown meta above handles the common case for both platforms.
+    if pid and _USE_UNIX:
         for _ in range(75):
             try:
                 os.kill(pid, 0)
@@ -122,7 +145,7 @@ def restart_daemon(name=None):
                 os.kill(pid, signal.SIGTERM)
             except ProcessLookupError:
                 pass
-    for f in (sock, pid_path):
+    for f in (addr, pid_path):
         try:
             os.unlink(f)
         except FileNotFoundError:

--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,5 @@
-"""CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.request
+"""CDP WS holder + local socket relay. One daemon per BU_NAME."""
+import asyncio, json, os, socket, sys, tempfile, time, urllib.request
 from collections import deque
 from pathlib import Path
 
@@ -21,9 +21,14 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+# POSIX uses AF_UNIX; Windows stdlib Python lacks it, so we fall back to TCP
+# loopback with the chosen ephemeral port written to a sibling .port file.
+_USE_UNIX = hasattr(socket, "AF_UNIX")
+_TMPDIR = "/tmp" if _USE_UNIX else tempfile.gettempdir()
+SOCK = os.path.join(_TMPDIR, f"bu-{NAME}.sock")
+PORT_FILE = os.path.join(_TMPDIR, f"bu-{NAME}.port")
+LOG = os.path.join(_TMPDIR, f"bu-{NAME}.log")
+PID = os.path.join(_TMPDIR, f"bu-{NAME}.pid")
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -185,9 +190,6 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
-        os.unlink(SOCK)
-
     async def handler(reader, writer):
         try:
             line = await reader.readline()
@@ -205,11 +207,29 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
-    async with server:
-        await d.stop.wait()
+    if _USE_UNIX:
+        if os.path.exists(SOCK):
+            os.unlink(SOCK)
+        server = await asyncio.start_unix_server(handler, path=SOCK)
+        os.chmod(SOCK, 0o600)
+        log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+        try:
+            async with server:
+                await d.stop.wait()
+        finally:
+            try: os.unlink(SOCK)
+            except FileNotFoundError: pass
+    else:
+        server = await asyncio.start_server(handler, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        Path(PORT_FILE).write_text(str(port))
+        log(f"listening on 127.0.0.1:{port} (name={NAME}, remote={REMOTE_ID or 'local'})")
+        try:
+            async with server:
+                await d.stop.wait()
+        finally:
+            try: os.unlink(PORT_FILE)
+            except FileNotFoundError: pass
 
 
 async def main():
@@ -220,15 +240,19 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        if _USE_UNIX:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
+            s.connect(SOCK); s.close(); return True
+        port = int(Path(PORT_FILE).read_text().strip())
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.settimeout(1)
+        s.connect(("127.0.0.1", port)); s.close(); return True
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, ValueError):
         return False
 
 
 if __name__ == "__main__":
     if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
+        print(f"daemon already running ({SOCK if _USE_UNIX else PORT_FILE})", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
     open(PID, "w").write(str(os.getpid()))

--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,5 @@
 """Browser control via CDP. Read, edit, extend -- this file is yours."""
-import base64, json, os, socket, time, urllib.request
+import base64, json, os, socket, tempfile, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -19,13 +19,23 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
+# Windows lacks socket.AF_UNIX in the stdlib build; fall back to a TCP loopback
+# port written to a sibling .port file. POSIX keeps the original unix-socket path.
+_USE_UNIX = hasattr(socket, "AF_UNIX")
+_TMPDIR = "/tmp" if _USE_UNIX else tempfile.gettempdir()
+SOCK = os.path.join(_TMPDIR, f"bu-{NAME}.sock")
+PORT_FILE = os.path.join(_TMPDIR, f"bu-{NAME}.port")
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
 def _send(req):
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
+    if _USE_UNIX:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(SOCK)
+    else:
+        port = int(Path(PORT_FILE).read_text().strip())
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(("127.0.0.1", port))
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):

--- a/run.py
+++ b/run.py
@@ -1,5 +1,14 @@
 import sys
 
+# Reconfigure stdio to UTF-8 so Windows' default CP1252 console doesn't
+# crash on non-ASCII output (e.g. the 🟢 tab-marker glyph in page titles).
+# No-op on POSIX where stdio is already UTF-8.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except (AttributeError, OSError):
+    pass
+
 from admin import (
     ensure_daemon,
     list_cloud_profiles,


### PR DESCRIPTION
## Summary

Python's stdlib `socket` module on Windows (both python.org binaries and `uv`'s CPython builds) is compiled without `HAVE_UNIX_SOCKETS`, so `socket.AF_UNIX` raises `AttributeError` at import time — even on Windows 11 where the kernel itself supports AF_UNIX. Today that blocks the harness before it can reach Chrome.

This PR keeps the POSIX path untouched and adds a Windows fallback, gated on `hasattr(socket, "AF_UNIX")`.

### What changes

- **`daemon.py`**: when `AF_UNIX` is unavailable, bind `asyncio.start_server` to `127.0.0.1:0` (ephemeral loopback port) and write the chosen port to a sibling `.port` file in the same tempdir.
- **`helpers.py` / `admin.py`**: read the `.port` file and connect over `AF_INET` instead of `AF_UNIX`.
- **`admin.py` `restart_daemon`**: skip the `os.kill(pid, 0)` polling loop on Windows (`sig=0` raises `OSError` unconditionally there). The graceful `meta="shutdown"` message still runs on both platforms.
- **`run.py`**: `sys.stdout.reconfigure(encoding="utf-8")` so Windows' default cp1252 console doesn't `UnicodeEncodeError` on the `\U0001F7E2` tab-marker glyph in page titles.

POSIX behavior is unchanged — same socket path, same `chmod 0o600`, same pid-polling. The `tempfile.gettempdir()` call only runs on Windows; POSIX continues to hardcode `/tmp` for parity with existing daemons.

No new deps. `tempfile` is stdlib.

## Design notes

- Port file over random-but-stable port: avoids collisions when multiple `BU_NAME`s run concurrently, and still cleans up on shutdown (the `finally:` block in `serve()` unlinks it).
- `0o600` is POSIX-only, so Windows silently skips it. Loopback-only binding is the analogue; anything stronger would require Windows ACL manipulation.
- Kept the existing `/tmp/bu-<name>.sock` contract on POSIX so existing daemons/docs/skills keep working. Docs (`SKILL.md`, `interaction-skills/connection.md`) still mention `/tmp/bu-*.sock` — accurate on POSIX, wrong on Windows. Happy to sweep those in a follow-up if you prefer a single PR.

## Test plan

- [x] Windows 11 + Python 3.12 + Chrome 144 + `uv 0.11.6`: `new_tab`, `goto`, `wait_for_load`, `page_info`, `screenshot`, `list_tabs`, `restart_daemon` all work end-to-end against the user's real Chrome via `chrome://inspect/#remote-debugging`.
- [ ] macOS: not tested in this PR — code path is byte-identical to current `main` on POSIX. Would appreciate a reviewer spot-check.
- [ ] Linux: same as macOS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Windows support by falling back to TCP loopback when `socket.AF_UNIX` is missing, and switch stdio to UTF‑8 to prevent Windows console encoding errors. POSIX unix-socket behavior is unchanged.

- **New Features**
  - Windows: daemon binds `127.0.0.1:0` and writes the port to a `.port` file in `tempfile.gettempdir()`.
  - Clients (`admin.py`, `helpers.py`) read the `.port` file and connect over `AF_INET`.
  - `restart_daemon`: send graceful shutdown; skip `os.kill(pid, 0)` polling on Windows.

- **Bug Fixes**
  - Reconfigure `stdout`/`stderr` to UTF‑8 to avoid `UnicodeEncodeError` on Windows consoles.

<sup>Written for commit 9c0211e0f40d87919a7943c50f3291640a5908cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

