### PR TITLE
Support Windows via cross-platform IPC (TCP loopback on Win, AF_UNIX unchanged on Unix)

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -34,12 +34,33 @@ def _log_tail(name):
 
 
 def daemon_alive(name=None):
+    # Connect-only isn't enough on Windows: if the daemon crashed and
+    # the OS reused its port for an unrelated listener, plain connect()
+    # would succeed against that other process. Send a ping with the
+    # token from the .port file and require the expected pong response
+    # so we confirm the listener is actually our daemon.
     try:
-        s = ipc.connect_client(name or NAME)
-        s.close()
-        return True
+        s, token = ipc.connect_client(name or NAME)
     except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
         return False
+    try:
+        s.settimeout(1)
+        req = {"meta": "ping"}
+        if token:
+            req["token"] = token
+        s.sendall((json.dumps(req) + "\n").encode())
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = s.recv(1024)
+            if not chunk: break
+            data += chunk
+        r = json.loads(data or b"{}")
+        return r.get("pong") is True
+    except Exception:
+        return False
+    finally:
+        try: s.close()
+        except Exception: pass
 
 
 def ensure_daemon(wait=60.0, name=None, env=None):
@@ -102,8 +123,11 @@ def restart_daemon(name=None):
     n = name or NAME
     pidp = ipc.pid_path(n)
     try:
-        s = ipc.connect_client(n, timeout=5)
-        s.sendall(b'{"meta":"shutdown"}\n')
+        s, token = ipc.connect_client(n, timeout=5)
+        req = {"meta": "shutdown"}
+        if token:
+            req["token"] = token
+        s.sendall((json.dumps(req) + "\n").encode())
         s.recv(1024)
         s.close()
     except Exception:

--- a/admin.py
+++ b/admin.py
@@ -5,6 +5,8 @@ import time
 import urllib.request
 from pathlib import Path
 
+import ipc
+
 
 def _load_env():
     p = Path(__file__).parent / ".env"
@@ -24,27 +26,19 @@ NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"
 
 
-def _paths(name):
-    n = name or NAME
-    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
-
-
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
     try:
-        return Path(p).read_text().strip().splitlines()[-1]
+        return Path(ipc.log_path(name or NAME)).read_text().strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
         return None
 
 
 def daemon_alive(name=None):
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(1)
-        s.connect(_paths(name)[0])
+        s = ipc.connect_client(name or NAME)
         s.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
         return False
 
 
@@ -52,17 +46,26 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     """Idempotent. `env` is merged into the child process env."""
     if daemon_alive(name):
         return
-    import subprocess
+    import shutil, subprocess, sys
 
     e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
-    p = subprocess.Popen(
-        ["uv", "run", "daemon.py"],
+    popen_kw = dict(
         cwd=os.path.dirname(os.path.abspath(__file__)),
         env=e,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        start_new_session=True,
     )
+    if os.name == "nt":
+        # Detach on Windows so the daemon survives the parent's exit.
+        popen_kw["creationflags"] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kw["start_new_session"] = True
+    # Prefer `uv run` when uv is on PATH (keeps Unix behaviour unchanged).
+    # Fall back to the current Python — robust when the tool runs under a
+    # uv-managed venv but `uv` itself isn't resolvable (common on Windows).
+    uv = shutil.which("uv")
+    cmd = [uv, "run", "daemon.py"] if uv else [sys.executable, "daemon.py"]
+    p = subprocess.Popen(cmd, **popen_kw)
     deadline = time.time() + wait
     while time.time() < deadline:
         if daemon_alive(name):
@@ -71,7 +74,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             break
         time.sleep(0.2)
     msg = _log_tail(name)
-    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -96,18 +99,17 @@ def restart_daemon(name=None):
     ensure_daemon(). The function itself only stops."""
     import signal
 
-    sock, pid_path = _paths(name)
+    n = name or NAME
+    pidp = ipc.pid_path(n)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(5)
-        s.connect(sock)
+        s = ipc.connect_client(n, timeout=5)
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
         s.close()
     except Exception:
         pass
     try:
-        pid = int(open(pid_path).read())
+        pid = int(open(pidp).read())
     except (FileNotFoundError, ValueError):
         pid = None
     if pid:
@@ -115,18 +117,18 @@ def restart_daemon(name=None):
             try:
                 os.kill(pid, 0)
                 time.sleep(0.2)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 break
         else:
             try:
                 os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 pass
-    for f in (sock, pid_path):
-        try:
-            os.unlink(f)
-        except FileNotFoundError:
-            pass
+    ipc.cleanup_addr(n)
+    try:
+        os.unlink(pidp)
+    except FileNotFoundError:
+        pass
 
 
 def _browser_use(path, method, body=None):

--- a/daemon.py
+++ b/daemon.py
@@ -1,9 +1,13 @@
-"""CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
+"""CDP WS holder + local socket relay. One daemon per BU_NAME.
+
+IPC is AF_UNIX on Unix, TCP loopback on Windows (see ipc.py)."""
 import asyncio, json, os, socket, sys, time, urllib.request
 from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
+
+import ipc
 
 
 def _load_env():
@@ -21,9 +25,8 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+LOG = ipc.log_path(NAME)
+PID = ipc.pid_path(NAME)
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -185,9 +188,6 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
-        os.unlink(SOCK)
-
     async def handler(reader, writer):
         try:
             line = await reader.readline()
@@ -205,9 +205,8 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    server = await ipc.start_server(NAME, handler)
+    log(f"listening on {ipc.listening_addr(NAME)} (name={NAME}, remote={REMOTE_ID or 'local'})")
     async with server:
         await d.stop.wait()
 
@@ -220,15 +219,16 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        s = ipc.connect_client(NAME, timeout=1)
+        s.close()
+        return True
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
         return False
 
 
 if __name__ == "__main__":
     if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
+        print(f"daemon already running on {ipc.listening_addr(NAME)}", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
     open(PID, "w").write(str(os.getpid()))
@@ -241,5 +241,6 @@ if __name__ == "__main__":
         sys.exit(1)
     finally:
         stop_remote()
+        ipc.cleanup_addr(NAME)
         try: os.unlink(PID)
         except FileNotFoundError: pass

--- a/daemon.py
+++ b/daemon.py
@@ -156,7 +156,18 @@ class Daemon:
         self.cdp._event_registry.handle_event = tap
 
     async def handle(self, req):
+        # On Windows, gate every request on a per-daemon token the client
+        # must have read from %TEMP%\bu-<NAME>.port. Unix has no token
+        # (AF_UNIX + chmod 600 is the boundary) so expected_token is None
+        # there and this check is a no-op.
+        expected = ipc.expected_token()
+        if expected is not None and req.get("token") != expected:
+            return {"error": "unauthorized"}
         meta = req.get("meta")
+        # Liveness probe — lets clients confirm the listener on the
+        # recorded port is actually this daemon and not an unrelated
+        # process that happened to reuse the port after a crash.
+        if meta == "ping":        return {"pong": True}
         if meta == "drain_events":
             out = list(self.events); self.events.clear()
             return {"events": out}
@@ -218,12 +229,28 @@ async def main():
 
 
 def already_running():
+    # Ping-handshake so a stale .port file + port reuse doesn't make us
+    # think an unrelated listener is our daemon.
     try:
-        s = ipc.connect_client(NAME, timeout=1)
-        s.close()
-        return True
+        s, token = ipc.connect_client(NAME, timeout=1)
     except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
         return False
+    try:
+        req = {"meta": "ping"}
+        if token:
+            req["token"] = token
+        s.sendall((json.dumps(req) + "\n").encode())
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = s.recv(1024)
+            if not chunk: break
+            data += chunk
+        return json.loads(data or b"{}").get("pong") is True
+    except Exception:
+        return False
+    finally:
+        try: s.close()
+        except Exception: pass
 
 
 if __name__ == "__main__":

--- a/helpers.py
+++ b/helpers.py
@@ -3,6 +3,8 @@ import base64, json, os, socket, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
+import ipc
+
 
 def _load_env():
     p = Path(__file__).parent / ".env"
@@ -19,13 +21,11 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
 def _send(req):
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
+    s = ipc.connect_client(NAME, timeout=30)
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):

--- a/helpers.py
+++ b/helpers.py
@@ -25,7 +25,10 @@ INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension
 
 
 def _send(req):
-    s = ipc.connect_client(NAME, timeout=30)
+    s, token = ipc.connect_client(NAME, timeout=30)
+    if token:
+        # Token-gate on Windows. connect_client returns None on Unix.
+        req = {**req, "token": token}
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):

--- a/helpers.py
+++ b/helpers.py
@@ -98,7 +98,10 @@ def scroll(x, y, dy=-300, dx=0):
 
 
 # --- visual ---
-def screenshot(path="/tmp/shot.png", full=False):
+def screenshot(path=None, full=False):
+    if path is None:
+        import tempfile
+        path = os.path.join(tempfile.gettempdir(), "shot.png")
     r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
     open(path, "wb").write(base64.b64decode(r["data"]))
     return path

--- a/ipc.py
+++ b/ipc.py
@@ -64,7 +64,7 @@ def _read_addr(name):
             d = json.loads(raw)
             return int(d["port"]), d.get("token")
         return int(raw), None
-    except (FileNotFoundError, ValueError, KeyError, OSError):
+    except (FileNotFoundError, ValueError, KeyError, TypeError, OSError):
         return None, None
 
 

--- a/ipc.py
+++ b/ipc.py
@@ -1,0 +1,87 @@
+"""Cross-platform daemon IPC.
+
+Unix: AF_UNIX socket at /tmp/bu-<NAME>.sock (unchanged).
+Windows: TCP loopback on an ephemeral port; the port number lives in
+/tmp/bu-<NAME>.port so the client can find it. %TEMP% stands in for /tmp
+on Windows via tempfile.gettempdir().
+"""
+import asyncio
+import os
+import socket
+import tempfile
+
+IS_WIN = os.name == "nt"
+
+
+def _base(name):
+    return os.path.join(tempfile.gettempdir(), f"bu-{name}")
+
+
+def sock_path(name):
+    """Address artifact path: .sock on Unix (the socket itself), .port on Windows (a text file with the TCP port)."""
+    return _base(name) + (".port" if IS_WIN else ".sock")
+
+
+def log_path(name):
+    return _base(name) + ".log"
+
+
+def pid_path(name):
+    return _base(name) + ".pid"
+
+
+def _read_port(name):
+    try:
+        return int(open(sock_path(name)).read().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def connect_client(name, timeout=1.0):
+    """Return a connected blocking socket to the daemon. Raises on failure."""
+    if IS_WIN:
+        port = _read_port(name)
+        if port is None:
+            raise FileNotFoundError(sock_path(name))
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect(("127.0.0.1", port))
+        return s
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    s.connect(sock_path(name))
+    return s
+
+
+async def start_server(name, handler):
+    """Bind the daemon server. Returns the asyncio.Server.
+
+    Unix: start_unix_server at /tmp/bu-<NAME>.sock, chmod 600.
+    Windows: start_server on 127.0.0.1:ephemeral; writes port to bu-<NAME>.port.
+    """
+    path = sock_path(name)
+    if IS_WIN:
+        server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
+        port = server.sockets[0].getsockname()[1]
+        open(path, "w").write(str(port))
+        return server
+    if os.path.exists(path):
+        os.unlink(path)
+    server = await asyncio.start_unix_server(handler, path=path)
+    os.chmod(path, 0o600)
+    return server
+
+
+def listening_addr(name):
+    """Human-readable address for logs."""
+    if IS_WIN:
+        return f"127.0.0.1:{_read_port(name) or '?'} (via {sock_path(name)})"
+    return sock_path(name)
+
+
+def cleanup_addr(name):
+    """Remove the sock/port artifact; used on shutdown."""
+    try:
+        os.unlink(sock_path(name))
+    except FileNotFoundError:
+        pass

--- a/ipc.py
+++ b/ipc.py
@@ -1,81 +1,133 @@
 """Cross-platform daemon IPC.
 
-Unix: AF_UNIX socket at /tmp/bu-<NAME>.sock (unchanged).
-Windows: TCP loopback on an ephemeral port; the port number lives in
-/tmp/bu-<NAME>.port so the client can find it. %TEMP% stands in for /tmp
-on Windows via tempfile.gettempdir().
+Unix: AF_UNIX socket at /tmp/bu-<NAME>.sock (unchanged from upstream).
+Pinned at /tmp even though tempfile.gettempdir() would work on Linux —
+macOS's gettempdir() is under /var/folders/.../T/ which can push the
+full socket path past AF_UNIX's 108-char limit.
+
+Windows: TCP loopback on an ephemeral port. The daemon writes its
+address as JSON {"port": ..., "token": "..."} to %TEMP%\\bu-<NAME>.port
+so the client can find it. A random 32-byte hex token gates every
+request, because TCP loopback has no chmod-equivalent — any process on
+the same machine could otherwise connect and issue CDP commands.
 """
 import asyncio
+import json
 import os
+import secrets
 import socket
 import tempfile
 
 IS_WIN = os.name == "nt"
 
+# Token for the currently-running daemon (populated in start_server on
+# Windows, stays None on Unix where AF_UNIX + chmod 600 is the auth).
+_server_token = None
 
-def _base(name):
+
+def _win_base(name):
     return os.path.join(tempfile.gettempdir(), f"bu-{name}")
 
 
+def _unix_sock(name):
+    # Pinned at /tmp — see module docstring.
+    return f"/tmp/bu-{name}.sock"
+
+
 def sock_path(name):
-    """Address artifact path: .sock on Unix (the socket itself), .port on Windows (a text file with the TCP port)."""
-    return _base(name) + (".port" if IS_WIN else ".sock")
+    """Address artifact path. On Unix this is the AF_UNIX socket itself;
+    on Windows it's a JSON file holding the TCP port + auth token."""
+    return _win_base(name) + ".port" if IS_WIN else _unix_sock(name)
 
 
 def log_path(name):
-    return _base(name) + ".log"
+    if IS_WIN:
+        return _win_base(name) + ".log"
+    return f"/tmp/bu-{name}.log"
 
 
 def pid_path(name):
-    return _base(name) + ".pid"
+    if IS_WIN:
+        return _win_base(name) + ".pid"
+    return f"/tmp/bu-{name}.pid"
 
 
-def _read_port(name):
+def _read_addr(name):
+    """Read the Windows .port file → (port, token). Returns (None, None)
+    on any parse failure so callers fall through to 'no daemon running'."""
     try:
-        return int(open(sock_path(name)).read().strip())
-    except (FileNotFoundError, ValueError):
-        return None
+        with open(sock_path(name)) as f:
+            raw = f.read().strip()
+        # Accept both JSON (current format) and a bare port number
+        # (previous format, kept for one release of forward-compat).
+        if raw.startswith("{"):
+            d = json.loads(raw)
+            return int(d["port"]), d.get("token")
+        return int(raw), None
+    except (FileNotFoundError, ValueError, KeyError, OSError):
+        return None, None
 
 
 def connect_client(name, timeout=1.0):
-    """Return a connected blocking socket to the daemon. Raises on failure."""
+    """Return (connected_socket, token). `token` is None on Unix (no
+    wire-level auth needed), a hex string on Windows. Callers that send
+    JSON requests MUST include the token as `req["token"]` on Windows
+    or the daemon will reject the request."""
     if IS_WIN:
-        port = _read_port(name)
+        port, token = _read_addr(name)
         if port is None:
             raise FileNotFoundError(sock_path(name))
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(timeout)
         s.connect(("127.0.0.1", port))
-        return s
+        return s, token
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     s.settimeout(timeout)
-    s.connect(sock_path(name))
-    return s
+    s.connect(_unix_sock(name))
+    return s, None
 
 
 async def start_server(name, handler):
     """Bind the daemon server. Returns the asyncio.Server.
 
-    Unix: start_unix_server at /tmp/bu-<NAME>.sock, chmod 600.
-    Windows: start_server on 127.0.0.1:ephemeral; writes port to bu-<NAME>.port.
+    Unix: start_unix_server at /tmp/bu-<NAME>.sock, chmod 600 (unchanged).
+    Windows: start_server on 127.0.0.1:ephemeral, generate a 32-byte
+    hex token, write {port, token} atomically to bu-<NAME>.port.
     """
-    path = sock_path(name)
+    global _server_token
     if IS_WIN:
         server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
         port = server.sockets[0].getsockname()[1]
-        open(path, "w").write(str(port))
+        _server_token = secrets.token_hex(32)
+        # Atomic write: write to .tmp then rename, so a concurrent reader
+        # never sees a half-written file.
+        addr_path = sock_path(name)
+        tmp = addr_path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump({"port": port, "token": _server_token}, f)
+        os.replace(tmp, addr_path)
         return server
+    path = _unix_sock(name)
     if os.path.exists(path):
         os.unlink(path)
     server = await asyncio.start_unix_server(handler, path=path)
     os.chmod(path, 0o600)
+    _server_token = None
     return server
+
+
+def expected_token():
+    """The token this daemon will accept, or None on Unix where AF_UNIX
+    + chmod 600 is the boundary. Called by daemon.handle() to gate
+    every incoming request on Windows."""
+    return _server_token
 
 
 def listening_addr(name):
     """Human-readable address for logs."""
     if IS_WIN:
-        return f"127.0.0.1:{_read_port(name) or '?'} (via {sock_path(name)})"
+        port, _ = _read_addr(name)
+        return f"127.0.0.1:{port or '?'} (via {sock_path(name)})"
     return sock_path(name)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ dependencies = [
 browser-harness = "run:main"
 
 [tool.setuptools]
-py-modules = ["run", "helpers", "daemon", "admin"]
+py-modules = ["run", "helpers", "daemon", "admin", "ipc"]

--- a/run.py
+++ b/run.py
@@ -1,5 +1,13 @@
 import sys
 
+# Force UTF-8 stdio so the ♞ daemon title marker (U+1F7E2) and other
+# non-ASCII page data survive print() on Windows' default cp1252 console.
+for stream in (sys.stdout, sys.stderr):
+    try:
+        stream.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
 from admin import (
     ensure_daemon,
     list_cloud_profiles,


### PR DESCRIPTION
## Why

Browser Harness fails immediately at import time on Windows:

```
File "admin.py", line 42, in daemon_alive
    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
AttributeError: module 'socket' has no attribute 'AF_UNIX'
```

Python on Windows does not expose `socket.AF_UNIX`, and `asyncio.start_unix_server` is not available either. The daemon IPC (one Unix socket at `/tmp/bu-<NAME>.sock` per daemon) is the only significant portability gap — everything else (CDP websocket, Chrome discovery, subprocess spawn) is already cross-platform.

## What this PR does

Introduces a thin `ipc.py` abstraction behind which:

- **Unix** keeps using `AF_UNIX` at `/tmp/bu-<NAME>.sock`, `asyncio.start_unix_server`, `chmod 600`, and `start_new_session=True` — **byte-identical to the current behavior**. Every Unix-specific line is preserved.
- **Windows** uses TCP loopback on an ephemeral port. The daemon writes its port number to `%TEMP%\bu-<NAME>.port`; the client reads it to connect. `asyncio.start_server` replaces `start_unix_server`. Subprocess spawn uses `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` instead of `start_new_session`.

Every platform branch is gated on `os.name == "nt"`, so Unix callers see zero behavioral change.

## Other small Windows fixes bundled

- `helpers.screenshot()` default path was `/tmp/shot.png`; now uses `tempfile.gettempdir()` on every platform.
- `admin.ensure_daemon` prefers `uv run daemon.py` when `uv` is on PATH, falling back to `[sys.executable, "daemon.py"]` when it is not — common on Windows where `uv tool install -e .` installs `browser-harness` globally but leaves `uv` itself in a project venv that is not on the system PATH.
- `run.py` calls `sys.stdout.reconfigure(encoding="utf-8")` at import. Harmless on Unix (already UTF-8). Necessary on Windows because the daemon prefixes the active tab's title with 🟢 (U+1F7E2), which the default cp1252 console cannot encode — `print(page_info())` raises `UnicodeEncodeError` otherwise.
- `pyproject.toml` — added `ipc` to `py-modules` so the editable install picks it up.

## Verified

Tested on Windows 11 + Python 3.13.9 against an isolated Chrome launched with `--remote-debugging-port=7341 --user-data-dir=C:\temp\bh-profile`:

- Daemon spawns detached and survives the parent's exit.
- `new_tab`, `wait_for_load`, `page_info`, `js`, `click`, `screenshot`, `cdp(...)` all work.
- `restart_daemon()` cleanly stops the daemon and unlinks the port/pid files.
- Daemon reuse on subsequent `browser-harness` invocations works (no respawn).
- No behavioral regression on helpers.py (other than the screenshot default path).

Unix behavior not retested by me — changes under `if os.name == "nt"` should leave Unix paths untouched; would appreciate a CI run or a quick local check on macOS/Linux before merge.

## Trade-offs to review

- TCP loopback on Windows means no `chmod 600` filesystem permission boundary. The port is bound to `127.0.0.1` so no external access, but any local user on the same Windows session could connect to the daemon if they discover the port. For the same-user-only threat model the upstream is designed for, I think this is acceptable — happy to tighten (e.g. token handshake) if reviewers disagree.
- Kept `uv run` as the preferred daemon invocation on Windows too (with fallback) to minimize behavioral drift. An alternative is to always use `sys.executable` — simpler but departs from the Unix convention. Preserved the existing invocation pattern instead.

## Commits

- `feat: support Windows via cross-platform IPC layer` — the core IPC abstraction.
- `fix(helpers): screenshot default path uses tempfile.gettempdir()` — one small follow-up.

Happy to squash/split on request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Windows support with a cross-platform IPC layer. Windows uses TCP loopback with a `.port` JSON file and per-daemon token; Unix keeps `AF_UNIX` sockets at `/tmp` unchanged.

- **New Features**
  - New `ipc` module abstracts IPC: Unix `/tmp/bu-<NAME>.sock`; Windows `127.0.0.1` with atomic `.port` JSON `{port, token}`. Provides `connect_client()`, `start_server()`, `listening_addr()`, `cleanup_addr()`.
  - Token auth on Windows and a `meta:"ping"` endpoint. Clients include the token; the daemon rejects unauthorized requests.
  - Detach daemon on Windows (`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`); Unix keeps `start_new_session=True`. Prefer `uv run daemon.py`, fallback to `[sys.executable, "daemon.py"]`. Added `ipc` to `py-modules`.

- **Bug Fixes**
  - Pin Unix socket path to `/tmp` to avoid macOS `AF_UNIX` path length issues.
  - Liveness checks require `{"pong": true}` to avoid false positives from stale `.port` files and port reuse.
  - Handle `TypeError` when parsing Windows `.port` JSON; invalid files now read as “no daemon running” instead of crashing.
  - `helpers.screenshot()` default path uses `tempfile.gettempdir()`; force UTF-8 on `sys.stdout`/`sys.stderr` to prevent `UnicodeEncodeError` on Windows.

<sup>Written for commit 81c014a9968b7847a44d268f7f87d717735d63a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

