### PR TITLE
Add Windows-compatible daemon IPC

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,6 +1,10 @@
 import json
 import os
 import socket
+import hashlib
+import shutil
+import sys
+import tempfile
 import time
 import urllib.request
 from pathlib import Path
@@ -22,15 +26,44 @@ _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"
+IS_WINDOWS = os.name == "nt" or not hasattr(socket, "AF_UNIX")
+RUNTIME_DIR = Path(os.environ.get("BU_RUNTIME_DIR") or tempfile.gettempdir()) / "browser-harness"
+if IS_WINDOWS:
+    RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _port_for_name(name):
+    digest = hashlib.sha256((name or NAME).encode()).digest()
+    return 37000 + int.from_bytes(digest[:2], "big") % 20000
 
 
 def _paths(name):
     n = name or NAME
+    if IS_WINDOWS:
+        return f"127.0.0.1:{_port_for_name(n)}", str(RUNTIME_DIR / f"bu-{n}.pid")
     return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
 
 
+def _log_path(name):
+    if IS_WINDOWS:
+        return str(RUNTIME_DIR / f"bu-{name or NAME}.log")
+    return f"/tmp/bu-{name or NAME}.log"
+
+
+def _client_socket(name=None):
+    sock, _ = _paths(name)
+    if IS_WINDOWS:
+        host, port = sock.rsplit(":", 1)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((host, int(port)))
+        return s
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(sock)
+    return s
+
+
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
+    p = _log_path(name)
     try:
         return Path(p).read_text().strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
@@ -39,12 +72,11 @@ def _log_tail(name):
 
 def daemon_alive(name=None):
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s = _client_socket(name)
         s.settimeout(1)
-        s.connect(_paths(name)[0])
         s.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+    except (FileNotFoundError, ConnectionRefusedError, OSError, socket.timeout):
         return False
 
 
@@ -55,8 +87,10 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     import subprocess
 
     e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
+    uv = shutil.which("uv")
+    daemon_cmd = [uv, "run", "daemon.py"] if uv else [sys.executable, "daemon.py"]
     p = subprocess.Popen(
-        ["uv", "run", "daemon.py"],
+        daemon_cmd,
         cwd=os.path.dirname(os.path.abspath(__file__)),
         env=e,
         stdout=subprocess.DEVNULL,
@@ -71,7 +105,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             break
         time.sleep(0.2)
     msg = _log_tail(name)
-    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {_log_path(name)}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -98,9 +132,8 @@ def restart_daemon(name=None):
 
     sock, pid_path = _paths(name)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s = _client_socket(name)
         s.settimeout(5)
-        s.connect(sock)
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
         s.close()
@@ -111,18 +144,26 @@ def restart_daemon(name=None):
     except (FileNotFoundError, ValueError):
         pid = None
     if pid:
-        for _ in range(75):
-            try:
-                os.kill(pid, 0)
-                time.sleep(0.2)
-            except ProcessLookupError:
-                break
-        else:
+        if IS_WINDOWS:
             try:
                 os.kill(pid, signal.SIGTERM)
             except ProcessLookupError:
                 pass
+        else:
+            for _ in range(75):
+                try:
+                    os.kill(pid, 0)
+                    time.sleep(0.2)
+                except ProcessLookupError:
+                    break
+            else:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
     for f in (sock, pid_path):
+        if IS_WINDOWS and str(f).startswith("127.0.0.1:"):
+            continue
         try:
             os.unlink(f)
         except FileNotFoundError:

--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.request
+import asyncio, hashlib, json, os, socket, sys, tempfile, time, urllib.request
 from collections import deque
 from pathlib import Path
 
@@ -21,9 +21,25 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+IS_WINDOWS = os.name == "nt" or not hasattr(socket, "AF_UNIX")
+RUNTIME_DIR = Path(os.environ.get("BU_RUNTIME_DIR") or tempfile.gettempdir()) / "browser-harness"
+if IS_WINDOWS:
+    RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _port_for_name(name):
+    digest = hashlib.sha256((name or NAME).encode()).digest()
+    return 37000 + int.from_bytes(digest[:2], "big") % 20000
+
+
+if IS_WINDOWS:
+    SOCK = f"127.0.0.1:{_port_for_name(NAME)}"
+    LOG = str(RUNTIME_DIR / f"bu-{NAME}.log")
+    PID = str(RUNTIME_DIR / f"bu-{NAME}.pid")
+else:
+    SOCK = f"/tmp/bu-{NAME}.sock"
+    LOG = f"/tmp/bu-{NAME}.log"
+    PID = f"/tmp/bu-{NAME}.pid"
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -188,7 +204,7 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
+    if not IS_WINDOWS and os.path.exists(SOCK):
         os.unlink(SOCK)
 
     async def handler(reader, writer):
@@ -208,8 +224,12 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
+    if IS_WINDOWS:
+        host, port = SOCK.rsplit(":", 1)
+        server = await asyncio.start_server(handler, host=host, port=int(port))
+    else:
+        server = await asyncio.start_unix_server(handler, path=SOCK)
+        os.chmod(SOCK, 0o600)
     log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
     async with server:
         await d.stop.wait()
@@ -223,9 +243,16 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        if IS_WINDOWS:
+            host, port = SOCK.rsplit(":", 1)
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(1)
+            s.connect((host, int(port)))
+        else:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
+            s.connect(SOCK)
+        s.close(); return True
+    except (FileNotFoundError, ConnectionRefusedError, OSError, socket.timeout):
         return False
 
 
@@ -246,3 +273,6 @@ if __name__ == "__main__":
         stop_remote()
         try: os.unlink(PID)
         except FileNotFoundError: pass
+        if not IS_WINDOWS:
+            try: os.unlink(SOCK)
+            except FileNotFoundError: pass

--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,5 @@
 """Browser control via CDP. Read, edit, extend -- this file is yours."""
-import base64, json, os, socket, time, urllib.request
+import base64, hashlib, json, os, socket, tempfile, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -19,13 +19,32 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
+IS_WINDOWS = os.name == "nt" or not hasattr(socket, "AF_UNIX")
+RUNTIME_DIR = Path(os.environ.get("BU_RUNTIME_DIR") or tempfile.gettempdir()) / "browser-harness"
+if IS_WINDOWS:
+    RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _port_for_name(name):
+    digest = hashlib.sha256((name or NAME).encode()).digest()
+    return 37000 + int.from_bytes(digest[:2], "big") % 20000
+
+
+SOCK = f"127.0.0.1:{_port_for_name(NAME)}" if IS_WINDOWS else f"/tmp/bu-{NAME}.sock"
+IPC_TIMEOUT = float(os.environ.get("BU_IPC_TIMEOUT_SEC", "30"))
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
 def _send(req):
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
+    if IS_WINDOWS:
+        host, port = SOCK.rsplit(":", 1)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(IPC_TIMEOUT)
+        s.connect((host, int(port)))
+    else:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(IPC_TIMEOUT)
+        s.connect(SOCK)
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):

--- a/run.py
+++ b/run.py
@@ -37,7 +37,8 @@ def main():
             "  PY"
         )
     ensure_daemon()
-    exec(sys.stdin.read())
+    ns = globals()
+    exec(sys.stdin.read(), ns, ns)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add deterministic localhost TCP IPC on Windows when Unix domain sockets are unavailable
- keep the existing Unix socket paths and behavior on platforms with `socket.AF_UNIX`
- store Windows runtime pid/log files under the temp `browser-harness` directory, with `BU_RUNTIME_DIR` override support
- run stdin scripts with shared globals so imports are visible to functions defined by `browser-harness run`
- use the current Python executable when `uv` is not on PATH for daemon startup
- avoid the long Unix-style PID wait on Windows daemon shutdown
- add a bounded `BU_IPC_TIMEOUT_SEC` helper timeout for stuck IPC calls

## Validation
- `python -m py_compile admin.py daemon.py helpers.py run.py`
- Windows remote Browser Harness adapter run against `https://example.com/` with direct fallback disabled
- Windows remote Browser Harness adapter run against WCCA with direct fallback disabled
- Windows remote Browser Harness adapter runs against SC official candidate pages with direct fallback disabled