### PR TITLE
Add Spotify web player playback skill

### DIFF
--- a/domain-skills/spotify/api-internals.md
+++ b/domain-skills/spotify/api-internals.md
@@ -231,6 +231,85 @@ def get_lyrics(track_id):
 
 Response: `{lyrics: {syncType, lines: [{startTimeMs, words, syllables, endTimeMs, transliteratedWords}]}, colors, hasVocalRemoval}`. `syncType` is `LINE_SYNCED`, `SYLLABLE_SYNCED` (word-level), or `UNSYNCED`. The `/image/<cover-art-url>` segment the Web Player uses is optional.
 
+## Playlist mutations
+
+Creating playlists uses a REST endpoint; adding/removing/moving tracks uses pathfinder. All share the same auth pair.
+
+### Create a playlist
+
+```python
+def create_playlist(name):
+    url = "https://spclient.wg.spotify.com/playlist/v2/playlist"
+    body = json.dumps({
+        "ops": [{"kind": "UPDATE_LIST_ATTRIBUTES",
+                 "updateListAttributes": {"newAttributes": {"values": {"name": name}}}}]
+    }).encode()
+    req = urllib.request.Request(url, data=body, headers=send_headers, method="POST")
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())   # {"uri": "spotify:playlist:<id>", "revision": "..."}
+```
+
+New playlists don't automatically appear in the user's sidebar. To show it, add it to the rootlist:
+
+```python
+def add_to_rootlist(username, playlist_uri):
+    url = f"https://spclient.wg.spotify.com/playlist/v2/user/{username}/rootlist/changes"
+    body = json.dumps({"deltas": [{
+        "ops": [{"kind": "ADD", "add": {
+            "items": [{"uri": playlist_uri, "attributes": {"timestamp": str(int(time.time()*1000))}}],
+            "addFirst": True}}],
+        "info": {"source": {"client": "WEBPLAYER"}},
+    }]}).encode()
+    urllib.request.urlopen(urllib.request.Request(url, data=body, headers=send_headers, method="POST"))
+```
+
+The `username` is available from any captured user-scoped endpoint (e.g. `/collection/v2/contains` bodies include `"username": "<id>"`).
+
+### Add / remove / move tracks
+
+Three pathfinder ops, all sharing one hash, differing by operation name:
+
+```python
+def add_tracks(playlist_uri, track_uris):
+    # Cap batches at 25 — larger calls return 200 OK but silently add nothing.
+    for i in range(0, len(track_uris), 25):
+        pathfinder("addToPlaylist", {
+            "playlistUri": playlist_uri,
+            "playlistItemUris": track_uris[i:i+25],
+            "newPosition": {"moveType": "BOTTOM_OF_PLAYLIST"},
+        })
+
+def remove_tracks(playlist_uri, uids):
+    # `uids` are per-playlist-item identifiers from fetchPlaylistContents, NOT track URIs.
+    pathfinder("removeFromPlaylist", {"playlistUri": playlist_uri, "uids": uids})
+
+def move_tracks(playlist_uri, uids, new_position):
+    pathfinder("moveItemsInPlaylist", {
+        "playlistUri": playlist_uri, "uids": uids, "newPosition": new_position,
+    })
+```
+
+**`uid` vs `uri`.** Playlist items have both: the `uri` is the track's global URI; the `uid` is a per-slot identifier unique to *this* playlist's instance of that track. `removeFromPlaylist` and `moveItemsInPlaylist` operate on `uid` (so you can have duplicates and delete one specific copy). Read them out of `fetchPlaylistContents`:
+
+```python
+r = pathfinder("fetchPlaylistContents", {
+    "uri": playlist_uri, "offset": 0, "limit": 100,
+    "includeEpisodeContentRatingsV2": False,
+})
+for item in r["data"]["playlistV2"]["content"]["items"]:
+    uid = item["uid"]
+    track = item["itemV2"]["data"]
+    # {uri, name, artists, ...}
+```
+
+### Trap: silent 25-track cap on `addToPlaylist`
+
+Calling `addToPlaylist` with >25 URIs in `playlistItemUris` returns `200` with `{"data": {"addItemsToPlaylist": {"__typename": "AddItemsToPlaylistPayload"}}}` — looks successful, adds nothing. Always batch to 25 max. The response is the same whether zero or all tracks landed; verify with `fetchPlaylistContents.totalCount` if it matters.
+
+### Using error-driven probing to find variable shapes
+
+`addToPlaylist`'s error messages directly name the variables you're missing (`VALIDATION_INVALID_TYPE_VARIABLE` → `$playlistItemUris: [String!]!` → `$newPosition: PlaylistItemPositionInput!`). See "Probing unknown operations" above — same technique works here.
+
 ## Playback control — `connect-state`
 
 ```
@@ -274,6 +353,8 @@ Everything not covered above follows the same `pathfinder(op, vars)` shape:
 | Batch curation ("saved" heart state)| `isCurated`                |
 | Search (all categories)             | `searchDesktop` (route chunk) |
 | Autocomplete / recent searches      | `searchSuggestions`, `recentSearches` |
+| Add / remove / move playlist items  | `addToPlaylist` / `removeFromPlaylist` / `moveItemsInPlaylist` |
+| Create playlist (REST)              | `POST spclient.wg.spotify.com/playlist/v2/playlist` |
 
 ## Gotchas
 

--- a/domain-skills/spotify/api-internals.md
+++ b/domain-skills/spotify/api-internals.md
@@ -47,7 +47,114 @@ for e in drain_events():
             break
 ```
 
-Save every header verbatim and reuse on replay. Tokens last ~1h — re-intercept on 401.
+Save every header verbatim and reuse on replay.
+
+## Keeping tokens fresh
+
+Bearer tokens last ~1h. Beyond that you get `HTTP 401` on every call until you refresh. Two paths, pick based on whether the browser stays open:
+
+### Fast path: piggyback on the Web Player's own refresh (~2ms reads)
+
+Install a one-shot `fetch` interceptor that caches every outgoing pathfinder/spclient call's headers. The Web Player makes these requests constantly (library navigation, metadata, connect-state heartbeats), so the cache stays <60s stale without any effort. Skip the re-intercept dance entirely.
+
+```python
+INTERCEPTOR = r"""
+(() => {
+  if (window.__authCache) return;
+  window.__authCache = null;
+  const origFetch = window.fetch;
+  window.fetch = async function(input, init) {
+    const url = typeof input === 'string' ? input : input.url;
+    if (/pathfinder|spclient\.wg|connect-state/.test(url) && init?.headers) {
+      const h = init.headers instanceof Headers ? Object.fromEntries(init.headers) : {...init.headers};
+      if (h.authorization || h.Authorization) {
+        window.__authCache = {captured_at: Date.now(), headers: h};
+      }
+    }
+    return origFetch.apply(this, arguments);
+  };
+})();
+"""
+
+# Install once per harness session — survives navigations
+cdp("Page.enable")
+cdp("Page.addScriptToEvaluateOnNewDocument", source=INTERCEPTOR)
+js(INTERCEPTOR)   # also inject into current page
+
+# Every subsequent read is ~2ms and always fresh
+def get_headers():
+    c = json.loads(js("JSON.stringify(window.__authCache)") or "null")
+    if not c:                       # cold start — wait for Web Player's first call
+        time.sleep(2)
+        c = json.loads(js("JSON.stringify(window.__authCache)") or "null")
+    return {k: v for k, v in c["headers"].items()
+            if k.lower() not in ("host", "content-length")}
+```
+
+**Measured:** full "read cache + call `/presence-view/v1/buddylist`" cycle is ~400ms, dominated by network. The token read itself is <2ms. Compared to the subprocess-based path (below), this is ~30× faster and eliminates 401 handling entirely as long as the browser tab is alive.
+
+### Fallback: subprocess-based re-intercept
+
+Use when the browser isn't attached (cron jobs, CI) or the interceptor cache is somehow dead. Slower (~10-15s per refresh) because it spawns a fresh `browser-harness` subprocess that navigates, forces a request, and drains CDP events.
+
+```python
+REINTERCEPT = r"""
+import time, json
+cdp("Network.enable")
+cdp("Network.setCacheDisabled", cacheDisabled=True)
+js("window.location.href = 'https://open.spotify.com/collection/tracks'")
+time.sleep(3)
+js('''(() => {
+  const sc = [...document.querySelectorAll('*')].filter(e => {
+    const s = getComputedStyle(e);
+    return s.overflowY === 'auto' && e.scrollHeight > e.clientHeight + 100;
+  }).sort((a,b) => b.scrollHeight - a.scrollHeight)[0];
+  if (sc) sc.scrollTop += 20000;
+})()''')
+time.sleep(3)
+for e in drain_events():
+    if e.get("method") == "Network.requestWillBeSent":
+        req = e["params"]["request"]
+        if "pathfinder" in req["url"] and "fetchLibraryTracks" in (req.get("postData") or ""):
+            json.dump(req["headers"], open("/tmp/pf_headers.json", "w"))
+            print("ok")
+            break
+else:
+    print("MISS")
+"""
+
+def reintercept():
+    r = subprocess.run(["browser-harness"], input=REINTERCEPT,
+                        capture_output=True, text=True, timeout=45)
+    return "ok" in r.stdout
+
+def call_with_retry(fn, *args, **kwargs):
+    try:
+        return fn(*args, **kwargs)
+    except urllib.error.HTTPError as e:
+        if e.code != 401: raise
+        if not reintercept(): raise
+        return fn(*args, **kwargs)   # retry once
+```
+
+### Choosing between them
+
+| Scenario                                        | Use                |
+|-------------------------------------------------|--------------------|
+| Browser attached, interactive or long-running   | Fast path          |
+| Unattended cron job, Chrome closes between runs | Fallback only      |
+| CI / server deploy without ever touching a GUI  | Neither — you need full TOTP refresh (below) |
+
+### Downsides of the fast path (know before you ship it)
+
+- **Dies with the tab.** Closing Chrome kills `window.__authCache`. Fallback is required for scripts that survive browser quits.
+- **Doesn't refresh on idle tabs off `open.spotify.com`.** The Web Player has to keep issuing requests for the cache to stay fresh. Browse to `google.com` and the cache ages out.
+- **Monkey-patches `window.fetch`.** No current detection, but not tamper-proof if Spotify ever adds feature-checks.
+- **Cache-empty cold start.** First read after a page load can be null for ~2s until the Web Player's first natural request lands. The `get_headers()` helper above sleeps once to cover this.
+
+### Full token refresh without a browser
+
+Out of scope for this doc — included here for honesty about the gap. The Web Player refreshes its own tokens by POSTing to `https://open.spotify.com/api/token` with a **TOTP-signed** payload derived from a secret embedded in the main JS bundle. Replicating it is a separate RE task: extract the TOTP secret, implement the signing, match the exact request shape. Until that's done, every long-running tool needs either a live browser (fast path) or a one-shot human re-auth (fallback).
 
 ## Persisted-query hashes
 
@@ -360,7 +467,7 @@ Everything not covered above follows the same `pathfinder(op, vars)` shape:
 
 - **Persisted-query hashes rotate.** Use `load_pathfinder_hashes()`; re-run on `PersistedQueryNotFound`.
 - **`client-token` is required.** Missing it is the #1 cause of 403. Curl/Python won't auto-add it.
-- **Tokens expire ~1h.** Re-intercept on 401.
+- **Tokens expire ~1h.** Use the fetch-interceptor fast path above; fall back to subprocess re-intercept when the browser isn't attached.
 - **`api.spotify.com/v1` is poisoned.** Even a valid Bearer hits `429` almost immediately there; use pathfinder/spclient/guc3 only.
 - **Parallelism ceiling is ~10 workers.** Connections start dropping around 20+.
 - **Never commit captured headers.** They carry user identity (Bearer + client-token). `/tmp` only.

--- a/domain-skills/spotify/api-internals.md
+++ b/domain-skills/spotify/api-internals.md
@@ -1,0 +1,285 @@
+# Spotify — Web Player Internals (Pathfinder + REST)
+
+The Web Player's private APIs. Replay its GraphQL (pathfinder) and REST calls with the session's own tokens — library extraction, search, lyrics, and playback control all become single HTTP calls instead of UI work.
+
+Companion files: `playback.md` for UI automation, `scraping.md` for no-auth HTTP.
+
+---
+
+## Core pattern
+
+Three endpoints cover everything in this file. They share the same Bearer+client-token auth pair.
+
+| Purpose              | URL                                                                    |
+|----------------------|------------------------------------------------------------------------|
+| GraphQL (pathfinder) | `POST https://api-partner.spotify.com/pathfinder/v2/query`             |
+| REST (spclient)      | `GET/POST https://spclient.wg.spotify.com/...`                         |
+| Player commands      | `POST https://guc3-spclient.spotify.com/connect-state/v1/player/command/...` |
+
+Do **not** use `api.spotify.com/v1` — it's IP-rate-limited and a single burst earns a ~22h ban. Stick to pathfinder/spclient/guc3 even when you have a valid token.
+
+## Extracting both tokens
+
+Pathfinder requires `Authorization: Bearer <user-token>` **and** `client-token: <client-token>`. Without `client-token` you get `403 Forbidden`. Intercept any pathfinder request to grab both:
+
+```python
+import time, json
+from helpers import cdp, drain_events, js
+
+cdp("Network.enable")
+cdp("Network.setCacheDisabled", cacheDisabled=True)
+js("window.location.href = 'https://open.spotify.com/collection/tracks'")
+time.sleep(3)
+js("""(() => {
+  const sc = [...document.querySelectorAll('*')].filter(e => {
+    const s = getComputedStyle(e);
+    return s.overflowY === 'auto' && e.scrollHeight > e.clientHeight + 100;
+  }).sort((a,b) => b.scrollHeight - a.scrollHeight)[0];
+  if (sc) sc.scrollTop = 20000;
+})()""")
+time.sleep(3)
+
+for e in drain_events():
+    if e.get("method") == "Network.requestWillBeSent":
+        req = e["params"]["request"]
+        if "pathfinder" in req["url"] and "fetchLibraryTracks" in (req.get("postData") or ""):
+            json.dump(req["headers"], open("/tmp/pf_headers.json", "w"))
+            break
+```
+
+Save every header verbatim and reuse on replay. Tokens last ~1h — re-intercept on 401.
+
+## Persisted-query hashes
+
+Pathfinder uses persisted queries. The hash is `SHA256(query_text)` — public protocol info derived from the JS bundle, not user-specific. It rotates when Spotify ships a new bundle, so never hardcode it.
+
+```python
+import urllib.request, re, gzip
+from helpers import http_get
+
+def load_pathfinder_hashes():
+    """Return {operationName: sha256Hash} for every op in the main Web Player bundle."""
+    html = http_get("https://open.spotify.com/")
+    bundles = re.findall(r'https://open\.spotifycdn\.com/cdn/build/web-player/[^"\'\s]+\.js', html)
+    ops = {}
+    for url in bundles:
+        try:
+            src = http_get(url, timeout=60)
+        except Exception:
+            continue
+        for op, h in re.findall(r'\("(\w+)","(?:query|mutation|subscription)","([0-9a-f]{64})"', src):
+            ops[op] = h
+    return ops
+
+OPS = load_pathfinder_hashes()   # ~100 ops from the main bundle
+```
+
+Cache the result; only re-run on `PersistedQueryNotFound`.
+
+### Lazy-loaded route chunks hide more ops
+
+The main bundle has ~100 ops. Route-specific ones (search, recent searches, some modal flows) live in lazy-loaded `xpui-routes-*.<hash>.js` chunks. `searchDesktop`, `browseAll`, and 11 search-type variants all live in `xpui-routes-search.<hash>.js`.
+
+The chunk URLs baked into the main bundle's webpack manifest don't resolve via direct HTTPS. Trigger the route in the browser so its chunk loads, then read `performance`:
+
+```python
+js("window.location.href = 'https://open.spotify.com/search/anything'")
+time.sleep(3)
+chunk_js = js("""(async () => {
+  const urls = [...new Set(performance.getEntriesByType('resource')
+    .map(e => e.name)
+    .filter(u => /xpui-routes-[^/]*\\.[a-f0-9]+\\.js$/.test(u)))];
+  const out = {};
+  for (const url of urls) {
+    try { out[url] = await (await fetch(url)).text(); } catch(e) {}
+  }
+  return out;
+})()""")
+for src in chunk_js.values():
+    for op, h in re.findall(r'\\("(\\w+)","(?:query|mutation|subscription)","([0-9a-f]{64})"', src):
+        OPS[op] = h
+```
+
+## Shared `pathfinder()` helper
+
+Every subsequent example uses this — load headers once, call ops by name.
+
+```python
+import json, urllib.request
+headers = json.load(open("/tmp/pf_headers.json"))
+headers = {k: v for k, v in headers.items() if k.lower() not in ("host", "content-length")}
+
+def pathfinder(op, variables, version="v2"):
+    body = json.dumps({
+        "variables": variables,
+        "operationName": op,
+        "extensions": {"persistedQuery": {"version": 1, "sha256Hash": OPS[op]}},
+    }).encode()
+    req = urllib.request.Request(
+        f"https://api-partner.spotify.com/pathfinder/{version}/query",
+        data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read())
+```
+
+## Library extraction
+
+### Liked Songs — `fetchLibraryTracks` (paginated)
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+first = pathfinder("fetchLibraryTracks", {"offset": 0, "limit": 1})
+total = first["data"]["me"]["library"]["tracks"]["totalCount"]
+
+with ThreadPoolExecutor(max_workers=10) as ex:
+    pages = list(ex.map(
+        lambda o: pathfinder("fetchLibraryTracks", {"offset": o, "limit": 50}),
+        range(0, total, 50)))
+
+tracks = [
+    {
+        "uri":     it["track"]["_uri"],
+        "name":    it["track"]["data"]["name"],
+        "artists": [(a["uri"].split(":")[-1], a["profile"]["name"])
+                    for a in it["track"]["data"]["artists"]["items"]],
+        "addedAt": it["addedAt"]["isoString"],
+    }
+    for p in pages for it in p["data"]["me"]["library"]["tracks"]["items"]
+]
+# Seconds instead of minutes, regardless of library size.
+```
+
+Response shape:
+```
+data.me.library.tracks.totalCount   # int
+data.me.library.tracks.items[]      # UserLibraryTrackResponse
+  .addedAt.isoString
+  .track._uri                       # "spotify:track:<id>"
+  .track.data.{name, artists, albumOfTrack}
+```
+
+### Everything else — `libraryV3`
+
+Saved albums, followed artists, playlists, folders — one op, swap `filters`:
+
+```python
+def lib_page(filters, order="Recents", offset=0, limit=50, text=""):
+    return pathfinder("libraryV3", {
+        "filters": filters, "order": order, "textFilter": text,
+        "offset": offset, "limit": limit,
+    })
+
+albums    = lib_page(["Albums"])     # item.__typename = AlbumResponseWrapper
+artists   = lib_page(["Artists"])    # ArtistResponseWrapper
+playlists = lib_page(["Playlists"])  # PlaylistResponseWrapper
+```
+
+No `totalCount`; walk until the returned page is shorter than `limit`. Valid `order` values come back in the response itself under `availableSortOrders` — typically `"Recents"`, `"Recently Added"`, `"Alphabetical"`, `"Creator"`.
+
+### Probing unknown operations
+
+Invalid values come back as structured responses with `__typename: "Library*Error"` and a plain-text `message`. Probe, read the error, iterate — much faster than reading the minified bundle:
+
+```python
+r = pathfinder("libraryV3", {"filters": ["Albums"], "order": "RECENTLY_ADDED", "offset": 0, "limit": 5, "textFilter": ""})
+# data.me.libraryV3 = {
+#   "__typename": "LibraryInvalidSortOrderIdError",
+#   "message": "RECENTLY_ADDED is not a valid sort order",
+#   "invalidSortOrderId": "RECENTLY_ADDED"
+# }
+```
+
+## Search — `searchDesktop`
+
+Closes `scraping.md`'s "search is not accessible via http_get" gap. Lives in the lazy route chunk (extract hashes with the chunk trick above).
+
+```python
+def search(term, limit=10):
+    r = pathfinder("searchDesktop", {
+        "searchTerm": term, "offset": 0, "limit": limit, "numberOfTopResults": 5,
+        "includeAudiobooks": False, "includeArtistHasConcertsField": False,
+        "includePreReleases": False, "includeLocalConcertsField": False,
+    })
+    return r["data"]["searchV2"]
+
+# Returns all sections in one call (~1s):
+# { topResultsV2, tracksV2, albumsV2, artists, playlists,
+#   podcasts, episodes, genres, users, chipOrder }
+```
+
+Type-specific variants in the same chunk, cheaper when you want one category: `searchTracks`, `searchAlbums`, `searchArtists`, `searchPlaylists`, `searchPodcasts`, `searchEpisodes`, `searchAudiobooks`, `searchGenres`, `searchUsers`.
+
+`searchSuggestions` is autocomplete only — returns `SearchAutoCompleteEntity` strings plus a handful of typed hits. Not a full search.
+
+## Lyrics — `color-lyrics` (REST)
+
+Not pathfinder. Regular REST on `spclient.wg.spotify.com`, same auth pair.
+
+```python
+def get_lyrics(track_id):
+    url = f"https://spclient.wg.spotify.com/color-lyrics/v2/track/{track_id}?format=json&market=from_token"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None      # no lyrics for this track
+        raise
+```
+
+Response: `{lyrics: {syncType, lines: [{startTimeMs, words, syllables, endTimeMs, transliteratedWords}]}, colors, hasVocalRemoval}`. `syncType` is `LINE_SYNCED`, `SYLLABLE_SYNCED` (word-level), or `UNSYNCED`. The `/image/<cover-art-url>` segment the Web Player uses is optional.
+
+## Playback control — `connect-state`
+
+```
+POST https://guc3-spclient.spotify.com/connect-state/v1/player/command/from/<device-id>/to/<device-id>
+```
+
+`<device-id>` is a 40-char hex string from any live request URL (e.g. the `track-playback/v1/devices/<id>/state` puts you see while something is playing). Returns `HTTP 200` with `{"ack_id": "..."}`.
+
+**Play a context** (track/album/playlist/collection). `skip_to.track_uri` optionally jumps to a specific track inside a playlist:
+```json
+{"command": {
+  "context": {"uri": "spotify:track:4PTG3Z6ehGkBFwjybzWkR8", "url": "context://spotify:track:4PTG3Z6ehGkBFwjybzWkR8", "metadata": {}},
+  "play_origin": {"feature_identifier": "harness"},
+  "options": {"license": "tft", "skip_to": {}, "player_options_override": {}},
+  "logging_params": {"command_id": "<uuid>"},
+  "endpoint": "play"
+}}
+```
+
+**Queue a track:**
+```json
+{"command": {
+  "track": {"uri": "spotify:track:4PTG3Z6ehGkBFwjybzWkR8", "metadata": {"is_queued": "true"}, "provider": "queue"},
+  "endpoint": "add_to_queue",
+  "logging_params": {"command_id": "<uuid>"}
+}}
+```
+
+## Operation reference
+
+Everything not covered above follows the same `pathfinder(op, vars)` shape:
+
+| Action                              | `operationName`            |
+|-------------------------------------|----------------------------|
+| Saved tracks (Liked Songs)          | `fetchLibraryTracks`       |
+| Saved albums / artists / playlists  | `libraryV3`                |
+| Full playlist contents              | `fetchPlaylist`            |
+| Album page                          | `getAlbum` / `queryAlbumTracks` |
+| Artist overview                     | `queryArtistOverview` / `queryArtistDiscographyAlbums` |
+| Is-saved check, N URIs              | `areEntitiesInLibrary`     |
+| Batch curation ("saved" heart state)| `isCurated`                |
+| Search (all categories)             | `searchDesktop` (route chunk) |
+| Autocomplete / recent searches      | `searchSuggestions`, `recentSearches` |
+
+## Gotchas
+
+- **Persisted-query hashes rotate.** Use `load_pathfinder_hashes()`; re-run on `PersistedQueryNotFound`.
+- **`client-token` is required.** Missing it is the #1 cause of 403. Curl/Python won't auto-add it.
+- **Tokens expire ~1h.** Re-intercept on 401.
+- **`api.spotify.com/v1` is poisoned.** Even a valid Bearer hits `429` almost immediately there; use pathfinder/spclient/guc3 only.
+- **Parallelism ceiling is ~10 workers.** Connections start dropping around 20+.
+- **Never commit captured headers.** They carry user identity (Bearer + client-token). `/tmp` only.

--- a/domain-skills/spotify/playback.md
+++ b/domain-skills/spotify/playback.md
@@ -89,7 +89,7 @@ Spotify IDs can be looked up via the oEmbed / embed approaches in `scraping.md` 
 
 ## Fast path: hijack the Web Player's internal GraphQL (pathfinder)
 
-Scrolling a virtualized list to extract a user's library is slow (~5 minutes for ~3.8k Liked Songs, with gaps from virtualization). The Web Player itself paginates via `api-partner.spotify.com/pathfinder/v2/query` — hijack its auth headers and replay the persisted query in parallel. 77 parallel requests covered 3,849 tracks in **4.5s**, with 100% coverage (15+ tracks more than the scroll path caught).
+Scrolling a virtualized list to extract a user's library is slow (minutes for a multi-thousand-song library) and misses tracks due to virtualization gaps. The Web Player itself paginates via `api-partner.spotify.com/pathfinder/v2/query` — hijack its auth headers and replay the persisted query in parallel. Measured in seconds regardless of library size, with 100% coverage.
 
 ### Why not `api.spotify.com/v1`?
 
@@ -127,6 +127,37 @@ for e in drain_events():
 
 Save every header — `Authorization`, `client-token`, `app-platform`, `spotify-app-version`, `accept`, `content-type`, etc. — and reuse them verbatim on your replay requests. Both tokens last ~1 hour; re-intercept when you start getting 401s.
 
+### Getting the persisted-query hash (don't hardcode it)
+
+Persisted-query hashes rotate when Spotify ships a new bundle. Look them up at runtime from the public Web Player JS — no auth, no browser needed. Every operation the Web Player can make is registered as `new X.l("<opName>","query"|"mutation","<sha256>",null)` in the main bundle.
+
+```python
+import urllib.request, re, gzip
+from helpers import http_get
+
+def load_pathfinder_hashes():
+    """Return {operationName: sha256Hash} for every pathfinder op the Web Player knows."""
+    html = http_get("https://open.spotify.com/")
+    bundles = re.findall(r'https://open\.spotifycdn\.com/cdn/build/web-player/[^"\'\s]+\.js', html)
+    ops = {}
+    for url in bundles:
+        try:
+            js = http_get(url, timeout=60)
+        except Exception:
+            continue
+        for op, h in re.findall(r'\("(\w+)","(?:query|mutation|subscription)","([0-9a-f]{64})"', js):
+            ops[op] = h
+    return ops
+
+OPS = load_pathfinder_hashes()
+# {'fetchLibraryTracks': '087278b2...', 'fetchPlaylist': '32b05e92...',
+#  'getAlbum': 'b9bfabef...', 'queryArtistOverview': '7f86ff63...',
+#  'isCurated': 'e4ed1f91...', 'areEntitiesInLibrary': '13433799...',  ...}
+# ~100 operations total; one HTTP round-trip per bundle (typically 3 bundles).
+```
+
+Cache the result — the hashes only change on bundle rollouts, so re-parsing on every call is wasteful. Invalidate when you see `PersistedQueryNotFound`.
+
 ### Replaying `fetchLibraryTracks` (Liked Songs in parallel)
 
 ```python
@@ -136,7 +167,7 @@ from concurrent.futures import ThreadPoolExecutor
 headers = json.load(open("/tmp/pf_headers.json"))
 headers = {k: v for k, v in headers.items() if k.lower() not in ("host", "content-length")}
 
-HASH = "087278b20b743578a6262c2b0b4bcd20d879c503cc359a2285baf083ef944240"  # verified 2026-04-19
+HASH = OPS["fetchLibraryTracks"]   # from load_pathfinder_hashes()
 
 def fetch_page(offset, limit=50):
     body = json.dumps({
@@ -150,7 +181,7 @@ def fetch_page(offset, limit=50):
     with urllib.request.urlopen(req, timeout=20) as r:
         return json.loads(r.read())
 
-# Hit /me endpoint first to get totalCount, then fan out
+# Hit the endpoint once to get totalCount, then fan out
 first = fetch_page(0, 1)
 total = first["data"]["me"]["library"]["tracks"]["totalCount"]
 offsets = list(range(0, total, 50))
@@ -169,7 +200,7 @@ for page in pages:
                         for a in t["artists"]["items"]],
             "addedAt": item["addedAt"]["isoString"],
         })
-# ~4-5s for ~3.8k tracks at 10 workers.
+# Order-of-magnitude: seconds instead of minutes, regardless of library size.
 ```
 
 ### Response shape (fetchLibraryTracks)
@@ -198,7 +229,7 @@ Watch the Network tab while doing each action; each persisted-query hash comes s
 
 ### Gotchas
 
-- **Persisted-query hashes rotate.** The SHA256 above is a snapshot. If you start getting `PersistedQueryNotFound` errors, re-intercept — don't hardcode the hash in long-lived code without a fallback that reads it from the Web Player bundle or a live request.
+- **Persisted-query hashes rotate.** Never hardcode them. Bundle rollouts invalidate cached hashes; use `load_pathfinder_hashes()` above and re-run it when you see `PersistedQueryNotFound`.
 - **`client-token` is required.** 403 without it. Easy to miss because every browser tool auto-includes it; curl / Python do not.
 - **Tokens expire ~1h.** Plan for re-interception, or run the extraction → API batch in one session.
 - **Don't cross-use with `/v1`.** The same Bearer token is treated as rate-limit-poisoned on `api.spotify.com/v1` even if it works on pathfinder. Pick a lane.

--- a/domain-skills/spotify/playback.md
+++ b/domain-skills/spotify/playback.md
@@ -1,0 +1,86 @@
+# Spotify — Web Player Playback
+
+Field-tested against open.spotify.com on 2026-04-19. Requires the user to be logged in to the Web Player.
+
+---
+
+## Trap: coordinate clicks don't trigger playback
+
+`click(x, y)` on a play button or a track row is the obvious move, but Spotify's React handlers **do not fire** on `Input.dispatchMouseEvent`. The row visibly highlights and the tooltip appears, but the player state does not change.
+
+Drive playback through the DOM instead:
+
+```python
+js("""document.querySelector('button[aria-label="Play BKJB by Nation"]').click()""")
+```
+
+This is one of the cases in the SKILL.md "if compositor clicks are the wrong tool" bucket. Use coordinate clicks only for things that aren't reactive buttons (e.g. scrubber position on the progress bar).
+
+## Stable selector: `aria-label="Play <Track> by <Artist>"`
+
+Every in-page play button — top result, song rows, artist/album tiles — exposes the same aria-label shape:
+
+- Song row:       `Play <Track> by <Artist>`
+- Album/playlist: `Play <Album name>` / `Play <Playlist name>`
+- Top Result:     aria-label is just `Play` — use `[data-testid="top-result-card"] button[aria-label="Play"]` to scope.
+
+These survive React re-renders and are exact-match unique, so `querySelector` via aria-label is more reliable than DOM position.
+
+## Search URL pattern
+
+```
+https://open.spotify.com/search/<url-encoded query>
+```
+
+Loads full search results SSR-free (client-side render). No need to click into the search box and type — navigate directly, then `wait_for_load()` + a short `wait(2)` for React to hydrate.
+
+```python
+from urllib.parse import quote
+new_tab(f"https://open.spotify.com/search/{quote('bkjb nation')}")
+wait_for_load(); wait(2)
+js('document.querySelector(\'button[aria-label="Play BKJB by Nation"]\').click()')
+```
+
+## Player state selectors
+
+Read current playback state without screenshots:
+
+| What                 | Selector                                                 | Value        |
+|----------------------|----------------------------------------------------------|--------------|
+| Current track title  | `[data-testid="context-item-link"]`                      | `innerText`  |
+| Current artist       | `[data-testid="context-item-info-artist"]`               | `innerText`  |
+| Play/pause state     | `[data-testid="control-button-playpause"]`               | aria-label is `"Play"` (paused) or `"Pause"` (playing) |
+| Now-playing widget   | `[data-testid="now-playing-widget"]`                     | presence check |
+| Top result card      | `[data-testid="top-result-card"]`                        | scope container |
+
+```python
+state = js("""(() => ({
+  title:   document.querySelector('[data-testid="context-item-link"]')?.innerText,
+  artist:  document.querySelector('[data-testid="context-item-info-artist"]')?.innerText,
+  state:   document.querySelector('[data-testid="control-button-playpause"]')?.getAttribute('aria-label'),
+}))()""")
+# {'title': 'BKJB', 'artist': 'Nation', 'state': 'Pause'}  # state='Pause' means currently playing
+```
+
+Invert the `state` field when reading — the button shows the *action available*, not the current state.
+
+## Deep links that skip search entirely
+
+If you already have a Spotify ID, prefer a direct URL over search → click:
+
+```
+https://open.spotify.com/track/<id>     # opens the track page, then click the big Play
+https://open.spotify.com/album/<id>
+https://open.spotify.com/playlist/<id>
+```
+
+On the track/album page the main play button is `button[data-testid="play-button"]` (also has aria-label `Play` / `Pause`).
+
+Spotify IDs can be looked up via the oEmbed / embed approaches in `scraping.md` without needing a browser.
+
+## Traps
+
+- **Row-hover tooltip ≠ play triggered.** If a screenshot shows the "Play X by Y" tooltip appearing over a row, that only means the hover fired. Verify with the `control-button-playpause` aria-label, not the tooltip.
+- **First track title may lag.** Immediately after clicking, `context-item-link` can still show the *previous* track for ~500ms. Sleep 1-2 seconds before reading, or poll until the title changes.
+- **Coordinate click on the play-button area sometimes works on the top-result card but not on song rows.** Don't rely on it — use the DOM click path everywhere for consistency.
+- **Autoplay policies.** If the tab has never had user interaction, Chrome may block audio autoplay. The UI will show "Pause" (meaning it thinks it's playing) but no audio comes out. A real `click()` (dispatched via the DOM) counts as a user gesture for this purpose; navigating with `new_tab` + DOM click has been reliable.

--- a/domain-skills/spotify/playback.md
+++ b/domain-skills/spotify/playback.md
@@ -216,16 +216,71 @@ data.me.library.tracks.items[]         # UserLibraryTrackResponse
   .track.data.albumOfTrack             # album metadata
 ```
 
-### Other pathfinder operations to intercept the same way
+### Non-track library: `libraryV3`
 
-Watch the Network tab while doing each action; each persisted-query hash comes straight off the request body:
+Tracks use `fetchLibraryTracks` (above). **Every other library type** — saved albums, followed artists, playlists, folders — goes through one unified op, `libraryV3`. Swap the `filters` variable to pivot between them.
+
+```python
+HASH = OPS["libraryV3"]
+
+def lib_page(filters, order="Recents", offset=0, limit=50, text=""):
+    body = json.dumps({
+        "variables": {"filters": filters, "order": order, "textFilter": text, "offset": offset, "limit": limit},
+        "operationName": "libraryV3",
+        "extensions": {"persistedQuery": {"version": 1, "sha256Hash": HASH}},
+    }).encode()
+    req = urllib.request.Request("https://api-partner.spotify.com/pathfinder/v2/query",
+                                  data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read())
+
+albums    = lib_page(["Albums"])     # AlbumResponseWrapper
+artists   = lib_page(["Artists"])    # ArtistResponseWrapper
+playlists = lib_page(["Playlists"])  # PlaylistResponseWrapper
+# No totalCount in the response — walk until the returned page is shorter than `limit`.
+```
+
+Valid `order` values come back in the response itself under `availableSortOrders`: `"Recents"`, `"Recently Added"`, `"Alphabetical"`, `"Creator"`.
+
+Response shape:
+```
+data.me.libraryV3.__typename = "LibraryPage"
+data.me.libraryV3.availableSortOrders[]  # [{id, name}] — self-documenting
+data.me.libraryV3.items[]                # one per saved item
+  .addedAt.isoString
+  .item.__typename                       # AlbumResponseWrapper | ArtistResponseWrapper | PlaylistResponseWrapper
+  .item._uri                             # "spotify:album:..." etc.
+  .item.data                             # typed payload (Album|Artist|Playlist)
+```
+
+### Probing an unknown operation
+
+When you don't know what variables an op takes, pathfinder hands you the answer for free: invalid values come back as structured GraphQL responses with `__typename: "Library*Error"` (or similar) and a plain-text `message`. Probe, read the error, iterate.
+
+```python
+r = lib_page(["Albums"], order="RECENTLY_ADDED")
+# -> data.me.libraryV3 = {
+#      "__typename": "LibraryInvalidSortOrderIdError",
+#      "message": "RECENTLY_ADDED is not a valid sort order",
+#      "invalidSortOrderId": "RECENTLY_ADDED"
+#    }
+```
+
+Much faster than reading the minified bundle. Works for any pathfinder op that returns union types.
+
+### Other pathfinder operations worth knowing
+
+Watch the Network tab while doing each action; each persisted-query hash comes out of `load_pathfinder_hashes()` — no need to scrape request bodies.
 
 | Action                              | `operationName`            |
 |-------------------------------------|----------------------------|
-| Load Liked Songs (paginated)        | `fetchLibraryTracks`       |
-| Load a playlist                     | `fetchPlaylist`            |
-| Load album/artist pages             | `getAlbum` / `queryArtistOverview` |
-| Batch track metadata                | `TracksMetadata` (takes `{uris: [...]}` — seen in every page load) |
+| Saved tracks (Liked Songs)          | `fetchLibraryTracks`       |
+| Saved albums / followed artists / playlists | `libraryV3` (see above) |
+| Full playlist contents              | `fetchPlaylist`            |
+| Album page                          | `getAlbum` / `queryAlbumTracks` |
+| Artist overview                     | `queryArtistOverview` / `queryArtistDiscographyAlbums` |
+| Is-saved check, N URIs              | `areEntitiesInLibrary`     |
+| Batch curation flags                | `isCurated` (for "saved" heart state) |
 
 ### Gotchas
 

--- a/domain-skills/spotify/playback.md
+++ b/domain-skills/spotify/playback.md
@@ -153,10 +153,40 @@ OPS = load_pathfinder_hashes()
 # {'fetchLibraryTracks': '087278b2...', 'fetchPlaylist': '32b05e92...',
 #  'getAlbum': 'b9bfabef...', 'queryArtistOverview': '7f86ff63...',
 #  'isCurated': 'e4ed1f91...', 'areEntitiesInLibrary': '13433799...',  ...}
-# ~100 operations total; one HTTP round-trip per bundle (typically 3 bundles).
+# ~100 operations from the main bundle.
 ```
 
 Cache the result — the hashes only change on bundle rollouts, so re-parsing on every call is wasteful. Invalidate when you see `PersistedQueryNotFound`.
+
+#### Lazy-loaded route chunks hide extra ops
+
+The main bundle only contains ~100 ops. **Route-specific operations** (search, recent searches, some modal flows) live in lazy-loaded `xpui-routes-*.<hash>.js` chunks that the Web Player fetches on demand. `searchDesktop`, `browseAll`, `searchTracks`, `searchAlbums`, `searchArtists`, `searchPlaylists`, `searchPodcasts`, `searchEpisodes`, `searchAudiobooks`, `searchGenres`, `searchUsers`, `searchTopResultsOnly`, `searchTopResultsList` are all in `xpui-routes-search.<hash>.js`, for example.
+
+To get these, trigger the route in the browser so its chunk loads, then read it out of `performance` inside the page:
+
+```python
+# Make the route load its chunk
+js("window.location.href = 'https://open.spotify.com/search/anything'")
+time.sleep(3)
+
+# Fetch each route chunk via the page's own fetch (cache hit, no network)
+chunk_js = js("""(async () => {
+  const entries = performance.getEntriesByType('resource')
+    .map(e => e.name)
+    .filter(u => /xpui-routes-[^/]*\\.[a-f0-9]+\\.js$/.test(u));
+  const out = {};
+  for (const url of [...new Set(entries)]) {
+    try { out[url] = await (await fetch(url)).text(); } catch(e) {}
+  }
+  return out;
+})()""")
+
+for url, src in chunk_js.items():
+    for op, h in re.findall(r'\\("(\\w+)","(?:query|mutation|subscription)","([0-9a-f]{64})"', src):
+        OPS[op] = h
+```
+
+Scrape what you need from the main bundle first; fall back to triggering the relevant route only when the op you want isn't found. Missing chunk URLs (e.g. bare filenames inside the main bundle's webpack chunk manifest) don't resolve via direct HTTPS — you have to fetch through the browser's resolved URL or via `performance.getEntriesByType('resource')`.
 
 ### Replaying `fetchLibraryTracks` (Liked Songs in parallel)
 
@@ -268,6 +298,91 @@ r = lib_page(["Albums"], order="RECENTLY_ADDED")
 
 Much faster than reading the minified bundle. Works for any pathfinder op that returns union types.
 
+### Search: `searchDesktop` (+ type-specific variants)
+
+`scraping.md` notes search as "not accessible via http_get". It is — just not from the main bundle. `searchDesktop` lives in the `xpui-routes-search` chunk (see "Lazy-loaded route chunks" above for extraction).
+
+```python
+HASH = OPS["searchDesktop"]
+
+def search(term, limit=10):
+    body = json.dumps({
+        "variables": {
+            "searchTerm": term, "offset": 0, "limit": limit, "numberOfTopResults": 5,
+            "includeAudiobooks": False, "includeArtistHasConcertsField": False,
+            "includePreReleases": False, "includeLocalConcertsField": False,
+        },
+        "operationName": "searchDesktop",
+        "extensions": {"persistedQuery": {"version": 1, "sha256Hash": HASH}},
+    }).encode()
+    req = urllib.request.Request("https://api-partner.spotify.com/pathfinder/v2/query",
+                                  data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.loads(r.read())["data"]["searchV2"]
+
+# Returns all sections in one call (~1s):
+# { topResultsV2, tracksV2, albumsV2, artists, playlists,
+#   podcasts, episodes, genres, users, chipOrder }
+```
+
+Type-specific variants live alongside it in the same chunk — use them when you only want one category, they're cheaper: `searchTracks`, `searchAlbums`, `searchArtists`, `searchPlaylists`, `searchPodcasts`, `searchEpisodes`, `searchAudiobooks`, `searchGenres`, `searchUsers`.
+
+`searchSuggestions` is different — it's the autocomplete op, returns a mix of `SearchAutoCompleteEntity` strings and a handful of typed results. Useful for "what would the dropdown show?", not for full search.
+
+### Lyrics: `color-lyrics` REST endpoint
+
+Not a pathfinder op — a regular REST endpoint on `spclient.wg.spotify.com`. Same auth pair (Bearer + client-token).
+
+```python
+def get_lyrics(track_id):
+    url = f"https://spclient.wg.spotify.com/color-lyrics/v2/track/{track_id}?format=json&market=from_token"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None  # no lyrics for this track
+        raise
+```
+
+Response: `{lyrics: {syncType, lines: [{startTimeMs, words, syllables, endTimeMs, transliteratedWords}]}, colors, hasVocalRemoval}`. `syncType` is `LINE_SYNCED`, `SYLLABLE_SYNCED` (word-level), or `UNSYNCED`. The `/image/<cover-art-url>` path segment the Web Player uses is **optional** — the minimal URL above works.
+
+404 simply means no lyrics exist. Tracks missing lyrics include most instrumental/obscure releases.
+
+### Playback control via `connect-state`
+
+Not pathfinder — a REST endpoint on `guc3-spclient.spotify.com`. Same auth pair.
+
+```
+POST https://guc3-spclient.spotify.com/connect-state/v1/player/command/from/<device-id>/to/<device-id>
+```
+
+`<device-id>` is a 40-char hex string the Web Player uses for its own session. Capture it from any live request URL (e.g. the `track-playback/v1/devices/<id>/state` puts you see during playback).
+
+**Play a track/album/playlist/collection context:**
+```json
+{"command": {
+  "context": {"uri": "spotify:track:...", "url": "context://spotify:track:...", "metadata": {}},
+  "play_origin": {"feature_identifier": "harness"},
+  "options": {"license": "tft", "skip_to": {"track_uri": "spotify:track:..."}, "player_options_override": {}},
+  "logging_params": {"command_id": "<uuid>"},
+  "endpoint": "play"
+}}
+```
+`skip_to.track_uri` is optional — use it to jump to a specific track inside a playlist/album context.
+
+**Queue a track:**
+```json
+{"command": {
+  "track": {"uri": "spotify:track:...", "metadata": {"is_queued": "true"}, "provider": "queue"},
+  "endpoint": "add_to_queue",
+  "logging_params": {"command_id": "<uuid>"}
+}}
+```
+
+Both return `HTTP 200` with `{"ack_id": "..."}`. No DOM clicks needed; playback starts within ~500ms of the 200 coming back.
+
 ### Other pathfinder operations worth knowing
 
 Watch the Network tab while doing each action; each persisted-query hash comes out of `load_pathfinder_hashes()` — no need to scrape request bodies.
@@ -281,6 +396,8 @@ Watch the Network tab while doing each action; each persisted-query hash comes o
 | Artist overview                     | `queryArtistOverview` / `queryArtistDiscographyAlbums` |
 | Is-saved check, N URIs              | `areEntitiesInLibrary`     |
 | Batch curation flags                | `isCurated` (for "saved" heart state) |
+| Search (all categories)             | `searchDesktop` (route chunk — see above) |
+| Autocomplete / recent               | `searchSuggestions`, `recentSearches` |
 
 ### Gotchas
 

--- a/domain-skills/spotify/playback.md
+++ b/domain-skills/spotify/playback.md
@@ -84,3 +84,123 @@ Spotify IDs can be looked up via the oEmbed / embed approaches in `scraping.md` 
 - **First track title may lag.** Immediately after clicking, `context-item-link` can still show the *previous* track for ~500ms. Sleep 1-2 seconds before reading, or poll until the title changes.
 - **Coordinate click on the play-button area sometimes works on the top-result card but not on song rows.** Don't rely on it — use the DOM click path everywhere for consistency.
 - **Autoplay policies.** If the tab has never had user interaction, Chrome may block audio autoplay. The UI will show "Pause" (meaning it thinks it's playing) but no audio comes out. A real `click()` (dispatched via the DOM) counts as a user gesture for this purpose; navigating with `new_tab` + DOM click has been reliable.
+
+---
+
+## Fast path: hijack the Web Player's internal GraphQL (pathfinder)
+
+Scrolling a virtualized list to extract a user's library is slow (~5 minutes for ~3.8k Liked Songs, with gaps from virtualization). The Web Player itself paginates via `api-partner.spotify.com/pathfinder/v2/query` — hijack its auth headers and replay the persisted query in parallel. 77 parallel requests covered 3,849 tracks in **4.5s**, with 100% coverage (15+ tracks more than the scroll path caught).
+
+### Why not `api.spotify.com/v1`?
+
+The classic Web API at `api.spotify.com/v1/*` is IP-rate-limited aggressively — even with a valid user Bearer token, expect `429 API rate limit exceeded` within a handful of calls (scraping.md documents `Retry-After` of 22 hours on anonymous tokens). Pathfinder has separate, much looser limits because the Web Player hammers it on every page load.
+
+### Extracting both tokens
+
+Pathfinder requires two headers that are easy to miss: `Authorization: Bearer <user-token>` **and** `client-token: <client-token>`. Without `client-token` you get `403 Forbidden`. Intercept any pathfinder request to grab both:
+
+```python
+import time, json
+from helpers import cdp, drain_events, js
+
+cdp("Network.enable")
+cdp("Network.setCacheDisabled", cacheDisabled=True)
+# Force a fresh pathfinder call — navigate to a virtualized page, then scroll
+js("window.location.href = 'https://open.spotify.com/collection/tracks'")
+time.sleep(3)
+js("""(() => {
+  const sc = [...document.querySelectorAll('*')].filter(e => {
+    const s = getComputedStyle(e);
+    return s.overflowY === 'auto' && e.scrollHeight > e.clientHeight + 100;
+  }).sort((a,b) => b.scrollHeight - a.scrollHeight)[0];
+  if (sc) sc.scrollTop = 20000;
+})()""")
+time.sleep(3)
+
+for e in drain_events():
+    if e.get("method") == "Network.requestWillBeSent":
+        req = e["params"]["request"]
+        if "pathfinder" in req["url"] and "fetchLibraryTracks" in (req.get("postData") or ""):
+            json.dump(req["headers"], open("/tmp/pf_headers.json", "w"))
+            break
+```
+
+Save every header — `Authorization`, `client-token`, `app-platform`, `spotify-app-version`, `accept`, `content-type`, etc. — and reuse them verbatim on your replay requests. Both tokens last ~1 hour; re-intercept when you start getting 401s.
+
+### Replaying `fetchLibraryTracks` (Liked Songs in parallel)
+
+```python
+import json, urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+headers = json.load(open("/tmp/pf_headers.json"))
+headers = {k: v for k, v in headers.items() if k.lower() not in ("host", "content-length")}
+
+HASH = "087278b20b743578a6262c2b0b4bcd20d879c503cc359a2285baf083ef944240"  # verified 2026-04-19
+
+def fetch_page(offset, limit=50):
+    body = json.dumps({
+        "variables": {"offset": offset, "limit": limit},
+        "operationName": "fetchLibraryTracks",
+        "extensions": {"persistedQuery": {"version": 1, "sha256Hash": HASH}},
+    }).encode()
+    req = urllib.request.Request(
+        "https://api-partner.spotify.com/pathfinder/v2/query",
+        data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read())
+
+# Hit /me endpoint first to get totalCount, then fan out
+first = fetch_page(0, 1)
+total = first["data"]["me"]["library"]["tracks"]["totalCount"]
+offsets = list(range(0, total, 50))
+
+with ThreadPoolExecutor(max_workers=10) as ex:
+    pages = list(ex.map(fetch_page, offsets))
+
+tracks = []
+for page in pages:
+    for item in page["data"]["me"]["library"]["tracks"]["items"]:
+        t = item["track"]["data"]
+        tracks.append({
+            "uri":     item["track"]["_uri"],
+            "name":    t["name"],
+            "artists": [(a["uri"].split(":")[-1], a["profile"]["name"])
+                        for a in t["artists"]["items"]],
+            "addedAt": item["addedAt"]["isoString"],
+        })
+# ~4-5s for ~3.8k tracks at 10 workers.
+```
+
+### Response shape (fetchLibraryTracks)
+
+```
+data.me.library.tracks.totalCount      # int
+data.me.library.tracks.pagingInfo      # {limit, offset}
+data.me.library.tracks.items[]         # UserLibraryTrackResponse
+  .addedAt.isoString                   # when liked
+  .track._uri                          # "spotify:track:<id>"
+  .track.data.name                     # track title
+  .track.data.artists.items[]          # list of {uri, profile.name}
+  .track.data.albumOfTrack             # album metadata
+```
+
+### Other pathfinder operations to intercept the same way
+
+Watch the Network tab while doing each action; each persisted-query hash comes straight off the request body:
+
+| Action                              | `operationName`            |
+|-------------------------------------|----------------------------|
+| Load Liked Songs (paginated)        | `fetchLibraryTracks`       |
+| Load a playlist                     | `fetchPlaylist`            |
+| Load album/artist pages             | `getAlbum` / `queryArtistOverview` |
+| Batch track metadata                | `TracksMetadata` (takes `{uris: [...]}` — seen in every page load) |
+
+### Gotchas
+
+- **Persisted-query hashes rotate.** The SHA256 above is a snapshot. If you start getting `PersistedQueryNotFound` errors, re-intercept — don't hardcode the hash in long-lived code without a fallback that reads it from the Web Player bundle or a live request.
+- **`client-token` is required.** 403 without it. Easy to miss because every browser tool auto-includes it; curl / Python do not.
+- **Tokens expire ~1h.** Plan for re-interception, or run the extraction → API batch in one session.
+- **Don't cross-use with `/v1`.** The same Bearer token is treated as rate-limit-poisoned on `api.spotify.com/v1` even if it works on pathfinder. Pick a lane.
+- **Parallelism ceiling is ~10 workers.** Spotify starts dropping connections around 20+ concurrent. 10 is a good default for `ThreadPoolExecutor`.
+- **Do not commit captured headers.** They contain user identity (Bearer + client-token). `/tmp` staging is fine; a repo file is not.

--- a/domain-skills/spotify/playback.md
+++ b/domain-skills/spotify/playback.md
@@ -1,409 +1,64 @@
-# Spotify — Web Player Playback
+# Spotify — Web Player UI Automation
 
-Field-tested against open.spotify.com on 2026-04-19. Requires the user to be logged in to the Web Player.
+Driving open.spotify.com's player via the DOM. For HTTP-only library/search/lyrics/playback, see `api-internals.md` — it's usually faster than clicking through the UI. Use this file when you genuinely need the user's visible tab to do the work.
 
----
+Requires the user to be logged in to the Web Player.
 
 ## Trap: coordinate clicks don't trigger playback
 
-`click(x, y)` on a play button or a track row is the obvious move, but Spotify's React handlers **do not fire** on `Input.dispatchMouseEvent`. The row visibly highlights and the tooltip appears, but the player state does not change.
-
-Drive playback through the DOM instead:
+`click(x, y)` on a play button or track row is the obvious move, but Spotify's React handlers **do not fire** on `Input.dispatchMouseEvent`. The row visibly highlights and the tooltip appears, but player state does not change. Drive playback through the DOM instead:
 
 ```python
-js("""document.querySelector('button[aria-label="Play BKJB by Nation"]').click()""")
+js("""document.querySelector('button[aria-label="Play Never Gonna Give You Up by Rick Astley"]').click()""")
 ```
 
-This is one of the cases in the SKILL.md "if compositor clicks are the wrong tool" bucket. Use coordinate clicks only for things that aren't reactive buttons (e.g. scrubber position on the progress bar).
+One of the SKILL.md "if compositor clicks are the wrong tool" cases. Reserve `click(x, y)` for non-reactive targets (e.g. the scrubber position on the progress bar).
 
 ## Stable selector: `aria-label="Play <Track> by <Artist>"`
 
-Every in-page play button — top result, song rows, artist/album tiles — exposes the same aria-label shape:
+Every in-page play button exposes the same aria-label shape — it survives React re-renders and is exact-match unique, so `querySelector` via aria-label beats DOM position.
 
 - Song row:       `Play <Track> by <Artist>`
 - Album/playlist: `Play <Album name>` / `Play <Playlist name>`
-- Top Result:     aria-label is just `Play` — use `[data-testid="top-result-card"] button[aria-label="Play"]` to scope.
-
-These survive React re-renders and are exact-match unique, so `querySelector` via aria-label is more reliable than DOM position.
-
-## Search URL pattern
-
-```
-https://open.spotify.com/search/<url-encoded query>
-```
-
-Loads full search results SSR-free (client-side render). No need to click into the search box and type — navigate directly, then `wait_for_load()` + a short `wait(2)` for React to hydrate.
-
-```python
-from urllib.parse import quote
-new_tab(f"https://open.spotify.com/search/{quote('bkjb nation')}")
-wait_for_load(); wait(2)
-js('document.querySelector(\'button[aria-label="Play BKJB by Nation"]\').click()')
-```
+- Top Result:     just `Play` — scope with `[data-testid="top-result-card"] button[aria-label="Play"]`
+- Collab tracks:  `Play <Track> by <Artist A>, <Artist B>` (full comma-joined list)
 
 ## Player state selectors
 
-Read current playback state without screenshots:
+Read playback state without screenshots:
 
-| What                 | Selector                                                 | Value        |
-|----------------------|----------------------------------------------------------|--------------|
-| Current track title  | `[data-testid="context-item-link"]`                      | `innerText`  |
-| Current artist       | `[data-testid="context-item-info-artist"]`               | `innerText`  |
-| Play/pause state     | `[data-testid="control-button-playpause"]`               | aria-label is `"Play"` (paused) or `"Pause"` (playing) |
-| Now-playing widget   | `[data-testid="now-playing-widget"]`                     | presence check |
-| Top result card      | `[data-testid="top-result-card"]`                        | scope container |
+| What                 | Selector                                                 | Value                                          |
+|----------------------|----------------------------------------------------------|------------------------------------------------|
+| Current track title  | `[data-testid="context-item-link"]`                      | `innerText`                                    |
+| Current artist       | `[data-testid="context-item-info-artist"]`               | `innerText`                                    |
+| Play/pause state     | `[data-testid="control-button-playpause"]`               | aria-label `"Play"` (paused) / `"Pause"` (playing) |
+| Now-playing widget   | `[data-testid="now-playing-widget"]`                     | presence check                                 |
 
 ```python
 state = js("""(() => ({
-  title:   document.querySelector('[data-testid="context-item-link"]')?.innerText,
-  artist:  document.querySelector('[data-testid="context-item-info-artist"]')?.innerText,
-  state:   document.querySelector('[data-testid="control-button-playpause"]')?.getAttribute('aria-label'),
+  title:  document.querySelector('[data-testid="context-item-link"]')?.innerText,
+  artist: document.querySelector('[data-testid="context-item-info-artist"]')?.innerText,
+  state:  document.querySelector('[data-testid="control-button-playpause"]')?.getAttribute('aria-label'),
 }))()""")
-# {'title': 'BKJB', 'artist': 'Nation', 'state': 'Pause'}  # state='Pause' means currently playing
 ```
 
-Invert the `state` field when reading — the button shows the *action available*, not the current state.
+**Invert the `state` field** — the button shows the *action available*, not the current state. `state == "Pause"` means currently playing.
 
-## Deep links that skip search entirely
-
-If you already have a Spotify ID, prefer a direct URL over search → click:
+## URL patterns
 
 ```
-https://open.spotify.com/track/<id>     # opens the track page, then click the big Play
+https://open.spotify.com/search/<url-encoded query>   # client-side search results page
+https://open.spotify.com/track/<id>                   # track page (big Play button)
 https://open.spotify.com/album/<id>
 https://open.spotify.com/playlist/<id>
+https://open.spotify.com/collection/tracks            # your Liked Songs
 ```
 
-On the track/album page the main play button is `button[data-testid="play-button"]` (also has aria-label `Play` / `Pause`).
+Navigate directly, then `wait_for_load()` + a short `wait(2)` for React to hydrate. On track/album pages the main play button is `button[data-testid="play-button"]` (same `Play`/`Pause` aria-label convention).
 
-Spotify IDs can be looked up via the oEmbed / embed approaches in `scraping.md` without needing a browser.
+Spotify IDs can be looked up via oEmbed / embed (see `scraping.md`) or via `searchDesktop` (see `api-internals.md`), both without a browser.
 
 ## Traps
 
-- **Row-hover tooltip ≠ play triggered.** If a screenshot shows the "Play X by Y" tooltip appearing over a row, that only means the hover fired. Verify with the `control-button-playpause` aria-label, not the tooltip.
-- **First track title may lag.** Immediately after clicking, `context-item-link` can still show the *previous* track for ~500ms. Sleep 1-2 seconds before reading, or poll until the title changes.
-- **Coordinate click on the play-button area sometimes works on the top-result card but not on song rows.** Don't rely on it — use the DOM click path everywhere for consistency.
-- **Autoplay policies.** If the tab has never had user interaction, Chrome may block audio autoplay. The UI will show "Pause" (meaning it thinks it's playing) but no audio comes out. A real `click()` (dispatched via the DOM) counts as a user gesture for this purpose; navigating with `new_tab` + DOM click has been reliable.
-
----
-
-## Fast path: hijack the Web Player's internal GraphQL (pathfinder)
-
-Scrolling a virtualized list to extract a user's library is slow (minutes for a multi-thousand-song library) and misses tracks due to virtualization gaps. The Web Player itself paginates via `api-partner.spotify.com/pathfinder/v2/query` — hijack its auth headers and replay the persisted query in parallel. Measured in seconds regardless of library size, with 100% coverage.
-
-### Why not `api.spotify.com/v1`?
-
-The classic Web API at `api.spotify.com/v1/*` is IP-rate-limited aggressively — even with a valid user Bearer token, expect `429 API rate limit exceeded` within a handful of calls (scraping.md documents `Retry-After` of 22 hours on anonymous tokens). Pathfinder has separate, much looser limits because the Web Player hammers it on every page load.
-
-### Extracting both tokens
-
-Pathfinder requires two headers that are easy to miss: `Authorization: Bearer <user-token>` **and** `client-token: <client-token>`. Without `client-token` you get `403 Forbidden`. Intercept any pathfinder request to grab both:
-
-```python
-import time, json
-from helpers import cdp, drain_events, js
-
-cdp("Network.enable")
-cdp("Network.setCacheDisabled", cacheDisabled=True)
-# Force a fresh pathfinder call — navigate to a virtualized page, then scroll
-js("window.location.href = 'https://open.spotify.com/collection/tracks'")
-time.sleep(3)
-js("""(() => {
-  const sc = [...document.querySelectorAll('*')].filter(e => {
-    const s = getComputedStyle(e);
-    return s.overflowY === 'auto' && e.scrollHeight > e.clientHeight + 100;
-  }).sort((a,b) => b.scrollHeight - a.scrollHeight)[0];
-  if (sc) sc.scrollTop = 20000;
-})()""")
-time.sleep(3)
-
-for e in drain_events():
-    if e.get("method") == "Network.requestWillBeSent":
-        req = e["params"]["request"]
-        if "pathfinder" in req["url"] and "fetchLibraryTracks" in (req.get("postData") or ""):
-            json.dump(req["headers"], open("/tmp/pf_headers.json", "w"))
-            break
-```
-
-Save every header — `Authorization`, `client-token`, `app-platform`, `spotify-app-version`, `accept`, `content-type`, etc. — and reuse them verbatim on your replay requests. Both tokens last ~1 hour; re-intercept when you start getting 401s.
-
-### Getting the persisted-query hash (don't hardcode it)
-
-Persisted-query hashes rotate when Spotify ships a new bundle. Look them up at runtime from the public Web Player JS — no auth, no browser needed. Every operation the Web Player can make is registered as `new X.l("<opName>","query"|"mutation","<sha256>",null)` in the main bundle.
-
-```python
-import urllib.request, re, gzip
-from helpers import http_get
-
-def load_pathfinder_hashes():
-    """Return {operationName: sha256Hash} for every pathfinder op the Web Player knows."""
-    html = http_get("https://open.spotify.com/")
-    bundles = re.findall(r'https://open\.spotifycdn\.com/cdn/build/web-player/[^"\'\s]+\.js', html)
-    ops = {}
-    for url in bundles:
-        try:
-            js = http_get(url, timeout=60)
-        except Exception:
-            continue
-        for op, h in re.findall(r'\("(\w+)","(?:query|mutation|subscription)","([0-9a-f]{64})"', js):
-            ops[op] = h
-    return ops
-
-OPS = load_pathfinder_hashes()
-# {'fetchLibraryTracks': '087278b2...', 'fetchPlaylist': '32b05e92...',
-#  'getAlbum': 'b9bfabef...', 'queryArtistOverview': '7f86ff63...',
-#  'isCurated': 'e4ed1f91...', 'areEntitiesInLibrary': '13433799...',  ...}
-# ~100 operations from the main bundle.
-```
-
-Cache the result — the hashes only change on bundle rollouts, so re-parsing on every call is wasteful. Invalidate when you see `PersistedQueryNotFound`.
-
-#### Lazy-loaded route chunks hide extra ops
-
-The main bundle only contains ~100 ops. **Route-specific operations** (search, recent searches, some modal flows) live in lazy-loaded `xpui-routes-*.<hash>.js` chunks that the Web Player fetches on demand. `searchDesktop`, `browseAll`, `searchTracks`, `searchAlbums`, `searchArtists`, `searchPlaylists`, `searchPodcasts`, `searchEpisodes`, `searchAudiobooks`, `searchGenres`, `searchUsers`, `searchTopResultsOnly`, `searchTopResultsList` are all in `xpui-routes-search.<hash>.js`, for example.
-
-To get these, trigger the route in the browser so its chunk loads, then read it out of `performance` inside the page:
-
-```python
-# Make the route load its chunk
-js("window.location.href = 'https://open.spotify.com/search/anything'")
-time.sleep(3)
-
-# Fetch each route chunk via the page's own fetch (cache hit, no network)
-chunk_js = js("""(async () => {
-  const entries = performance.getEntriesByType('resource')
-    .map(e => e.name)
-    .filter(u => /xpui-routes-[^/]*\\.[a-f0-9]+\\.js$/.test(u));
-  const out = {};
-  for (const url of [...new Set(entries)]) {
-    try { out[url] = await (await fetch(url)).text(); } catch(e) {}
-  }
-  return out;
-})()""")
-
-for url, src in chunk_js.items():
-    for op, h in re.findall(r'\\("(\\w+)","(?:query|mutation|subscription)","([0-9a-f]{64})"', src):
-        OPS[op] = h
-```
-
-Scrape what you need from the main bundle first; fall back to triggering the relevant route only when the op you want isn't found. Missing chunk URLs (e.g. bare filenames inside the main bundle's webpack chunk manifest) don't resolve via direct HTTPS — you have to fetch through the browser's resolved URL or via `performance.getEntriesByType('resource')`.
-
-### Replaying `fetchLibraryTracks` (Liked Songs in parallel)
-
-```python
-import json, urllib.request
-from concurrent.futures import ThreadPoolExecutor
-
-headers = json.load(open("/tmp/pf_headers.json"))
-headers = {k: v for k, v in headers.items() if k.lower() not in ("host", "content-length")}
-
-HASH = OPS["fetchLibraryTracks"]   # from load_pathfinder_hashes()
-
-def fetch_page(offset, limit=50):
-    body = json.dumps({
-        "variables": {"offset": offset, "limit": limit},
-        "operationName": "fetchLibraryTracks",
-        "extensions": {"persistedQuery": {"version": 1, "sha256Hash": HASH}},
-    }).encode()
-    req = urllib.request.Request(
-        "https://api-partner.spotify.com/pathfinder/v2/query",
-        data=body, headers=headers, method="POST")
-    with urllib.request.urlopen(req, timeout=20) as r:
-        return json.loads(r.read())
-
-# Hit the endpoint once to get totalCount, then fan out
-first = fetch_page(0, 1)
-total = first["data"]["me"]["library"]["tracks"]["totalCount"]
-offsets = list(range(0, total, 50))
-
-with ThreadPoolExecutor(max_workers=10) as ex:
-    pages = list(ex.map(fetch_page, offsets))
-
-tracks = []
-for page in pages:
-    for item in page["data"]["me"]["library"]["tracks"]["items"]:
-        t = item["track"]["data"]
-        tracks.append({
-            "uri":     item["track"]["_uri"],
-            "name":    t["name"],
-            "artists": [(a["uri"].split(":")[-1], a["profile"]["name"])
-                        for a in t["artists"]["items"]],
-            "addedAt": item["addedAt"]["isoString"],
-        })
-# Order-of-magnitude: seconds instead of minutes, regardless of library size.
-```
-
-### Response shape (fetchLibraryTracks)
-
-```
-data.me.library.tracks.totalCount      # int
-data.me.library.tracks.pagingInfo      # {limit, offset}
-data.me.library.tracks.items[]         # UserLibraryTrackResponse
-  .addedAt.isoString                   # when liked
-  .track._uri                          # "spotify:track:<id>"
-  .track.data.name                     # track title
-  .track.data.artists.items[]          # list of {uri, profile.name}
-  .track.data.albumOfTrack             # album metadata
-```
-
-### Non-track library: `libraryV3`
-
-Tracks use `fetchLibraryTracks` (above). **Every other library type** — saved albums, followed artists, playlists, folders — goes through one unified op, `libraryV3`. Swap the `filters` variable to pivot between them.
-
-```python
-HASH = OPS["libraryV3"]
-
-def lib_page(filters, order="Recents", offset=0, limit=50, text=""):
-    body = json.dumps({
-        "variables": {"filters": filters, "order": order, "textFilter": text, "offset": offset, "limit": limit},
-        "operationName": "libraryV3",
-        "extensions": {"persistedQuery": {"version": 1, "sha256Hash": HASH}},
-    }).encode()
-    req = urllib.request.Request("https://api-partner.spotify.com/pathfinder/v2/query",
-                                  data=body, headers=headers, method="POST")
-    with urllib.request.urlopen(req, timeout=20) as r:
-        return json.loads(r.read())
-
-albums    = lib_page(["Albums"])     # AlbumResponseWrapper
-artists   = lib_page(["Artists"])    # ArtistResponseWrapper
-playlists = lib_page(["Playlists"])  # PlaylistResponseWrapper
-# No totalCount in the response — walk until the returned page is shorter than `limit`.
-```
-
-Valid `order` values come back in the response itself under `availableSortOrders`: `"Recents"`, `"Recently Added"`, `"Alphabetical"`, `"Creator"`.
-
-Response shape:
-```
-data.me.libraryV3.__typename = "LibraryPage"
-data.me.libraryV3.availableSortOrders[]  # [{id, name}] — self-documenting
-data.me.libraryV3.items[]                # one per saved item
-  .addedAt.isoString
-  .item.__typename                       # AlbumResponseWrapper | ArtistResponseWrapper | PlaylistResponseWrapper
-  .item._uri                             # "spotify:album:..." etc.
-  .item.data                             # typed payload (Album|Artist|Playlist)
-```
-
-### Probing an unknown operation
-
-When you don't know what variables an op takes, pathfinder hands you the answer for free: invalid values come back as structured GraphQL responses with `__typename: "Library*Error"` (or similar) and a plain-text `message`. Probe, read the error, iterate.
-
-```python
-r = lib_page(["Albums"], order="RECENTLY_ADDED")
-# -> data.me.libraryV3 = {
-#      "__typename": "LibraryInvalidSortOrderIdError",
-#      "message": "RECENTLY_ADDED is not a valid sort order",
-#      "invalidSortOrderId": "RECENTLY_ADDED"
-#    }
-```
-
-Much faster than reading the minified bundle. Works for any pathfinder op that returns union types.
-
-### Search: `searchDesktop` (+ type-specific variants)
-
-`scraping.md` notes search as "not accessible via http_get". It is — just not from the main bundle. `searchDesktop` lives in the `xpui-routes-search` chunk (see "Lazy-loaded route chunks" above for extraction).
-
-```python
-HASH = OPS["searchDesktop"]
-
-def search(term, limit=10):
-    body = json.dumps({
-        "variables": {
-            "searchTerm": term, "offset": 0, "limit": limit, "numberOfTopResults": 5,
-            "includeAudiobooks": False, "includeArtistHasConcertsField": False,
-            "includePreReleases": False, "includeLocalConcertsField": False,
-        },
-        "operationName": "searchDesktop",
-        "extensions": {"persistedQuery": {"version": 1, "sha256Hash": HASH}},
-    }).encode()
-    req = urllib.request.Request("https://api-partner.spotify.com/pathfinder/v2/query",
-                                  data=body, headers=headers, method="POST")
-    with urllib.request.urlopen(req, timeout=15) as r:
-        return json.loads(r.read())["data"]["searchV2"]
-
-# Returns all sections in one call (~1s):
-# { topResultsV2, tracksV2, albumsV2, artists, playlists,
-#   podcasts, episodes, genres, users, chipOrder }
-```
-
-Type-specific variants live alongside it in the same chunk — use them when you only want one category, they're cheaper: `searchTracks`, `searchAlbums`, `searchArtists`, `searchPlaylists`, `searchPodcasts`, `searchEpisodes`, `searchAudiobooks`, `searchGenres`, `searchUsers`.
-
-`searchSuggestions` is different — it's the autocomplete op, returns a mix of `SearchAutoCompleteEntity` strings and a handful of typed results. Useful for "what would the dropdown show?", not for full search.
-
-### Lyrics: `color-lyrics` REST endpoint
-
-Not a pathfinder op — a regular REST endpoint on `spclient.wg.spotify.com`. Same auth pair (Bearer + client-token).
-
-```python
-def get_lyrics(track_id):
-    url = f"https://spclient.wg.spotify.com/color-lyrics/v2/track/{track_id}?format=json&market=from_token"
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=10) as r:
-            return json.loads(r.read())
-    except urllib.error.HTTPError as e:
-        if e.code == 404:
-            return None  # no lyrics for this track
-        raise
-```
-
-Response: `{lyrics: {syncType, lines: [{startTimeMs, words, syllables, endTimeMs, transliteratedWords}]}, colors, hasVocalRemoval}`. `syncType` is `LINE_SYNCED`, `SYLLABLE_SYNCED` (word-level), or `UNSYNCED`. The `/image/<cover-art-url>` path segment the Web Player uses is **optional** — the minimal URL above works.
-
-404 simply means no lyrics exist. Tracks missing lyrics include most instrumental/obscure releases.
-
-### Playback control via `connect-state`
-
-Not pathfinder — a REST endpoint on `guc3-spclient.spotify.com`. Same auth pair.
-
-```
-POST https://guc3-spclient.spotify.com/connect-state/v1/player/command/from/<device-id>/to/<device-id>
-```
-
-`<device-id>` is a 40-char hex string the Web Player uses for its own session. Capture it from any live request URL (e.g. the `track-playback/v1/devices/<id>/state` puts you see during playback).
-
-**Play a track/album/playlist/collection context:**
-```json
-{"command": {
-  "context": {"uri": "spotify:track:...", "url": "context://spotify:track:...", "metadata": {}},
-  "play_origin": {"feature_identifier": "harness"},
-  "options": {"license": "tft", "skip_to": {"track_uri": "spotify:track:..."}, "player_options_override": {}},
-  "logging_params": {"command_id": "<uuid>"},
-  "endpoint": "play"
-}}
-```
-`skip_to.track_uri` is optional — use it to jump to a specific track inside a playlist/album context.
-
-**Queue a track:**
-```json
-{"command": {
-  "track": {"uri": "spotify:track:...", "metadata": {"is_queued": "true"}, "provider": "queue"},
-  "endpoint": "add_to_queue",
-  "logging_params": {"command_id": "<uuid>"}
-}}
-```
-
-Both return `HTTP 200` with `{"ack_id": "..."}`. No DOM clicks needed; playback starts within ~500ms of the 200 coming back.
-
-### Other pathfinder operations worth knowing
-
-Watch the Network tab while doing each action; each persisted-query hash comes out of `load_pathfinder_hashes()` — no need to scrape request bodies.
-
-| Action                              | `operationName`            |
-|-------------------------------------|----------------------------|
-| Saved tracks (Liked Songs)          | `fetchLibraryTracks`       |
-| Saved albums / followed artists / playlists | `libraryV3` (see above) |
-| Full playlist contents              | `fetchPlaylist`            |
-| Album page                          | `getAlbum` / `queryAlbumTracks` |
-| Artist overview                     | `queryArtistOverview` / `queryArtistDiscographyAlbums` |
-| Is-saved check, N URIs              | `areEntitiesInLibrary`     |
-| Batch curation flags                | `isCurated` (for "saved" heart state) |
-| Search (all categories)             | `searchDesktop` (route chunk — see above) |
-| Autocomplete / recent               | `searchSuggestions`, `recentSearches` |
-
-### Gotchas
-
-- **Persisted-query hashes rotate.** Never hardcode them. Bundle rollouts invalidate cached hashes; use `load_pathfinder_hashes()` above and re-run it when you see `PersistedQueryNotFound`.
-- **`client-token` is required.** 403 without it. Easy to miss because every browser tool auto-includes it; curl / Python do not.
-- **Tokens expire ~1h.** Plan for re-interception, or run the extraction → API batch in one session.
-- **Don't cross-use with `/v1`.** The same Bearer token is treated as rate-limit-poisoned on `api.spotify.com/v1` even if it works on pathfinder. Pick a lane.
-- **Parallelism ceiling is ~10 workers.** Spotify starts dropping connections around 20+ concurrent. 10 is a good default for `ThreadPoolExecutor`.
-- **Do not commit captured headers.** They contain user identity (Bearer + client-token). `/tmp` staging is fine; a repo file is not.
+- **First track title lags.** Immediately after clicking Play, `context-item-link` can still show the *previous* track for ~500ms. Sleep 1-2s before reading, or poll until the title changes.
+- **Autoplay policies.** If the tab has never had user interaction, Chrome may block audio autoplay. The UI will show `Pause` (meaning it thinks it's playing) but no audio comes out. A real DOM `click()` counts as a user gesture; `new_tab` + DOM click has been reliable.

--- a/domain-skills/spotify/scraping.md
+++ b/domain-skills/spotify/scraping.md
@@ -275,30 +275,21 @@ def get_embed_token(resource_type="track", resource_id="4PTG3Z6ehGkBFwjybzWkR8")
 
 ---
 
-## What Requires a Browser
+## What Requires Auth (But Not a Browser)
 
-The following are **not accessible** via http_get and require the CDP browser:
+The following need a logged-in session but can be driven over HTTP once you've intercepted the Web Player's tokens — see `api-internals.md` for the full pattern:
 
-- Lyrics (login-gated; JSON-LD confirms: `isAccessibleForFree: false`)
-- Search (`/search?q=...`) — loads client-side only, no meaningful HTML on first response
-- User library / listening history — requires OAuth
-- Full audio playback — requires OAuth + Widevine DRM
-- Podcast episodes — oEmbed returns 404; embed page `__NEXT_DATA__` lacks `state.data.entity`
-- Track recommendations beyond the top-10 artist view
-- Artist discography / full album list
+- Lyrics (`color-lyrics` REST endpoint; line- or syllable-synced)
+- Search — full results via `searchDesktop` pathfinder op
+- User library — `fetchLibraryTracks` (tracks) and `libraryV3` (albums/artists/playlists)
+- Recently played / listening history
+- Podcast episodes, track recommendations, artist discography
 
-If browser access is needed for search:
+Still not accessible at all:
 
-```python
-goto("https://open.spotify.com/search")
-wait_for_load()
-wait(2)
-# Type into the search box
-js("document.querySelector('input[data-testid=\"search-input\"]').focus()")
-type_text("never gonna give you up")
-wait(1)
-# Results appear in [data-testid="top-results-card"] or similar dynamic selectors
-```
+- Full audio playback — requires Widevine DRM
+
+If you specifically need to drive the visible tab (rare — the HTTP path is faster), see `playback.md`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `domain-skills/spotify/playback.md` covering browser-driven playback on open.spotify.com (complements the existing scraping-only `scraping.md`)
- Main non-obvious finding: `click(x, y)` (CDP `Input.dispatchMouseEvent`) does **not** trigger Spotify's React play handlers — rows highlight and tooltips appear but playback never starts. Must drive via `element.click()` through `js(...)`.
- Documents stable `aria-label="Play <Track> by <Artist>"` selectors, direct search URL pattern (`open.spotify.com/search/<q>`), and player state selectors (`control-button-playpause` aria-label, `context-item-link`, etc.)

## Test plan
- [x] Verified: navigating to `open.spotify.com/search/bkjb%20nation` and calling `js('document.querySelector(\'button[aria-label="Play BKJB by Nation"]\').click()')` starts playback; coordinate click on the same button does not
- [x] Verified: `[data-testid="control-button-playpause"]` aria-label flips from `Play` → `Pause` after successful playback trigger
- [ ] Reviewer: sanity-check against a different account / fresh session (autoplay gotcha noted in the doc)

Generated with [Claude Code](https://claude.com/claude-code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Spotify Web Player playback skill and an HTTP internals guide to speed up library, search, lyrics, playlist edits, and playback control by replaying Web Player API calls. Adds a fast token-refresh interceptor to keep headers fresh and cut call latency, plus playlist create/add/remove/move coverage with key limits and IDs.

- **New Features**
  - `domain-skills/spotify/playback.md`: DOM-driven playback with stable `aria-label` selectors, required `element.click()` (coordinate clicks don’t fire), player-state selectors, and direct search URLs.
  - `domain-skills/spotify/api-internals.md`: Pathfinder GraphQL + spclient REST + connect-state with `Authorization: Bearer` + `client-token`; runtime persisted-query hash extraction (main bundle + lazy `xpui-routes-*`); shared `pathfinder(op, vars)` helper; fast token-refresh via a `window.fetch` interceptor that caches headers (<2ms reads) with a documented subprocess re-intercept fallback.
  - Library, search, lyrics, control, playlists: `fetchLibraryTracks` + `libraryV3`; `searchDesktop` and type ops; lyrics via `spclient.wg.spotify.com/color-lyrics`; playback via `connect-state/v1/player/command`; playlist create via `playlist/v2/playlist` + `rootlist/changes`, add/remove/move via `addToPlaylist`/`removeFromPlaylist`/`moveItemsInPlaylist` (batch adds ≤25; remove/move use item `uid`, not track `uri`).
  - `scraping.md`: Reframed to “requires auth (not a browser)” for search/lyrics/library; audio playback still needs Widevine.

<sup>Written for commit 00f67c1c94efdd1c84155c2f3123613703e05483. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

