### PR TITLE
feat: upload_file supports iframe target_id

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -198,12 +198,15 @@ def dispatch_key(selector, key="Enter", event="keypress"):
         f"(()=>{{const e=document.querySelector({json.dumps(selector)});if(e){{e.focus();e.dispatchEvent(new KeyboardEvent({json.dumps(event)},{{key:{json.dumps(key)},code:{json.dumps(key)},keyCode:{kc},which:{kc},bubbles:true}}));}}}})()"
     )
 
-def upload_file(selector, path):
-    """Set files on a file input via CDP DOM.setFileInputFiles. `path` is an absolute filepath (use tempfile.mkstemp if needed)."""
-    doc = cdp("DOM.getDocument", depth=-1)
-    nid = cdp("DOM.querySelector", nodeId=doc["root"]["nodeId"], selector=selector)["nodeId"]
+def upload_file(selector, path, target_id=None):
+    """Set files on a file input via CDP DOM.setFileInputFiles. `path` is an absolute filepath.
+
+    Pass `target_id` (from iframe_target()) to upload into a file input inside an iframe."""
+    sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
+    doc = cdp("DOM.getDocument", session_id=sid, depth=-1)
+    nid = cdp("DOM.querySelector", session_id=sid, nodeId=doc["root"]["nodeId"], selector=selector)["nodeId"]
     if not nid: raise RuntimeError(f"no element for {selector}")
-    cdp("DOM.setFileInputFiles", files=[path] if isinstance(path, str) else list(path), nodeId=nid)
+    cdp("DOM.setFileInputFiles", session_id=sid, files=[path] if isinstance(path, str) else list(path), nodeId=nid)
 
 def http_get(url, headers=None, timeout=20.0):
     """Pure HTTP — no browser. Use for static pages / APIs. Wrap in ThreadPoolExecutor for bulk."""


### PR DESCRIPTION
## What

Adds an optional `target_id` kwarg to `upload_file()` so `DOM.setFileInputFiles` can target a file input inside an iframe (attached via `iframe_target()`).

Default behavior unchanged: no `target_id` -> upload into the current top-level page target.

## Why

Many sites host their upload form inside a cross-origin iframe. A concrete example: Shiny-hosted apps at `*.shinyapps.io` (embedded by `centilebrain.org` and many biomedical tools) put `<input type=file>` inside their iframe, so the previous implementation couldn't reach it -- `cdp("DOM.getDocument", depth=-1)` from the top frame returned a document whose `#file1` selector didn't match.

## Change

```diff
-def upload_file(selector, path):
-    doc = cdp("DOM.getDocument", depth=-1)
-    nid = cdp("DOM.querySelector", nodeId=doc["root"]["nodeId"], selector=selector)["nodeId"]
+def upload_file(selector, path, target_id=None):
+    sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
+    doc = cdp("DOM.getDocument", session_id=sid, depth=-1)
+    nid = cdp("DOM.querySelector", session_id=sid, nodeId=doc["root"]["nodeId"], selector=selector)["nodeId"]
     if not nid: raise RuntimeError(f"no element for {selector}")
-    cdp("DOM.setFileInputFiles", files=..., nodeId=nid)
+    cdp("DOM.setFileInputFiles", session_id=sid, files=..., nodeId=nid)
```

Mirrors the session-attach pattern already used by `js(expression, target_id=None)`.

## Usage

```python
t = iframe_target("shinyapps.io/SV-MALE")
upload_file("#file1", "/abs/path/file.xlsx", target_id=t)
```

## Test

Verified end-to-end against `centilebrain.org` -- three modalities (SubcorticalVolume, CorticalThickness, SurfaceArea), three xlsx uploads into a Shiny iframe, compute + download, all via the harness with no other modifications.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a `target_id` option to `upload_file()` so you can upload to file inputs inside iframes. Default behavior is unchanged.

- **New Features**
  - You can pass `target_id` (from `iframe_target()`) to run DOM queries and `DOM.setFileInputFiles` inside the iframe’s session.
  - Matches the session-attach pattern used by `js(..., target_id=None)`.

<sup>Written for commit a0b28498c7ce13a4b6fe1521699f9e5d0241acae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

