### PR TITLE
feat: add browser rollout audit and observatory pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .env
 uv.lock
 *.egg-info/
+.hermes/reports/
+.hermes/plans/

--- a/.hermes/scripts/browser_harness_evidence_packet.py
+++ b/.hermes/scripts/browser_harness_evidence_packet.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path("/Users/odinbot33/Developer/browser-harness")
+REPORT_DIR = REPO_ROOT / ".hermes" / "reports"
+REPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class CmdResult:
+    command: str
+    exit_code: int
+    stdout: str
+    stderr: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "command": self.command,
+            "exit_code": self.exit_code,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+        }
+
+
+def run(command: str, timeout: int = 180) -> CmdResult:
+    proc = subprocess.run(
+        command,
+        shell=True,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+        timeout=timeout,
+    )
+    return CmdResult(
+        command=command,
+        exit_code=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
+
+
+def parse_json(text: str) -> Any:
+    text = text.strip()
+    if not text:
+        return None
+    return json.loads(text)
+
+
+def write_text(path: Path, content: str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return str(path)
+
+
+def tail_result(command: str, path: Path) -> dict[str, Any]:
+    result = run(command, timeout=60)
+    write_text(path, result.stdout + ("\n[stderr]\n" + result.stderr if result.stderr else ""))
+    return result.to_dict() | {"artifact": str(path)}
+
+
+now = datetime.now().astimezone()
+stamp = now.strftime("%Y-%m-%d_%H%M%S_%Z")
+base = REPORT_DIR / f"{stamp}-browser-harness"
+
+artifacts: dict[str, str] = {}
+commands: dict[str, Any] = {}
+summary: dict[str, Any] = {
+    "generated_at": now.isoformat(),
+    "repo_root": str(REPO_ROOT),
+    "artifacts": artifacts,
+    "commands": commands,
+}
+
+
+audit = run("browser-harness-rollout-audit --json", timeout=240)
+commands["rollout_audit"] = audit.to_dict()
+audit_artifact = base.with_name(base.name + "-rollout-audit.json")
+write_text(audit_artifact, audit.stdout if audit.stdout else json.dumps({"error": "empty stdout", **audit.to_dict()}, indent=2))
+artifacts["rollout_audit"] = str(audit_artifact)
+
+try:
+    audit_json = parse_json(audit.stdout)
+except Exception as exc:  # pragma: no cover - defensive
+    audit_json = {"parse_error": str(exc), "raw": audit.stdout}
+
+summary["rollout_audit_exit_code"] = audit.exit_code
+summary["rollout_audit"] = audit_json
+
+failures: list[dict[str, Any]] = []
+for node_name, node in (audit_json.get("nodes") or {}).items():
+    smoke = node.get("smoke") or {}
+    integrations = node.get("integrations") or {}
+    broken_integrations = [name for name, info in integrations.items() if info.get("status") != "ok"]
+    if smoke.get("status") != "pass" or broken_integrations:
+        failures.append(
+            {
+                "node": node_name,
+                "smoke_status": smoke.get("status"),
+                "error_code": smoke.get("error_code"),
+                "phase": smoke.get("phase"),
+                "hints": smoke.get("hints"),
+                "broken_integrations": broken_integrations,
+            }
+        )
+summary["failures"] = failures
+summary["verdict"] = "green" if not failures else "red"
+
+local_log = base.with_name(base.name + "-athame-bu-smoke.log")
+remote_log = base.with_name(base.name + "-furnace-bu-smoke.log")
+artifacts["athame_smoke_log_tail"] = str(local_log)
+artifacts["furnace_smoke_log_tail"] = str(remote_log)
+commands["athame_smoke_log_tail"] = tail_result("tail -n 200 /tmp/bu-smoke.log || true", local_log)
+commands["furnace_smoke_log_tail"] = tail_result("ssh furnace 'tail -n 200 /tmp/bu-smoke.log || true'", remote_log)
+
+local_preflight = base.with_name(base.name + "-athame-preflight.json")
+remote_preflight = base.with_name(base.name + "-furnace-preflight.json")
+artifacts["athame_preflight_json"] = str(local_preflight)
+artifacts["furnace_preflight_json"] = str(remote_preflight)
+commands["athame_preflight_json"] = tail_result("cat /tmp/browser-harness-preflight.json || true", local_preflight)
+commands["furnace_preflight_json"] = tail_result("ssh furnace 'cat /tmp/browser-harness-preflight.json || true'", remote_preflight)
+
+local_tests = run("python3 -m unittest discover -s tests -v", timeout=240)
+remote_tests = run("ssh furnace 'cd /Users/odinbot33/Developer/browser-harness && python3 -m unittest discover -s tests -v'", timeout=240)
+commands["athame_tests"] = local_tests.to_dict()
+commands["furnace_tests"] = remote_tests.to_dict()
+local_tests_path = base.with_name(base.name + "-athame-tests.txt")
+remote_tests_path = base.with_name(base.name + "-furnace-tests.txt")
+write_text(local_tests_path, local_tests.stdout + ("\n[stderr]\n" + local_tests.stderr if local_tests.stderr else ""))
+write_text(remote_tests_path, remote_tests.stdout + ("\n[stderr]\n" + remote_tests.stderr if remote_tests.stderr else ""))
+artifacts["athame_tests"] = str(local_tests_path)
+artifacts["furnace_tests"] = str(remote_tests_path)
+
+status = run("git -C /Users/odinbot33/Developer/browser-harness status --short", timeout=60)
+diffstat = run("git -C /Users/odinbot33/Developer/browser-harness diff --stat", timeout=60)
+commands["git_status"] = status.to_dict()
+commands["git_diff_stat"] = diffstat.to_dict()
+status_path = base.with_name(base.name + "-git-status.txt")
+diffstat_path = base.with_name(base.name + "-git-diff-stat.txt")
+write_text(status_path, status.stdout + ("\n[stderr]\n" + status.stderr if status.stderr else ""))
+write_text(diffstat_path, diffstat.stdout + ("\n[stderr]\n" + diffstat.stderr if diffstat.stderr else ""))
+artifacts["git_status"] = str(status_path)
+artifacts["git_diff_stat"] = str(diffstat_path)
+
+summary_path = base.with_name(base.name + "-summary.json")
+markdown_path = base.with_name(base.name + "-summary.md")
+write_text(summary_path, json.dumps(summary, indent=2, sort_keys=True))
+artifacts["summary_json"] = str(summary_path)
+
+lines = [
+    f"# Browser Harness evidence packet {stamp}",
+    "",
+    f"- Verdict: {summary['verdict']}",
+    f"- Rollout audit exit: {audit.exit_code}",
+    f"- Local tests exit: {local_tests.exit_code}",
+    f"- Remote tests exit: {remote_tests.exit_code}",
+    "",
+    "## Failures",
+]
+if failures:
+    for failure in failures:
+        lines.extend(
+            [
+                f"- node: {failure['node']}",
+                f"  - smoke_status: {failure['smoke_status']}",
+                f"  - error_code: {failure['error_code']}",
+                f"  - phase: {failure['phase']}",
+                f"  - hints: {failure['hints']}",
+                f"  - broken_integrations: {failure['broken_integrations']}",
+            ]
+        )
+else:
+    lines.append("- none")
+lines.extend(["", "## Artifacts"])
+for key, value in sorted(artifacts.items()):
+    lines.append(f"- {key}: {value}")
+write_text(markdown_path, "\n".join(lines) + "\n")
+artifacts["summary_md"] = str(markdown_path)
+
+print(json.dumps(summary, indent=2, sort_keys=True))

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,31 @@ Easiest and most powerful way to interact with the browser. **Read this file in 
 
 Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `install.md` first.
 
+Quick readiness check (fresh lane, read-only):
+
+```bash
+BU_NAME=smoke browser-harness-smoke --json
+```
+
+Cross-node rollout audit (auto-switches between ATHAME and FURNACE; override with `--remote-host` or `BROWSER_HARNESS_REMOTE_HOST`):
+
+```bash
+browser-harness-rollout-audit --json
+```
+
+Evidence packet (rollout audit + smoke/log tails + local/remote tests + git state artifacts):
+
+```bash
+browser-harness-evidence-packet
+```
+
+Mandatory shared-agent preflight contract:
+- Before the first `browser-harness` call in any lane, run `BU_NAME=<lane> browser-harness-smoke --json`.
+- If smoke returns `status=fail`, stop and surface the `error_code`, raw error, phase/`phase_timings`, and hints instead of pushing ahead blindly.
+- Prefer an explicit fresh `BU_NAME` for every meaningful task. Avoid the implicit `default` lane for shared/prod work.
+
+Interactive browser check:
+
 ```bash
 browser-harness <<'PY'
 new_tab("https://browser-use.com")
@@ -19,7 +44,8 @@ print(page_info())
 PY
 ```
 
-- Invoke as `browser-harness` — it's on `$PATH`. No `cd`, no `uv run`.
+- Invoke as `browser-harness` / `browser-harness-smoke` — both should be on `$PATH`. No `cd`, no `uv run`.
+- Prefer `BU_NAME=smoke` (or any fresh lane name) for preflight checks so you don't inherit a stale default daemon.
 - First navigation is `new_tab(url)`, not `goto(url)` — `goto` runs in the user's active tab and clobbers their work.
 
 The code is the doc.
@@ -39,6 +65,7 @@ PY
 ```
 
 `run.py` calls `ensure_daemon()` before `exec` — you never start/stop manually unless you want to.
+For shared agent surfaces, treat `browser-harness-smoke` as the mandatory gate and `browser-harness-rollout-audit` as the inspectable proof that Hermes / Claude Code / Codex wiring is still intact.
 
 ### Remote browsers
 

--- a/domain-skills/cathedral/browser-observatory.md
+++ b/domain-skills/cathedral/browser-observatory.md
@@ -1,0 +1,57 @@
+# Cathedral runbook — Browser observatory checks
+
+Use this to convert browser-harness from a one-off tool into an observatory layer.
+
+## Principle
+
+Browser checks should be:
+- low-noise
+- high-signal
+- anomaly-oriented
+- evidence-backed
+
+Do **not** run chatty browser sweeps that spam Mahuki.
+
+## Best recurring checks
+
+### Daily / on-change checks
+- Vercel latest successful vs latest attempted deployment
+- Cloudflare zone warnings / custom domain health
+- Supabase project/project-selection drift
+- GitHub Actions/red workflow review for key repos
+- Microsoft 365 domain setup / DKIM readiness for active domains
+
+### Weekly checks
+- GoDaddy renewal / transfer-lock / attached product inventory
+- vendor billing/product inventory snapshots
+- cross-console domain stack consistency review
+
+## Trigger model
+
+Preferred triggers:
+- after deploy
+- after DNS change
+- before registrar/billing action
+- when an anomaly is detected elsewhere
+
+Acceptable scheduled triggers:
+- one compact sweep per domain or product family
+- only emit if changed, risky, or decision-worthy
+
+## Output discipline
+
+Each check produces:
+- one evidence packet
+- risk rating
+- change/no-change result
+- recommended next action
+
+If nothing changed, store locally and do not spam the user.
+
+## Best Cathedral observatory packs
+
+- `deploy-proof`
+- `domain-stack-audit`
+- `m365-mail-hardening-audit`
+- `supabase-config-drift-audit`
+- `vendor-billing-inventory`

--- a/domain-skills/cathedral/console-anomaly-review.md
+++ b/domain-skills/cathedral/console-anomaly-review.md
@@ -1,0 +1,33 @@
+# Cathedral runbook — Console anomaly review
+
+Use this when another signal already suggests a problem, and the browser must determine what the console is actually warning about.
+
+Examples:
+- deploy looks broken
+- domain looks half-configured
+- dashboard shows warnings not visible in API output
+- permissions or org/team mismatch is suspected
+
+## Goal
+
+Turn a vague anomaly into a precise statement:
+- where the warning is
+- what the UI says
+- whether it is actionable
+- whether it needs approval
+
+## Method
+
+1. open the exact console and scope
+2. capture overview screenshot
+3. drill into warning badge / banner / failed status
+4. record visible message text and nearby controls
+5. map it to one of: cosmetic, configuration drift, blocked workflow, production risk, billing risk, security risk
+
+## Output
+
+- anomaly source
+- visible warning text
+- blast radius
+- recommended next action
+- approval boundary

--- a/domain-skills/cathedral/deploy-proof.md
+++ b/domain-skills/cathedral/deploy-proof.md
@@ -1,0 +1,46 @@
+# Cathedral runbook — Deploy proof
+
+Use this when proving a deploy actually landed across code, platform, and edge.
+
+Typical stack:
+- GitHub
+- Vercel
+- Cloudflare
+
+## Goal
+
+Answer, with evidence:
+- was code merged/pushed?
+- did the deployment succeed?
+- is the correct domain serving the correct build?
+- is the edge/routing layer pointing where we think it is?
+
+## Browser lane plan
+
+- `github`
+- `vercel`
+- `cloudflare`
+
+## Order of operations
+
+1. **GitHub**
+   - confirm branch / commit / workflow status / repo settings if relevant
+2. **Vercel**
+   - confirm latest attempted deploy vs latest successful deploy
+   - capture production domain and deployment metadata
+3. **Cloudflare**
+   - confirm DNS and any Workers / Pages / proxy routing that could override behavior
+4. **Terminal/API**
+   - `curl -I`, cert check, response fingerprints, HTML markers
+
+## Required output
+
+- latest code state
+- latest deployment state
+- live domain behavior
+- mismatch point if broken
+- recommended next action
+
+## Best use
+
+This is the default post-deploy truth runbook when “it should be live” is not good enough.

--- a/domain-skills/cathedral/domain-stack-audit.md
+++ b/domain-skills/cathedral/domain-stack-audit.md
@@ -1,0 +1,59 @@
+# Cathedral runbook — Domain stack audit
+
+Use this when auditing a domain spread across:
+- GoDaddy or another registrar
+- Cloudflare DNS
+- Vercel hosting
+- Microsoft 365 mail
+
+## Goal
+
+Produce a single evidence-backed ownership map:
+- registrar
+- authoritative DNS
+- website hosting
+- website SSL
+- inbound mail
+- outbound mail authorization
+- leftovers that still depend on legacy vendors
+
+## Browser lane plan
+
+Use separate `BU_NAME`s if running in parallel:
+- `godaddy`
+- `cloudflare`
+- `vercel`
+- `m365`
+
+## Order of operations
+
+1. **GoDaddy / registrar first**
+   - confirm expiry, lock state, auto-renew, attached products
+2. **Cloudflare second**
+   - confirm zone, DNS records, proxy state, SSL mode, nameservers
+3. **Vercel third**
+   - confirm project, production domain assignment, latest healthy deploy
+4. **Microsoft 365 fourth**
+   - confirm domain present, mailbox ownership, DKIM/readiness surfaces
+5. **Terminal/API cross-check last**
+   - `whois`, `dig`, `curl`, cert inspection
+
+## Output contract
+
+For each console, return:
+- account/tenant
+- object inspected
+- key state
+- screenshot summary
+- risk
+- approval boundary
+
+Then synthesize:
+- what still depends on vendor A
+- what is safe now
+- what must be verified first
+- what must not be touched blindly
+
+## Best use
+
+This is the default browser-harness runbook for registrar / DNS / deploy / mail uncertainty.

--- a/domain-skills/cathedral/evidence-packet-schema.md
+++ b/domain-skills/cathedral/evidence-packet-schema.md
@@ -1,0 +1,62 @@
+# Cathedral runbook — Browser evidence packet schema
+
+Use this whenever browser-harness work needs to produce a reusable artifact instead of a loose summary.
+
+## Why
+
+Browser work is most valuable when it returns:
+- repeatable evidence
+- screenshot references
+- exact UI truth
+- approval boundaries
+
+Without a packet, browser sessions become anecdotes.
+
+## Required fields
+
+- `packet_id`
+- `created_at`
+- `operator`
+- `node`
+- `lane` (`BU_NAME`)
+- `workflow`
+- `objective`
+- `console`
+- `page_title`
+- `page_url`
+- `object_under_inspection`
+- `observed_state`
+- `expected_state`
+- `drift_or_issue`
+- `risk_level`
+- `recommended_next_action`
+- `approval_required`
+- `screenshot_paths`
+- `supporting_artifacts`
+
+## Canonical output pair
+
+Create both:
+- markdown packet for humans
+- JSON packet for machines
+
+## Suggested locations
+
+- `~/Cathedral/state/browser-observatory/packets/...`
+- keep screenshots referenced, not embedded in raw markdown
+
+## Minimal judgment rubric
+
+### Risk levels
+- `low` — observation only, no urgent user action
+- `medium` — mismatch or warning with bounded blast radius
+- `high` — likely breakage, billing risk, security risk, or production drift
+- `critical` — active outage, imminent expiry, destructive misconfiguration, or exposed security issue
+
+### Approval field
+- `false` for observation/inventory/verification only
+- `true` for destructive, external, billing, registrar, identity, or production-changing action
+
+## Best practice
+
+Every browser task should end with one evidence packet, even if the result is “no drift found.”

--- a/domain-skills/cathedral/m365-mail-hardening-audit.md
+++ b/domain-skills/cathedral/m365-mail-hardening-audit.md
@@ -1,0 +1,49 @@
+# Cathedral runbook — Microsoft 365 mail hardening audit
+
+Use this when a domain appears to receive mail through Microsoft 365 but DNS/security posture is unclear.
+
+## Goal
+
+Determine:
+- whether Microsoft 365 is the real inbound mail platform
+- whether the domain is fully wired there
+- what hardening is missing
+- whether legacy GoDaddy or other sender traces still remain
+
+## Console order
+
+1. `m365`
+2. `cloudflare`
+3. optionally `godaddy` if legacy residue is suspected
+
+## What to verify
+
+### In Microsoft 365
+- target domain present
+- mailbox/domain ownership visible
+- DKIM/config surfaces available
+- shared mailbox / alias presence if relevant
+
+### In Cloudflare
+- MX
+- SPF
+- `_dmarc`
+- DKIM selectors
+- `autodiscover`
+- any stale GoDaddy-ish records
+
+### In GoDaddy if needed
+- active email or Microsoft 365 products sold through GoDaddy
+- forwarding / SMTP / legacy mail products
+
+## Common outputs
+
+- inbound mail owner
+- outbound authorization owner
+- missing hardening records
+- legacy residue
+- approval-required next steps
+
+## Best use
+
+Default runbook for “is this domain really on Microsoft 365 and what hardening is still missing?”

--- a/domain-skills/cathedral/multi-console-ops.md
+++ b/domain-skills/cathedral/multi-console-ops.md
@@ -1,0 +1,77 @@
+# Cathedral — Multi-console operator pack
+
+Use this when a task spans multiple vendor consoles such as:
+- Cloudflare
+- Vercel
+- GoDaddy
+- Microsoft 365
+- Supabase
+- GitHub
+
+This is the Cathedral pattern for browser-harness.
+
+## Core doctrine
+
+Use browser-harness for:
+- evidence
+- inventory
+- UI truth
+- preflight verification
+- post-change verification
+
+Do **not** default to using the browser for every mutation. Let terminal/API/MCP do the durable scripted work where possible.
+
+## Best operating pattern
+
+### 1. One session name per workstream
+
+Use separate `BU_NAME` values such as:
+- `cloudflare`
+- `vercel`
+- `godaddy`
+- `m365`
+- `supabase`
+- `github`
+- `agm-audit`
+- `deploy`
+
+This prevents agents from fighting over the same default browser socket.
+
+### 2. One console, one evidence packet
+
+For each console visited, return:
+- page title / route
+- screenshot summary
+- exact state observed
+- risk
+- next action
+- whether approval is required
+
+### 3. Browser first for truth, API second for scale
+
+Pattern:
+1. use browser to confirm what the console really says
+2. use terminal/API/MCP to do scalable extraction or mutation
+3. use browser again to verify the result landed in the UI
+
+This is the 1000000x loop.
+
+## Highest-value Cathedral workflows
+
+- domain stack audits (GoDaddy + Cloudflare + Vercel + M365)
+- deploy verification (GitHub + Vercel + Cloudflare)
+- auth/config truth checks (Supabase + Vercel + GitHub)
+- post-change screenshot proof
+- vendor billing/dependency inventory
+
+## Output discipline
+
+Never return a vague "looks right" summary.
+
+Return:
+- console
+- object under inspection
+- state observed
+- proof artifact (screenshot summary / visible labels)
+- recommended action
+- approval boundary

--- a/domain-skills/cathedral/public-site-smoke.md
+++ b/domain-skills/cathedral/public-site-smoke.md
@@ -1,0 +1,40 @@
+# Cathedral runbook — Public site smoke
+
+Use this after deploys or content/config changes to verify public-facing surfaces.
+
+Best targets:
+- home page
+- pricing page
+- nav/footer
+- primary CTA paths
+- contact / lead forms
+- login entrypoints
+
+## Goal
+
+Confirm that the public site:
+- loads
+- renders the intended IA/content
+- exposes the intended primary actions
+- does not visibly regress
+
+## Pattern
+
+1. open site in a real tab
+2. capture screenshot at load
+3. verify title, hero, nav, CTA, footer
+4. follow one or two primary actions
+5. capture evidence packet
+
+## Great pairings
+
+- browser-harness for visual truth
+- terminal `curl` for headers/status
+- deploy-proof runbook when tied to a release
+
+## Output
+
+- page checked
+- visible regressions
+- CTA/form state
+- pass/fail with screenshot references

--- a/domain-skills/cathedral/supabase-config-drift-audit.md
+++ b/domain-skills/cathedral/supabase-config-drift-audit.md
@@ -1,0 +1,37 @@
+# Cathedral runbook — Supabase config drift audit
+
+Use this when repo assumptions, environment variables, and Supabase dashboard state may have drifted apart.
+
+## Goal
+
+Answer:
+- are we in the right project?
+- does the dashboard match repo/env assumptions?
+- are Auth / Edge Functions / settings configured as expected?
+- where is the drift?
+
+## Workflow
+
+1. **Supabase dashboard**
+   - confirm org/project
+   - inspect relevant surfaces (Auth, Edge Functions, Settings, Storage)
+2. **Repo/config comparison**
+   - compare project IDs, URLs, expected providers, function names
+3. **Endpoint verification**
+   - test live endpoint/health from terminal
+
+## Good audit targets
+
+- OEE vs AGM project confusion
+- missing auth providers
+- functions deployed in one project but not another
+- secrets/env mismatch between platform and repo assumptions
+
+## Output
+
+- project inspected
+- expected state
+- observed state
+- drift found
+- probable blast radius
+- next fix

--- a/domain-skills/cathedral/vendor-billing-inventory.md
+++ b/domain-skills/cathedral/vendor-billing-inventory.md
@@ -1,0 +1,47 @@
+# Cathedral runbook — Vendor billing inventory
+
+Use this when the question is:
+- what are we still paying for?
+- what still matters operationally?
+- what can be safely cancelled later?
+
+Best targets:
+- GoDaddy
+- Microsoft 365
+- Cloudflare
+- Vercel
+- GitHub
+- any vendor with account-level product clutter
+
+## Goal
+
+Split every visible product into one of four buckets:
+- operationally critical now
+- useful but non-critical
+- probably stale / removable after verification
+- obvious upsell / ignore
+
+## Method
+
+1. visit vendor billing/products page
+2. screenshot product list
+3. capture renewal names / plan names / attached domains or projects
+4. cross-link each product to actual live dependencies seen elsewhere
+
+## Key rule
+
+Do not equate “billing exists” with “dependency exists.”
+Do not equate “upsell visible” with “product active.”
+
+## Output contract
+
+For each product:
+- vendor
+- product name
+- renewal risk
+- live dependency evidence
+- safe now / verify first / do not touch blindly
+
+## Best use
+
+This is the browser-harness runbook for cleanup and cost sovereignty without breaking production.

--- a/domain-skills/cloudflare/operator.md
+++ b/domain-skills/cloudflare/operator.md
@@ -1,0 +1,121 @@
+# Cloudflare — Operator workflows for Cathedral
+
+`https://dash.cloudflare.com`
+
+Use Cloudflare in browser-harness for **dashboard truth** and UI-only operations:
+- zone inventory
+- DNS verification
+- Workers/routes checks
+- account / billing / security settings review
+- nameserver / registrar / domain-state confirmation
+
+## Default stance
+
+Prefer browser automation for:
+- confirming what the dashboard actually shows
+- inventorying zones, records, routes, rules, plans, and alerts
+- preparing a change and stopping before the final destructive click
+
+Prefer API / terminal / IaC for:
+- bulk DNS export
+- high-volume mutations
+- reproducible deploy flows
+
+Use the browser when the truth is trapped in the UI.
+
+## High-value routes
+
+Start at:
+- `https://dash.cloudflare.com/`
+
+Common destinations once a zone is selected:
+- DNS
+- Workers & Pages
+- Rules
+- SSL/TLS
+- Security
+- Analytics
+- Domain Registration / Registrar when present
+
+Cloudflare moves fast. Prefer:
+- account switcher first
+- zone search second
+- then left-nav labels by visible text
+
+## Reliable workflow pattern
+
+1. `ensure_real_tab()`
+2. `goto("https://dash.cloudflare.com")`
+3. `wait_for_load()`
+4. `screenshot()` immediately
+5. use visible text + links/buttons, not brittle CSS classes
+6. after every major navigation, `screenshot()` again
+
+## What to extract every time
+
+For a zone audit, collect:
+- selected account name
+- selected zone
+- plan tier
+- nameserver pair
+- DNS record table snapshot
+- proxy status for key records
+- SSL mode / cert status
+- Workers routes / Pages custom domains if relevant
+
+## DNS record review
+
+Best practice:
+- filter/search by record name
+- inspect visible table rows
+- read type, name, content/target, proxy state, TTL
+
+For Cathedral work, always verify at least:
+- apex
+- `www`
+- mail records (`MX`, `TXT`, `_dmarc`, DKIM selectors, `autodiscover`)
+- app / API subdomains
+- challenge / verification records
+
+## Safe actions
+
+Usually safe:
+- inventory
+- screenshots
+- open forms
+- review pending values
+- compare dashboard state against live DNS
+
+Approval boundary:
+- saving DNS edits
+- changing nameservers / registrar settings
+- changing SSL mode
+- deleting records / routes / rules
+- billing / subscription changes
+
+## Common traps
+
+- **Wrong account context** — the UI may remember the last account. Confirm account name before every conclusion.
+- **Search/filter residue** — Cloudflare tables often persist filters. Clear filters before claiming a record is absent.
+- **Proxy misunderstanding** — orange-cloud vs grey-cloud is operationally important; capture it explicitly.
+- **Workers/Pages split-brain** — custom domains may be configured under either product surface. Check both when troubleshooting.
+- **UI truth vs live truth** — confirm important claims with browser + terminal (`dig`, `curl`, cert check). Cloudflare UI alone is not enough.
+
+## Best Cathedral uses
+
+- domain stack audits
+- pre-change screenshots before DNS work
+- post-change verification after deploys
+- Workers / Pages routing review
+- registrar-transfer readiness review
+
+## Output format for Cathedral agents
+
+Return:
+- account
+- zone
+- page visited
+- screenshot summary
+- exact state observed
+- recommended action
+- whether action requires approval

--- a/domain-skills/github/admin.md
+++ b/domain-skills/github/admin.md
@@ -1,0 +1,43 @@
+# GitHub — Settings/admin workflows for Cathedral
+
+`https://github.com`
+
+This complements `github/scraping.md`.
+
+Use browser-harness here for:
+- org/repo settings verification
+- branch protection / ruleset visibility
+- Actions / secrets / environments review
+- GitHub UI-only admin surfaces
+
+Prefer API/gh CLI for normal repo metadata. Use the browser when the truth is in Settings.
+
+## Reliable workflow
+
+1. confirm logged-in account/org first
+2. open the exact repo or org
+3. navigate to Settings / Actions / Secrets / Rulesets / Environments as needed
+4. screenshot the evidence page before summarizing
+
+## High-value Cathedral uses
+
+- confirm repo visibility and org placement
+- inspect Actions state and failures
+- verify environment names and protection rules exist
+- check branch protections/rulesets visually
+- review Pages/app settings where CLI coverage is poor
+
+## Common traps
+
+- **Wrong org or personal account context**
+- **Settings permissions missing** — lack of UI access is itself evidence; report it clearly.
+- **Secret presence only** — verify existence/scope, not values.
+- **Actions tab vs workflow run page confusion** — state exactly which screen you are using.
+
+## Approval boundary
+
+Approval required before:
+- changing repo visibility
+- deleting environments/secrets
+- modifying rulesets/branch protections
+- changing app/webhook/security settings

--- a/domain-skills/godaddy/operator.md
+++ b/domain-skills/godaddy/operator.md
@@ -1,0 +1,76 @@
+# GoDaddy — Registrar and product inventory workflows
+
+`https://account.godaddy.com/`
+
+Use GoDaddy in browser-harness for:
+- domain-registration truth checks
+- product inventory
+- auto-renew / lock / privacy review
+- transfer-readiness review
+- finding legacy email/SSL leftovers
+
+## Default stance
+
+GoDaddy is most valuable in Cathedral as an **inventory surface**.
+
+Use the browser to answer:
+- what products still exist?
+- what renews?
+- is the domain locked?
+- is auto-renew enabled?
+- are there stale mail / SSL / upsell dependencies still attached?
+
+## What to capture on every visit
+
+- account identity / tenant if visible
+- domain list or searched domain
+- expiration date
+- transfer-lock state
+- auto-renew state
+- privacy / protection state
+- any attached products:
+  - SSL
+  - email
+  - Microsoft 365 via GoDaddy
+  - forwarding / Workspace / Professional Email
+
+## Recommended workflow
+
+1. go to product/domain list first
+2. search the exact domain
+3. screenshot the product card / domain row
+4. open the domain detail page
+5. capture lock / renew / contact / protection / DNS hints
+6. separately inspect product/billing list for attached leftovers
+
+## High-value Cathedral use cases
+
+- registrar-transfer readiness checks
+- GoDaddy dependency audits
+- confirming whether a domain is still operationally tied to GoDaddy
+- finding legacy SSL and email products safe to retire later
+
+## Common traps
+
+- **Domain row vs billing row mismatch** — the domain can be active while stale add-ons still bill elsewhere.
+- **Confusing DNS host with registrar** — GoDaddy can remain registrar even when DNS is elsewhere.
+- **Transfer path buried in detail views** — inventory first, then locate transfer controls only after confirming ownership.
+- **Support/upsell surfaces** — avoid interpreting upsell prompts as active dependencies.
+
+## Approval boundary
+
+Approval required before:
+- unlocking for transfer
+- requesting auth/EPP code
+- disabling protection/privacy
+- cancelling products
+- changing contact/ownership/billing details
+
+## Best Cathedral output
+
+Return a clean split:
+- registrar dependency
+- renew-risk items
+- attached products
+- safe-to-ignore upsells
+- approval-required next actions

--- a/domain-skills/microsoft-365/admin.md
+++ b/domain-skills/microsoft-365/admin.md
@@ -1,0 +1,70 @@
+# Microsoft 365 — Admin-center workflows for Cathedral
+
+Primary surfaces:
+- `https://admin.microsoft.com/`
+- Exchange / Defender / Entra admin centers as linked from the main portal
+
+Use browser-harness here for:
+- domain and mailbox inventory
+- admin-center truth checks
+- Exchange / mail-flow surface verification
+- DKIM / domain / connector readiness review
+
+## Default stance
+
+Use the browser to verify:
+- what domains are present
+- domain health / setup state
+- mailbox existence
+- user/license assignment presence
+- whether DKIM or mail security surfaces are available
+
+Prefer PowerShell/API/CLI for bulk user or mailbox mutation.
+
+## Reliable workflow
+
+1. land on `admin.microsoft.com`
+2. confirm tenant/account first
+3. use global search when possible
+4. open Domains / Users / Teams / Exchange / Billing only after tenant confirmation
+5. screenshot every final evidence page
+
+## High-value pages
+
+- Settings / Domains
+- Active users
+- Shared mailboxes (often via Exchange admin)
+- Exchange admin → mail flow / accepted domains / DKIM-related surfaces
+- Billing / licenses when dependency questions exist
+
+## What to collect
+
+- tenant name
+- domain list
+- target domain status
+- whether mailboxes are visibly hosted there
+- whether shared mailboxes/aliases exist
+- whether DKIM/configuration surfaces exist for the domain
+- whether licenses appear to be direct Microsoft 365 vs third-party managed
+
+## Common traps
+
+- **Wrong admin center** — many mail settings are not in the main M365 center; they live in Exchange admin.
+- **Tenant confusion** — Microsoft loves cross-tenant context drift. Confirm tenant banner/account before drawing conclusions.
+- **License presence != operational ownership** — record both license view and domain/mailbox view.
+- **DKIM surface can be buried** — do not conclude “not supported” until search + Exchange path are checked.
+
+## Best Cathedral uses
+
+- verify whether Microsoft 365 is the real mail platform
+- inventory mailbox/domain state before DNS changes
+- check if DKIM/domain hardening can be completed
+- determine whether GoDaddy is still involved or only billing-proxy residue remains
+
+## Approval boundary
+
+Approval required before:
+- changing users/licenses
+- changing mail flow/connectors
+- enabling security policies with blast radius
+- altering domains / federation / identity state

--- a/domain-skills/supabase/dashboard.md
+++ b/domain-skills/supabase/dashboard.md
@@ -1,0 +1,63 @@
+# Supabase — Dashboard truth and configuration verification
+
+`https://supabase.com/dashboard`
+
+Use browser-harness for:
+- project inventory
+- environment/config truth checks
+- Auth / Database / Edge Functions / Storage / Logs surface verification
+- dashboard state that is awkward to confirm purely by API
+
+## Default stance
+
+Supabase browser work is mainly for **config truth**, not data-plane work.
+
+Use API/SQL/terminal for:
+- querying data
+- migrations
+- schema diffs
+- automated deployments
+
+Use the dashboard for:
+- project selection confirmation
+- environment/settings review
+- Auth provider status
+- Edge Function deployment visibility
+- secrets/config presence checks
+- storage bucket / policy sanity checks
+
+## Reliable workflow
+
+1. confirm org/team
+2. open exact project
+3. screenshot overview
+4. navigate to the specific surface:
+   - Database
+   - Auth
+   - Edge Functions
+   - Storage
+   - Logs
+   - Project Settings
+
+## High-value Cathedral use cases
+
+- verify OEE vs AGM project selection before making claims
+- confirm Auth/provider settings visually
+- inspect whether edge functions are present and healthy
+- compare dashboard configuration with repo assumptions
+- grab visual proof for broken settings or environment drift
+
+## Common traps
+
+- **Wrong project** — always state project ID/name explicitly.
+- **Wrong environment/context** — if multiple browser tabs exist, activate and rescreenshot before extracting facts.
+- **UI confirms presence, not runtime correctness** — combine dashboard truth with live endpoint/API checks.
+- **Secret values** — never exfiltrate secrets from the UI unless Mahuki explicitly asks.
+
+## Approval boundary
+
+Approval required before:
+- changing auth providers
+- rotating secrets
+- deleting tables/buckets/functions
+- running destructive SQL from the browser

--- a/domain-skills/vercel/operator.md
+++ b/domain-skills/vercel/operator.md
@@ -1,0 +1,82 @@
+# Vercel — Operator workflows for Cathedral
+
+`https://vercel.com/dashboard`
+
+Use Vercel in browser-harness for:
+- project inventory
+- deployment verification
+- domain assignment review
+- environment variable confirmation
+- build/runtime config truth checks
+
+## Default stance
+
+Prefer browser automation for:
+- confirming the live project/dashboard state
+- checking failed deploy details in the UI
+- verifying environment variables exist
+- checking domain bindings, aliases, redirects, and preview/prod state
+
+Prefer CLI/API for:
+- deploy execution
+- logs export
+- scripted environment changes
+
+## High-value surfaces
+
+- dashboard / team picker
+- project overview
+- Deployments
+- Settings → Domains
+- Settings → Environment Variables
+- Functions / Runtime / Observability surfaces when present
+
+## Reliable workflow pattern
+
+1. confirm team scope first
+2. search project by visible name
+3. open project overview
+4. capture screenshot
+5. drill into Deployments or Settings as needed
+
+## What to capture
+
+For every Vercel check, record:
+- team/account name
+- project name
+- production domain(s)
+- latest deployment status
+- latest deployment commit/branch if visible
+- whether environment variables are present (do not expose secret values)
+- whether domains are assigned and verified
+
+## Environment-variable rule
+
+Use the browser to verify that a variable exists in the expected scope:
+- Production
+- Preview
+- Development
+
+Do **not** reveal secret contents back into chat. Presence/absence and scope are enough unless Mahuki explicitly asks for value handling.
+
+## Common traps
+
+- **Wrong team scope** — many Vercel mistakes come from being inside the wrong team/org.
+- **Preview vs Production confusion** — always name which environment you are looking at.
+- **Latest successful vs latest attempted deploy** — the top deployment is not always the last healthy one.
+- **Domain present but not healthy** — inspect status badges / warnings, not just presence in the list.
+
+## Best Cathedral uses
+
+- verify that Cathedral / OEE / AGM sites point at the intended project
+- confirm env wiring after secret changes
+- inspect failed deploy reasons before using terminal-heavy recovery
+- check custom-domain health after DNS changes
+
+## Approval boundary
+
+Approval required before:
+- changing environment variables
+- deleting domains / projects
+- promoting / rolling back manually
+- changing production routing or team billing settings

--- a/harness_smoke.py
+++ b/harness_smoke.py
@@ -1,0 +1,299 @@
+import argparse
+import json
+import os
+import platform
+import shutil
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from admin import daemon_alive, ensure_daemon, restart_daemon
+from helpers import INTERNAL, current_tab, ensure_real_tab, js, list_tabs, page_info
+
+REPAIRABLE_ERROR_FRAGMENTS = (
+    "no close frame received or sent",
+    "stale",
+    "connection refused",
+    "didn't come up",
+    "broken pipe",
+)
+
+PHASE_TIMEOUTS = {
+    "ensure_daemon": 20.0,
+    "ensure_real_tab": 12.0,
+    "list_tabs": 5.0,
+    "current_tab": 5.0,
+    "page_info": 8.0,
+    "ready_state": 4.0,
+}
+
+
+class SmokePhaseError(RuntimeError):
+    def __init__(self, phase: str, message: str, phase_timings: dict):
+        super().__init__(message)
+        self.phase = phase
+        self.phase_timings = dict(phase_timings or {})
+
+
+def format_phase_timings(phase_timings: Optional[dict]) -> str:
+    items = []
+    for name, seconds in (phase_timings or {}).items():
+        try:
+            items.append(f"{name}:{float(seconds):.3f}s")
+        except (TypeError, ValueError):
+            items.append(f"{name}:{seconds}")
+    return ", ".join(items)
+
+
+def timed_phase(phase: str, fn, phase_timings: dict):
+    timeout = PHASE_TIMEOUTS.get(phase)
+    start = time.monotonic()
+    timer_supported = sys.platform != "win32" and hasattr(signal, "setitimer") and hasattr(signal, "SIGALRM")
+    previous_handler = None
+
+    def _raise_timeout(_signum, _frame):
+        raise TimeoutError(f"timed out during {phase} after {timeout:.1f}s")
+
+    if timeout and timer_supported:
+        previous_handler = signal.getsignal(signal.SIGALRM)
+        signal.signal(signal.SIGALRM, _raise_timeout)
+        signal.setitimer(signal.ITIMER_REAL, timeout)
+
+    try:
+        result = fn()
+    except Exception as exc:
+        phase_timings[phase] = round(time.monotonic() - start, 3)
+        if isinstance(exc, SmokePhaseError):
+            raise
+        raise SmokePhaseError(phase=phase, message=str(exc), phase_timings=phase_timings) from exc
+    finally:
+        if timeout and timer_supported:
+            signal.setitimer(signal.ITIMER_REAL, 0.0)
+            signal.signal(signal.SIGALRM, previous_handler)
+
+    phase_timings[phase] = round(time.monotonic() - start, 3)
+    return result
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def is_repairable_error(message: str) -> bool:
+    lowered = (message or "").lower()
+    return any(fragment in lowered for fragment in REPAIRABLE_ERROR_FRAGMENTS)
+
+
+def classify_error_code(message: str) -> str:
+    lowered = (message or "").lower()
+    if "devtoolsactiveport" in lowered:
+        return "BH-ATTACH-001"
+    if "opening handshake" in lowered or "click allow" in lowered or "allow in chrome" in lowered:
+        return "BH-ATTACH-003"
+    if "connection refused" in lowered:
+        return "BH-ATTACH-002"
+    if "timed out during ensure_daemon" in lowered:
+        return "BH-DAEMON-005"
+    if "timed out during ensure_real_tab" in lowered or "timed out during list_tabs" in lowered or "timed out during current_tab" in lowered:
+        return "BH-ATTACH-005"
+    if "timed out during page_info" in lowered:
+        return "BH-PAGE-001"
+    if "timed out during ready_state" in lowered:
+        return "BH-PAGE-002"
+    if "didn't come up" in lowered:
+        return "BH-DAEMON-002"
+    if "no real non-internal browser tab found" in lowered:
+        return "BH-TAB-002"
+    if "no close frame received or sent" in lowered:
+        return "BH-DAEMON-003"
+    if "stale" in lowered:
+        return "BH-DAEMON-004"
+    return "BH-UNKNOWN-001"
+
+
+def failure_hints(message: str) -> list[str]:
+    lowered = (message or "").lower()
+    hints = []
+    if "devtoolsactiveport" in lowered:
+        hints.append("Enable Chrome remote debugging once in chrome://inspect/#remote-debugging for your normal profile.")
+    if "no real non-internal browser tab found" in lowered:
+        hints.append("Open at least one normal webpage tab; chrome:// pages do not count.")
+    if "connection refused" in lowered or "didn't come up" in lowered:
+        hints.append("Start Google Chrome and keep your normal profile open, then rerun the smoke test.")
+    if "opening handshake" in lowered or "click allow" in lowered or "allow in chrome" in lowered:
+        hints.append("Chrome is likely waiting on its remote-debugging Allow prompt; click Allow in Chrome, then rerun.")
+    if "timed out during page_info" in lowered or "timed out during ready_state" in lowered:
+        hints.append("The browser attached but the post-attach smoke path stalled; inspect /tmp/bu-<lane>.log and rerun on a fresh BU_NAME.")
+    if "timed out during ensure_real_tab" in lowered or "timed out during list_tabs" in lowered or "timed out during current_tab" in lowered:
+        hints.append("The attach/tab-selection phase stalled; check for Chrome prompts or stale CDP state, then rerun.")
+    if "timed out during ensure_daemon" in lowered:
+        hints.append("The daemon bootstrap stalled; inspect /tmp/bu-<lane>.log and verify Chrome/CDP is reachable.")
+    if "no close frame received or sent" in lowered or "stale" in lowered:
+        hints.append("The daemon websocket looks stale; rerun once or use restart_daemon() before retrying.")
+    if not hints:
+        hints.append("Check /tmp/bu-default.log or rerun with Chrome already open on a normal webpage.")
+    return hints
+
+
+def collect_smoke_details() -> dict:
+    phase_timings = {}
+    daemon_preexisting = daemon_alive()
+    timed_phase("ensure_daemon", lambda: ensure_daemon(wait=20.0), phase_timings)
+    selected_tab = timed_phase("ensure_real_tab", ensure_real_tab, phase_timings)
+    tabs = timed_phase("list_tabs", lambda: list_tabs(include_chrome=False), phase_timings)
+    current = timed_phase("current_tab", current_tab, phase_timings)
+
+    if not tabs and (not current.get("url") or current["url"].startswith(INTERNAL)):
+        raise SmokePhaseError(
+            phase="tab_validation",
+            message="no real non-internal browser tab found; open at least one normal webpage tab",
+            phase_timings=phase_timings,
+        )
+
+    info = timed_phase("page_info", page_info, phase_timings)
+    ready_state = None if "dialog" in info else timed_phase("ready_state", lambda: js("document.readyState"), phase_timings)
+
+    return {
+        "status": "pass",
+        "error_code": None,
+        "host": platform.node(),
+        "repo_root": str(repo_root()),
+        "command_path": shutil.which("browser-harness"),
+        "smoke_command_path": shutil.which("browser-harness-smoke"),
+        "bu_name": os.environ.get("BU_NAME", "default"),
+        "daemon_preexisting": daemon_preexisting,
+        "daemon_running": daemon_alive(),
+        "tab_count": len(tabs),
+        "selected_tab": selected_tab,
+        "current_tab": current,
+        "page": info,
+        "ready_state": ready_state,
+        "phase_timings": phase_timings,
+        "repair_attempted": False,
+        "repair_trigger": None,
+    }
+
+
+def run_smoke(repair_once: bool = True) -> dict:
+    repair_attempted = False
+    repair_trigger = None
+
+    for attempt in range(2 if repair_once else 1):
+        try:
+            result = collect_smoke_details()
+            result["repair_attempted"] = repair_attempted
+            result["repair_trigger"] = repair_trigger
+            return result
+        except Exception as exc:
+            message = str(exc)
+            if attempt == 0 and repair_once and is_repairable_error(message):
+                repair_attempted = True
+                repair_trigger = message
+                restart_daemon()
+                time.sleep(1.0)
+                continue
+            raise
+
+    raise RuntimeError("smoke test exhausted retries")
+
+
+def make_failure(exc: Exception, repair_attempted: bool = False, repair_trigger: Optional[str] = None) -> dict:
+    message = str(exc)
+    phase = getattr(exc, "phase", None)
+    phase_timings = getattr(exc, "phase_timings", None)
+    return {
+        "status": "fail",
+        "error_code": classify_error_code(message),
+        "host": platform.node(),
+        "repo_root": str(repo_root()),
+        "command_path": shutil.which("browser-harness"),
+        "smoke_command_path": shutil.which("browser-harness-smoke"),
+        "bu_name": os.environ.get("BU_NAME", "default"),
+        "error": message,
+        "phase": phase,
+        "phase_timings": phase_timings,
+        "repair_attempted": repair_attempted,
+        "repair_trigger": repair_trigger,
+        "hints": failure_hints(message),
+    }
+
+
+def format_text(result: dict) -> str:
+    if result.get("status") == "pass":
+        current = result.get("current_tab") or {}
+        page = result.get("page") or {}
+        lines = [
+            "PASS browser-harness smoke",
+            f"host={result.get('host')}",
+            f"bu_name={result.get('bu_name')}",
+            f"repo_root={result.get('repo_root')}",
+            f"command_path={result.get('command_path')}",
+            f"smoke_command_path={result.get('smoke_command_path')}",
+            f"daemon_preexisting={result.get('daemon_preexisting')}",
+            f"daemon_running={result.get('daemon_running')}",
+            f"tab_count={result.get('tab_count')}",
+            f"current_title={current.get('title')}",
+            f"current_url={current.get('url')}",
+            f"page_title={page.get('title')}",
+            f"page_url={page.get('url')}",
+            f"ready_state={result.get('ready_state')}",
+            f"phase_timings={format_phase_timings(result.get('phase_timings'))}",
+            f"repair_attempted={result.get('repair_attempted')}",
+        ]
+        if result.get("repair_trigger"):
+            lines.append(f"repair_trigger={result['repair_trigger']}")
+        if page.get("dialog"):
+            lines.append(f"dialog={json.dumps(page['dialog'], sort_keys=True)}")
+        return "\n".join(lines)
+
+    lines = [
+        "FAIL browser-harness smoke",
+        f"host={result.get('host')}",
+        f"bu_name={result.get('bu_name')}",
+        f"repo_root={result.get('repo_root')}",
+        f"command_path={result.get('command_path')}",
+        f"smoke_command_path={result.get('smoke_command_path')}",
+        f"error_code={result.get('error_code')}",
+        f"phase={result.get('phase')}",
+        f"phase_timings={format_phase_timings(result.get('phase_timings'))}",
+        f"error={result.get('error')}",
+        f"repair_attempted={result.get('repair_attempted')}",
+    ]
+    if result.get("repair_trigger"):
+        lines.append(f"repair_trigger={result['repair_trigger']}")
+    for hint in result.get("hints") or []:
+        lines.append(f"hint={hint}")
+    return "\n".join(lines)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Read-only browser-harness attach smoke test")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    parser.add_argument("--no-repair", action="store_true", help="Disable the one-time stale-daemon repair retry")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    repair_once = not args.no_repair
+    repair_attempted = False
+    repair_trigger = None
+    try:
+        result = run_smoke(repair_once=repair_once)
+        output = json.dumps(result, indent=2, sort_keys=True) if args.json else format_text(result)
+        print(output)
+        return 0
+    except Exception as exc:
+        if repair_once and is_repairable_error(str(exc)):
+            repair_attempted = True
+            repair_trigger = str(exc)
+        result = make_failure(exc, repair_attempted=repair_attempted, repair_trigger=repair_trigger)
+        output = json.dumps(result, indent=2, sort_keys=True) if args.json else format_text(result)
+        print(output)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/install.md
+++ b/install.md
@@ -20,14 +20,39 @@ git clone https://github.com/browser-use/browser-harness
 cd browser-harness
 uv tool install -e .
 command -v browser-harness
+command -v browser-harness-smoke
+command -v browser-harness-rollout-audit
+command -v browser-harness-evidence-packet
 ```
 
+Then verify readiness:
+
+```bash
+BU_NAME=smoke browser-harness-smoke --json
+browser-harness-rollout-audit --json
+browser-harness-evidence-packet
+```
+
+- `browser-harness-smoke` verifies that a lane can actually attach and reports a machine-readable `error_code` when it cannot. Newer builds also emit `phase` + `phase_timings` so post-attach stalls are diagnosable.
+- `browser-harness-rollout-audit` verifies the local repo/skill wiring and auto-switches the remote probe between ATHAME and FURNACE. Override with `--remote-host <name>` or `BROWSER_HARNESS_REMOTE_HOST=<name>` when needed.
+- `browser-harness-evidence-packet` writes a timestamped packet under `.hermes/reports/` with rollout audit JSON, smoke log tails, local/remote test transcripts, and git status artifacts.
+
 That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `browser-harness` uses the new code immediately. Prefer a stable path like `~/Developer/browser-harness`, not `/tmp`.
+
+If `uv` exists at `~/.local/bin/uv` but non-login shells cannot find it, add a tiny wrapper so `admin.ensure_daemon()` can spawn `uv` reliably:
+
+```bash
+mkdir -p ~/.cargo/bin
+printf '#!/bin/sh\nexec "$HOME/.local/bin/uv" "$@"\n' > ~/.cargo/bin/uv
+chmod +x ~/.cargo/bin/uv
+command -v uv
+```
 
 ## Make it global for the current agent
 
 After the repo is installed, register this repo's `SKILL.md` with the agent you are using:
 
+- **Hermes**: add/symlink this file into the shared skill tree (`~/.hermes/skills/software-development/browser-harness/SKILL.md`) and each active profile skill tree that should auto-load it.
 - **Codex**: add this file as a global skill at `$CODEX_HOME/skills/browser-harness/SKILL.md` (often `~/.codex/skills/browser-harness/SKILL.md`). A symlink to this repo's `SKILL.md` is fine.
 - **Claude Code**: add an import to `~/.claude/CLAUDE.md` that points at this repo's `SKILL.md`, for example `@~/src/browser-harness/SKILL.md`.
 
@@ -38,6 +63,18 @@ mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness" && ln -sf "$PWD/SK
 ```
 
 That makes new Codex or Claude Code sessions in other folders load the runtime browser harness instructions automatically. An empty `~/.codex/skills/browser-harness/` directory is fine; the symlink command above populates it.
+
+## Shared-operator guardrails (recommended on ATHAME/FURNACE)
+
+For shared agent surfaces, do two extra things:
+
+1. Put a small PATH-precedence wrapper in `~/bin/browser-harness` (or `~/.cargo/bin/browser-harness` on shells that only expose that path) that runs `BU_NAME=${BU_NAME:-smoke} browser-harness-smoke --json` before delegating to the real installed binary.
+2. In Claude Code, add a `PreToolUse` Bash hook that blocks `browser-harness` commands without an explicit `BU_NAME=` assignment so agents do not casually pile into the implicit default lane.
+
+Those two guardrails give you:
+- mandatory preflight before browser authority
+- explicit lane discipline
+- a clean failure surface with `error_code` + hints when Chrome/CDP is not actually ready
 
 ## Browser bootstrap
 

--- a/public_site_audit.py
+++ b/public_site_audit.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+import re
+import socket
+import sys
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+SITE_PROFILES: dict[str, dict[str, Any]] = {
+    "agm": {
+        "url": "https://aquaguardmanagement.com",
+        "markers": ["Aqua-Guard", "Pool Management", "Training", "Employment"],
+        "routes": [
+            {"path": "/", "slug": "root", "markers": ["Aqua-Guard", "Pool Management"]},
+            {"path": "/services", "slug": "services", "markers": ["Services", "Pool Management"]},
+            {"path": "/training", "slug": "training", "markers": ["Training", "Certification"]},
+            {"path": "/employment", "slug": "employment", "markers": ["Employment", "Lifeguard"]},
+            {"path": "/contact", "slug": "contact", "markers": ["Contact", "Quote"]},
+        ],
+    },
+    "oee-oracle": {
+        "url": "https://oracle.odinseyeenterprises.com",
+        "markers": ["THE ORACLE", "LOGOS", "Grimoire", "Birth Chord"],
+        "routes": [
+            {"path": "/", "slug": "root", "markers": ["THE ORACLE", "LOGOS", "Grimoire"]},
+            {"path": "/pricing", "slug": "pricing", "markers": ["Acolyte", "Architect", "Hermit"]},
+            {"path": "/developers", "slug": "developers", "markers": ["API", "LOGOS", "Developers"]},
+            {"path": "/free-chart", "slug": "free-chart", "markers": ["Free", "Chart"]},
+            {"path": "/login", "slug": "login", "markers": ["Login", "Sanctum"]},
+        ],
+    },
+}
+
+
+class _SiteParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_title = False
+        self.in_h1 = False
+        self.title_parts: list[str] = []
+        self.current_h1: list[str] = []
+        self.h1: list[str] = []
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "title":
+            self.in_title = True
+        elif tag == "h1":
+            self.in_h1 = True
+            self.current_h1 = []
+        elif tag == "a":
+            href = dict(attrs).get("href")
+            if href:
+                self.links.append(href)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self.in_title = False
+        elif tag == "h1":
+            self.in_h1 = False
+            text = " ".join(part.strip() for part in self.current_h1 if part.strip()).strip()
+            if text:
+                self.h1.append(re.sub(r"\s+", " ", text))
+            self.current_h1 = []
+
+    def handle_data(self, data: str) -> None:
+        if self.in_title:
+            self.title_parts.append(data)
+        if self.in_h1:
+            self.current_h1.append(data)
+
+
+def _normalize_links(base_url: str, links: list[str]) -> list[str]:
+    base = urlparse(base_url)
+    out: list[str] = []
+    seen: set[str] = set()
+    for href in links:
+        if href.startswith(("mailto:", "tel:", "javascript:")):
+            continue
+        absolute = urljoin(base_url, href)
+        parsed = urlparse(absolute)
+        if parsed.scheme not in {"http", "https"}:
+            continue
+        if parsed.netloc != base.netloc:
+            continue
+        normalized = parsed._replace(fragment="").geturl()
+        if normalized not in seen:
+            seen.add(normalized)
+            out.append(normalized)
+    return out
+
+
+def analyze_html(url: str, html: str) -> dict[str, Any]:
+    parser = _SiteParser()
+    parser.feed(html)
+    title = re.sub(r"\s+", " ", " ".join(parser.title_parts)).strip()
+    internal_links = _normalize_links(url, parser.links)
+    issues: list[str] = []
+    if not title:
+        issues.append("missing_title")
+    if not parser.h1:
+        issues.append("missing_h1")
+    return {
+        "title": title,
+        "h1": parser.h1,
+        "internal_links": internal_links,
+        "issues": issues,
+    }
+
+
+def evaluate_markers(text: str, markers: list[str]) -> dict[str, list[str]]:
+    lowered = text.lower()
+    present: list[str] = []
+    missing: list[str] = []
+    for marker in markers:
+        if marker.lower() in lowered:
+            present.append(marker)
+        else:
+            missing.append(marker)
+    return {"present": present, "missing": missing}
+
+
+def write_packet(outdir: Path, packet: dict[str, Any]) -> None:
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / "packet.json").write_text(json.dumps(packet, indent=2))
+    lines = [
+        "# Browser Evidence Packet",
+        "",
+        f"- **Packet ID:** {packet['packet_id']}",
+        f"- **Created At:** {packet['created_at']}",
+        f"- **Operator:** {packet['operator']}",
+        f"- **Node:** {packet['node']}",
+        f"- **Lane:** {packet['lane']}",
+        f"- **Workflow:** {packet['workflow']}",
+        f"- **Objective:** {packet['objective']}",
+        "",
+        "## Console Context",
+        f"- **Console:** {packet['console']}",
+        f"- **Page Title:** {packet['page_title']}",
+        f"- **Page URL:** {packet['page_url']}",
+        f"- **Object Under Inspection:** {packet['object_under_inspection']}",
+        "",
+        "## Findings",
+        f"- **Observed State:** {packet['observed_state']}",
+        f"- **Expected State:** {packet['expected_state']}",
+        f"- **Drift / Issue:** {packet['drift_or_issue']}",
+        f"- **Risk Level:** {packet['risk_level']}",
+        "",
+        "## Action",
+        f"- **Recommended Next Action:** {packet['recommended_next_action']}",
+        f"- **Approval Required:** {packet['approval_required']}",
+        "",
+        "## Evidence",
+        f"- **Screenshot Paths:** {packet['screenshot_paths']}",
+        f"- **Supporting Artifacts:** {packet['supporting_artifacts']}",
+        "",
+        "## Notes",
+        str(packet.get("notes", "")),
+        "",
+    ]
+    (outdir / "packet.md").write_text("\n".join(lines))
+
+
+def fetch_html(url: str) -> tuple[str, dict[str, str]]:
+    req = Request(url, headers={"User-Agent": "CathedralBrowserAudit/1.0"})
+    with urlopen(req, timeout=20) as resp:
+        charset = resp.headers.get_content_charset() or "utf-8"
+        body = resp.read().decode(charset, errors="replace")
+        headers = {k.lower(): v for k, v in resp.headers.items()}
+        headers[":status"] = str(resp.status)
+    return body, headers
+
+
+def _risk_from_issues(issues: list[str]) -> str:
+    if not issues:
+        return "low"
+    if "missing_title" in issues and "missing_h1" in issues:
+        return "high"
+    if "missing_expected_markers" in issues:
+        return "high"
+    return "medium"
+
+
+def _packet_root(stamp: datetime, packet_id: str) -> Path:
+    return Path.home() / "Cathedral" / "state" / "browser-observatory" / "packets" / stamp.strftime("%Y") / stamp.strftime("%m") / stamp.strftime("%d") / packet_id
+
+
+def _make_route_packet(url: str, workflow: str, lane: str, packet_id: str, outdir: Path, route_label: str, markers: list[str]) -> dict[str, Any]:
+    html, headers = fetch_html(url)
+    analysis = analyze_html(url, html)
+    marker_result = evaluate_markers(html, markers)
+    if marker_result["missing"]:
+        analysis["issues"].append("missing_expected_markers")
+    packet = {
+        "packet_id": packet_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "operator": Path.home().name,
+        "node": socket.gethostname(),
+        "lane": lane,
+        "workflow": workflow,
+        "objective": f"Audit {url}",
+        "console": "public-web",
+        "page_title": analysis["title"],
+        "page_url": url,
+        "object_under_inspection": route_label,
+        "observed_state": f"status={headers.get(':status')} markers_present={marker_result['present']} markers_missing={marker_result['missing']} h1={analysis['h1'][:2]}",
+        "expected_state": f"Route markers should be present: {markers}",
+        "drift_or_issue": ", ".join(analysis["issues"]) if analysis["issues"] else "",
+        "risk_level": _risk_from_issues(analysis["issues"]),
+        "recommended_next_action": "Review route IA/content regression if markers are missing; otherwise keep as healthy.",
+        "approval_required": "false",
+        "screenshot_paths": [],
+        "supporting_artifacts": [str(outdir / "analysis.json")],
+        "notes": f"server={headers.get('server','')} content_type={headers.get('content-type','')} internal_link_count={len(analysis['internal_links'])}",
+    }
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / "analysis.json").write_text(json.dumps({"headers": headers, **analysis, "markers": marker_result}, indent=2))
+    write_packet(outdir, packet)
+    return packet
+
+
+def make_packet(url: str, workflow: str = "public-site-smoke", lane: str = "deploy") -> tuple[Path, dict[str, Any]]:
+    now = datetime.now(timezone.utc)
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    hostname = urlparse(url).netloc.replace(":", "-")
+    packet_id = f"{stamp}-{lane}-{hostname}"
+    outdir = _packet_root(now, packet_id)
+    packet = _make_route_packet(url, workflow, lane, packet_id, outdir, urlparse(url).path or "/", [])
+    return outdir, packet
+
+
+def audit_profile(profile_name: str, profile: dict[str, Any] | None = None, workflow: str = "public-site-smoke", lane: str = "deploy") -> tuple[Path, dict[str, Any]]:
+    profile = profile or SITE_PROFILES[profile_name]
+    base_url = profile["url"]
+    now = datetime.now(timezone.utc)
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    root = _packet_root(now, f"{stamp}-{lane}-{profile_name}")
+    routes_root = root / "routes"
+    route_summaries: list[dict[str, Any]] = []
+    overall_issues: list[str] = []
+    worst_risk = "low"
+    risk_rank = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+    for route in profile.get("routes", [{"path": "/", "slug": "root", "markers": profile.get("markers", [])}]):
+        path = route["path"]
+        slug = route.get("slug") or (path.strip("/").replace("/", "-") or "root")
+        url = urljoin(base_url, path)
+        packet = _make_route_packet(url, workflow, lane, f"{stamp}-{lane}-{profile_name}-{slug}", routes_root / slug, slug, route.get("markers", []))
+        route_summaries.append({
+            "slug": slug,
+            "url": url,
+            "risk_level": packet["risk_level"],
+            "drift_or_issue": packet["drift_or_issue"],
+            "page_title": packet["page_title"],
+        })
+        if packet["drift_or_issue"]:
+            overall_issues.append(f"{slug}:{packet['drift_or_issue']}")
+        if risk_rank[packet["risk_level"]] > risk_rank[worst_risk]:
+            worst_risk = packet["risk_level"]
+    summary = {
+        "profile": profile_name,
+        "base_url": base_url,
+        "workflow": workflow,
+        "lane": lane,
+        "risk_level": worst_risk,
+        "issues": overall_issues,
+        "routes": route_summaries,
+    }
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "summary.json").write_text(json.dumps(summary, indent=2))
+    packet = {
+        "packet_id": f"{stamp}-{lane}-{profile_name}",
+        "created_at": now.isoformat(),
+        "operator": Path.home().name,
+        "node": socket.gethostname(),
+        "lane": lane,
+        "workflow": workflow,
+        "objective": f"Profile audit {profile_name}",
+        "console": "public-web",
+        "page_title": profile_name,
+        "page_url": base_url,
+        "object_under_inspection": profile_name,
+        "observed_state": f"routes_checked={len(route_summaries)} highest_risk={worst_risk}",
+        "expected_state": "All profiled routes should load and satisfy expected content markers.",
+        "drift_or_issue": "; ".join(overall_issues),
+        "risk_level": worst_risk,
+        "recommended_next_action": "Review flagged route packets if any route is medium/high risk; otherwise keep the profile healthy.",
+        "approval_required": "false",
+        "screenshot_paths": [],
+        "supporting_artifacts": [str(root / "summary.json")],
+        "notes": f"routes={[r['slug'] for r in route_summaries]}",
+    }
+    write_packet(root, packet)
+    return root, packet
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: browser-site-audit <url> [url ...] | --profile <name> [--profile <name> ...]", file=sys.stderr)
+        return 1
+    args = sys.argv[1:]
+    if args[0] == "--profile":
+        names = [args[i + 1] for i, arg in enumerate(args[:-1]) if arg == "--profile"]
+        for name in names:
+            if name not in SITE_PROFILES:
+                print(f"unknown profile: {name}", file=sys.stderr)
+                return 2
+            outdir, packet = audit_profile(name)
+            print(f"profile:{name} -> {outdir} risk={packet['risk_level']}")
+        return 0
+    for url in args:
+        outdir, packet = make_packet(url)
+        print(f"{url} -> {outdir} risk={packet['risk_level']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
 
 [project.scripts]
 browser-harness = "run:main"
+browser-harness-smoke = "harness_smoke:main"
+browser-harness-rollout-audit = "rollout_audit:main"
+browser-site-audit = "public_site_audit:main"
+browser-observatory-run = "run_browser_observatory:main"
 
 [tool.setuptools]
-py-modules = ["run", "helpers", "daemon", "admin"]
+py-modules = ["run", "helpers", "daemon", "admin", "harness_smoke", "rollout_audit", "public_site_audit", "run_browser_observatory"]

--- a/rollout_audit.py
+++ b/rollout_audit.py
@@ -1,0 +1,266 @@
+import argparse
+import json
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable, Optional
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def expected_skill_path(repo: Optional[Path] = None) -> Path:
+    return (repo or repo_root()) / "SKILL.md"
+
+
+def path_exists(path: Path) -> bool:
+    return path.exists() or path.is_symlink()
+
+
+def resolve_path(path: Path) -> Optional[str]:
+    if not path_exists(path):
+        return None
+    try:
+        return str(path.resolve())
+    except OSError:
+        return None
+
+
+def audit_link(path: Path, target: Path) -> dict:
+    exists = path_exists(path)
+    resolved = resolve_path(path)
+    target_resolved = str(target.resolve())
+    return {
+        "path": str(path),
+        "target": str(target),
+        "resolved": resolved,
+        "status": "ok" if exists and resolved == target_resolved else ("drift" if exists else "missing"),
+    }
+
+
+def audit_claude_import(path: Path, target: Path) -> dict:
+    if not path_exists(path):
+        return {
+            "path": str(path),
+            "target": str(target),
+            "import_present": False,
+            "status": "missing",
+        }
+    text = path.read_text()
+    target_text = str(target)
+    import_present = f"@{target_text}" in text or target_text in text
+    return {
+        "path": str(path),
+        "target": target_text,
+        "import_present": import_present,
+        "status": "ok" if import_present else "drift",
+    }
+
+
+def run_smoke_command(lane: str = "smoke") -> dict:
+    env = os.environ.copy()
+    env["BU_NAME"] = lane
+    try:
+        proc = subprocess.run(["browser-harness-smoke", "--json"], capture_output=True, text=True, env=env, timeout=45)
+    except (subprocess.TimeoutExpired, TimeoutError):
+        return {
+            "status": "fail",
+            "error_code": "BH-ATTACH-005",
+            "error": "browser-harness-smoke timed out after 45s",
+            "lane": lane,
+            "exit_code": 124,
+        }
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    try:
+        data = json.loads(stdout) if stdout else {}
+    except json.JSONDecodeError:
+        data = {
+            "status": "fail",
+            "error_code": "BH-UNKNOWN-001",
+            "error": stdout or stderr or "browser-harness-smoke returned non-JSON output",
+        }
+    data.setdefault("status", "pass" if proc.returncode == 0 else "fail")
+    data.setdefault("lane", lane)
+    data["lane"] = lane
+    data["exit_code"] = proc.returncode
+    if stderr:
+        data["stderr"] = stderr
+    return data
+
+
+def collect_local_audit(
+    home: Optional[Path] = None,
+    repo: Optional[Path] = None,
+    smoke_runner: Optional[Callable[[str], dict]] = None,
+    lane: str = "smoke",
+) -> dict:
+    home = home or Path.home()
+    repo = repo or repo_root()
+    smoke_runner = smoke_runner or run_smoke_command
+    skill = expected_skill_path(repo)
+
+    integrations = {
+        "hermes": audit_link(home / ".hermes" / "skills" / "software-development" / "browser-harness" / "SKILL.md", skill),
+        "claude": audit_claude_import(home / ".claude" / "CLAUDE.md", skill),
+        "codex": audit_link(home / ".codex" / "skills" / "browser-harness" / "SKILL.md", skill),
+    }
+
+    return {
+        "host": platform.node(),
+        "repo_root": str(repo),
+        "expected_skill": str(skill),
+        "command_path": shutil.which("browser-harness"),
+        "smoke_command_path": shutil.which("browser-harness-smoke"),
+        "integrations": integrations,
+        "smoke": smoke_runner(lane),
+    }
+
+
+def canonical_host_tokens(name: Optional[str]) -> set:
+    if not name:
+        return set()
+    raw = str(name).strip().lower()
+    tokens = {raw}
+    short = raw.split(".")[0]
+    tokens.add(short)
+    for part in short.replace("_", "-").split("-"):
+        if part:
+            tokens.add(part)
+    if "macbook" in raw or "athame" in raw:
+        tokens.add("athame")
+    if "mac-mini" in raw or "macmini" in raw or "furnace" in raw:
+        tokens.add("furnace")
+    return tokens
+
+
+def is_self_host(host: Optional[str], node_name: Optional[str] = None) -> bool:
+    if not host:
+        return False
+    return bool(canonical_host_tokens(host) & canonical_host_tokens(node_name or platform.node()))
+
+
+def default_remote_host(node_name: Optional[str] = None) -> str:
+    tokens = canonical_host_tokens(node_name or platform.node())
+    if "furnace" in tokens:
+        return "athame"
+    return "furnace"
+
+
+def resolve_remote_host(remote_host: Optional[str] = None, node_name: Optional[str] = None) -> Optional[str]:
+    requested = (remote_host or "").strip()
+    if requested and requested.lower() != "auto":
+        return requested
+    env_remote = (os.environ.get("BROWSER_HARNESS_REMOTE_HOST") or "").strip()
+    if env_remote:
+        return env_remote
+    return default_remote_host(node_name=node_name)
+
+
+def collect_remote_audit(host: str, repo: Optional[Path] = None, lane: str = "smoke") -> dict:
+    repo = repo or repo_root()
+    command = [
+        "ssh",
+        host,
+        f"cd {shlex.quote(str(repo))} && python3 rollout_audit.py --json --local-only --lane {shlex.quote(lane)}",
+    ]
+    proc = subprocess.run(command, capture_output=True, text=True)
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if stdout:
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError:
+            payload = None
+        else:
+            local_payload = (payload.get("nodes") or {}).get("local")
+            if isinstance(local_payload, dict):
+                return local_payload
+    if proc.returncode != 0:
+        return {
+            "host": host,
+            "repo_root": str(repo),
+            "expected_skill": str(expected_skill_path(repo)),
+            "command_path": None,
+            "smoke_command_path": None,
+            "integrations": {},
+            "smoke": {
+                "status": "fail",
+                "error_code": "BH-REMOTE-900",
+                "error": stderr or stdout or f"remote audit failed for {host}",
+                "lane": lane,
+                "exit_code": proc.returncode,
+            },
+        }
+    payload = json.loads(stdout)
+    return payload["nodes"]["local"]
+
+
+def build_audit(remote_host: Optional[str] = None, lane: str = "smoke", local_only: bool = False) -> dict:
+    repo = repo_root()
+    chosen_remote = None if local_only else resolve_remote_host(remote_host)
+    audit = {
+        "repo_root": str(repo),
+        "expected_skill": str(expected_skill_path(repo)),
+        "remote_host": chosen_remote,
+        "nodes": {
+            "local": collect_local_audit(repo=repo, lane=lane),
+        },
+    }
+    if chosen_remote and not is_self_host(chosen_remote, audit["nodes"]["local"].get("host")):
+        audit["nodes"][chosen_remote] = collect_remote_audit(chosen_remote, repo=repo, lane=lane)
+    return audit
+
+
+def format_text(audit: dict) -> str:
+    lines = [
+        "BROWSER HARNESS ROLLOUT AUDIT",
+        f"repo_root={audit.get('repo_root')}",
+        f"expected_skill={audit.get('expected_skill')}",
+        f"remote_host={audit.get('remote_host')}",
+    ]
+    for node_name, node in (audit.get("nodes") or {}).items():
+        smoke = node.get("smoke") or {}
+        lines.append("")
+        lines.append(f"node={node_name} host={node.get('host')}")
+        lines.append(f"  browser_harness={node.get('command_path')}")
+        lines.append(f"  browser_harness_smoke={node.get('smoke_command_path')}")
+        lines.append(f"  smoke={smoke.get('status')} error_code={smoke.get('error_code')}")
+        if smoke.get("error"):
+            lines.append(f"  smoke_error={smoke.get('error')}")
+        for name, integration in (node.get("integrations") or {}).items():
+            lines.append(f"  {name}={integration.get('status')} path={integration.get('path')}")
+    return "\n".join(lines)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Audit browser-harness rollout across local and remote nodes")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    parser.add_argument(
+        "--remote-host",
+        default="auto",
+        help="Remote host to audit over ssh (default: auto-switch between athame and furnace; env override: BROWSER_HARNESS_REMOTE_HOST)",
+    )
+    parser.add_argument("--local-only", action="store_true", help="Only audit the local node")
+    parser.add_argument("--lane", default="smoke", help="BU_NAME lane to use for smoke checks")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    audit = build_audit(remote_host=args.remote_host, lane=args.lane, local_only=args.local_only)
+    print(json.dumps(audit, indent=2, sort_keys=True) if args.json else format_text(audit))
+    failures = [
+        node.get("smoke", {}).get("status") == "fail"
+        or any(integration.get("status") != "ok" for integration in (node.get("integrations") or {}).values())
+        for node in audit.get("nodes", {}).values()
+    ]
+    return 1 if any(failures) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/run_browser_observatory.py
+++ b/run_browser_observatory.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from public_site_audit import SITE_PROFILES, audit_profile
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Run Cathedral browser observatory public-site audits.')
+    parser.add_argument('--profile', action='append', dest='profiles', help='Profile name to audit; repeatable')
+    parser.add_argument('--all', action='store_true', help='Audit all known profiles')
+    parser.add_argument('--lane', default='deploy', help='Browser lane name')
+    parser.add_argument('--workflow', default='public-site-smoke', help='Workflow label for packets')
+    args = parser.parse_args()
+
+    profiles = args.profiles or []
+    if args.all:
+        profiles = list(SITE_PROFILES.keys())
+    if not profiles:
+        parser.error('provide --profile NAME or --all')
+
+    for name in profiles:
+        if name not in SITE_PROFILES:
+            parser.error(f'unknown profile: {name}')
+        outdir, packet = audit_profile(name, workflow=args.workflow, lane=args.lane)
+        print(f'{name} -> {outdir} risk={packet["risk_level"]}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/templates/browser-evidence-packet.json
+++ b/templates/browser-evidence-packet.json
@@ -1,0 +1,22 @@
+{
+  "packet_id": "{{packet_id}}",
+  "created_at": "{{created_at}}",
+  "operator": "{{operator}}",
+  "node": "{{node}}",
+  "lane": "{{lane}}",
+  "workflow": "{{workflow}}",
+  "objective": "{{objective}}",
+  "console": "{{console}}",
+  "page_title": "{{page_title}}",
+  "page_url": "{{page_url}}",
+  "object_under_inspection": "{{object_under_inspection}}",
+  "observed_state": "{{observed_state}}",
+  "expected_state": "{{expected_state}}",
+  "drift_or_issue": "{{drift_or_issue}}",
+  "risk_level": "{{risk_level}}",
+  "recommended_next_action": "{{recommended_next_action}}",
+  "approval_required": "{{approval_required}}",
+  "screenshot_paths": ["{{screenshot_path}}"],
+  "supporting_artifacts": [],
+  "notes": "{{notes}}"
+}

--- a/templates/browser-evidence-packet.md
+++ b/templates/browser-evidence-packet.md
@@ -1,0 +1,32 @@
+# Browser Evidence Packet
+
+- **Packet ID:** {{packet_id}}
+- **Created At:** {{created_at}}
+- **Operator:** {{operator}}
+- **Node:** {{node}}
+- **Lane:** {{lane}}
+- **Workflow:** {{workflow}}
+- **Objective:** {{objective}}
+
+## Console Context
+- **Console:** {{console}}
+- **Page Title:** {{page_title}}
+- **Page URL:** {{page_url}}
+- **Object Under Inspection:** {{object_under_inspection}}
+
+## Findings
+- **Observed State:** {{observed_state}}
+- **Expected State:** {{expected_state}}
+- **Drift / Issue:** {{drift_or_issue}}
+- **Risk Level:** {{risk_level}}
+
+## Action
+- **Recommended Next Action:** {{recommended_next_action}}
+- **Approval Required:** {{approval_required}}
+
+## Evidence
+- **Screenshot Paths:** {{screenshot_paths}}
+- **Supporting Artifacts:** {{supporting_artifacts}}
+
+## Notes
+{{notes}}

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -1,0 +1,167 @@
+import unittest
+from unittest.mock import patch
+
+
+class HarnessSmokeTests(unittest.TestCase):
+    def test_run_smoke_restarts_once_on_stale_error_then_succeeds(self):
+        import harness_smoke
+
+        calls = []
+
+        def fake_collect():
+            if not calls:
+                calls.append("fail")
+                raise RuntimeError("no close frame received or sent")
+            return {"status": "pass", "page": {"url": "https://example.com"}}
+
+        with patch("harness_smoke.collect_smoke_details", side_effect=fake_collect), patch(
+            "harness_smoke.restart_daemon"
+        ) as restart, patch("harness_smoke.time.sleep"):
+            result = harness_smoke.run_smoke()
+
+        self.assertEqual(result["status"], "pass")
+        restart.assert_called_once()
+
+    def test_collect_smoke_details_handles_dialog_without_ready_state(self):
+        import harness_smoke
+
+        with patch("harness_smoke.daemon_alive", return_value=False), patch(
+            "harness_smoke.ensure_daemon"
+        ), patch(
+            "harness_smoke.ensure_real_tab",
+            return_value={"targetId": "1", "url": "https://example.com", "title": "Example"},
+        ), patch(
+            "harness_smoke.current_tab",
+            return_value={"targetId": "1", "url": "https://example.com", "title": "Example"},
+        ), patch(
+            "harness_smoke.list_tabs",
+            return_value=[{"targetId": "1", "url": "https://example.com", "title": "Example"}],
+        ), patch(
+            "harness_smoke.page_info",
+            return_value={"dialog": {"type": "alert", "message": "hi"}},
+        ), patch("harness_smoke.shutil.which", side_effect=lambda name: f"/bin/{name}"):
+            result = harness_smoke.collect_smoke_details()
+
+        self.assertEqual(result["status"], "pass")
+        self.assertIsNone(result["ready_state"])
+        self.assertEqual(result["page"]["dialog"]["type"], "alert")
+
+    def test_format_text_renders_pass_summary(self):
+        import harness_smoke
+
+        text = harness_smoke.format_text(
+            {
+                "status": "pass",
+                "host": "athame",
+                "repo_root": "/repo",
+                "command_path": "/bin/browser-harness",
+                "smoke_command_path": "/bin/browser-harness-smoke",
+                "daemon_preexisting": True,
+                "daemon_running": True,
+                "tab_count": 2,
+                "current_tab": {"title": "Example", "url": "https://example.com"},
+                "page": {"url": "https://example.com", "title": "Example"},
+                "ready_state": "complete",
+                "phase_timings": {"ensure_daemon": 0.1, "ensure_real_tab": 0.2},
+                "repair_attempted": False,
+                "repair_trigger": None,
+                "bu_name": "default",
+            }
+        )
+
+        self.assertIn("PASS browser-harness smoke", text)
+        self.assertIn("current_title=Example", text)
+        self.assertIn("ready_state=complete", text)
+        self.assertIn("phase_timings=ensure_daemon:0.100s, ensure_real_tab:0.200s", text)
+
+    def test_failure_hints_cover_allow_prompt(self):
+        import harness_smoke
+
+        hints = harness_smoke.failure_hints(
+            "fatal: CDP WS handshake failed: timed out during opening handshake -- click Allow in Chrome if prompted, then retry"
+        )
+
+        self.assertTrue(any("Allow prompt" in hint or "click Allow" in hint for hint in hints))
+
+    def test_classify_error_code_detects_devtools_active_port(self):
+        import harness_smoke
+
+        code = harness_smoke.classify_error_code(
+            "fatal: DevToolsActivePort not found in ['/Users/me/Library/Application Support/Google/Chrome']"
+        )
+
+        self.assertEqual(code, "BH-ATTACH-001")
+
+    def test_format_text_renders_failure_error_code(self):
+        import harness_smoke
+
+        text = harness_smoke.format_text(
+            {
+                "status": "fail",
+                "host": "furnace",
+                "repo_root": "/repo",
+                "command_path": "/bin/browser-harness",
+                "smoke_command_path": "/bin/browser-harness-smoke",
+                "bu_name": "smoke",
+                "error": "fatal: CDP WS handshake failed: timed out during opening handshake -- click Allow in Chrome if prompted, then retry",
+                "error_code": "BH-ATTACH-003",
+                "phase": "ensure_real_tab",
+                "phase_timings": {"ensure_daemon": 0.1, "ensure_real_tab": 10.0},
+                "repair_attempted": False,
+                "repair_trigger": None,
+                "hints": ["Chrome is likely waiting on its remote-debugging Allow prompt; click Allow in Chrome, then rerun."],
+            }
+        )
+
+        self.assertIn("error_code=BH-ATTACH-003", text)
+        self.assertIn("phase=ensure_real_tab", text)
+        self.assertIn("phase_timings=ensure_daemon:0.100s, ensure_real_tab:10.000s", text)
+
+    def test_make_failure_preserves_phase_context(self):
+        import harness_smoke
+
+        error = harness_smoke.SmokePhaseError(
+            phase="page_info",
+            message="timed out during page_info after 10.0s",
+            phase_timings={"ensure_daemon": 0.1, "page_info": 10.0},
+        )
+
+        with patch("harness_smoke.platform.node", return_value="athame"), patch(
+            "harness_smoke.shutil.which", side_effect=lambda name: f"/bin/{name}"
+        ):
+            result = harness_smoke.make_failure(error)
+
+        self.assertEqual(result["phase"], "page_info")
+        self.assertEqual(result["phase_timings"], {"ensure_daemon": 0.1, "page_info": 10.0})
+
+    def test_collect_smoke_details_records_phase_timings(self):
+        import harness_smoke
+
+        with patch("harness_smoke.daemon_alive", side_effect=[False, True]), patch(
+            "harness_smoke.ensure_daemon"
+        ), patch(
+            "harness_smoke.ensure_real_tab",
+            return_value={"targetId": "1", "url": "https://example.com", "title": "Example"},
+        ), patch(
+            "harness_smoke.current_tab",
+            return_value={"targetId": "1", "url": "https://example.com", "title": "Example"},
+        ), patch(
+            "harness_smoke.list_tabs",
+            return_value=[{"targetId": "1", "url": "https://example.com", "title": "Example"}],
+        ), patch(
+            "harness_smoke.page_info",
+            return_value={"url": "https://example.com", "title": "Example"},
+        ), patch(
+            "harness_smoke.js",
+            return_value="complete",
+        ), patch("harness_smoke.shutil.which", side_effect=lambda name: f"/bin/{name}"):
+            result = harness_smoke.collect_smoke_details()
+
+        self.assertEqual(result["status"], "pass")
+        self.assertIn("ensure_daemon", result["phase_timings"])
+        self.assertIn("page_info", result["phase_timings"])
+        self.assertIn("ready_state", result["phase_timings"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_marker_evaluation.py
+++ b/tests/test_marker_evaluation.py
@@ -1,0 +1,20 @@
+import unittest
+
+from public_site_audit import evaluate_markers
+
+
+class MarkerEvaluationTests(unittest.TestCase):
+    def test_reports_missing_required_markers(self):
+        text = "The Cathedral powered by LOGOS and Grimoire"
+        result = evaluate_markers(text, ["LOGOS", "Sanctum"])
+        self.assertEqual(result["present"], ["LOGOS"])
+        self.assertEqual(result["missing"], ["Sanctum"])
+
+    def test_is_case_insensitive(self):
+        text = "expert pool management & staffing solutions"
+        result = evaluate_markers(text, ["Expert Pool Management", "Staffing Solutions"])
+        self.assertEqual(result["missing"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_profile_observatory.py
+++ b/tests/test_profile_observatory.py
@@ -1,0 +1,44 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from public_site_audit import SITE_PROFILES, audit_profile
+
+
+class ProfileObservatoryTests(unittest.TestCase):
+    def test_profile_defines_multiple_routes(self):
+        self.assertGreaterEqual(len(SITE_PROFILES['agm']['routes']), 3)
+        self.assertGreaterEqual(len(SITE_PROFILES['oee-oracle']['routes']), 3)
+
+    def test_audit_profile_writes_summary_and_route_packets(self):
+        responses = {
+            'https://example.com/': ('<html><head><title>Home</title></head><body><h1>Home</h1>Alpha <a href="/about">About</a></body></html>', {':status': '200', 'server': 'Vercel', 'content-type': 'text/html'}),
+            'https://example.com/about': ('<html><head><title>About</title></head><body><h1>About</h1>Beta</body></html>', {':status': '200', 'server': 'Vercel', 'content-type': 'text/html'}),
+        }
+        profile = {
+            'url': 'https://example.com',
+            'markers': ['Alpha'],
+            'routes': [
+                {'path': '/', 'markers': ['Alpha']},
+                {'path': '/about', 'markers': ['Beta']},
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch('public_site_audit.Path.home', return_value=root), patch('public_site_audit.fetch_html', side_effect=lambda url: responses[url]):
+                outdir, summary = audit_profile('example', profile, workflow='public-site-smoke', lane='deploy')
+
+            self.assertTrue((outdir / 'summary.json').exists())
+            data = json.loads((outdir / 'summary.json').read_text())
+            self.assertEqual(data['profile'], 'example')
+            self.assertEqual(len(data['routes']), 2)
+            self.assertEqual(summary['risk_level'], 'low')
+            self.assertTrue((outdir / 'routes' / 'root' / 'packet.json').exists())
+            self.assertTrue((outdir / 'routes' / 'about' / 'packet.json').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_public_site_audit.py
+++ b/tests/test_public_site_audit.py
@@ -1,0 +1,71 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from public_site_audit import analyze_html, write_packet
+
+
+class AnalyzeHtmlTests(unittest.TestCase):
+    def test_extracts_title_h1_and_internal_links(self):
+        html = """
+        <html>
+          <head><title>Test Site</title></head>
+          <body>
+            <h1>Main Signal</h1>
+            <a href="/pricing">Pricing</a>
+            <a href="https://example.com/login">Login</a>
+            <a href="mailto:test@example.com">Email</a>
+          </body>
+        </html>
+        """
+        result = analyze_html("https://example.com", html)
+        self.assertEqual(result["title"], "Test Site")
+        self.assertEqual(result["h1"], ["Main Signal"])
+        self.assertEqual(result["internal_links"], ["https://example.com/pricing", "https://example.com/login"])
+        self.assertEqual(result["issues"], [])
+
+    def test_flags_missing_title_and_h1(self):
+        html = "<html><body><p>No signal</p></body></html>"
+        result = analyze_html("https://example.com", html)
+        self.assertIn("missing_title", result["issues"])
+        self.assertIn("missing_h1", result["issues"])
+
+
+class WritePacketTests(unittest.TestCase):
+    def test_writes_markdown_and_json_packets(self):
+        packet = {
+            "packet_id": "pkt-1",
+            "created_at": "2026-04-19T00:00:00Z",
+            "operator": "odinbot33",
+            "node": "furnace",
+            "lane": "deploy",
+            "workflow": "public-site-smoke",
+            "objective": "Audit site",
+            "console": "public-web",
+            "page_title": "Site",
+            "page_url": "https://example.com",
+            "object_under_inspection": "homepage",
+            "observed_state": "healthy",
+            "expected_state": "healthy",
+            "drift_or_issue": "",
+            "risk_level": "low",
+            "recommended_next_action": "none",
+            "approval_required": "false",
+            "screenshot_paths": [],
+            "supporting_artifacts": [],
+            "notes": "ok",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            outdir = Path(tmp)
+            write_packet(outdir, packet)
+            self.assertTrue((outdir / "packet.json").exists())
+            self.assertTrue((outdir / "packet.md").exists())
+            data = json.loads((outdir / "packet.json").read_text())
+            self.assertEqual(data["packet_id"], "pkt-1")
+            md = (outdir / "packet.md").read_text()
+            self.assertIn("Packet ID:** pkt-1", md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rollout_audit.py
+++ b/tests/test_rollout_audit.py
@@ -1,0 +1,161 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class RolloutAuditTests(unittest.TestCase):
+    def test_collect_local_audit_marks_integrations_ready(self):
+        import rollout_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "browser-harness"
+            repo.mkdir()
+            skill = repo / "SKILL.md"
+            skill.write_text("# skill\n")
+
+            hermes_skill = root / ".hermes" / "skills" / "software-development" / "browser-harness"
+            hermes_skill.mkdir(parents=True)
+            (hermes_skill / "SKILL.md").symlink_to(skill)
+
+            claude_dir = root / ".claude"
+            claude_dir.mkdir()
+            (claude_dir / "CLAUDE.md").write_text(f"@{skill}\n")
+
+            codex_skill = root / ".codex" / "skills" / "browser-harness"
+            codex_skill.mkdir(parents=True)
+            (codex_skill / "SKILL.md").symlink_to(skill)
+
+            audit = rollout_audit.collect_local_audit(
+                home=root,
+                repo=repo,
+                smoke_runner=lambda lane: {"status": "pass", "error_code": None, "lane": lane},
+            )
+
+        self.assertEqual(audit["integrations"]["hermes"]["status"], "ok")
+        self.assertEqual(audit["integrations"]["claude"]["status"], "ok")
+        self.assertEqual(audit["integrations"]["codex"]["status"], "ok")
+        self.assertEqual(audit["smoke"]["status"], "pass")
+        self.assertEqual(audit["smoke"]["lane"], "smoke")
+
+    def test_collect_local_audit_captures_missing_integrations_and_failed_smoke(self):
+        import rollout_audit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "browser-harness"
+            repo.mkdir()
+            (repo / "SKILL.md").write_text("# skill\n")
+
+            audit = rollout_audit.collect_local_audit(
+                home=root,
+                repo=repo,
+                smoke_runner=lambda lane: {
+                    "status": "fail",
+                    "error_code": "BH-ATTACH-001",
+                    "error": "DevToolsActivePort not found",
+                    "lane": lane,
+                },
+            )
+
+        self.assertEqual(audit["integrations"]["hermes"]["status"], "missing")
+        self.assertEqual(audit["integrations"]["claude"]["status"], "missing")
+        self.assertEqual(audit["integrations"]["codex"]["status"], "missing")
+        self.assertEqual(audit["smoke"]["status"], "fail")
+        self.assertEqual(audit["smoke"]["error_code"], "BH-ATTACH-001")
+
+    def test_format_text_renders_node_summary(self):
+        import rollout_audit
+
+        text = rollout_audit.format_text(
+            {
+                "repo_root": "/repo",
+                "expected_skill": "/repo/SKILL.md",
+                "nodes": {
+                    "local": {
+                        "host": "athame",
+                        "smoke": {"status": "fail", "error_code": "BH-ATTACH-003", "error": "allow prompt"},
+                        "integrations": {
+                            "hermes": {"status": "ok", "path": "/Users/me/.hermes/skills/software-development/browser-harness/SKILL.md"},
+                            "claude": {"status": "ok", "path": "/Users/me/.claude/CLAUDE.md"},
+                            "codex": {"status": "missing", "path": "/Users/me/.codex/skills/browser-harness/SKILL.md"},
+                        },
+                    }
+                },
+            }
+        )
+
+        self.assertIn("BROWSER HARNESS ROLLOUT AUDIT", text)
+        self.assertIn("node=local host=athame", text)
+        self.assertIn("smoke=fail error_code=BH-ATTACH-003", text)
+        self.assertIn("codex=missing", text)
+
+    def test_run_smoke_command_timeout_returns_typed_failure(self):
+        import rollout_audit
+
+        with patch("rollout_audit.subprocess.run", side_effect=TimeoutError):
+            result = rollout_audit.run_smoke_command("smoke")
+
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["error_code"], "BH-ATTACH-005")
+        self.assertEqual(result["lane"], "smoke")
+
+    def test_default_remote_host_flips_between_athame_and_furnace(self):
+        import rollout_audit
+
+        self.assertEqual(rollout_audit.default_remote_host("Odins-MacBook-Pro.local"), "furnace")
+        self.assertEqual(rollout_audit.default_remote_host("Odins-Mac-mini.local"), "athame")
+        self.assertEqual(rollout_audit.default_remote_host("athame"), "furnace")
+        self.assertEqual(rollout_audit.default_remote_host("furnace"), "athame")
+
+    def test_build_audit_skips_self_remote_probe(self):
+        import rollout_audit
+
+        fake_repo = Path("/repo")
+        local_payload = {
+            "host": "Odins-Mac-mini.local",
+            "repo_root": str(fake_repo),
+            "expected_skill": str(fake_repo / "SKILL.md"),
+            "command_path": "/Users/me/.cargo/bin/browser-harness",
+            "smoke_command_path": "/Users/me/.cargo/bin/browser-harness-smoke",
+            "integrations": {},
+            "smoke": {"status": "pass", "error_code": None, "lane": "smoke"},
+        }
+
+        with patch("rollout_audit.repo_root", return_value=fake_repo), patch(
+            "rollout_audit.collect_local_audit", return_value=local_payload
+        ), patch("rollout_audit.collect_remote_audit") as collect_remote:
+            audit = rollout_audit.build_audit(remote_host="furnace", lane="smoke", local_only=False)
+
+        collect_remote.assert_not_called()
+        self.assertEqual(list(audit["nodes"].keys()), ["local"])
+
+    def test_collect_remote_audit_parses_json_even_on_nonzero_exit(self):
+        import rollout_audit
+
+        payload = {
+            "nodes": {
+                "local": {
+                    "host": "Odins-MacBook-Pro.local",
+                    "repo_root": "/repo",
+                    "expected_skill": "/repo/SKILL.md",
+                    "command_path": "/Users/me/.cargo/bin/browser-harness",
+                    "smoke_command_path": "/Users/me/.cargo/bin/browser-harness-smoke",
+                    "integrations": {},
+                    "smoke": {"status": "fail", "error_code": "BH-ATTACH-005", "lane": "smoke"},
+                }
+            }
+        }
+        proc = type("Proc", (), {"returncode": 1, "stdout": json.dumps(payload), "stderr": ""})()
+
+        with patch("rollout_audit.subprocess.run", return_value=proc):
+            result = rollout_audit.collect_remote_audit("athame", repo=Path("/repo"), lane="smoke")
+
+        self.assertEqual(result["host"], "Odins-MacBook-Pro.local")
+        self.assertEqual(result["smoke"]["error_code"], "BH-ATTACH-005")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_browser_observatory.py
+++ b/tests/test_run_browser_observatory.py
@@ -1,0 +1,26 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from run_browser_observatory import main
+
+
+class BrowserObservatoryRunnerTests(unittest.TestCase):
+    def test_runs_all_profiles(self):
+        called = []
+
+        def fake_audit_profile(name, workflow='public-site-smoke', lane='deploy'):
+            called.append((name, workflow, lane))
+            return '/tmp/out', {'risk_level': 'low'}
+
+        with patch('run_browser_observatory.audit_profile', side_effect=fake_audit_profile):
+            with patch('sys.argv', ['run_browser_observatory.py', '--all']):
+                with redirect_stdout(io.StringIO()):
+                    rc = main()
+        self.assertEqual(rc, 0)
+        self.assertGreaterEqual(len(called), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a typed `browser-harness-smoke` readiness CLI for shared-agent preflight
- add a host-aware `browser-harness-rollout-audit` command for ATHAME/FURNACE-style cross-node rollout verification
- add a one-command evidence packet generator plus templates and docs updates
- add observatory/public-site audit commands, tests, and reusable domain-skill/operator notes

## What this includes
- `harness_smoke.py`
  - typed failure codes
  - phase/phase timing output
  - machine-readable JSON for automation
- `rollout_audit.py`
  - integration verification for Hermes / Claude Code / Codex
  - host-aware remote probing
  - remote JSON preservation on nonzero remote exit
- `.hermes/scripts/browser_harness_evidence_packet.py`
  - timestamped summary artifacts for audit/reporting
- `public_site_audit.py` and `run_browser_observatory.py`
- new/expanded tests
- docs for shared-agent rollout, preflight, evidence packets, and install/verification

## Test Plan
- `python3 -m unittest discover -s tests -v`
- live `browser-harness-smoke --json`
- live `browser-harness-rollout-audit --json`
- live `browser-harness-evidence-packet`

## Notes
- This is a broad operational pack assembled from real shared-agent rollout work across ATHAME/FURNACE.
- The `domain-skills/*` additions are operator-oriented notes gathered during that work. If maintainers prefer, those can be split into a follow-up PR or trimmed to keep the upstream surface narrower.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a browser rollout and observatory pack: a readiness CLI, cross-node rollout audit, evidence packet tooling, and public-site audits with reusable operator runbooks. Improves reliability with typed failure codes, JSON outputs, and artifacts for audits and reviews.

- **New Features**
  - `browser-harness-smoke`: readiness CLI with typed failure codes, JSON output, phase timings, and one-time stale-daemon repair.
  - `browser-harness-rollout-audit`: host-aware audit that auto-picks ATHAME/FURNACE, verifies Hermes/Claude Code/Codex skill wiring, and returns JSON/text with nonzero exit on failures.
  - Evidence packets: `.hermes/scripts/browser_harness_evidence_packet.py` generates timestamped artifacts (`.hermes/reports/`) including rollout JSON, smoke/log tails, local/remote test transcripts, and git state; markdown and JSON summaries included.
  - Public-site observatory: `browser-site-audit` and `browser-observatory-run` profile routes, evaluate content markers, and write packets under `~/Cathedral/state/browser-observatory/packets/...`.
  - Docs/runbooks: adds Cathedral operator notes for Cloudflare, Vercel, GoDaddy, Microsoft 365, Supabase, GitHub, plus domain audits (`deploy-proof`, `domain-stack-audit`, `m365-mail-hardening-audit`, `supabase-config-drift-audit`, `vendor-billing-inventory`) and updated `SKILL.md`/`install.md`.
  - Tooling: new entry points in `pyproject.toml` (`browser-harness-smoke`, `browser-harness-rollout-audit`, `browser-site-audit`, `browser-observatory-run`), templates for packets, expanded tests, and `.gitignore` for `.hermes/reports/` and `.hermes/plans/`.

- **Migration**
  - Install/update and verify commands: `command -v browser-harness-smoke browser-harness-rollout-audit browser-site-audit browser-observatory-run`.
  - Run readiness before any browser work: `BU_NAME=smoke browser-harness-smoke --json`.
  - Validate rollout: `browser-harness-rollout-audit --json` (auto-picks remote; override with `--remote-host` or `BROWSER_HARNESS_REMOTE_HOST`).
  - Generate artifacts when needed: run the evidence packet script at `.hermes/scripts/browser_harness_evidence_packet.py`.

<sup>Written for commit 5b4a77ffc355dc7678e6a5b6f084ad237588b2ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

