### PR TITLE
docs: point onboarding fast-start at docs.browser-use.com

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,7 +13,7 @@ Read `helpers.py` first. For first-time install or reconnect/bootstrap, read `in
 
 ```bash
 browser-harness <<'PY'
-new_tab("https://browser-use.com")
+new_tab("https://docs.browser-use.com")
 wait_for_load()
 print(page_info())
 PY


### PR DESCRIPTION
## Summary
- Swap the Fast start example URL in `SKILL.md` from `https://browser-use.com` to `https://docs.browser-use.com`.
- The URL in the snippet is purely illustrative — pointing it at docs gives agents a more useful first landing page.

Refs #102

## Test plan
- [ ] Run the Fast start snippet and confirm `new_tab` + `wait_for_load` + `page_info` works against docs.browser-use.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Fast start snippet in `SKILL.md` to open https://docs.browser-use.com instead of https://browser-use.com. This points first runs at the docs for a more useful onboarding experience.

<sup>Written for commit 590c473b46f6a2402b1a72ea7ce864d88bf8411e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

