### PR TITLE
fix: disambiguate CDP handshake error between local Chrome and cloud remote

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -139,6 +139,12 @@ class Daemon:
         try:
             await self.cdp.start()
         except Exception as e:
+            if os.environ.get("BU_CDP_WS"):
+                raise RuntimeError(
+                    f"CDP WS handshake failed: {e} -- remote browser WebSocket connection failed. "
+                    "This can happen when network policy blocks the connection, the WS URL is wrong or expired, or the remote endpoint is down. "
+                    "If you use Browser Use cloud, verify BROWSER_USE_API_KEY and get a fresh URL via start_remote_daemon()."
+                )
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event


### PR DESCRIPTION
## Summary

When `start_remote_daemon()` fails because the remote CDP WebSocket is rejected (e.g. data-center IP blocked, expired `cdpUrl`, remote browser stopped), `daemon.py` raised an error that pointed users at the local "click Allow in Chrome" flow. That guidance does not apply on the cloud/remote path and sends users in the wrong direction, as reported in #108.

## Fix

Branch on `BU_CDP_WS` at the handshake-failure catch site in `Daemon.start`. `daemon.py` already reads this env var in `get_ws_url()` (line 58), so it is the reliable signal for the remote code path.

Before:

```
CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry
```

After (local, unchanged):

```
CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry
```

After (remote, when `BU_CDP_WS` is set):

```
CDP WS handshake failed: {e} -- remote browser WebSocket connection failed.
This can happen when network policy blocks the connection, the WS URL is wrong
or expired, or the remote endpoint is down. If you use Browser Use cloud, verify
BROWSER_USE_API_KEY and get a fresh URL via start_remote_daemon().
```

The remote message is intentionally generic because `BU_CDP_WS` can point at any remote CDP endpoint, not only the Browser Use free-cdp proxy. Browser Use-specific remediation is mentioned as one path, not the only one.

Both branches still interpolate the original exception inline so stack-trace context is preserved.

## Changes

- `daemon.py`: 6-line diff, one file. Local message byte-identical to previous.

## Verification

- `python3 -c "import ast; ast.parse(open(\"daemon.py\").read())"` passes
- No test suite in repo, so no tests added
- Reviewed the two error paths against `get_ws_url()` and `start_remote_daemon()` call sites

Closes #108

This contribution was developed with AI assistance (Codex).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified CDP handshake errors by distinguishing local Chrome vs cloud/remote failures. When `BU_CDP_WS` is set, show a remote-specific message with likely causes and next steps; fixes the misleading guidance in #108.

- **Bug Fixes**
  - Check `BU_CDP_WS` in `Daemon.start` and raise a remote-connection error message on handshake failure.
  - Keep the local “click Allow in Chrome” message unchanged; preserve the original exception in both paths.
  - Touches `daemon.py` only (6 lines).

<sup>Written for commit 2d23211d346c7a12bdb2ce03e49b2d955f4769b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

