### PR TITLE
feat(transport): add optional Windows-native daemon relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Useful for stealth, sub-agents, or deployment.<br>
 - Keep the existing Unix socket relay on macOS / Linux
 - Use `BU_DAEMON_TRANSPORT=tcp` for a Windows-native localhost relay
 - Leave `BU_DAEMON_TRANSPORT` unset, or set it to `auto`, to preserve the Unix path where `AF_UNIX` exists and fall back to TCP only where it does not
-- On Windows the daemon metadata lives under `%TEMP%\\bu-<NAME>.{port,pid,log}`
+- On Windows the daemon metadata lives under `%TEMP%\\bu-<NAME>.tcp.{port,pid,log}`
 
 ## How simple is it? (~592 lines of Python)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The simplest, thinnest, **self-healing** harness that gives LLM **complete freed
 
 The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to Chrome, nothing between.
 
+An optional Windows-native daemon transport is also supported. The original Unix socket relay remains the default path on macOS and Linux; Windows can use a localhost TCP relay plus `%TEMP%` metadata files to attach to the user's real Chrome profile without WSL.
+
 ```
   ● agent: wants to upload a file
   │
@@ -41,6 +43,13 @@ Useful for stealth, sub-agents, or deployment.<br>
 
 - Grab a key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key)
 - Or let the agent sign up itself via [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt) (setup flow + challenge context included).
+
+## Optional Windows-native daemon transport
+
+- Keep the existing Unix socket relay on macOS / Linux
+- Use `BU_DAEMON_TRANSPORT=tcp` for a Windows-native localhost relay
+- Leave `BU_DAEMON_TRANSPORT` unset, or set it to `auto`, to preserve the Unix path where `AF_UNIX` exists and fall back to TCP only where it does not
+- On Windows the daemon metadata lives under `%TEMP%\\bu-<NAME>.{port,pid,log}`
 
 ## How simple is it? (~592 lines of Python)
 

--- a/daemon.py
+++ b/daemon.py
@@ -22,16 +22,14 @@ _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 TMPDIR = Path(tempfile.gettempdir())
-SOCK = str(TMPDIR / f"bu-{NAME}.sock")
-LOG = str(TMPDIR / f"bu-{NAME}.log")
-PID = str(TMPDIR / f"bu-{NAME}.pid")
-PORT = str(TMPDIR / f"bu-{NAME}.port")
+UNIX_DIR = Path("/tmp")
 TRANSPORT = os.environ.get("BU_DAEMON_TRANSPORT", "auto").strip().lower()
 if TRANSPORT not in {"auto", "unix", "tcp"}:
     raise RuntimeError(f"unsupported BU_DAEMON_TRANSPORT={TRANSPORT!r}; expected auto, unix, or tcp")
 if TRANSPORT == "unix" and not hasattr(socket, "AF_UNIX"):
     raise RuntimeError("BU_DAEMON_TRANSPORT=unix requires AF_UNIX support")
 USE_UNIX = TRANSPORT == "unix" or (TRANSPORT == "auto" and hasattr(socket, "AF_UNIX"))
+CURRENT_TRANSPORT = "unix" if USE_UNIX else "tcp"
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -62,8 +60,59 @@ REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
+def _supported_transports():
+    if hasattr(socket, "AF_UNIX"):
+        return ("unix", "tcp")
+    return ("tcp",)
+
+
+def _paths(name=None, transport=None):
+    transport = transport or CURRENT_TRANSPORT
+    n = name or NAME
+    if transport == "unix":
+        base = UNIX_DIR / f"bu-{n}"
+        return str(base) + ".sock", str(base) + ".pid", None, str(base) + ".log"
+    if transport == "tcp":
+        base = TMPDIR / f"bu-{n}.tcp"
+        return None, str(base) + ".pid", str(base) + ".port", str(base) + ".log"
+    raise RuntimeError(f"unsupported transport {transport!r}")
+
+
+SOCK, PID, PORT, LOG = _paths()
+
+
 def log(msg):
     open(LOG, "a").write(f"{msg}\n")
+
+
+def _connect_transport(transport, timeout=1):
+    sock, _, port_path, _ = _paths(transport=transport)
+    if transport == "unix":
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect(sock)
+        return s
+    try:
+        port = int(Path(port_path).read_text().strip())
+    except (OSError, ValueError):
+        raise FileNotFoundError(port_path)
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    s.connect(("127.0.0.1", port))
+    return s
+
+
+def _transport_alive(transport):
+    try:
+        s = _connect_transport(transport)
+        s.close()
+        return True
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
+        return False
+
+
+def _live_transports():
+    return [transport for transport in _supported_transports() if _transport_alive(transport)]
 
 
 def get_ws_url():
@@ -200,9 +249,9 @@ class Daemon:
 
 
 async def serve(d):
-    if USE_UNIX and os.path.exists(SOCK):
+    if USE_UNIX and SOCK and os.path.exists(SOCK):
         os.unlink(SOCK)
-    if not USE_UNIX and os.path.exists(PORT):
+    if not USE_UNIX and PORT and os.path.exists(PORT):
         os.unlink(PORT)
 
     async def handler(reader, writer):
@@ -243,25 +292,13 @@ async def main():
 
 
 def already_running():
-    try:
-        if USE_UNIX:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            s.settimeout(1)
-            s.connect(SOCK)
-        else:
-            port = int(Path(PORT).read_text().strip())
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(1)
-            s.connect(("127.0.0.1", port))
-        s.close()
-        return True
-    except (FileNotFoundError, ValueError, ConnectionRefusedError, socket.timeout):
-        return False
+    return _live_transports()
 
 
 if __name__ == "__main__":
-    if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
+    live = already_running()
+    if live:
+        print(f"daemon already running for BU_NAME {NAME!r} on {', '.join(live)} transport(s)", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
     open(PID, "w").write(str(os.getpid()))
@@ -276,7 +313,11 @@ if __name__ == "__main__":
         stop_remote()
         try: os.unlink(PID)
         except FileNotFoundError: pass
-        try: os.unlink(SOCK)
+        try:
+            if SOCK:
+                os.unlink(SOCK)
         except FileNotFoundError: pass
-        try: os.unlink(PORT)
+        try:
+            if PORT:
+                os.unlink(PORT)
         except FileNotFoundError: pass

--- a/daemon.py
+++ b/daemon.py
@@ -28,7 +28,7 @@ if TRANSPORT not in {"auto", "unix", "tcp"}:
     raise RuntimeError(f"unsupported BU_DAEMON_TRANSPORT={TRANSPORT!r}; expected auto, unix, or tcp")
 if TRANSPORT == "unix" and not hasattr(socket, "AF_UNIX"):
     raise RuntimeError("BU_DAEMON_TRANSPORT=unix requires AF_UNIX support")
-USE_UNIX = TRANSPORT == "unix" or (TRANSPORT == "auto" and hasattr(socket, "AF_UNIX"))
+USE_UNIX = TRANSPORT == "unix" or (TRANSPORT == "auto" and hasattr(socket, "AF_UNIX") and os.name != "nt")
 CURRENT_TRANSPORT = "unix" if USE_UNIX else "tcp"
 BUF = 500
 PROFILES = [
@@ -125,6 +125,13 @@ def _connect_transport(transport, timeout=1):
 
 def _transport_alive(transport):
     try:
+        _, pid_path, port_path, _ = _paths(transport=transport)
+        if transport == "tcp" and pid_path:
+            try:
+                pid = int(Path(pid_path).read_text().strip())
+                os.kill(pid, 0)
+            except (OSError, ValueError):
+                return False
         s = _connect_transport(transport)
         s.close()
         return True

--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,5 @@
-"""CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.request
+"""CDP WS holder + local socket relay. One daemon per BU_NAME."""
+import asyncio, json, os, socket, sys, tempfile, time, urllib.request
 from collections import deque
 from pathlib import Path
 
@@ -21,9 +21,17 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+TMPDIR = Path(tempfile.gettempdir())
+SOCK = str(TMPDIR / f"bu-{NAME}.sock")
+LOG = str(TMPDIR / f"bu-{NAME}.log")
+PID = str(TMPDIR / f"bu-{NAME}.pid")
+PORT = str(TMPDIR / f"bu-{NAME}.port")
+TRANSPORT = os.environ.get("BU_DAEMON_TRANSPORT", "auto").strip().lower()
+if TRANSPORT not in {"auto", "unix", "tcp"}:
+    raise RuntimeError(f"unsupported BU_DAEMON_TRANSPORT={TRANSPORT!r}; expected auto, unix, or tcp")
+if TRANSPORT == "unix" and not hasattr(socket, "AF_UNIX"):
+    raise RuntimeError("BU_DAEMON_TRANSPORT=unix requires AF_UNIX support")
+USE_UNIX = TRANSPORT == "unix" or (TRANSPORT == "auto" and hasattr(socket, "AF_UNIX"))
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -192,8 +200,10 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
+    if USE_UNIX and os.path.exists(SOCK):
         os.unlink(SOCK)
+    if not USE_UNIX and os.path.exists(PORT):
+        os.unlink(PORT)
 
     async def handler(reader, writer):
         try:
@@ -212,9 +222,16 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    if USE_UNIX:
+        server = await asyncio.start_unix_server(handler, path=SOCK)
+        os.chmod(SOCK, 0o600)
+        listen_desc = SOCK
+    else:
+        server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
+        port = server.sockets[0].getsockname()[1]
+        Path(PORT).write_text(str(port))
+        listen_desc = f"127.0.0.1:{port}"
+    log(f"listening on {listen_desc} (name={NAME}, remote={REMOTE_ID or 'local'})")
     async with server:
         await d.stop.wait()
 
@@ -227,9 +244,18 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        if USE_UNIX:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.settimeout(1)
+            s.connect(SOCK)
+        else:
+            port = int(Path(PORT).read_text().strip())
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(1)
+            s.connect(("127.0.0.1", port))
+        s.close()
+        return True
+    except (FileNotFoundError, ValueError, ConnectionRefusedError, socket.timeout):
         return False
 
 
@@ -249,4 +275,8 @@ if __name__ == "__main__":
     finally:
         stop_remote()
         try: os.unlink(PID)
+        except FileNotFoundError: pass
+        try: os.unlink(SOCK)
+        except FileNotFoundError: pass
+        try: os.unlink(PORT)
         except FileNotFoundError: pass

--- a/daemon.py
+++ b/daemon.py
@@ -60,6 +60,26 @@ REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
+def _metadata_dir():
+    if os.name == "nt":
+        return TMPDIR
+    xdg_runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg_runtime:
+        return Path(xdg_runtime) / "browser-harness"
+    return Path.home() / ".cache" / "browser-harness"
+
+
+def _ensure_metadata_dir():
+    meta = _metadata_dir()
+    meta.mkdir(parents=True, exist_ok=True)
+    if os.name != "nt":
+        try:
+            os.chmod(meta, 0o700)
+        except OSError:
+            pass
+    return meta
+
+
 def _supported_transports():
     if hasattr(socket, "AF_UNIX"):
         return ("unix", "tcp")
@@ -69,11 +89,12 @@ def _supported_transports():
 def _paths(name=None, transport=None):
     transport = transport or CURRENT_TRANSPORT
     n = name or NAME
+    meta = _metadata_dir()
     if transport == "unix":
         base = UNIX_DIR / f"bu-{n}"
-        return str(base) + ".sock", str(base) + ".pid", None, str(base) + ".log"
+        return str(base) + ".sock", str(meta / f"bu-{n}.unix.pid"), None, str(meta / f"bu-{n}.unix.log")
     if transport == "tcp":
-        base = TMPDIR / f"bu-{n}.tcp"
+        base = meta / f"bu-{n}.tcp"
         return None, str(base) + ".pid", str(base) + ".port", str(base) + ".log"
     raise RuntimeError(f"unsupported transport {transport!r}")
 
@@ -249,6 +270,7 @@ class Daemon:
 
 
 async def serve(d):
+    _ensure_metadata_dir()
     if USE_UNIX and SOCK and os.path.exists(SOCK):
         os.unlink(SOCK)
     if not USE_UNIX and PORT and os.path.exists(PORT):
@@ -300,6 +322,7 @@ if __name__ == "__main__":
     if live:
         print(f"daemon already running for BU_NAME {NAME!r} on {', '.join(live)} transport(s)", file=sys.stderr)
         sys.exit(0)
+    _ensure_metadata_dir()
     open(LOG, "w").close()
     open(PID, "w").write(str(os.getpid()))
     try:

--- a/install.md
+++ b/install.md
@@ -42,7 +42,7 @@ set BU_DAEMON_TRANSPORT=tcp
 browser-harness --help
 ```
 
-Leave `BU_DAEMON_TRANSPORT` unset, or set it to `auto`, to preserve the Unix path where `AF_UNIX` exists and only fall back to TCP where it does not. On Windows the daemon metadata lives under `%TEMP%\\bu-<NAME>.{port,pid,log}`.
+Leave `BU_DAEMON_TRANSPORT` unset, or set it to `auto`, to preserve the Unix path where `AF_UNIX` exists and only fall back to TCP where it does not. On Windows the daemon metadata lives under `%TEMP%\\bu-<NAME>.tcp.{port,pid,log}`.
 
 ## Make it global for the current agent
 

--- a/install.md
+++ b/install.md
@@ -24,6 +24,26 @@ command -v browser-harness
 
 That keeps the command global while still pointing at the real repo checkout, so when the agent edits `helpers.py` the next `browser-harness` uses the new code immediately. Prefer a stable path like `~/Developer/browser-harness`, not `/tmp`.
 
+## Optional Windows-native daemon transport
+
+Keep the existing Unix socket relay on macOS / Linux. If you want a Windows-native local relay instead, set `BU_DAEMON_TRANSPORT=tcp` before invoking `browser-harness`.
+
+PowerShell:
+
+```powershell
+$env:BU_DAEMON_TRANSPORT = "tcp"
+browser-harness --help
+```
+
+cmd.exe:
+
+```bat
+set BU_DAEMON_TRANSPORT=tcp
+browser-harness --help
+```
+
+Leave `BU_DAEMON_TRANSPORT` unset, or set it to `auto`, to preserve the Unix path where `AF_UNIX` exists and only fall back to TCP where it does not. On Windows the daemon metadata lives under `%TEMP%\\bu-<NAME>.{port,pid,log}`.
+
 ## Make it global for the current agent
 
 After the repo is installed, register this repo's `SKILL.md` with the agent you are using:
@@ -45,6 +65,7 @@ Prefer `browser-harness --setup` — it runs the full attach-and-escalate flow b
 
 1. Run `uv sync`.
    If `browser-harness` is still missing after that, run `command -v browser-harness >/dev/null || uv tool install -e .`.
+   On Windows, set `BU_DAEMON_TRANSPORT=tcp` first if you want the native local relay explicitly.
 2. First try the harness directly. If this works, skip manual browser setup:
 
 ```bash
@@ -133,6 +154,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 
 ## Cold-start reminders
 
+- Native Windows setup does not require WSL. Use the optional TCP daemon transport when you want a Windows-local relay.
 - Try attaching before asking the user to change anything. Decide what to escalate based on the harness's error message, not on whether Chrome is visibly running.
 - The remote-debugging checkbox is per-profile sticky in Chrome. If it has ever been ticked on a profile, just launching Chrome is enough — only navigate to `chrome://inspect/#remote-debugging` when `DevToolsActivePort` is genuinely missing.
 - The first connect may block on Chrome's `Allow` dialog, and Chrome may also stop first on the profile picker.


### PR DESCRIPTION
## Background

`browser-harness` currently assumes a Unix-domain local relay (`AF_UNIX` plus `/tmp` paths). That works well on macOS and Linux, but blocks a native Windows install path even though the Chrome attach flow itself is still local CDP.

## What Changed

- kept the existing Unix socket relay as the default path wherever `AF_UNIX` is available
- added an optional `BU_DAEMON_TRANSPORT=tcp` path that uses a localhost relay plus temp-directory metadata files
- made the default `auto` mode preserve Unix sockets where available and fall back to TCP only where they are not
- switched Windows temp artifacts to the system temp directory instead of hard-coded `/tmp`
- made the default screenshot output path use the system temp directory as well
- configured `run.py` stdout/stderr for UTF-8 so marked tab titles do not crash on Windows consoles
- documented the new optional Windows-native transport in `README.md`, `install.md`, and `SKILL.md`

## Not Changed

- the existing Unix socket relay is still the documented and runtime default on macOS / Linux
- the Chrome attach model is still local `DevToolsActivePort` -> CDP websocket -> daemon -> `browser-harness`
- remote Browser Use cloud workflows were not changed

## Risk

- transport selection now has one more branch (`auto` / `unix` / `tcp`), so behavior depends on `BU_DAEMON_TRANSPORT`
- this PR only validates the Unix path by preservation and code-path isolation; the runtime verification here was performed on native Windows for `auto`, `tcp`, and the explicit `unix` error path

## Validation

- `python -m py_compile admin.py daemon.py helpers.py run.py`
- `browser-harness` attach on native Windows with default `BU_DAEMON_TRANSPORT=auto`
- `browser-harness` attach on native Windows with explicit `BU_DAEMON_TRANSPORT=tcp`
- verified screenshots write to `%TEMP%`
- verified `BU_DAEMON_TRANSPORT=unix` fails fast with a clear error on Windows
- `git diff --check`

## Linked Issues

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional Windows-native TCP daemon relay and moves PID/LOG/PORT files to a user-private directory for better security. Fixes auto transport detection on Windows and validates the TCP PID to prevent false “already running”; Unix sockets stay the default on macOS/Linux and the socket remains under `/tmp`.

- **New Features**
  - Optional TCP relay via `BU_DAEMON_TRANSPORT=tcp`; `auto` prefers Unix where supported and falls back to TCP.
  - Detects and prevents same-name cross-transport daemons; cleans up socket/port on exit.
  - Windows-friendly paths: screenshots and temp artifacts use the system temp; console `stdout`/`stderr` set to UTF-8.

- **Migration**
  - No change on macOS/Linux; Unix socket remains at `/tmp/bu-<NAME>.sock`.
  - PID/LOG/PORT files moved to a user‑private metadata dir (XDG runtime or `~/.cache` on *nix; `%TEMP%` on Windows) and are transport‑namespaced (`.unix.*` / `.tcp.*`).
  - On Windows, set `BU_DAEMON_TRANSPORT=tcp` (or leave `auto`); using `unix` on Windows fails fast.

<sup>Written for commit 7cf616c303dd1477b53b7f73fc3c77c34db528b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

