### PR TITLE
docs: WSL → Windows Chrome bridge + Salesforce opportunities skill

### DIFF
--- a/domain-skills/salesforce/opportunities.md
+++ b/domain-skills/salesforce/opportunities.md
@@ -1,0 +1,83 @@
+# salesforce — opportunities (Lightning)
+
+Patterns for reading Opportunity data out of Salesforce Lightning. Tested against Sales Cloud with the standard pipeline.
+
+## URL patterns
+
+- `https://<instance>.lightning.force.com/lightning/o/Opportunity/list?filterName=<ViewName>` — list view.
+- `https://<instance>.lightning.force.com/lightning/o/Opportunity/pipelineInspection?filterName=<viewId>` — Pipeline Inspection. This is the view you want when you need a **Stage** column without modifying the user's saved list view.
+
+## Shadow DOM is mandatory
+
+Most Salesforce Lightning structural elements (tables, rows, cells, toolbar buttons) live inside nested `shadowRoot`s. `document.querySelectorAll('table')` returns 0. Always walk shadow roots:
+
+```js
+function* walk(root) {
+  const q = [root];
+  while (q.length) {
+    const el = q.shift();
+    if (el.nodeType === 1) yield el;
+    if (el.shadowRoot) q.push(el.shadowRoot);
+    for (const c of (el.childNodes || [])) q.push(c);
+  }
+}
+// usage: for (const el of walk(document)) { ... }
+```
+
+Every selector in this file assumes this walk. Without it, counts come back as 0 and you waste time doubting your target.
+
+## Kanban board — virtualizer cap
+
+Kanban view (`Select list display` → `Kanban`) columns use the class `.runtime_sales_pipelineboardPipelineViewColumnHeader` for the header; cards are `li.runtime_sales_pipelineboardPipelineViewCardStencil`; the per-column scroll container is `div.listContent`.
+
+Each card's Opportunity ID is embedded in a class on the inner `.pipelineViewCard` div — e.g. `<div class="006Ts00000V5K5tIAF pipelineViewCard uiDraggable">`. Parse it out with `className.split(/\s+/).find(c => /^006[A-Za-z0-9]{12,15}$/.test(c))`.
+
+**Trap — cards/column cap at 13.** The column virtualizer renders at most ~13 cards regardless of how much you scroll (`scrollTop`, CDP `mouseWheel`, `Emulation.setDeviceMetricsOverride` to a tall viewport — none of these change it). The column **header** still shows the true count in parentheses, e.g. `Proposal sent   (16)`, so when rendered cards < header count you know you're missing rows. Don't fight the virtualizer — switch to Pipeline Inspection instead.
+
+## Pipeline Inspection — the Stage column
+
+Top-right of the list view there's a `Pipeline Inspection` button. It opens a different view (`/lightning/o/Opportunity/pipelineInspection?...`) with a real `Stage` column and a proper virtualized table.
+
+The table has a `Stage` header (matchable via `th.innerText.match(/Stage/)`). Example row extraction:
+
+```js
+// inside walk(document)
+for (const el of walk(document)) {
+  if (el.tagName === 'TABLE') {
+    const ths = [...el.querySelectorAll('th')].map(th => th.innerText || '');
+    if (ths.some(t => t.match(/Stage/))) {
+      return [...el.querySelectorAll('tbody tr')].map(tr =>
+        [...tr.querySelectorAll('th, td')].map(c => c.innerText.trim().split('\n')[0])
+      );
+    }
+  }
+}
+```
+
+Defaults that will surprise you:
+
+- **`Close Date = This Quarter`** — hides opportunities with close dates outside the current quarter even when the stage filter is broad. Open the Close Date dropdown, pick `Custom`, and set Start/End to something like `1/1/2020` and `31/12/2030`. Set the `<input placeholder="Pick a date">` value via the native `HTMLInputElement` setter and dispatch `input`+`change`+`blur`, otherwise Lightning won't enable the Apply button:
+
+  ```js
+  const set = (el, v) => {
+    const s = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    s.call(el, v);
+    ['input','change','blur'].forEach(e => el.dispatchEvent(new Event(e, {bubbles:true})));
+  };
+  ```
+
+- **`Forecast filter = Open Pipeline`** — hides `Closed Won` / `Closed Lost`. If you need won/lost, change the filter via the top-right dropdown.
+- **Scroll stalls before rendering all rows.** Re-rendering on filter change reshuffles the window; scroll-and-collect across multiple passes (before and after the filter change) rather than expecting one scroll to reveal every row.
+
+## List view — "Select Fields to Display" is destructive
+
+The gear icon on the list view offers `Select Fields to Display`. **Saving changes here persists to the user's saved list view** — it is not a temporary tweak. If all you need is a `Stage` column, use Pipeline Inspection; don't mutate someone's list view.
+
+## Filter chooser and other toolbar buttons
+
+The `List View Controls`, `Select list display`, and date-filter dropdowns are buttons with `title` attributes like `List View Controls` and `Select list display`, but they live inside shadow roots. Enumerate them via the shadow-walk above and click with CDP `click(x,y)` at the `getBoundingClientRect` center — calling `.click()` on a shadow-hosted button occasionally no-ops because focus events don't fire the same way.
+
+## Don't try
+
+- `fetch('/services/data/...')` from the page context. Lightning Locker / CSP blocks it. Salesforce REST API calls need to be made from `myinstance.my.salesforce.com` with a session ID, not from `lightning.force.com`.
+- Directly opening each opportunity detail page just to read its Stage — Pipeline Inspection already exposes it.

--- a/install.md
+++ b/install.md
@@ -103,3 +103,69 @@ PY
 - Chrome may open the profile picker before any real tab exists.
 - On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.
 - Microsoft Edge (including Beta/Dev/Canary) works too — substitute the app name; steps are identical.
+
+## WSL → Windows Chrome
+
+Default WSL2 networking cannot reach Windows `127.0.0.1`, and Chrome's `--remote-debugging-port` binds only to loopback. Running the harness in WSL against Chrome on the Windows host therefore needs a bridge. The harness itself must stay on the WSL side — python.org's Python on Windows lacks `socket.AF_UNIX`, which `daemon.py` requires.
+
+Prerequisites on Windows:
+
+- Chrome launched with `--remote-debugging-port=9222`. If `chrome://inspect/#remote-debugging` shows "Server running at: starting" and never advances, the flag was swallowed by Chrome's singleton — fully exit Chrome (including the system-tray background app) and relaunch.
+
+Bridge Chrome's CDP onto a WSL-reachable interface. Two options:
+
+1. **Mirrored networking** (cleanest, but disrupts running WSL). Write `%UserProfile%\.wslconfig`:
+
+   ```ini
+   [wsl2]
+   networkingMode=mirrored
+   ```
+
+   Then `wsl --shutdown` and reopen. WSL's `127.0.0.1:9222` now reaches Windows's `127.0.0.1:9222` directly; no relay, no firewall rule.
+
+2. **TCP relay** (works in the current WSL session — no shutdown). Drop a Python TCP relay on the Windows side, listening on `0.0.0.0:9223` and forwarding to `127.0.0.1:9222`:
+
+   ```python
+   # C:\...\relay.py — run with Windows Python
+   import socket, threading
+   def pump(a, b):
+       try:
+           while (d := a.recv(65536)): b.sendall(d)
+       except Exception: pass
+       finally:
+           for s in (a, b):
+               try: s.close()
+               except Exception: pass
+   srv = socket.socket()
+   srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+   srv.bind(("0.0.0.0", 9223)); srv.listen(128)
+   while True:
+       c, _ = srv.accept()
+       u = socket.socket(); u.connect(("127.0.0.1", 9222))
+       threading.Thread(target=pump, args=(c, u), daemon=True).start()
+       threading.Thread(target=pump, args=(u, c), daemon=True).start()
+   ```
+
+   Add a Windows Firewall allow rule for port 9223 (admin, once):
+
+   ```powershell
+   New-NetFirewallRule -DisplayName 'WSL CDP Relay 9223' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 9223 -Profile Any
+   ```
+
+From WSL, resolve the Windows host and set `BU_CDP_WS`:
+
+```bash
+HOST=$(ip route show default | awk '/default/ {print $3}')       # Windows side of WSL vEthernet
+export BU_CDP_WS=$(curl -s http://$HOST:9223/json/version | python3 -c "import sys,json;print(json.load(sys.stdin)['webSocketDebuggerUrl'])")
+browser-harness <<'PY'
+print(page_info())
+PY
+```
+
+Chrome rewrites the returned `webSocketDebuggerUrl` to include the `Host:` header of the request, so it comes back already pointing at `$HOST:9223` — no further rewriting needed.
+
+WSL gotchas:
+
+- **Do not use a PowerShell TCP relay.** `[System.Threading.Tasks.Task]::Run([Action]{...})` loses variable scope when run on a thread-pool thread in PS 5.1, so copy loops silently fail and connections close with zero bytes. `Start-ThreadJob` is PS 7+ only. Python is fine.
+- **Chrome's browser UUID changes on restart.** Re-fetch `BU_CDP_WS` via `/json/version` after any restart of the CDP Chrome instance.
+- **Domain sockets stay local to WSL.** The bridge only crosses the network boundary; the harness's `/tmp/bu-*.sock` and `daemon.py` still live on the WSL side.


### PR DESCRIPTION
Two independent docs contributions in one PR — happy to split into two if you prefer.

## 1. `docs: install — WSL → Windows Chrome bridge`

Running the harness in WSL against Chrome on the Windows host is increasingly common (WSL2 + Windows Chrome as the daily driver) but hits three non-obvious issues:

- Default WSL2 networking can't reach Windows `127.0.0.1`, and Chrome's `--remote-debugging-port` binds only to loopback.
- Windows-side Python (python.org 3.14) lacks `socket.AF_UNIX`, so `daemon.py` can't run on Windows — the harness itself must stay in WSL.
- Chrome's singleton behavior swallows `--remote-debugging-port` when another Chrome instance (or system-tray background app) is already alive, leaving `chrome://inspect` stuck on `Server running at: starting`.

The new section in `install.md` covers both routing options (WSL2 mirrored networking vs. a Python TCP relay on the Windows side), the firewall rule needed for the relay, the `ip route show default`-based host resolution from WSL, and the gotchas around PowerShell's broken task-scope variable capture (thread-pool tasks silently drop stream copies) and Chrome's browser UUID changing on restart.

## 2. `docs(skill): salesforce — opportunities`

The existing `domain-skills/salesforce/` directory was empty. I went in to pull a list of Opportunities by Stage and hit three traps worth capturing:

- **Nothing is in the light DOM.** Tables, rows, toolbar buttons all live inside nested `shadowRoot`s — `document.querySelectorAll('table')` returns `0`. Every selector needs a shadow-walker.
- **Kanban virtualizer caps rendered cards.** A column headed `Proposal sent (16)` will stabilize at ~13 rendered `li.runtime_sales_pipelineboardPipelineViewCardStencil` elements no matter how you scroll (`scrollTop`, CDP `mouseWheel`, `Emulation.setDeviceMetricsOverride` to a tall viewport). You can't defeat it — you have to switch views.
- **Pipeline Inspection is the right view** when you need a `Stage` column without mutating the user's saved list view. `Select Fields to Display` on the standard list view persists changes to the saved view, which is a destructive side-effect for a read-only scrape.

The skill also documents the Custom date filter (Lightning's input-setter dance required to enable the Apply button) and the Lightning Locker CSP blocking `/services/data/` fetches from the page context, so agents don't waste a round reaching for the REST API.

## Test plan

- [x] `install.md` — built the WSL+relay setup end-to-end on Windows 11 + WSL2 Ubuntu; harness attached and ran `page_info()` against Windows Chrome.
- [x] `domain-skills/salesforce/opportunities.md` — used the shadow-walk + Pipeline Inspection approach to scrape a full My Opportunities pipeline against a production Salesforce Lightning org; recovered all 33 opportunities across 5 stages (sums matched the column-header totals to the cent).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for running the harness in WSL against Windows Chrome and a Salesforce Lightning Opportunities guide. Improves setup reliability and shows how to extract stages without changing user views.

- **New Features**
  - Install: WSL → Windows Chrome bridge. Use `networkingMode=mirrored` or a Windows Python TCP relay (9223→9222) with a firewall rule; discover the Windows host from WSL and set `BU_CDP_WS`. Notes: keep the harness in WSL (`socket.AF_UNIX`), fully quit Chrome if it swallows `--remote-debugging-port`, re-fetch `BU_CDP_WS` after restarts, avoid PowerShell relays.
  - Salesforce: Opportunities (Lightning). Walk nested shadow roots; Kanban caps ~13 cards/column, so use Pipeline Inspection for a real `Stage` column. Enable Custom date filter via the native input setter + `input/change/blur`; changing list-view fields persists; Locker/CSP blocks `/services/data/` fetches from the page context.

<sup>Written for commit 9507160045951ecc564cbc2c0ab1c8ecd22b2f01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

