### PR TITLE
Handle local Chrome CDP discovery fallbacks

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.request
+import asyncio, json, os, re, socket, sys, time, urllib.request
 from collections import deque
 from pathlib import Path
 
@@ -54,10 +54,76 @@ def log(msg):
     open(LOG, "a").write(f"{msg}\n")
 
 
+def _running_debug_endpoints(ps_output=None):
+    """(profile_path, port) from real browser processes, ordered by how likely they are to be user-facing."""
+    if ps_output is None:
+        import subprocess
+
+        try:
+            ps_output = subprocess.check_output(["ps", "-axww", "-o", "command="], text=True)
+        except Exception:
+            return []
+
+    ranked = []
+    for line in ps_output.splitlines():
+        line = line.strip()
+        if not line or "--type=" in line or "--remote-debugging-port" not in line:
+            continue
+        path_match = re.search(r"--user-data-dir(?:=|\s+)(\S+)", line)
+        port_match = re.search(r"--remote-debugging-port(?:=|\s+)(\d+)", line)
+        if not path_match or not port_match:
+            continue
+        score = 0
+        if "--no-startup-window" in line:
+            score += 100
+        if "playwright_" in line or "chromiumdev_profile" in line:
+            score += 50
+        ranked.append((score, len(ranked), Path(path_match.group(1)), int(port_match.group(1))))
+
+    out, seen = [], set()
+    for _, _, path, port in sorted(ranked):
+        key = (str(path), port)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((path, port))
+    return out
+
+
+def _running_profile_roots(ps_output=None):
+    return [path for path, _ in _running_debug_endpoints(ps_output)]
+
+
+def _profile_roots(debug_endpoints=None):
+    debug_endpoints = debug_endpoints if debug_endpoints is not None else _running_debug_endpoints()
+    out, seen = [], set()
+    for path in [path for path, _ in debug_endpoints] + PROFILES:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(path)
+    return out
+
+
+def _ws_url_from_port(port, wait=30):
+    deadline = time.time() + wait
+    while True:
+        try:
+            body = urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=2).read()
+            return json.loads(body)["webSocketDebuggerUrl"]
+        except Exception:
+            if time.time() >= deadline:
+                return None
+            time.sleep(1)
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
-    for base in PROFILES:
+    debug_endpoints = _running_debug_endpoints()
+    profiles = _profile_roots(debug_endpoints)
+    for base in profiles:
         try:
             port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
         except (FileNotFoundError, NotADirectoryError):
@@ -78,7 +144,11 @@ def get_ws_url():
             finally:
                 probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
-    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
+    for path, port in debug_endpoints:
+        if url := _ws_url_from_port(port):
+            log(f"using /json/version fallback on 127.0.0.1:{port} from {path}")
+            return url
+    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in profiles]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 
 def stop_remote():

--- a/daemon.py
+++ b/daemon.py
@@ -51,7 +51,8 @@ API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
 def log(msg):
-    open(LOG, "a").write(f"{msg}\n")
+    with open(LOG, "a") as f:
+        f.write(f"{msg}\n")
 
 
 def _running_debug_endpoints(ps_output=None):
@@ -118,36 +119,49 @@ def _ws_url_from_port(port, wait=30):
             time.sleep(1)
 
 
+def _ws_url_from_devtools_active_port(base, wait=30):
+    try:
+        port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
+    except (FileNotFoundError, NotADirectoryError):
+        return None, None
+
+    deadline = time.time() + wait
+    while True:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.settimeout(1)
+        try:
+            probe.connect(("127.0.0.1", int(port.strip())))
+            return f"ws://127.0.0.1:{port.strip()}{path.strip()}", None
+        except OSError:
+            if time.time() >= deadline:
+                return None, (
+                    f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} "
+                    "— if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
+                )
+            time.sleep(1)
+        finally:
+            probe.close()
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
     debug_endpoints = _running_debug_endpoints()
     profiles = _profile_roots(debug_endpoints)
+    last_active_port_error = None
     for base in profiles:
-        try:
-            port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
-        except (FileNotFoundError, NotADirectoryError):
-            continue
-        deadline = time.time() + 30
-        while True:
-            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            probe.settimeout(1)
-            try:
-                probe.connect(("127.0.0.1", int(port.strip())))
-                break
-            except OSError:
-                if time.time() >= deadline:
-                    raise RuntimeError(
-                        f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
-                    )
-                time.sleep(1)
-            finally:
-                probe.close()
-        return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+        url, error = _ws_url_from_devtools_active_port(base)
+        if url:
+            return url
+        if error:
+            log(f"ignoring stale DevToolsActivePort in {base}: {error}")
+            last_active_port_error = error
     for path, port in debug_endpoints:
         if url := _ws_url_from_port(port):
             log(f"using /json/version fallback on 127.0.0.1:{port} from {path}")
             return url
+    if last_active_port_error:
+        raise RuntimeError(last_active_port_error)
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in profiles]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+import daemon
+
+
+class RunningProfileRootsTests(unittest.TestCase):
+    def test_prefers_real_browser_profiles_over_helpers(self):
+        ps_output = """
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --type=renderer --user-data-dir=/Users/test/.chrome-real --remote-debugging-port=9222
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=50088 --user-data-dir=/var/folders/tmp/playwright_chromiumdev_profile-A2etvi --remote-debugging-pipe --no-startup-window
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --no-first-run --remote-debugging-port=9222 --user-data-dir=/Users/test/.chrome-real
+""".strip()
+
+        self.assertEqual(
+            daemon._running_profile_roots(ps_output),
+            [
+                Path("/Users/test/.chrome-real"),
+                Path("/var/folders/tmp/playwright_chromiumdev_profile-A2etvi"),
+            ],
+        )
+
+    def test_extracts_remote_debugging_ports_from_real_browser_processes(self):
+        ps_output = """
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --type=renderer --user-data-dir=/Users/test/.chrome-real --remote-debugging-port=9222
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=50088 --user-data-dir=/var/folders/tmp/playwright_chromiumdev_profile-A2etvi --remote-debugging-pipe --no-startup-window
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --no-first-run --remote-debugging-port=9222 --user-data-dir=/Users/test/.chrome-real
+""".strip()
+
+        self.assertEqual(
+            daemon._running_debug_endpoints(ps_output),
+            [
+                (Path("/Users/test/.chrome-real"), 9222),
+                (Path("/var/folders/tmp/playwright_chromiumdev_profile-A2etvi"), 50088),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,5 +1,8 @@
+import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 import daemon
 
@@ -34,6 +37,29 @@ class RunningProfileRootsTests(unittest.TestCase):
                 (Path("/var/folders/tmp/playwright_chromiumdev_profile-A2etvi"), 50088),
             ],
         )
+
+    def test_falls_back_to_json_version_when_devtoolsactiveport_is_stale(self):
+        with tempfile.TemporaryDirectory() as td:
+            profile = Path(td)
+            (profile / "DevToolsActivePort").write_text("9999\n/devtools/browser/stale")
+
+            fake_socket = SimpleNamespace(
+                settimeout=lambda _: None,
+                connect=lambda *_: (_ for _ in ()).throw(OSError("connection refused")),
+                close=lambda: None,
+            )
+
+            with mock.patch.object(daemon, "_running_debug_endpoints", return_value=[(profile, 9222)]):
+                with mock.patch.object(daemon, "_ws_url_from_port", return_value="ws://127.0.0.1:9222/devtools/browser/live") as ws_from_port:
+                    with mock.patch.object(daemon.socket, "socket", return_value=fake_socket):
+                        with mock.patch.object(daemon.time, "time", side_effect=[0, 31]):
+                            with mock.patch.object(daemon.time, "sleep"):
+                                self.assertEqual(
+                                    daemon.get_ws_url(),
+                                    "ws://127.0.0.1:9222/devtools/browser/live",
+                                )
+
+        ws_from_port.assert_called_once_with(9222)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- detect locally running Chrome instances started with a custom `--user-data-dir`
- fall back to `/json/version` when `DevToolsActivePort` is absent but the local CDP port is already live
- add regression tests for local process discovery and port extraction

## Why
On my macOS setup, Chrome was running with a custom profile path and remote debugging enabled, but no `DevToolsActivePort` file was present in that profile directory. `browser-harness` therefore reported setup failure even though `http://127.0.0.1:<port>/json/version` was reachable and the browser websocket was available.

This keeps the existing `DevToolsActivePort` path as the primary discovery path, then falls back to the live local debugging port advertised by the real Chrome process.

## Testing
- `uv run python -m unittest discover -s tests -p 'test_*.py'`
- `browser-harness <<'PY'`
- `print(page_info())`
- `PY`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix local Chrome CDP discovery by detecting custom profile runs and skipping stale `DevToolsActivePort` files, falling back to `/json/version` when needed. Prevents false setup failures in `browser-harness` when a local debugging port is live.

- **Bug Fixes**
  - Detect running Chrome processes with custom `--user-data-dir` and extract `--remote-debugging-port`; prefer real profiles over helper processes.
  - Skip stale `DevToolsActivePort` after a short wait and log it, then use `http://127.0.0.1:<port>/json/version` to get `webSocketDebuggerUrl`.
  - Keep `DevToolsActivePort` as the primary path when it’s live.
  - Add regression tests for process discovery, port extraction, and stale-file fallback.

<sup>Written for commit f3db6a4041039b335491970cb14879714260aafb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

