### PR TITLE
domain-skills: reddit + medium article hydration

### DIFF
--- a/domain-skills/medium/article-hydration.md
+++ b/domain-skills/medium/article-hydration.md
@@ -1,0 +1,120 @@
+# Medium — Article Body via DOM
+
+Extract a Medium article's body as clean markdown using the logged-in browser. Use this when API paths in `scraping.md` are blocked or truncated:
+
+- Cloudflare challenge on the `?format=json` endpoint ("Performing security verification")
+- Member-only post that the API returns locked (`isSubscriptionLocked=True`) but the logged-in browser can render in full
+- JS-only variant where the article is gated behind a client-side paywall modal
+
+If the article is free and the API works, prefer `scraping.md` — it's faster and doesn't need a visible tab.
+
+## URL patterns
+
+- Canonical: `https://medium.com/@<author>/<slug>-<id>`
+- Publication: `https://<pub>.medium.com/<slug>-<id>` or `https://medium.com/<pub>/<slug>-<id>`
+- Custom domain: some publications (e.g. `towardsdatascience.com`) proxy Medium; the same DOM extractor works there.
+
+All variants render the article body inside a single `<article>` element.
+
+## Site structure
+
+- The article body lives under the page's single `<article>` element.
+- Block-level content: `h1`–`h4`, `p`, `pre`, `blockquote`, `ul`, `ol`, `figure`.
+- Images are always wrapped in `<figure>` with a `<figcaption>` sibling; the real resolution lives on `miro.medium.com/v2/resize:fit:<N>/...`.
+- Code blocks are `<pre>` — no language class is exposed in the DOM, so emit plain fenced blocks.
+- Pull quotes render as `<blockquote>` with nested `<p>`.
+
+## Cruft to strip
+
+Medium injects engagement UI **inside** `<article>`. The text "6 2 Listen Share More" at the top is the clap/comment/listen/share button row, not content. Also expect a follow button near the author's name and sometimes a "Help" / "Status" footer.
+
+Safe pattern: take the extracted markdown, then drop leading paragraphs that are shorter than ~12 characters until you hit the first real block (the "Last updated" line, the H1, or the first long paragraph).
+
+## Extractor
+
+````bash
+browser-harness <<'PY'
+new_tab("https://medium.com/@user/slug-abc123")
+wait_for_load()
+wait(2.0)  # Medium hydrates more UI after readyState=complete
+
+md = js(r"""
+(()=>{
+  const article = document.querySelector('article');
+  if(!article) return null;
+  const blocks = article.querySelectorAll('h1, h2, h3, h4, p, pre, blockquote, ul, ol, figure');
+  const out = [];
+  const seen = new Set();
+  for(const el of blocks){
+    let skip = false;
+    for(const s of seen){ if(s.contains(el) && s !== el){ skip=true; break; } }
+    if(skip) continue;
+    seen.add(el);
+    const tag = el.tagName;
+    const txt = (el.innerText || '').trim();
+    if(!txt && tag !== 'FIGURE') continue;
+    if(tag === 'H1') out.push('# ' + txt);
+    else if(tag === 'H2') out.push('## ' + txt);
+    else if(tag === 'H3') out.push('### ' + txt);
+    else if(tag === 'H4') out.push('#### ' + txt);
+    else if(tag === 'PRE') out.push('```\n' + txt + '\n```');
+    else if(tag === 'BLOCKQUOTE') out.push(txt.split('\n').map(l=>'> '+l).join('\n'));
+    else if(tag === 'UL' || tag === 'OL'){
+      const items = [...el.querySelectorAll(':scope > li')].map((li,i)=>{
+        const t = li.innerText.trim();
+        return (tag==='OL' ? (i+1)+'. ' : '- ') + t;
+      });
+      out.push(items.join('\n'));
+    }
+    else if(tag === 'FIGURE'){
+      const img = el.querySelector('img');
+      const cap = el.querySelector('figcaption');
+      if(img && img.src){
+        const alt = img.alt || (cap ? cap.innerText.trim() : '');
+        out.push('![' + alt + '](' + img.src + ')');
+      }
+    }
+    else if(tag === 'P') out.push(txt);
+  }
+  return out.join('\n\n');
+})()
+""")
+
+# Strip engagement-button cruft from the top
+paras = md.split('\n\n')
+while paras and len(paras[0]) < 12:
+    paras.pop(0)
+md = '\n\n'.join(paras)
+print(md)
+PY
+````
+
+The `seen` set avoids double-emitting when an `<li>` matches the block query inside its `<ul>`.
+
+## Waits
+
+- `wait_for_load()` is necessary but not sufficient — Medium continues to hydrate author-card and clap widgets after `readyState=complete`. An additional `wait(2.0)` avoids cases where the article outer frame exists but the first few paragraphs are still skeleton `<div>`s.
+- For member-only articles, if `<article>` renders but text length is suspiciously short (<500 chars), the paywall modal intercepted. Confirm the tab is on your logged-in profile and retry.
+
+## Paywall / login detection
+
+```python
+state = js("""
+(()=>{
+  const art = document.querySelector('article');
+  const len = art ? art.innerText.length : 0;
+  const hasPaywall = !!document.querySelector('[data-testid*="paywall"], [aria-label*="Sign in" i]');
+  return {len, hasPaywall};
+})()
+""")
+```
+
+If `hasPaywall` is true or `len < 500`, fall back to `scraping.md` API paths (the article may simply be locked for this account).
+
+## Traps
+
+- **Don't use `article.innerText` alone.** It drops structure — code blocks lose their fences, lists lose their markers, figures disappear. The block walker above preserves each element kind.
+- **Don't rely on CSS class names.** Medium's class names are hashed (`pw-post-body-paragraph`, etc.) and rotate; select by tag instead.
+- **`<figure>` caption text is often also repeated as `<img alt>`.** Prefer `alt`, fall back to `figcaption`, so you don't emit both.
+- **The article ends before the "About the Author" card sometimes, sometimes not.** The walker captures both, which is fine for archival. If you need body-only, cut at the last `h2`/`h3` before a `<hr>`-equivalent divider, or trim by known footer strings (`Follow`, `More from`, `Written by`).
+- **Tab marker.** `new_tab()` prepends 🟢 to the title. Don't include `document.title` in the emitted markdown — use the article's `<h1>` instead.

--- a/domain-skills/reddit/scraping.md
+++ b/domain-skills/reddit/scraping.md
@@ -1,0 +1,124 @@
+# Reddit — Scraping & Post Extraction
+
+Reddit's "new" web UI (`reddit.com`) is a Lit / web-components SPA built around custom elements (`shreddit-post`, `shreddit-comment`, `faceplate-*`). This makes DOM extraction unusually reliable — the custom element tags are stable and exposed on the element itself (no hashed class names).
+
+Use the browser when you're logged in (private subreddits, NSFW gates, rate-limit avoidance). For fully public content, the JSON API path below is faster.
+
+## URL patterns
+
+- Full post: `https://www.reddit.com/r/<sub>/comments/<id>/<slug>/`
+- Share short-link: `https://www.reddit.com/r/<sub>/s/<hash>` — redirects to the full URL once the page loads. `new_tab(short_url)` + `wait_for_load()` is enough; by the time you read `location.href` it will be the canonical one.
+- Old Reddit: append `/.json` to any post URL for anonymous JSON: `https://www.reddit.com/r/<sub>/comments/<id>/.json`.
+- Old UI (simpler DOM, no web components): `https://old.reddit.com/r/<sub>/comments/<id>/` — useful fallback when `shreddit-*` selectors change.
+
+## Path 1: JSON API (fastest for public posts)
+
+```python
+from helpers import http_get
+import json
+
+url = "https://www.reddit.com/r/cursor/comments/1l0u9y7/claude_code_prompt_to_autogenerate_full_cursor/.json"
+data = json.loads(http_get(url, headers={"User-Agent": "Mozilla/5.0"}))
+post = data[0]["data"]["children"][0]["data"]
+# post fields: title, selftext, author, score, num_comments, created_utc, url, permalink
+comments = data[1]["data"]["children"]  # list of { kind: "t1", data: {...} } or { kind: "more" }
+```
+
+Fails on:
+
+- Private / quarantined subreddits (401)
+- NSFW posts without an authenticated session
+- Anti-scraping 429s under load — back off or switch to the browser path
+
+## Path 2: Browser DOM extraction (logged-in)
+
+Core selector: every post renders inside a single `<shreddit-post>` custom element. Top-level comments are `<shreddit-comment depth="0">`.
+
+```bash
+browser-harness <<'PY'
+new_tab("https://www.reddit.com/r/vibecoding/comments/1kwuqpz/")
+wait_for_load()
+wait(3.0)  # SPA still hydrating after readyState=complete
+
+# Scroll to force comment tree lazy-load (twice, ~2000px each)
+scroll(500, 500, dy=2000); wait(1.0)
+scroll(500, 500, dy=2000); wait(1.0)
+
+data = js(r"""
+(()=>{
+  const postEl = document.querySelector('shreddit-post');
+  if(!postEl) return null;
+  const title = (postEl.querySelector('h1, [slot="title"]')||{}).innerText?.trim() || '';
+  const bodyEl = postEl.querySelector('[slot="text-body"] .md, [slot="text-body"]');
+  const body = bodyEl ? bodyEl.innerText.trim() : '';
+  const author = (postEl.querySelector('[slot="authorName"] a, a[data-testid="post_author_link"]')||{}).innerText?.trim() || '';
+  const subM = location.pathname.match(/^\/r\/([^\/]+)/);
+  const subreddit = subM ? subM[1] : '';
+  const scoreEl = postEl.querySelector('faceplate-number');
+  const score = scoreEl ? scoreEl.getAttribute('number') || scoreEl.innerText : '';
+  const comments = [];
+  for(const c of document.querySelectorAll('shreddit-comment[depth="0"]')){
+    const cBodyEl = c.querySelector('[slot="comment"] .md, [slot="comment"]');
+    const cBody = cBodyEl ? cBodyEl.innerText.trim() : '';
+    if(!cBody) continue;
+    comments.push({
+      author: c.getAttribute('author') || '',
+      score: c.getAttribute('score') || '',
+      body: cBody
+    });
+    if(comments.length >= 10) break;
+  }
+  return {subreddit, title, author, score, body, comments, url: location.href};
+})()
+""")
+print(data["title"], "·", len(data["body"]), "chars ·", len(data["comments"]), "comments")
+PY
+```
+
+### Key selectors
+
+| Target                 | Selector                                                              | Notes                                                                                                   |
+| ---------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Post container         | `shreddit-post`                                                       | One per post page. Attributes include `post-title`, `post-id`, `subreddit-name`, `author`.              |
+| Post title             | `shreddit-post h1` or `[slot="title"]`                                | H1 is also the page title.                                                                              |
+| Post text body         | `shreddit-post [slot="text-body"] .md`                                | `.md` is the rendered markdown container. For link posts this selector returns null (there is no body). |
+| Post author name       | `[slot="authorName"] a`                                               | Plain text.                                                                                             |
+| Vote score             | `shreddit-post faceplate-number`                                      | Read the `number` attribute (digit string) — `innerText` is abbreviated ("1.2k").                       |
+| Top-level comment      | `shreddit-comment[depth="0"]`                                         | Depth is an attribute — `depth="1"` is a reply, etc.                                                    |
+| Comment body           | `shreddit-comment [slot="comment"] .md`                               | Same pattern as post body.                                                                              |
+| Comment author / score | `shreddit-comment` attributes: `author`, `score`, `created-timestamp` | Use `getAttribute`, not DOM descendants.                                                                |
+
+### Share links
+
+`/s/<hash>` URLs redirect before the SPA mounts. You don't need to resolve them manually — just `new_tab(url)` + `wait_for_load()` + `wait(2)`, then read `location.href` for the canonical path.
+
+### Comment tree lazy-loading
+
+New Reddit renders only the initial visible comments. To get more, **scroll twice**. `ensureReplies` / `more` placeholders exist but clicking them is brittle; scroll is the most reliable trigger. For a deep thread, loop `scroll + wait` until `shreddit-comment` count stabilizes between passes.
+
+### Login / gate detection
+
+```python
+state = js("""
+(()=>{
+  const loginWall = !!document.querySelector('a[href*="/login"], [data-testid="login-button"]');
+  const ageGate = !!document.querySelector('[data-testid="nsfw-gate"], shreddit-interstitial');
+  return {loginWall, ageGate};
+})()
+""")
+```
+
+If `ageGate` is true and you are logged in but haven't opted into NSFW content, the gate blocks extraction — toggle NSFW in account settings, not programmatically.
+
+## Gotchas
+
+- **`faceplate-number.innerText` is abbreviated** ("1.2k", "16.6k"). Always prefer `getAttribute('number')` for the exact digit count.
+- **`shreddit-comment` is a custom element, not a `<div>`.** CSS descendant selectors still work, but older jQuery-style parent traversals may not — stick to standard DOM.
+- **`depth="0"` is a string attribute.** `[depth="0"]` in a CSS selector works; `depth=0` (no quotes) also works in the newer parser, but the quoted form is safest.
+- **Collapsed comments render with body still in the DOM, but behind `expando-button`.** The `.md` selector still grabs the text — you don't need to expand.
+- **Post body can be empty.** For link posts or image posts, `[slot="text-body"]` doesn't exist; null-check before reading `.innerText`.
+- **`wait_for_load()` is not enough.** Reddit sometimes paints the post skeleton before the content hydrates. Add `wait(2.0)`–`wait(3.0)` after `wait_for_load()` or retry reads on null `shreddit-post`.
+- **Share URLs (`/s/<hash>`) can't be deep-linked into a comment.** They always land at the post top. If the original raindrop captured `/s/...`, the in-DOM permalink (read from `location.href` after load) is the canonical URL worth storing.
+- **Old Reddit (`old.reddit.com`) is a separate DOM** — no `shreddit-*` elements, no `faceplate-*`. If your login session was established on new Reddit, `old.reddit.com` will still honor the cookie.
+- **For NSFW or quarantined subs**, the browser path requires your account to have opted in. The JSON API requires OAuth with appropriate scope.
+- **`[slot="text-body"] .md .md`** — Reddit occasionally double-wraps; the selector `[slot="text-body"] .md` is the outer one and is what you want. Using `[slot="text-body"]` alone works too, but may include meta text.


### PR DESCRIPTION
## Summary

Two new domain skills, discovered while using the harness to re-hydrate a personal Obsidian vault of web clippings:

- **`domain-skills/reddit/scraping.md`** — new dir. Covers both the `/.json` public API (fast path for public posts) and the logged-in browser path via `shreddit-*` custom elements. Documents the selector table (`shreddit-post`, `shreddit-comment[depth="0"]`, `[slot="text-body"] .md`, `faceplate-number[number]`), the share-link (`/s/<hash>`) redirect behavior, and the "scroll twice to lazy-load comments" pattern.

- **`domain-skills/medium/article-hydration.md`** — new sibling to the existing `medium/scraping.md`. Covers the logged-in browser fallback for when Cloudflare blocks the `?format=json` endpoint or when a member-only post is `isSubscriptionLocked` in the API but the browser can render it. Block-level DOM walker emits markdown for `h1`–`h4`, `p`, `pre`, `blockquote`, `ul`/`ol`, `figure`. Notes the engagement-button cruft ("6 2 Listen Share More") that needs stripping.

Both skills are proven out — reddit extractor was validated against three posts (r/cursor, r/vibecoding, r/ClaudeAI), medium extractor against a Cloudflare-blocked post where every other fetcher returned the challenge page.

## Test plan

- [x] Medium extractor: validated against a Cloudflare-blocked post (`?format=json` returned "Performing security verification"; the DOM extractor returned ~4KB of correct content).
- [x] Reddit extractor: validated against 3 posts across different subs. Short-link (`/s/<hash>`) redirects resolve cleanly via `new_tab` + `wait_for_load`.
- [x] Custom-element selectors (`shreddit-post`, `shreddit-comment`) verified stable as of 2026-04-20.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two domain skills for reliable content extraction: Reddit post/comment scraping and Medium article hydration via the logged-in browser when API paths are blocked.

- **New Features**
  - `domain-skills/reddit/scraping.md`
    - Documents JSON API via `/.json` for public posts.
    - Browser DOM path using `shreddit-post`, `shreddit-comment[depth="0"]`, `[slot="text-body"] .md`, `faceplate-number[number]`.
    - Notes `/s/<hash>` share-link redirects and “scroll twice” to load comments.
  - `domain-skills/medium/article-hydration.md`
    - Logged-in DOM fallback when `?format=json` is blocked or `isSubscriptionLocked`.
    - Block walker emits markdown for `h1`–`h4`, `p`, `pre`, `blockquote`, `ul/ol`, `figure`.
    - Guidance to strip engagement cruft (“Listen Share More”) from the top.

<sup>Written for commit a603b7e99793c30146bc7cfe6cebe2f38a326c85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

