### PR TITLE
fix(run): exec scoping for comprehensions + sharpen click guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -126,7 +126,7 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 ## What actually works
 
 - **Screenshots first**: use `screenshot()` to understand the current page quickly, find visible targets, and decide whether you need a click, a selector, or more navigation.
-- **Clicking**: `screenshot()` → look → `click(x, y)` → `screenshot()` again to verify the result. Coordinate clicks pass through iframes/shadow/cross-origin at the compositor level.
+- **Clicking**: `screenshot()` → read the pixel off the image → `click(x, y)` → `screenshot()` to verify. Suppress the Playwright-habit reflex of "locate first, then click" — no `getBoundingClientRect`, no selector hunt. Drop to DOM only when the target has no visible geometry (hidden input, 0×0 node). Hit-testing happens in Chrome's browser process, so clicks go through iframes / shadow DOM / cross-origin without extra work.
 - **Bulk HTTP**: `http_get(url)` + `ThreadPoolExecutor`. No browser for static pages (249 Netflix pages in 2.8s).
 - **After goto**: `wait_for_load()`.
 - **Wrong/stale tab**: `ensure_real_tab()`. Use it when the current tab is stale or internal; the daemon also auto-recovers from stale sessions on the next call.

--- a/run.py
+++ b/run.py
@@ -37,7 +37,7 @@ def main():
             "  PY"
         )
     ensure_daemon()
-    exec(sys.stdin.read())
+    exec(sys.stdin.read(), globals())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Two small changes that came out of a post-mortem on an agent session that kept stumbling over the same two papercuts:

- **`run.py`** — `exec(sys.stdin.read())` inside `main()` passes different dicts for globals and locals. Comprehensions/generator expressions compile to a nested function whose free-variable lookups can only see globals, so `any(k in low for k in KEYS)` inside a `for` loop fails with `NameError: 'low' not defined`. Passing `globals()` to `exec` makes it use the same dict for both, and comprehensions resolve cleanly.

- **`SKILL.md`** — the Clicking bullet said `screenshot() -> look -> click(x, y)` but didn't rule out roundtripping through `js("...getBoundingClientRect()")`. Agents with Playwright/Selenium habits locate-first-click-second even when the screenshot already shows the target, which is slower and brittle on hidden inputs (`x=-9999`), CSS-transformed elements, and pseudo-elements. Bullet now explicitly suppresses that reflex and scopes the DOM-fallback to elements with no visible geometry. Also swaps the loose "compositor level" phrasing for the real mechanism (Chrome browser-process hit-testing).

## Test plan
- [x] Reproduce the `NameError` against old `run.py`, confirm it disappears with the fix:
  ```
  browser-harness <<'PY'
  KEYS = ['plan','cancel']
  items = [{'text':'cancel me'}, {'text':'boring'}]
  for it in items:
      low = it['text'].lower()
      print(it['text'], '->', any(k in low for k in KEYS))
  PY
  ```
- [x] `SKILL.md` renders cleanly and keeps section ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix exec scoping in `run.py` by calling `exec(sys.stdin.read(), globals())` so comprehensions and generator expressions resolve free variables and avoid `NameError`. Clarify clicking guidance in `SKILL.md` to read coordinates from screenshots (no `getBoundingClientRect` or selector hunt), drop to DOM only for elements with no visible geometry, and note Chrome browser-process hit-testing passes clicks through iframes, shadow DOM, and cross-origin.

<sup>Written for commit 68e8661c2569fa88463d582be12be2714d4df93f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

