### PR TITLE
Add Brave browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The simplest, thinnest, **self-healing** harness that gives LLM **complete freedom** to complete any browser task. Built directly on CDP.
 
-The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to Chrome, nothing between.
+The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to a Chromium browser, nothing between.
 
 ```
   ● agent: wants to upload a file

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-harness
-description: Direct browser control via CDP. Use when the user wants to automate, scrape, test, or interact with web pages. Connects to the user's already-running Chrome.
+description: Direct browser control via CDP. Use when the user wants to automate, scrape, test, or interact with web pages. Connects to the user's already-running Chromium browser, including Chrome, Brave, or Edge.
 ---
 
 # browser-harness
@@ -134,7 +134,7 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 ## Design constraints
 
 - **Coordinate clicks default.** `Input.dispatchMouseEvent` goes through iframes/shadow/cross-origin at the compositor level.
-- **Connect to the user's running Chrome.** Don't launch your own browser.
+- **Connect to the user's running Chromium browser.** Don't launch your own browser unless setup requires opening the browser once.
 - **`cdp-use` is only for `CDPClient.send_raw`.** Prefer raw CDP strings over typed wrappers.
 - **`run.py` stays tiny.** No argparse, subcommands, or extra control layer.
 - **Helpers stay short.** Browser primitives in `helpers.py`; daemon/bootstrap and remote session admin live in `admin.py`.
@@ -143,7 +143,7 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 ## Architecture
 
 ```text
-Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.py
+Chromium browser / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.py
 ```
 
 - Protocol is one JSON line each way.
@@ -155,15 +155,15 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 
 ## Gotchas (field-tested)
 
-- **Chrome 144+ `chrome://inspect/#remote-debugging` does NOT serve `/json/version`.** Read `DevToolsActivePort` instead.
+- **Chromium 144+ `chrome://inspect/#remote-debugging` may NOT serve `/json/version`.** Read `DevToolsActivePort` instead.
 - **Try attaching before asking for setup.** If `uv run browser-harness` already works, skip the remote-debugging instructions entirely. Decide what to escalate from the harness's error message, not from whether Chrome is visibly running.
-- **The remote-debugging checkbox is per-profile sticky in Chrome.** Once ticked on a profile, every future Chrome launch auto-enables CDP — only navigate to `chrome://inspect/#remote-debugging` when `DevToolsActivePort` is genuinely missing on a fresh profile.
-- **The first connect may block on Chrome's Allow dialog.** If setup hangs, explicitly tell the user to click `Allow` in Chrome if it appears, then keep polling for up to 30 seconds instead of treating follow-on errors as a new failure.
+- **The remote-debugging checkbox is per-profile sticky in Chromium browsers.** Once ticked on a profile, every future launch for that profile auto-enables CDP. Only navigate to `chrome://inspect/#remote-debugging` when `DevToolsActivePort` is genuinely missing on a fresh profile.
+- **The first connect may block on the browser's Allow dialog.** If setup hangs, explicitly tell the user to click `Allow` if it appears, then keep polling for up to 30 seconds instead of treating follow-on errors as a new failure.
 - **`DevToolsActivePort` can exist before the port is actually listening.** Treat connection refused as "still enabling" and keep polling for up to 30 seconds.
-- **Chrome may open the profile picker before any real tab exists.** If Chrome opens both a profile picker and the remote-debugging page, tell the user to choose their normal profile first, then tick the checkbox and click `Allow` if shown.
-- **On macOS, if Chrome is already running, prefer AppleScript `open location` over `open -a ... URL`.** It reuses the current profile and avoids creating an extra startup path through the profile picker.
+- **The browser may open the profile picker before any real tab exists.** If it opens both a profile picker and the remote-debugging page, tell the user to choose their normal profile first, then tick the checkbox and click `Allow` if shown.
+- **On macOS, if the browser is already running, prefer AppleScript `open location` over `open -a ... URL`.** It reuses the current profile and avoids creating an extra startup path through the profile picker.
 - **Omnibox popups are fake `page` targets.** Filter `chrome://omnibox-popup...` and other internals when you need a real tab.
-- **CDP target order != Chrome's visible tab-strip order.** Use UI automation when the user means "the first/second tab I can see"; `Target.activateTarget` only shows a known target.
+- **CDP target order != the browser's visible tab-strip order.** Use UI automation when the user means "the first/second tab I can see"; `Target.activateTarget` only shows a known target.
 - **Default daemon sessions can go stale.** `ensure_real_tab()` re-attaches to a real page.
 - **`no close frame received or sent` usually means a stale daemon / websocket.** Restart the daemon once with:
   `uv run python - <<'PY'`
@@ -171,7 +171,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
   `restart_daemon()`
   `PY`
   before assuming setup is wrong.
-- **If `restart_daemon()` also hangs**, kill Chrome entirely (`pkill -9 -f "Google Chrome"`), clean sockets (`rm -f /tmp/bu-default.sock /tmp/bu-default.pid`), reopen Chrome (`open -a "Google Chrome"`), wait 5s, then reconnect. This resets all CDP state.
+- **If `restart_daemon()` also hangs**, kill the target browser entirely, clean sockets (`rm -f /tmp/bu-default.sock /tmp/bu-default.pid`), reopen the browser, wait 5s, then reconnect. This resets all CDP state.
 - **Browser Use API is camelCase on the wire.** `cdpUrl`, `proxyCountryCode`, etc.
 - **Remote `cdpUrl` is HTTPS, not ws.** Resolve the websocket URL via `/json/version`.
 - **Stop cloud browsers with `PATCH /browsers/{id}` + `{\"action\":\"stop\"}`.**

--- a/daemon.py
+++ b/daemon.py
@@ -27,15 +27,18 @@ PID = f"/tmp/bu-{NAME}.pid"
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
+    Path.home() / "Library/Application Support/BraveSoftware/Brave-Browser",
     Path.home() / "Library/Application Support/Microsoft Edge",
     Path.home() / "Library/Application Support/Microsoft Edge Beta",
     Path.home() / "Library/Application Support/Microsoft Edge Dev",
     Path.home() / "Library/Application Support/Microsoft Edge Canary",
     Path.home() / ".config/google-chrome",
+    Path.home() / ".config/BraveSoftware/Brave-Browser",
     Path.home() / ".config/microsoft-edge",
     Path.home() / ".config/microsoft-edge-beta",
     Path.home() / ".config/microsoft-edge-dev",
     Path.home() / "AppData/Local/Google/Chrome/User Data",
+    Path.home() / "AppData/Local/BraveSoftware/Brave-Browser/User Data",
     Path.home() / "AppData/Local/Microsoft/Edge/User Data",
     Path.home() / "AppData/Local/Microsoft/Edge Beta/User Data",
     Path.home() / "AppData/Local/Microsoft/Edge Dev/User Data",
@@ -69,13 +72,13 @@ def get_ws_url():
             except OSError:
                 if time.time() >= deadline:
                     raise RuntimeError(
-                        f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
+                        f"The browser's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} — if it opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
                     )
                 time.sleep(1)
             finally:
                 probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
-    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
+    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging in Chrome, Brave, or Edge, or set BU_CDP_WS for a remote browser")
 
 
 def stop_remote():
@@ -136,7 +139,7 @@ class Daemon:
         try:
             await self.cdp.start()
         except Exception as e:
-            raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
+            raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in the browser if prompted, then retry")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         mark_js = "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"

--- a/install.md
+++ b/install.md
@@ -1,6 +1,6 @@
 ---
 name: browser-harness-install
-description: Install and bootstrap browser-harness into the current agent, then connect it to the user's real Chrome with minimal prompting.
+description: Install and bootstrap browser-harness into the current agent, then connect it to the user's real Chromium browser with minimal prompting. Works with Chrome, Brave, and Edge.
 ---
 
 # browser-harness install
@@ -53,24 +53,37 @@ PY
 
    Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session.
 
-3. If it failed, **read the error and escalate from there — do not assume you need `chrome://inspect`**. The remote-debugging checkbox is per-profile sticky in Chrome, so any profile that has had it toggled on once will auto-enable CDP on every future launch; the inspect page is only needed the first time per profile.
+3. If it failed, **read the error and escalate from there — do not assume you need `chrome://inspect`**. The remote-debugging checkbox is per-profile sticky in Chromium browsers, so any profile that has had it toggled on once will auto-enable CDP on every future launch. The inspect page is only needed the first time per profile.
 
-   - **No Chrome process running** → just start Chrome and re-run the harness. On macOS: `open -a "Google Chrome"`. Do *not* navigate to `chrome://inspect` yet — if the user has ever ticked the checkbox on this profile, the harness will attach on its own.
-   - **`DevToolsActivePort` missing or empty after Chrome is up** → remote-debugging has never been enabled on this profile. *This* is when you open `chrome://inspect/#remote-debugging` and ask the user to tick the checkbox and click `Allow`. Once ticked, the setting sticks.
-   - **Port present but `connection refused` / `DevTools not live yet` / `/json/version` 404** → Chrome is mid-startup. Just keep polling for up to 30 seconds; do not restart Chrome and do not open the inspect page.
-   - **`no close frame received or sent` / stale websocket** → the daemon (not Chrome) is the problem. Run `restart_daemon()` once and retry — see step 7 below.
+   - **No browser process running** → just start the chosen browser and re-run the harness. On macOS examples: `open -a "Google Chrome"`, `open -a "Brave Browser"`, or `open -a "Microsoft Edge"`. Do *not* navigate to `chrome://inspect` yet. If the user has ever ticked the checkbox on this profile, the harness will attach on its own.
+   - **`DevToolsActivePort` missing or empty after the browser is up** → remote-debugging has never been enabled on this profile. *This* is when you open `chrome://inspect/#remote-debugging` and ask the user to tick the checkbox and click `Allow`. Once ticked, the setting sticks.
+   - **Port present but `connection refused` / `DevTools not live yet` / `/json/version` 404** → the browser is mid-startup. Just keep polling for up to 30 seconds. Do not restart it and do not open the inspect page again.
+   - **`no close frame received or sent` / stale websocket** → the daemon (not the browser) is the problem. Run `restart_daemon()` once and retry — see step 7 below.
 
-   When you do need to open the inspect page on macOS and Chrome is already running, prefer AppleScript so it reuses the current profile instead of going through the picker:
+   When you do need to open the inspect page on macOS and the browser is already running, prefer AppleScript so it reuses the current profile instead of going through the picker.
 
+   Chrome:
 ```bash
 osascript -e 'tell application "Google Chrome" to activate' \
           -e 'tell application "Google Chrome" to open location "chrome://inspect/#remote-debugging"'
 ```
 
-   On Linux: open that URL manually in the existing Chrome window.
-   If Chrome shows the profile picker first, tell the user to choose their normal profile, *then* (only if `DevToolsActivePort` is still missing) open the inspect page in that profile. Keep polling instead of waiting for the user to type a follow-up.
-4. Be explicit with the user about the two possible Chrome actions: choose their normal profile if the profile picker is open, and in the remote-debugging tab tick the checkbox and click `Allow` once if Chrome shows it.
-5. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the Chrome profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. After asking, keep retrying for at least 30 seconds even if you see connection-refused, stale websocket, or other weird transient attach errors.
+   Brave:
+```bash
+osascript -e 'tell application "Brave Browser" to activate' \
+          -e 'tell application "Brave Browser" to open location "chrome://inspect/#remote-debugging"'
+```
+
+   Edge:
+```bash
+osascript -e 'tell application "Microsoft Edge" to activate' \
+          -e 'tell application "Microsoft Edge" to open location "chrome://inspect/#remote-debugging"'
+```
+
+   On Linux: open that URL manually in the existing browser window.
+   If the browser shows the profile picker first, tell the user to choose their normal profile, *then* (only if `DevToolsActivePort` is still missing) open the inspect page in that profile. Keep polling instead of waiting for the user to type a follow-up.
+4. Be explicit with the user about the two possible browser actions: choose their normal profile if the profile picker is open, and in the remote-debugging tab tick the checkbox and click `Allow` once if the browser shows it.
+5. Try to do everything yourself. Only ask the user to do something if it is truly necessary, like selecting the browser profile or clicking `Allow`. While the user is doing that, sleep and check every 3 seconds whether it is completed. After asking, keep retrying for at least 30 seconds even if you see connection-refused, stale websocket, or other weird transient attach errors.
 6. If setup still lands on the profile picker, have the user choose their normal profile, then (only if `DevToolsActivePort` is still missing) open `chrome://inspect/#remote-debugging` in that profile and keep polling instead of restarting the explanation. As soon as attach succeeds, continue immediately with the verification task without asking again.
 7. Verify with:
 
@@ -95,11 +108,11 @@ PY
 
 ## Cold-start reminders
 
-- Try attaching before asking the user to change anything. Decide what to escalate based on the harness's error message, not on whether Chrome is visibly running.
-- The remote-debugging checkbox is per-profile sticky in Chrome. If it has ever been ticked on a profile, just launching Chrome is enough — only navigate to `chrome://inspect/#remote-debugging` when `DevToolsActivePort` is genuinely missing.
-- The first connect may block on Chrome's `Allow` dialog, and Chrome may also stop first on the profile picker.
+- Try attaching before asking the user to change anything. Decide what to escalate based on the harness's error message, not on whether the browser is visibly running.
+- The remote-debugging checkbox is per-profile sticky in Chromium browsers. If it has ever been ticked on a profile, just launching the browser is enough. Only navigate to `chrome://inspect/#remote-debugging` when `DevToolsActivePort` is genuinely missing.
+- The first connect may block on the browser's `Allow` dialog, and it may also stop first on the profile picker.
 - `DevToolsActivePort` can exist before the port is actually listening. Treat connection refused as "still enabling" and keep polling briefly.
 - If the port is listening but `/json/version` returns `404`, treat that as expected on newer Chrome builds and retry `browser-harness`.
-- Chrome may open the profile picker before any real tab exists.
-- On macOS, prefer AppleScript `open location` over `open -a ... URL` when Chrome is already running.
-- Microsoft Edge (including Beta/Dev/Canary) works too — substitute the app name; steps are identical.
+- The browser may open the profile picker before any real tab exists.
+- On macOS, prefer AppleScript `open location` over `open -a ... URL` when the browser is already running.
+- Brave and Microsoft Edge (including Beta/Dev/Canary) work too. Substitute the app name and use the matching profile path.


### PR DESCRIPTION
Adds Brave support across the local browser discovery and setup docs.

What changed

• daemon.py
  • added Brave profile path detection on macOS, Linux, and Windows
  • generalized browser-related error text beyond Chrome-only wording
• install.md
  • documented Brave in the remote-debugging setup flow
  • added the macOS AppleScript example for opening Brave to chrome://inspect/#remote-debugging
  • generalized setup language to Chromium browsers where appropriate
• SKILL.md
  • updated usage guidance to reflect support for Chrome, Brave, and Edge
• README.md
  • updated Chrome-only wording to Chromium-browser wording

Why

My actual browser setup is Brave-first, so Chrome-only discovery and documentation were too narrow for real use. This makes the harness work cleanly in Brave-based local environments too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Brave browser support and generalizes Chrome-only flows to Chromium, enabling seamless attach and setup for Chrome, Brave, and Edge.

- **New Features**
  - Detect Brave profile paths on macOS, Linux, and Windows in `daemon.py` to read `DevToolsActivePort`.
  - Generalize error/setup text from Chrome-specific to browser-agnostic.
  - Update install docs with Brave and Edge AppleScript examples and Chromium-first guidance.
  - Refresh `SKILL.md` and `README.md` to reflect Chromium support and clarify per-profile remote-debugging, profile picker, and Allow dialog behavior.

<sup>Written for commit 8387907977f9ef3a7441f5dd9d8cd1500a4831c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

