### PR TITLE
daemon: auto-launch Chrome on Linux when no CDP port found

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -25,12 +25,14 @@ SOCK = f"/tmp/bu-{NAME}.sock"
 LOG = f"/tmp/bu-{NAME}.log"
 PID = f"/tmp/bu-{NAME}.pid"
 BUF = 500
+LINUX_HARNESS_PROFILE = Path.home() / ".config/chrome-harness"
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
     Path.home() / "Library/Application Support/Microsoft Edge",
     Path.home() / "Library/Application Support/Microsoft Edge Beta",
     Path.home() / "Library/Application Support/Microsoft Edge Dev",
     Path.home() / "Library/Application Support/Microsoft Edge Canary",
+    LINUX_HARNESS_PROFILE,
     Path.home() / ".config/google-chrome",
     Path.home() / ".config/chromium",
     Path.home() / ".config/chromium-browser",
@@ -78,6 +80,27 @@ def get_ws_url():
             finally:
                 probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+    # On Linux with a display, auto-launch Chrome with remote debugging on the harness profile.
+    if sys.platform.startswith("linux") and (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")):
+        import shutil, subprocess
+        chrome = shutil.which("google-chrome") or shutil.which("google-chrome-stable") or shutil.which("chromium") or shutil.which("chromium-browser")
+        if chrome:
+            LINUX_HARNESS_PROFILE.mkdir(parents=True, exist_ok=True)
+            subprocess.Popen(
+                [chrome, f"--user-data-dir={LINUX_HARNESS_PROFILE}", "--remote-debugging-port=0"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+            )
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                try:
+                    port, path = (LINUX_HARNESS_PROFILE / "DevToolsActivePort").read_text().strip().split("\n", 1)
+                    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    probe.settimeout(1)
+                    probe.connect(("127.0.0.1", int(port.strip())))
+                    probe.close()
+                    return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+                except Exception:
+                    time.sleep(0.5)
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 


### PR DESCRIPTION
## Problem

On Linux, Chrome refuses `--remote-debugging-port` on the default profile:

```
DevTools remote debugging requires a non-default data directory. Specify this using --user-data-dir.
```

The `chrome://inspect/#remote-debugging` checkbox also doesn't help — it's a *discovery* UI for already-running remote targets, not a toggle to start the CDP server on the current browser. The per-profile sticky behaviour described in `install.md` is macOS-only.

## Solution

Two changes to `daemon.py`:

**1. `LINUX_HARNESS_PROFILE`** — a stable dedicated profile path (`~/.config/chrome-harness`) inserted at the top of `PROFILES`. Chrome can use this with `--remote-debugging-port=0` without complaining, and the path survives reboots (unlike `/tmp`).

**2. Auto-launch** — when `get_ws_url()` finds no `DevToolsActivePort` in any profile and we're on Linux with a display (`$DISPLAY` or `$WAYLAND_DISPLAY`), it:
- Finds the Chrome/Chromium binary via `shutil.which`
- Launches it with `--user-data-dir=~/.config/chrome-harness --remote-debugging-port=0`
- Polls until the port is live (up to 30 s)

## Result

`browser-harness` now works cold on Linux — just run it and Chrome opens automatically. No `chrome://inspect`, no manual `--remote-debugging-port` flags, no `BU_CDP_WS` exports needed.

Tested on Ubuntu 22.04, Chrome 137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-launches Chrome/Chromium on Linux when no CDP port is found by starting a dedicated profile and enabling remote debugging. This makes `browser-harness` work from a cold start with no manual setup.

- **New Features**
  - Added `LINUX_HARNESS_PROFILE` (`~/.config/chrome-harness`) and prioritized it in `PROFILES` so CDP can run on a non-default profile.
  - On Linux with a display (`DISPLAY` or `WAYLAND_DISPLAY`), `get_ws_url()` finds Chrome/Chromium, starts it with `--user-data-dir=~/.config/chrome-harness --remote-debugging-port=0`, and polls up to 30s for `DevToolsActivePort`.

<sup>Written for commit b9d12fe9e0bdff44212a0b482b07e99e06d471e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

