### PR TITLE
Fix Chrome 147+ blocking remote debugging on default profile (Linux, macOS, Windows)

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -6,6 +6,9 @@ import urllib.request
 from pathlib import Path
 
 
+from launch import launch_chrome  # noqa: F401 — re-exported for convenience
+
+
 def _load_env():
     p = Path(__file__).parent / ".env"
     if not p.exists():
@@ -35,7 +38,8 @@ def _paths(name):
 def _log_tail(name):
     p = f"/tmp/bu-{name or NAME}.log"
     try:
-        return Path(p).read_text().strip().splitlines()[-1]
+        lines = Path(p).read_text().strip().splitlines()
+        return "\n".join(lines[-5:])  # last 5 lines for context
     except (FileNotFoundError, IndexError):
         return None
 

--- a/admin.py
+++ b/admin.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 
 from launch import launch_chrome  # noqa: F401 — re-exported for convenience
+from transport import cleanup_endpoint, connect_client, runtime_paths, version_cache_path
 
 
 def _load_env():
@@ -26,43 +27,35 @@ _load_env()
 NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"
 GH_RELEASES = "https://api.github.com/repos/browser-use/browser-harness/releases/latest"
-VERSION_CACHE = Path("/tmp/bu-version-cache.json")
+VERSION_CACHE = version_cache_path()
 VERSION_CACHE_TTL = 24 * 3600
 
 
 def _paths(name):
     n = name or NAME
-    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
-
-
+    paths = runtime_paths(n)
+    return str(paths.sock), str(paths.pid)
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
+    p = runtime_paths(name or NAME).log
     try:
-        lines = Path(p).read_text().strip().splitlines()
+        lines = p.read_text().strip().splitlines()
         return "\n".join(lines[-5:])  # last 5 lines for context
     except (FileNotFoundError, IndexError):
         return None
-
-
 def daemon_alive(name=None):
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(1)
-        s.connect(_paths(name)[0])
+        s = connect_client(name or NAME, timeout=1)
         s.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+    except (FileNotFoundError, OSError, ValueError):
         return False
-
-
 def ensure_daemon(wait=60.0, name=None, env=None):
     """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
         try:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
-            s.connect(_paths(name)[0])
+            s = connect_client(name or NAME, timeout=3)
             s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
             data = b""
             while not data.endswith(b"\n"):
@@ -93,7 +86,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
             restart_daemon(name)
             continue
-        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {runtime_paths(name or NAME).log}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -120,7 +113,7 @@ def restart_daemon(name=None):
 
     sock, pid_path = _paths(name)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s = connect_client(name or NAME, timeout=5)
         s.settimeout(5)
         s.connect(sock)
         s.sendall(b'{"meta":"shutdown"}\n')
@@ -144,6 +137,7 @@ def restart_daemon(name=None):
                 os.kill(pid, signal.SIGTERM)
             except ProcessLookupError:
                 pass
+    cleanup_endpoint(name or NAME)
     for f in (sock, pid_path):
         try:
             os.unlink(f)
@@ -443,10 +437,100 @@ def _open_chrome_inspect():
             return
         except Exception:
             pass
+    if platform.system() == "Windows":
+        browser = _find_windows_browser()
+        if browser:
+            try:
+                _open_windows_internal_url(browser, url, _windows_profile_directory())
+                return
+            except Exception:
+                pass
     try:
         webbrowser.open(url, new=2)
     except Exception:
         pass
+
+
+def _windows_profile_directory():
+    state = Path.home() / "AppData/Local/Google/Chrome/User Data/Local State"
+    try:
+        profile = json.loads(state.read_text(encoding="utf-8")).get("profile", {})
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+
+    for candidate in profile.get("last_active_profiles") or []:
+        if candidate and candidate != "Guest Profile":
+            return candidate
+
+    last_used = profile.get("last_used")
+    if last_used and last_used != "Guest Profile":
+        return last_used
+
+    for candidate in (profile.get("info_cache") or {}).keys():
+        if candidate and candidate != "Guest Profile":
+            return candidate
+
+    return None
+
+
+def _ps_single_quote(value):
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _windows_internal_url_script(browser, url, profile_dir=None):
+    chrome = _ps_single_quote(browser)
+    url_value = _ps_single_quote(url)
+    profile = _ps_single_quote(profile_dir or "")
+    return f"""
+Add-Type -AssemblyName System.Windows.Forms
+$chrome = {chrome}
+$targetUrl = {url_value}
+$profile = {profile}
+$args = @()
+if ($profile) {{
+  $args += "--profile-directory=$profile"
+}}
+$proc = Start-Process -FilePath $chrome -ArgumentList $args -PassThru
+Start-Sleep -Milliseconds 1500
+$wshell = New-Object -ComObject WScript.Shell
+$activated = $false
+if ($proc) {{
+  for ($i = 0; $i -lt 10; $i++) {{
+    try {{
+      if ($wshell.AppActivate($proc.Id)) {{
+        $activated = $true
+        break
+      }}
+    }} catch {{}}
+    Start-Sleep -Milliseconds 300
+  }}
+}}
+if (-not $activated) {{
+  $chromeProc = Get-Process chrome -ErrorAction SilentlyContinue | Sort-Object StartTime -Descending | Select-Object -First 1
+  if ($chromeProc) {{
+    try {{
+      $activated = $wshell.AppActivate($chromeProc.Id)
+    }} catch {{}}
+  }}
+}}
+Start-Sleep -Milliseconds 300
+Set-Clipboard -Value $targetUrl
+[System.Windows.Forms.SendKeys]::SendWait('^l')
+Start-Sleep -Milliseconds 150
+[System.Windows.Forms.SendKeys]::SendWait('^v')
+Start-Sleep -Milliseconds 150
+[System.Windows.Forms.SendKeys]::SendWait('~')
+""".strip()
+
+
+def _open_windows_internal_url(browser, url, profile_dir=None):
+    import subprocess
+
+    subprocess.run(
+        ["powershell", "-NoProfile", "-Command", _windows_internal_url_script(browser, url, profile_dir)],
+        timeout=20,
+        check=True,
+    )
 
 
 def run_setup():

--- a/daemon.py
+++ b/daemon.py
@@ -58,6 +58,28 @@ def log(msg):
     open(LOG, "a").write(f"{msg}\n")
 
 
+def _probe_cdp_port(port=9222, timeout=30):
+    """Connect to a fixed CDP port and return the WebSocket debugger URL."""
+    deadline = time.time() + timeout
+    while True:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.settimeout(1)
+        try:
+            probe.connect(("127.0.0.1", port))
+            break
+        except OSError:
+            if time.time() >= deadline:
+                raise RuntimeError(
+                    f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port}"
+                )
+            time.sleep(1)
+        finally:
+            probe.close()
+    resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=5)
+    data = json.loads(resp.read())
+    return data.get("webSocketDebuggerUrl", f"ws://127.0.0.1:{port}/devtools/browser")
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
@@ -82,7 +104,18 @@ def get_ws_url():
             finally:
                 probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
-    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
+    # Chrome 147+ with CHROME_CONFIG_HOME may not write DevToolsActivePort.
+    # Fallback to the well-known default port.
+    try:
+        return _probe_cdp_port()
+    except RuntimeError:
+        pass
+    raise RuntimeError(
+        f"DevToolsActivePort not found in {[str(p) for p in PROFILES]}.\n"
+        "Chrome 147+ blocks remote debugging on the default profile — "
+        "see https://github.com/browser-use/browser-harness/blob/main/install.md#chrome-147-workaround.\n"
+        "Fix: use launch_chrome() from admin.py, or set BU_CDP_WS for a remote browser."
+    )
 
 
 def stop_remote():

--- a/daemon.py
+++ b/daemon.py
@@ -75,9 +75,18 @@ def _probe_cdp_port(port=9222, timeout=30):
             time.sleep(1)
         finally:
             probe.close()
-    resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=5)
-    data = json.loads(resp.read())
-    return data.get("webSocketDebuggerUrl", f"ws://127.0.0.1:{port}/devtools/browser")
+    try:
+        resp = urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/json/version", timeout=5
+        )
+        data = json.loads(resp.read())
+        return data.get(
+            "webSocketDebuggerUrl", f"ws://127.0.0.1:{port}/devtools/browser"
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"Found CDP port {port} open, but failed to fetch /json/version: {exc}"
+        )
 
 
 def get_ws_url():

--- a/daemon.py
+++ b/daemon.py
@@ -4,6 +4,7 @@ from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
+from transport import cleanup_endpoint, connect_client, runtime_paths, start_server
 
 
 def _load_env():
@@ -21,9 +22,9 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+PATHS = runtime_paths(NAME)
+LOG = str(PATHS.log)
+PID = str(PATHS.pid)
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -234,8 +235,8 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
-        os.unlink(SOCK)
+    cleanup_endpoint(NAME)
+    # os.unlink(SOCK)
 
     async def handler(reader, writer):
         try:
@@ -254,9 +255,9 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    server = await start_server(handler, NAME)
+    # os.chmod(SOCK, 0o600)
+    log(f"listening on {PATHS.sock} (name={NAME}, remote={REMOTE_ID or 'local'})")
     async with server:
         await d.stop.wait()
 
@@ -269,26 +270,8 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
+        s = connect_client(NAME, timeout=1)
+        s.close()
+        return True
     except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
         return False
-
-
-if __name__ == "__main__":
-    if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
-        sys.exit(0)
-    open(LOG, "w").close()
-    open(PID, "w").write(str(os.getpid()))
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        pass
-    except Exception as e:
-        log(f"fatal: {e}")
-        sys.exit(1)
-    finally:
-        stop_remote()
-        try: os.unlink(PID)
-        except FileNotFoundError: pass

--- a/install.md
+++ b/install.md
@@ -51,7 +51,7 @@ Even with `--user-data-dir` pointing to the real profile, Chrome 147 still shows
 
 **Root cause** (from `chromium/browser_process_impl.cc`): In Google Chrome branded builds, `IsRemoteDebuggingAllowed()` checks `IsUsingDefaultDataDirectory()` and returns `kDisabledByDefaultUserDataDir` when the paths match. This is hardcoded for `GOOGLE_CHROME_BRANDING` — Chromium builds skip this check.
 
-**The fix** — use `launch_chrome()` from `admin.py`, which sets `CHROME_CONFIG_HOME` to a temporary path. This makes Chrome think the real profile directory is "non-default" while keeping all user data (bookmarks, extensions, cookies) intact:
+**The fix** — use `launch_chrome()` from `admin.py`, which sets `CHROME_CONFIG_HOME` to a persistent fake path. This makes Chrome think the real profile directory is "non-default" while keeping all user data (bookmarks, extensions, cookies) intact:
 
 ```python
 from admin import launch_chrome, ensure_daemon
@@ -74,7 +74,7 @@ print(f"DevTools: {info['ws_url']}")
 PY
 ```
 
-**How it works**: Chrome computes the "default" user data dir as `$CHROME_CONFIG_HOME/google-chrome` (Linux) or equivalent. By setting `CHROME_CONFIG_HOME=/tmp/bu-chrome-config-XXXXX`, the default path becomes `/tmp/bu-chrome-config-XXXXX/google-chrome` while `--user-data-dir` still points to `~/.config/google-chrome`. The paths differ → `IsUsingDefaultDataDirectory()` returns false → remote debugging is allowed.
+**How it works**: Chrome computes the "default" user data dir as `$CHROME_CONFIG_HOME/google-chrome` (Linux) or equivalent. By setting `CHROME_CONFIG_HOME` to a persistent path under `~/.local/share/browser-harness/`, the default path becomes something like `~/.local/share/browser-harness/chrome-config-home/google-chrome` while `--user-data-dir` still points to `~/.config/google-chrome`. The paths differ → `IsUsingDefaultDataDirectory()` returns false → remote debugging is allowed.
 
 **Limitations**: This shares the real Chrome profile. If Chrome is already running without remote debugging, you need to close it first (Chrome's single-instance lock prevents two processes from using the same profile).
 

--- a/install.md
+++ b/install.md
@@ -39,6 +39,45 @@ mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness" && ln -sf "$PWD/SK
 
 That makes new Codex or Claude Code sessions in other folders load the runtime browser harness instructions automatically. An empty `~/.codex/skills/browser-harness/` directory is fine; the symlink command above populates it.
 
+## Chrome 147+ workaround
+
+**Chrome 147+** (Google Chrome branded builds) blocks `--remote-debugging-port` when using the **default** user data directory. The error message is:
+
+```
+DevTools remote debugging requires a non-default data directory. Specify this using --user-data-dir.
+```
+
+Even with `--user-data-dir` pointing to the real profile, Chrome 147 still shows an "Allow remote debugging" dialog that can't be dismissed programmatically on Wayland (no keyboard simulation tools work).
+
+**Root cause** (from `chromium/browser_process_impl.cc`): In Google Chrome branded builds, `IsRemoteDebuggingAllowed()` checks `IsUsingDefaultDataDirectory()` and returns `kDisabledByDefaultUserDataDir` when the paths match. This is hardcoded for `GOOGLE_CHROME_BRANDING` — Chromium builds skip this check.
+
+**The fix** — use `launch_chrome()` from `admin.py`, which sets `CHROME_CONFIG_HOME` to a temporary path. This makes Chrome think the real profile directory is "non-default" while keeping all user data (bookmarks, extensions, cookies) intact:
+
+```python
+from admin import launch_chrome, ensure_daemon
+
+# Start Chrome with remote debugging on your real profile
+info = launch_chrome(port=9222)
+print(f"Chrome started: PID {info['pid']}, WS {info['ws_url']}")
+
+# Now connect the daemon
+ensure_daemon()
+```
+
+Or from the shell:
+
+```bash
+browser-harness <<'PY'
+from launch import launch_chrome
+info = launch_chrome()
+print(f"DevTools: {info['ws_url']}")
+PY
+```
+
+**How it works**: Chrome computes the "default" user data dir as `$CHROME_CONFIG_HOME/google-chrome` (Linux) or equivalent. By setting `CHROME_CONFIG_HOME=/tmp/bu-chrome-config-XXXXX`, the default path becomes `/tmp/bu-chrome-config-XXXXX/google-chrome` while `--user-data-dir` still points to `~/.config/google-chrome`. The paths differ → `IsUsingDefaultDataDirectory()` returns false → remote debugging is allowed.
+
+**Limitations**: This shares the real Chrome profile. If Chrome is already running without remote debugging, you need to close it first (Chrome's single-instance lock prevents two processes from using the same profile).
+
 ## Browser bootstrap
 
 Prefer `browser-harness --setup` — it runs the full attach-and-escalate flow below as one interactive command. The manual steps that follow are only for when `--setup` is unavailable or you need to debug a specific failure.

--- a/install.md
+++ b/install.md
@@ -51,7 +51,10 @@ Even with `--user-data-dir` pointing to the real profile, Chrome 147 still shows
 
 **Root cause** (from `chromium/browser_process_impl.cc`): In Google Chrome branded builds, `IsRemoteDebuggingAllowed()` checks `IsUsingDefaultDataDirectory()` and returns `kDisabledByDefaultUserDataDir` when the paths match. This is hardcoded for `GOOGLE_CHROME_BRANDING` — Chromium builds skip this check.
 
-**The fix** — use `launch_chrome()` from `admin.py`, which sets `CHROME_CONFIG_HOME` to a persistent fake path. This makes Chrome think the real profile directory is "non-default" while keeping all user data (bookmarks, extensions, cookies) intact:
+**The fix** — use `launch_chrome()` from `admin.py`, which bypasses the default-profile check platform-specifically:
+
+- **Linux**: sets `CHROME_CONFIG_HOME` to a persistent fake path. Chrome computes the default user data dir as `$CHROME_CONFIG_HOME/google-chrome`; since that path differs from `--user-data-dir`, `IsUsingDefaultDataDirectory()` returns false.
+- **macOS / Windows**: `CHROME_CONFIG_HOME` is ignored, so `launch_chrome()` creates a temporary *copy* of the real profile and points `--user-data-dir` at the copy. The copy is refreshed on first launch after the real profile changes.
 
 ```python
 from admin import launch_chrome, ensure_daemon
@@ -73,8 +76,6 @@ info = launch_chrome()
 print(f"DevTools: {info['ws_url']}")
 PY
 ```
-
-**How it works**: Chrome computes the "default" user data dir as `$CHROME_CONFIG_HOME/google-chrome` (Linux) or equivalent. By setting `CHROME_CONFIG_HOME` to a persistent path under `~/.local/share/browser-harness/`, the default path becomes something like `~/.local/share/browser-harness/chrome-config-home/google-chrome` while `--user-data-dir` still points to `~/.config/google-chrome`. The paths differ → `IsUsingDefaultDataDirectory()` returns false → remote debugging is allowed.
 
 **Limitations**: This shares the real Chrome profile. If Chrome is already running without remote debugging, you need to close it first (Chrome's single-instance lock prevents two processes from using the same profile).
 

--- a/launch.py
+++ b/launch.py
@@ -2,13 +2,14 @@
 
 Chrome 147+ blocks --remote-debugging-port on the default user data
 directory (see chromium/browser_process_impl.cc kDisabledByDefaultUserDataDir).
-This module provides launch_chrome() which works around the restriction by
-setting CHROME_CONFIG_HOME to a temporary path, making Chrome think the
-real profile directory is "non-default" while keeping all user data intact.
+This module provides launch_chrome() which works around the restriction
+without copying data on Linux (CHROME_CONFIG_HOME), and by creating a
+temp profile copy on macOS/Windows where the env-var trick does not apply.
 """
 
 import os
 import platform
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -32,6 +33,13 @@ _CHROME_NAMES = {
 }
 
 
+_BH_STATE = Path.home() / ".local/share/browser-harness"
+if platform.system() == "Darwin":
+    _BH_STATE = Path.home() / "Library/Application Support/browser-harness"
+elif platform.system() == "Windows":
+    _BH_STATE = Path.home() / "AppData/Local/browser-harness"
+
+
 def _find_chrome():
     """Return the path to the Chrome binary, or None."""
     system = platform.system()
@@ -39,7 +47,6 @@ def _find_chrome():
         p = Path(name)
         if p.is_file():
             return str(p)
-        # Search PATH
         import shutil
         found = shutil.which(name)
         if found:
@@ -53,15 +60,24 @@ def _get_default_user_data_dir():
     return _DEFAULT_UDIR.get(system, Path.home() / ".config/google-chrome")
 
 
+def _copy_profile(src: Path, dst: Path):
+    """Copy a Chrome profile, skipping lock files that prevent multi-instance."""
+    def _ignore_locks(dirpath, names):
+        return {n for n in names if n in (
+            "SingletonLock", "SingletonSocket", "SingletonCookie",
+            "DevToolsActivePort",
+        )}
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, ignore=_ignore_locks, dirs_exist_ok=False)
+
+
 def _is_wayland_session():
     """Detect Wayland by checking loginctl or running processes."""
     try:
-        # Try loginctl with session ID
-        import subprocess
         r = subprocess.run(
             ["loginctl"], capture_output=True, text=True, timeout=3,
         )
-        # Parse session ID from output
         for line in r.stdout.strip().splitlines()[1:]:  # skip header
             parts = line.split()
             if len(parts) >= 1:
@@ -75,7 +91,6 @@ def _is_wayland_session():
     except Exception:
         pass
     try:
-        # Check if gnome-shell is running with wayland
         r = subprocess.run(
             ["pgrep", "-a", "gnome-shell"],
             capture_output=True, text=True, timeout=3,
@@ -84,7 +99,6 @@ def _is_wayland_session():
             return True
     except Exception:
         pass
-    # Check for wayland socket
     runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "/run/user/1000")
     if Path(runtime_dir, "wayland-0").exists():
         return True
@@ -122,8 +136,19 @@ def launch_chrome(
 ):
     """Launch Chrome with remote debugging enabled, bypassing the Allow dialog.
 
-    Works on Chrome 147+ by setting CHROME_CONFIG_HOME to a temp path so the
-    default-user-data-dir check doesn't block remote debugging.
+    Chrome 147+ branded builds block --remote-debugging-port when the
+    default user-data directory is used (chromium/browser_process_impl.cc
+    kDisabledByDefaultUserDataDir).
+
+    Strategy by platform:
+      - Linux: set CHROME_CONFIG_HOME to a persistent fake path. Chrome
+        computes the default dir as $CHROME_CONFIG_HOME/google-chrome; by
+        keeping --user-data-dir on the real profile the paths differ and the
+        check passes. No data copy needed.
+      - macOS / Windows: CHROME_CONFIG_HOME is not honoured, so we create a
+        temporary *copy* of the real profile and point --user-data-dir at the
+        copy. The copy is refreshed on first launch after the real profile
+        changes.
 
     Args:
         port:             Remote debugging port (default 9222).
@@ -139,7 +164,7 @@ def launch_chrome(
             user_data_dir:    Absolute path to the profile used.
             port:             The debugging port.
             ws_url:           WebSocket debugger URL (only if wait=True).
-            chrome_config_home: The temp CHROME_CONFIG_HOME path used.
+            chrome_config_home: The CHROME_CONFIG_HOME path used (Linux only).
 
     Raises:
         RuntimeError: If Chrome not found or DevTools doesn't come up.
@@ -151,28 +176,40 @@ def launch_chrome(
             "BU_CDP_WS to an existing browser's CDP WebSocket URL."
         )
 
-    udir = Path(user_data_dir) if user_data_dir else _get_default_user_data_dir()
-    udir = udir.expanduser().resolve()
-
-    # Create a temp CHROME_CONFIG_HOME so IsUsingDefaultDataDirectory() returns false.
-    # We set CHROME_CONFIG_HOME to /tmp/bu-chrome-config-XXXXX, and Chrome computes
-    # the "default" dir as $CHROME_CONFIG_HOME/google-chrome. Since our --user-data-dir
-    # points to the real ~/.config/google-chrome, the paths differ and the check passes.
     system = platform.system()
-    if system == "Darwin":
-        dir_name = "google-chrome"
-    elif system == "Windows":
-        dir_name = "Google\\Chrome"
-    else:
-        dir_name = "google-chrome"
+    real_udir = Path(user_data_dir) if user_data_dir else _get_default_user_data_dir()
+    real_udir = real_udir.expanduser().resolve()
 
-    # Persistent fake CHROME_CONFIG_HOME so Chrome only asks to "Allow remote
-    # debugging" once.  Chrome computes the default user-data dir from this
-    # path; by pointing --user-data-dir at the real profile the paths differ
-    # and Chrome 147+'s restriction is bypassed.  Keeping the same fake home
-    # across restarts makes the permission sticky.
-    config_home = Path.home() / ".local/share/browser-harness/chrome-config-home"
-    config_home.mkdir(parents=True, exist_ok=True)
+    # ------------------------------------------------------------------
+    # Cross-platform workaround for Chrome 147+ default-profile block.
+    # ------------------------------------------------------------------
+    if system == "Linux":
+        # Linux: CHROME_CONFIG_HOME is honoured by Chrome.
+        config_home = _BH_STATE / "chrome-config-home"
+        config_home.mkdir(parents=True, exist_ok=True)
+        udir = real_udir
+        env_extra = {"CHROME_CONFIG_HOME": str(config_home)}
+    else:
+        # macOS / Windows: CHROME_CONFIG_HOME is ignored.
+        # Create a temp copy so --user-data-dir is "non-default".
+        copy_udir = _BH_STATE / "chrome-profile-copy"
+        # Only re-copy if the real profile is newer than the copy.
+        should_copy = True
+        if copy_udir.exists():
+            real_mtime = max(
+                (p.stat().st_mtime for p in real_udir.rglob("*") if p.is_file()),
+                default=0,
+            )
+            copy_mtime = max(
+                (p.stat().st_mtime for p in copy_udir.rglob("*") if p.is_file()),
+                default=0,
+            )
+            should_copy = real_mtime > copy_mtime
+        if should_copy:
+            _copy_profile(real_udir, copy_udir)
+        udir = copy_udir
+        config_home = None
+        env_extra = {}
 
     cmd = [
         chrome,
@@ -194,7 +231,7 @@ def launch_chrome(
     if extra_args:
         cmd.extend(extra_args)
 
-    env = {**os.environ, "CHROME_CONFIG_HOME": config_home}
+    env = {**os.environ, **env_extra}
 
     proc = subprocess.Popen(
         cmd,
@@ -208,8 +245,9 @@ def launch_chrome(
         "pid": proc.pid,
         "user_data_dir": str(udir),
         "port": port,
-        "chrome_config_home": config_home,
     }
+    if config_home:
+        result["chrome_config_home"] = str(config_home)
 
     if wait:
         import socket as _socket
@@ -225,8 +263,9 @@ def launch_chrome(
                         return result
                 except Exception:
                     pass
-            # Method 2: Probe the port directly (Chrome 147+ may not write DevToolsActivePort
-            # when started with a fixed --remote-debugging-port and CHROME_CONFIG_HOME)
+            # Method 2: Probe the port directly (Chrome 147+ may not write
+            # DevToolsActivePort when started with a fixed
+            # --remote-debugging-port and CHROME_CONFIG_HOME).
             try:
                 s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
                 s.settimeout(1)
@@ -234,9 +273,14 @@ def launch_chrome(
                 s.close()
                 # Port is listening — fetch ws_url from /json/version
                 import urllib.request, json
-                resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=3)
+                resp = urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/json/version", timeout=3
+                )
                 data = json.loads(resp.read())
-                result["ws_url"] = data.get("webSocketDebuggerUrl", f"ws://127.0.0.1:{port}/devtools/browser")
+                result["ws_url"] = data.get(
+                    "webSocketDebuggerUrl",
+                    f"ws://127.0.0.1:{port}/devtools/browser",
+                )
                 return result
             except Exception:
                 pass
@@ -244,7 +288,8 @@ def launch_chrome(
             if proc.poll() is not None:
                 stderr = proc.stderr.read().decode(errors="replace")
                 raise RuntimeError(
-                    f"Chrome exited with code {proc.returncode}. stderr: {stderr[:500]}"
+                    f"Chrome exited with code {proc.returncode}. "
+                    f"stderr: {stderr[:500]}"
                 )
             time.sleep(0.5)
         raise RuntimeError(

--- a/launch.py
+++ b/launch.py
@@ -54,7 +54,7 @@ def _find_chrome():
     return None
 
 
-def _get_default_user_data_dir():
+def get_default_user_data_dir():
     """Return the platform-specific default Chrome user data directory."""
     system = platform.system()
     return _DEFAULT_UDIR.get(system, Path.home() / ".config/google-chrome")
@@ -84,16 +84,32 @@ def _is_wayland_session():
     try:
         sid = os.environ.get("XDG_SESSION_ID")
         if not sid:
-            # Fallback: ask loginctl for the current session
+            # Fallback: ask loginctl for the current user's sessions.
+            # loginctl may report multiple active session IDs.
+            login_name = None
+            try:
+                login_name = os.getlogin()
+            except OSError:
+                import pwd
+                login_name = pwd.getpwuid(os.getuid()).pw_name
             r = subprocess.run(
-                ["loginctl", "show-user", os.getlogin(), "-p", "Sessions"],
+                ["loginctl", "show-user", login_name, "-p", "Sessions"],
                 capture_output=True, text=True, timeout=3,
             )
             for line in r.stdout.strip().splitlines():
                 if line.startswith("Sessions="):
-                    sid = line.split("=", 1)[1].strip()
+                    # Sessions= may contain multiple space-separated IDs.
+                    for candidate in line.split("=", 1)[1].strip().split():
+                        if not candidate:
+                            continue
+                        r2 = subprocess.run(
+                            ["loginctl", "show-session", candidate, "-p", "Type"],
+                            capture_output=True, text=True, timeout=3,
+                        )
+                        if "wayland" in r2.stdout.lower():
+                            return True
                     break
-        if sid:
+        else:
             r2 = subprocess.run(
                 ["loginctl", "show-session", sid, "-p", "Type"],
                 capture_output=True, text=True, timeout=3,
@@ -182,7 +198,7 @@ def launch_chrome(
         )
 
     system = platform.system()
-    real_udir = Path(user_data_dir) if user_data_dir else _get_default_user_data_dir()
+    real_udir = Path(user_data_dir) if user_data_dir else get_default_user_data_dir()
     real_udir = real_udir.expanduser().resolve()
 
     # ------------------------------------------------------------------
@@ -211,7 +227,12 @@ def launch_chrome(
             )
             should_copy = real_mtime > copy_mtime
         if should_copy:
-            _copy_profile(real_udir, copy_udir)
+            if real_udir.exists():
+                _copy_profile(real_udir, copy_udir)
+            else:
+                # First run: Chrome hasn't created the default profile yet.
+                # Create an empty copy dir so Chrome can populate it.
+                copy_udir.mkdir(parents=True, exist_ok=True)
         udir = copy_udir
         config_home = None
         env_extra = {}
@@ -226,7 +247,7 @@ def launch_chrome(
     if system == "Linux":
         wayland = (
             os.environ.get("WAYLAND_DISPLAY")
-            or os.environ.get("XDG_SESSION_TYPE") == "wayland"
+            or os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland"
             or _is_wayland_session()
         )
         if wayland:
@@ -241,14 +262,16 @@ def launch_chrome(
     # Redirect stderr to a temp file so the pipe buffer can't block Chrome.
     stderr_path = _BH_STATE / f"chrome-{port}.stderr.log"
     stderr_fh = open(stderr_path, "wb")
-
-    proc = subprocess.Popen(
-        cmd,
-        env=env,
-        stdout=subprocess.DEVNULL,
-        stderr=stderr_fh,
-        start_new_session=True,
-    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_fh,
+            start_new_session=True,
+        )
+    finally:
+        stderr_fh.close()
 
     result = {
         "pid": proc.pid,

--- a/launch.py
+++ b/launch.py
@@ -1,0 +1,255 @@
+"""Launch Chrome with CDP remote debugging enabled on any profile.
+
+Chrome 147+ blocks --remote-debugging-port on the default user data
+directory (see chromium/browser_process_impl.cc kDisabledByDefaultUserDataDir).
+This module provides launch_chrome() which works around the restriction by
+setting CHROME_CONFIG_HOME to a temporary path, making Chrome think the
+real profile directory is "non-default" while keeping all user data intact.
+"""
+
+import os
+import platform
+import subprocess
+import time
+from pathlib import Path
+
+# Known default user data directories per platform
+_DEFAULT_UDIR = {
+    "Linux": Path.home() / ".config/google-chrome",
+    "Darwin": Path.home() / "Library/Application Support/Google/Chrome",
+    "Windows": Path.home() / "AppData/Local/Google/Chrome/User Data",
+}
+
+_CHROME_NAMES = {
+    "Linux": ["google-chrome", "chromium-browser", "chromium"],
+    "Darwin": ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"],
+    "Windows": [
+        str(Path(os.environ.get("PROGRAMFILES", "C:\\Program Files"))
+            / "Google/Chrome/Application/chrome.exe"),
+        str(Path(os.environ.get("PROGRAMFILES(X86)", "C:\\Program Files (x86)"))
+            / "Google/Chrome/Application/chrome.exe"),
+    ],
+}
+
+
+def _find_chrome():
+    """Return the path to the Chrome binary, or None."""
+    system = platform.system()
+    for name in _CHROME_NAMES.get(system, []):
+        p = Path(name)
+        if p.is_file():
+            return str(p)
+        # Search PATH
+        import shutil
+        found = shutil.which(name)
+        if found:
+            return found
+    return None
+
+
+def _get_default_user_data_dir():
+    """Return the platform-specific default Chrome user data directory."""
+    system = platform.system()
+    return _DEFAULT_UDIR.get(system, Path.home() / ".config/google-chrome")
+
+
+def _is_wayland_session():
+    """Detect Wayland by checking loginctl or running processes."""
+    try:
+        # Try loginctl with session ID
+        import subprocess
+        r = subprocess.run(
+            ["loginctl"], capture_output=True, text=True, timeout=3,
+        )
+        # Parse session ID from output
+        for line in r.stdout.strip().splitlines()[1:]:  # skip header
+            parts = line.split()
+            if len(parts) >= 1:
+                sid = parts[0]
+                r2 = subprocess.run(
+                    ["loginctl", "show-session", sid, "-p", "Type"],
+                    capture_output=True, text=True, timeout=3,
+                )
+                if "wayland" in r2.stdout.lower():
+                    return True
+    except Exception:
+        pass
+    try:
+        # Check if gnome-shell is running with wayland
+        r = subprocess.run(
+            ["pgrep", "-a", "gnome-shell"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if "wayland" in r.stdout.lower():
+            return True
+    except Exception:
+        pass
+    # Check for wayland socket
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "/run/user/1000")
+    if Path(runtime_dir, "wayland-0").exists():
+        return True
+    return False
+
+
+def is_chrome147_plus():
+    """Quick heuristic: Chrome 147+ blocks remote debugging on default profile."""
+    # We can check by trying to start Chrome with remote debugging on the
+    # default profile and seeing if DevToolsActivePort appears. But that's
+    # expensive. For now, we assume Chrome 147+ on branded builds (the
+    # check is #if BUILDFLAG(GOOGLE_CHROME_BRANDING)).
+    chrome = _find_chrome()
+    if not chrome:
+        return False
+    try:
+        out = subprocess.check_output([chrome, "--version"], text=True, timeout=5).strip()
+        # "Google Chrome 147.0.7727.55"
+        parts = out.split()
+        if len(parts) >= 3:
+            version = parts[2].split(".")[0]
+            return int(version) >= 147
+    except Exception:
+        pass
+    return False
+
+
+def launch_chrome(
+    port=9222,
+    user_data_dir=None,
+    headless=False,
+    extra_args=None,
+    wait=True,
+    wait_timeout=15,
+):
+    """Launch Chrome with remote debugging enabled, bypassing the Allow dialog.
+
+    Works on Chrome 147+ by setting CHROME_CONFIG_HOME to a temp path so the
+    default-user-data-dir check doesn't block remote debugging.
+
+    Args:
+        port:             Remote debugging port (default 9222).
+        user_data_dir:    Path to Chrome profile. Default: platform default.
+        headless:         Run headless (--headless=new).
+        extra_args:       Additional Chrome flags (list of strings).
+        wait:             Block until DevToolsActivePort appears.
+        wait_timeout:     Seconds to wait for DevToolsActivePort.
+
+    Returns:
+        dict with keys:
+            pid:              Chrome process PID.
+            user_data_dir:    Absolute path to the profile used.
+            port:             The debugging port.
+            ws_url:           WebSocket debugger URL (only if wait=True).
+            chrome_config_home: The temp CHROME_CONFIG_HOME path used.
+
+    Raises:
+        RuntimeError: If Chrome not found or DevTools doesn't come up.
+    """
+    chrome = _find_chrome()
+    if not chrome:
+        raise RuntimeError(
+            "Chrome not found. Install Google Chrome or Chromium, or set "
+            "BU_CDP_WS to an existing browser's CDP WebSocket URL."
+        )
+
+    udir = Path(user_data_dir) if user_data_dir else _get_default_user_data_dir()
+    udir = udir.expanduser().resolve()
+
+    # Create a temp CHROME_CONFIG_HOME so IsUsingDefaultDataDirectory() returns false.
+    # We set CHROME_CONFIG_HOME to /tmp/bu-chrome-config-XXXXX, and Chrome computes
+    # the "default" dir as $CHROME_CONFIG_HOME/google-chrome. Since our --user-data-dir
+    # points to the real ~/.config/google-chrome, the paths differ and the check passes.
+    system = platform.system()
+    if system == "Darwin":
+        dir_name = "google-chrome"
+    elif system == "Windows":
+        dir_name = "Google\\Chrome"
+    else:
+        dir_name = "google-chrome"
+
+    # Persistent fake CHROME_CONFIG_HOME so Chrome only asks to "Allow remote
+    # debugging" once.  Chrome computes the default user-data dir from this
+    # path; by pointing --user-data-dir at the real profile the paths differ
+    # and Chrome 147+'s restriction is bypassed.  Keeping the same fake home
+    # across restarts makes the permission sticky.
+    config_home = Path.home() / ".local/share/browser-harness/chrome-config-home"
+    config_home.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        chrome,
+        f"--remote-debugging-port={port}",
+        "--no-first-run",
+        f"--user-data-dir={udir}",
+    ]
+    # Auto-detect display server on Linux
+    if system == "Linux":
+        wayland = (
+            os.environ.get("WAYLAND_DISPLAY")
+            or os.environ.get("XDG_SESSION_TYPE") == "wayland"
+            or _is_wayland_session()
+        )
+        if wayland:
+            cmd.append("--ozone-platform=wayland")
+    if headless:
+        cmd.append("--headless=new")
+    if extra_args:
+        cmd.extend(extra_args)
+
+    env = {**os.environ, "CHROME_CONFIG_HOME": config_home}
+
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+
+    result = {
+        "pid": proc.pid,
+        "user_data_dir": str(udir),
+        "port": port,
+        "chrome_config_home": config_home,
+    }
+
+    if wait:
+        import socket as _socket
+        port_file = udir / "DevToolsActivePort"
+        deadline = time.time() + wait_timeout
+        while time.time() < deadline:
+            # Method 1: Check DevToolsActivePort file
+            if port_file.exists():
+                try:
+                    content = port_file.read_text().strip().split("\n")
+                    if len(content) >= 2:
+                        result["ws_url"] = f"ws://127.0.0.1:{content[0]}{content[1]}"
+                        return result
+                except Exception:
+                    pass
+            # Method 2: Probe the port directly (Chrome 147+ may not write DevToolsActivePort
+            # when started with a fixed --remote-debugging-port and CHROME_CONFIG_HOME)
+            try:
+                s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+                s.settimeout(1)
+                s.connect(("127.0.0.1", port))
+                s.close()
+                # Port is listening — fetch ws_url from /json/version
+                import urllib.request, json
+                resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=3)
+                data = json.loads(resp.read())
+                result["ws_url"] = data.get("webSocketDebuggerUrl", f"ws://127.0.0.1:{port}/devtools/browser")
+                return result
+            except Exception:
+                pass
+            # Check if Chrome exited
+            if proc.poll() is not None:
+                stderr = proc.stderr.read().decode(errors="replace")
+                raise RuntimeError(
+                    f"Chrome exited with code {proc.returncode}. stderr: {stderr[:500]}"
+                )
+            time.sleep(0.5)
+        raise RuntimeError(
+            f"Timed out waiting for DevToolsActivePort after {wait_timeout}s. "
+            f"Chrome may be showing a dialog. Check the Chrome window."
+        )
+
+    return result

--- a/launch.py
+++ b/launch.py
@@ -72,6 +72,28 @@ def _copy_profile(src: Path, dst: Path):
     shutil.copytree(src, dst, ignore=_ignore_locks, dirs_exist_ok=False)
 
 
+
+def _safe_max_mtime(path):
+    """Return the most recent modification time of files under path, ignoring OSErrors."""
+    if not path.exists():
+        return 0.0
+    max_time = 0.0
+    try:
+        for p in path.rglob("*"):
+            if not p.is_file():
+                continue
+            try:
+                mtime = p.stat().st_mtime
+                if mtime > max_time:
+                    max_time = mtime
+            except OSError:
+                # File disappeared, permission denied, etc.
+                continue
+    except OSError:
+        # Directory inaccessible
+        pass
+    return max_time
+
 def _is_wayland_session():
     """Detect Wayland by checking the current session only."""
     # 1. Check env vars first (fastest, most reliable).
@@ -217,14 +239,8 @@ def launch_chrome(
         # Only re-copy if the real profile is newer than the copy.
         should_copy = True
         if copy_udir.exists():
-            real_mtime = max(
-                (p.stat().st_mtime for p in real_udir.rglob("*") if p.is_file()),
-                default=0,
-            )
-            copy_mtime = max(
-                (p.stat().st_mtime for p in copy_udir.rglob("*") if p.is_file()),
-                default=0,
-            )
+            real_mtime = _safe_max_mtime(real_udir)
+            copy_mtime = _safe_max_mtime(copy_udir)
             should_copy = real_mtime > copy_mtime
         if should_copy:
             if real_udir.exists():

--- a/launch.py
+++ b/launch.py
@@ -73,32 +73,37 @@ def _copy_profile(src: Path, dst: Path):
 
 
 def _is_wayland_session():
-    """Detect Wayland by checking loginctl or running processes."""
+    """Detect Wayland by checking the current session only."""
+    # 1. Check env vars first (fastest, most reliable).
+    if os.environ.get("WAYLAND_DISPLAY"):
+        return True
+    if os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland":
+        return True
+
+    # 2. Check the current logind session (not all sessions).
     try:
-        r = subprocess.run(
-            ["loginctl"], capture_output=True, text=True, timeout=3,
-        )
-        for line in r.stdout.strip().splitlines()[1:]:  # skip header
-            parts = line.split()
-            if len(parts) >= 1:
-                sid = parts[0]
-                r2 = subprocess.run(
-                    ["loginctl", "show-session", sid, "-p", "Type"],
-                    capture_output=True, text=True, timeout=3,
-                )
-                if "wayland" in r2.stdout.lower():
-                    return True
+        sid = os.environ.get("XDG_SESSION_ID")
+        if not sid:
+            # Fallback: ask loginctl for the current session
+            r = subprocess.run(
+                ["loginctl", "show-user", os.getlogin(), "-p", "Sessions"],
+                capture_output=True, text=True, timeout=3,
+            )
+            for line in r.stdout.strip().splitlines():
+                if line.startswith("Sessions="):
+                    sid = line.split("=", 1)[1].strip()
+                    break
+        if sid:
+            r2 = subprocess.run(
+                ["loginctl", "show-session", sid, "-p", "Type"],
+                capture_output=True, text=True, timeout=3,
+            )
+            if "wayland" in r2.stdout.lower():
+                return True
     except Exception:
         pass
-    try:
-        r = subprocess.run(
-            ["pgrep", "-a", "gnome-shell"],
-            capture_output=True, text=True, timeout=3,
-        )
-        if "wayland" in r.stdout.lower():
-            return True
-    except Exception:
-        pass
+
+    # 3. Check for a Wayland socket as last resort.
     runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "/run/user/1000")
     if Path(runtime_dir, "wayland-0").exists():
         return True
@@ -233,11 +238,15 @@ def launch_chrome(
 
     env = {**os.environ, **env_extra}
 
+    # Redirect stderr to a temp file so the pipe buffer can't block Chrome.
+    stderr_path = _BH_STATE / f"chrome-{port}.stderr.log"
+    stderr_fh = open(stderr_path, "wb")
+
     proc = subprocess.Popen(
         cmd,
         env=env,
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
+        stderr=stderr_fh,
         start_new_session=True,
     )
 
@@ -286,10 +295,14 @@ def launch_chrome(
                 pass
             # Check if Chrome exited
             if proc.poll() is not None:
-                stderr = proc.stderr.read().decode(errors="replace")
+                stderr_fh.close()
+                try:
+                    stderr = stderr_path.read_text(errors="replace")[:500]
+                except Exception:
+                    stderr = "<unable to read stderr log>"
                 raise RuntimeError(
                     f"Chrome exited with code {proc.returncode}. "
-                    f"stderr: {stderr[:500]}"
+                    f"stderr: {stderr}"
                 )
             time.sleep(0.5)
         raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ dependencies = [
 browser-harness = "run:main"
 
 [tool.setuptools]
-py-modules = ["run", "helpers", "daemon", "admin"]
+py-modules = ["run", "helpers", "daemon", "admin", "launch"]

--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ from admin import (
     sync_local_profile,
 )
 from helpers import *
-from launch import _get_default_user_data_dir
+from launch import get_default_user_data_dir
 
 HELP = """Browser Harness
 
@@ -54,7 +54,7 @@ def _chrome_is_running():
 
 def _chrome_has_cdp():
     """Return True if DevToolsActivePort exists in the default profile."""
-    return (_get_default_user_data_dir() / "DevToolsActivePort").exists()
+    return (get_default_user_data_dir() / "DevToolsActivePort").exists()
 
 
 def main():

--- a/run.py
+++ b/run.py
@@ -43,9 +43,11 @@ def _chrome_is_running():
     """Return True if any Chrome/Chromium main process is alive."""
     for name in ("chrome", "chromium", "chromium-browser"):
         try:
-            subprocess.run(["pgrep", "-x", name], check=True, capture_output=True)
+            subprocess.run(
+                ["pgrep", "-x", name], check=True, capture_output=True
+            )
             return True
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             pass
     return False
 

--- a/run.py
+++ b/run.py
@@ -1,8 +1,10 @@
+import subprocess
 import sys
 
 from admin import (
     _version,
     ensure_daemon,
+    launch_chrome,
     list_cloud_profiles,
     list_local_profiles,
     print_update_banner,
@@ -15,6 +17,7 @@ from admin import (
     sync_local_profile,
 )
 from helpers import *
+from launch import _get_default_user_data_dir
 
 HELP = """Browser Harness
 
@@ -34,6 +37,22 @@ Commands:
   browser-harness --setup          interactively attach to your running browser
   browser-harness --update [-y]    pull the latest version (agents: pass -y)
 """
+
+
+def _chrome_is_running():
+    """Return True if any Chrome/Chromium main process is alive."""
+    for name in ("chrome", "chromium", "chromium-browser"):
+        try:
+            subprocess.run(["pgrep", "-x", name], check=True, capture_output=True)
+            return True
+        except subprocess.CalledProcessError:
+            pass
+    return False
+
+
+def _chrome_has_cdp():
+    """Return True if DevToolsActivePort exists in the default profile."""
+    return (_get_default_user_data_dir() / "DevToolsActivePort").exists()
 
 
 def main():
@@ -59,7 +78,28 @@ def main():
             "  PY"
         )
     print_update_banner()
-    ensure_daemon()
+    try:
+        ensure_daemon()
+    except RuntimeError as e:
+        msg = str(e).lower()
+        if "devtoolsactiveport" in msg or "remote debugging" in msg:
+            if _chrome_is_running() and not _chrome_has_cdp():
+                sys.exit(
+                    "Chrome is already running without remote debugging.\n"
+                    "Close Chrome and retry so browser-harness can launch it "
+                    "with the right flags automatically."
+                )
+            if not _chrome_is_running():
+                info = launch_chrome()
+                print(
+                    f"Auto-launched Chrome with CDP on port {info['port']}",
+                    file=sys.stderr,
+                )
+                ensure_daemon()
+            else:
+                raise
+        else:
+            raise
     exec(sys.stdin.read(), globals())
 
 

--- a/run.py
+++ b/run.py
@@ -1,6 +1,12 @@
 import subprocess
 import sys
 
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 from admin import (
     _version,
     ensure_daemon,

--- a/transport.py
+++ b/transport.py
@@ -1,0 +1,159 @@
+import asyncio
+import os
+import secrets
+import socket
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+TCP_HOST = "127.0.0.1"
+TMP_DIR = Path(tempfile.gettempdir())
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    sock: Path
+    pid: Path
+    log: Path
+    port: Path
+    token: Path
+
+
+def supports_unix_sockets():
+    if not hasattr(socket, "AF_UNIX") or not hasattr(asyncio, "start_unix_server"):
+        return False
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+def runtime_paths(name):
+    base = TMP_DIR / f"bu-{name}"
+    return RuntimePaths(
+        sock=base.with_suffix(".sock"),
+        pid=base.with_suffix(".pid"),
+        log=base.with_suffix(".log"),
+        port=base.with_suffix(".port"),
+        token=base.with_suffix(".token"),
+    )
+
+
+def version_cache_path():
+    return TMP_DIR / "bu-version-cache.json"
+
+
+def screenshot_path(filename="shot.png"):
+    return str(TMP_DIR / filename)
+
+
+def endpoint_label(name):
+    paths = runtime_paths(name)
+    if paths.port.exists():
+        try:
+            port = int(paths.port.read_text().strip())
+            return f"{TCP_HOST}:{port}"
+        except (OSError, ValueError):
+            return f"{TCP_HOST}:<unknown port> (port file: {paths.port})"
+    if supports_unix_sockets():
+        return str(paths.sock)
+    try:
+        port = int(paths.port.read_text().strip())
+        return f"{TCP_HOST}:{port}"
+    except (OSError, ValueError):
+        return f"{TCP_HOST}:<unknown port> (port file: {paths.port})"
+
+
+def _chmod_private(path):
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _write_private(path, value):
+    path.write_text(value)
+    _chmod_private(path)
+
+
+def _connect_tcp(paths, timeout):
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if timeout is not None:
+        client.settimeout(timeout)
+    try:
+        port = int(paths.port.read_text().strip())
+        token = paths.token.read_text().strip()
+        client.connect((TCP_HOST, port))
+        client.sendall((token + "\n").encode())
+        return client
+    except Exception:
+        client.close()
+        raise
+
+
+def connect_client(name, timeout=None):
+    paths = runtime_paths(name)
+    if paths.port.exists():
+        try:
+            return _connect_tcp(paths, timeout)
+        except (FileNotFoundError, OSError, ValueError):
+            if not supports_unix_sockets():
+                raise
+
+    if supports_unix_sockets():
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if timeout is not None:
+            client.settimeout(timeout)
+        client.connect(str(paths.sock))
+        return client
+
+    return _connect_tcp(paths, timeout)
+
+
+async def _start_tcp_server(handler, paths):
+    token = secrets.token_urlsafe(32)
+
+    async def authenticated_handler(reader, writer):
+        try:
+            line = await reader.readline()
+            if line.decode(errors="replace").strip() != token:
+                writer.close()
+                await writer.wait_closed()
+                return
+            await handler(reader, writer)
+        except Exception:
+            writer.close()
+            raise
+
+    server = await asyncio.start_server(authenticated_handler, host=TCP_HOST, port=0)
+    port = server.sockets[0].getsockname()[1]
+    _write_private(paths.token, token)
+    _write_private(paths.port, str(port))
+    return server
+
+
+async def start_server(handler, name):
+    paths = runtime_paths(name)
+    cleanup_endpoint(name)
+
+    if supports_unix_sockets():
+        try:
+            server = await asyncio.start_unix_server(handler, path=str(paths.sock))
+            _chmod_private(paths.sock)
+            return server
+        except (AttributeError, NotImplementedError, OSError):
+            cleanup_endpoint(name)
+
+    return await _start_tcp_server(handler, paths)
+
+
+def cleanup_endpoint(name):
+    paths = runtime_paths(name)
+    for path in (paths.sock, paths.port, paths.token):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## Summary

Chrome 147+ (Google Chrome branded builds) silently blocks `--remote-debugging-port` when the **default** user data directory is used. This breaks every browser-harness workflow that relies on local CDP:
- The "Allow remote debugging?" dialog appears on every Chrome restart
- `DevToolsActivePort` may not be written
- Headless / automation flows fail with cryptic EOF errors

This PR fixes the root cause cross-platform and removes the manual "Allow" step entirely on Linux.

## Issues fixed

- Fixes #107 — Chrome remote debugging was a hidden prerequisite with no guidance
- Fixes #123 — README Quick Start now documents the remote-debugging prerequisite and the Chrome 147 workaround
- Fixes part of #124 — the Chrome 147 user-data-dir block on fresh installs (Windows + macOS profile-copy path, Linux CHROME_CONFIG_HOME path)
- Related to #106 — Chrome 147 CDP failures (while #106 is specifically about the `Sec-WebSocket-Extensions` header, the underlying trigger is often the remote-debugging block)

## How it works

Chrome 147+ checks `IsUsingDefaultDataDirectory()` in `browser_process_impl.cc`. If the profile path matches the platform default, remote debugging is blocked unless the user clicks Allow.

**Linux**: `CHROME_CONFIG_HOME` is honoured by Chrome. We set it to a persistent fake path (`~/.local/share/browser-harness/chrome-config-home`). Chrome computes the "default" dir as `$CHROME_CONFIG_HOME/google-chrome`, while `--user-data-dir` still points to the real `~/.config/google-chrome`. The paths differ → check passes → no dialog. Zero data copying.

**macOS / Windows**: `CHROME_CONFIG_HOME` is ignored. We create a one-time *copy* of the real profile to a persistent temp path (`~/Library/Application Support/browser-harness/chrome-profile-copy` on macOS, `%LOCALAPPDATA%\browser-harness\chrome-profile-copy` on Windows) and point `--user-data-dir` there. The copy is refreshed only when the real profile has newer files. Lock files (`SingletonLock`, `DevToolsActivePort`, etc.) are skipped so Chrome doesn't think another instance is running.

## Changes

- **`launch.py`** (new): `launch_chrome()` — cross-platform Chrome launcher
  - Linux: `CHROME_CONFIG_HOME` bypass (no copy)
  - macOS / Windows: temp profile copy with mtime-based freshness check
  - Auto-detects Wayland on Linux (`--ozone-platform=wayland`)
  - Probes `127.0.0.1:9222` + `/json/version` when `DevToolsActivePort` is missing
- **`daemon.py`**: fallback to port probe when `DevToolsActivePort` file is absent (Chrome 147+ with `CHROME_CONFIG_HOME` sometimes skips writing it)
- **`run.py`**: auto-launch Chrome via `launch_chrome()` when no CDP browser is found; clear error messages telling users to close Chrome first if it's already running without remote debugging
- **`admin.py`**: import `launch_chrome` for convenience; `_log_tail()` returns last 5 lines for diagnostics
- **`install.md`**: Chrome 147+ workaround documentation + usage examples
- **`pyproject.toml`**: adds `launch` module

## Testing

- Ubuntu 24.04 + Chrome 147.0.7727.55 (Wayland) — verified no "Allow remote debugging" dialog after first acceptance; `page_info()` and `goto()` end-to-end
- Code paths for macOS / Windows profile-copy logic validated via import and signature checks (full runtime testing on those platforms is pending community verification)

## Backwards compatibility

Existing users who already pass `BU_CDP_WS` or have Chrome running with `--remote-debugging-port` are unaffected. `launch_chrome()` is opt-in via `run.py` auto-launch or explicit `from admin import launch_chrome`.