### PR TITLE
fix(admin): ensure_daemon self-heals cold-start failures

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -52,29 +52,44 @@ def daemon_alive(name=None):
 
 
 def ensure_daemon(wait=60.0, name=None, env=None):
-    """Idempotent. `env` is merged into the child process env."""
+    """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
-        return
-    import subprocess
+        # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
+        # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
+        try:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
+            s.connect(_paths(name)[0])
+            s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
+            data = b""
+            while not data.endswith(b"\n"):
+                chunk = s.recv(1 << 16)
+                if not chunk: break
+                data += chunk
+            if b'"result"' in data: return
+        except Exception: pass
+        restart_daemon(name)
 
-    e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
-    p = subprocess.Popen(
-        ["uv", "run", "daemon.py"],
-        cwd=os.path.dirname(os.path.abspath(__file__)),
-        env=e,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-    deadline = time.time() + wait
-    while time.time() < deadline:
-        if daemon_alive(name):
-            return
-        if p.poll() is not None:
-            break
-        time.sleep(0.2)
-    msg = _log_tail(name)
-    raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+    import subprocess, sys
+    local = not (env or {}).get("BU_CDP_WS") and not os.environ.get("BU_CDP_WS")
+    for attempt in (0, 1):
+        e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
+        p = subprocess.Popen(
+            ["uv", "run", "daemon.py"],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+        )
+        deadline = time.time() + wait
+        while time.time() < deadline:
+            if daemon_alive(name): return
+            if p.poll() is not None: break
+            time.sleep(0.2)
+        msg = _log_tail(name) or ""
+        if local and attempt == 0 and ("DevToolsActivePort not found" in msg or "not live yet" in msg or ("WS handshake failed" in msg and "403" in msg)):
+            _open_chrome_inspect()
+            print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
+            restart_daemon(name)
+            continue
+        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
 
 
 def stop_remote_daemon(name="remote"):


### PR DESCRIPTION
## Summary

A bare `browser-harness <<PY ... PY` invocation currently fails loudly on a cold machine (no Chrome running, stale daemon from a prior session, or `chrome://inspect` Allow checkbox not ticked) — the user has to know about `restart_daemon()` and `browser-harness --setup` to recover. This patch makes `ensure_daemon` self-heal all three cases by reusing the existing `_open_chrome_inspect()` helper.

## Three failures, one function

1. **Stale daemon** — previous run's Chrome was killed but the daemon still listens on the unix socket. Probe with a real CDP call (`Target.getTargets`) and require `"result"` in the reply. A `{"meta":"session"}` probe is *not* sufficient: the daemon answers meta requests from a cached Python dict even when its CDP WebSocket to Chrome is dead, so such a probe reports "healthy" on a stale daemon.
2. **Cold Chrome** — log tail says `DevToolsActivePort not found` or `not live yet`. `_open_chrome_inspect()` uses AppleScript `activate` which launches Chrome if absent, then opens the inspect page.
3. **Missing Allow on chrome://inspect** — log tail says `WS handshake failed ... 403`. Same recovery: open the inspect page, print one stderr hint, retry spawn once.

## Before / after (measured)

With Chrome dead and stale sockets present:

| | clean main | this PR |
|---|---|---|
| `browser-harness` invocations | 2 | **1** |
| Manual `restart_daemon()` calls | 1 | 0 |
| Error messages the user must parse | 2 misleading | 1 advisory |
| User action | pick profile + tick checkbox + click Allow | click Allow once |

Tested end-to-end from a fresh subagent with `pgrep`-less Chrome and stale `/tmp/bu-default.*` sockets; one invocation, one stderr line (`browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)`), one click from the user, success.

## Scope

- One function touched: `ensure_daemon` in `admin.py`.
- Net +37 / −22 lines.
- No new helpers — reuses `_open_chrome_inspect()` and `restart_daemon()` already on main.
- `run_setup()` / `run_doctor()` untouched; they become a bit redundant for the common case but remain useful as explicit user-facing commands.

## Test plan

- [x] Cold start with Chrome dead + stale daemon socket (reproduces the old 2-error cascade) → succeeds in one invocation with this patch.
- [x] `browser-harness` on a warm daemon (happy path) still returns immediately — the new probe only fires when `daemon_alive()` is true.
- [x] Remote daemons unaffected — the `_open_chrome_inspect` branch is gated on `not (env or {}).get("BU_CDP_WS")`.
- [ ] Linux/Windows behavior unchanged — `_open_chrome_inspect` is macOS-only today; this PR does not regress other platforms (they still hit the raw error, same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ensure_daemon` self-heal common cold-start failures so a bare `browser-harness` run works without manual `restart_daemon()` or `--setup`. It probes stale daemons, auto-launches Chrome, and prompts once to click Allow if needed.

- **Bug Fixes**
  - Detects stale daemons with a real CDP call (`Target.getTargets`); restarts if no `"result"`.
  - On "DevToolsActivePort not found", "not live yet", or WS 403, calls `_open_chrome_inspect()`, prints a single stderr hint, and retries once.
  - Skips local recovery when `BU_CDP_WS` is set; happy path and remote daemons unchanged.

<sup>Written for commit 71c8a363c8ae4c5ef771c5e86b194e187b1ee363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

