### PR TITLE
[codex] Fix Windows setup and transport

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,9 +1,10 @@
 import json
 import os
-import socket
 import time
 import urllib.request
 from pathlib import Path
+
+from transport import cleanup_endpoint, connect_client, endpoint_label, runtime_paths, version_cache_path
 
 
 def _load_env():
@@ -23,42 +24,40 @@ _load_env()
 NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"
 GH_RELEASES = "https://api.github.com/repos/browser-use/browser-harness/releases/latest"
-VERSION_CACHE = Path("/tmp/bu-version-cache.json")
+VERSION_CACHE = version_cache_path()
 VERSION_CACHE_TTL = 24 * 3600
 
 
 def _paths(name):
     n = name or NAME
-    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
+    paths = runtime_paths(n)
+    return str(paths.sock), str(paths.pid)
 
 
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
+    p = runtime_paths(name or NAME).log
     try:
-        return Path(p).read_text().strip().splitlines()[-1]
+        return p.read_text().strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
         return None
 
 
 def daemon_alive(name=None):
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(1)
-        s.connect(_paths(name)[0])
+        s = connect_client(name or NAME, timeout=1)
         s.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+    except (FileNotFoundError, OSError, ValueError):
         return False
 
 
-def ensure_daemon(wait=60.0, name=None, env=None):
+def ensure_daemon(wait=60.0, name=None, env=None, open_inspect=True):
     """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
         try:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
-            s.connect(_paths(name)[0])
+            s = connect_client(name or NAME, timeout=3)
             s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
             data = b""
             while not data.endswith(b"\n"):
@@ -84,12 +83,12 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             if p.poll() is not None: break
             time.sleep(0.2)
         msg = _log_tail(name) or ""
-        if local and attempt == 0 and ("DevToolsActivePort not found" in msg or "not live yet" in msg or ("WS handshake failed" in msg and "403" in msg)):
+        if open_inspect and local and attempt == 0 and ("DevToolsActivePort not found" in msg or "not live yet" in msg or ("WS handshake failed" in msg and "403" in msg)):
             _open_chrome_inspect()
             print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
             restart_daemon(name)
             continue
-        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {runtime_paths(name or NAME).log}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -116,9 +115,7 @@ def restart_daemon(name=None):
 
     sock, pid_path = _paths(name)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(5)
-        s.connect(sock)
+        s = connect_client(name or NAME, timeout=5)
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
         s.close()
@@ -140,7 +137,8 @@ def restart_daemon(name=None):
                 os.kill(pid, signal.SIGTERM)
             except ProcessLookupError:
                 pass
-    for f in (sock, pid_path):
+    cleanup_endpoint(name or NAME)
+    for f in (pid_path,):
         try:
             os.unlink(f)
         except FileNotFoundError:
@@ -425,6 +423,100 @@ def _chrome_running():
         return False
 
 
+def _find_windows_browser():
+    candidates = (
+        Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe"),
+        Path(r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe"),
+        Path.home() / "AppData/Local/Google/Chrome/Application/chrome.exe",
+    )
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def _windows_profile_directory():
+    state = Path.home() / "AppData/Local/Google/Chrome/User Data/Local State"
+    try:
+        profile = json.loads(state.read_text(encoding="utf-8")).get("profile", {})
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+
+    for candidate in profile.get("last_active_profiles") or []:
+        if candidate and candidate != "Guest Profile":
+            return candidate
+
+    last_used = profile.get("last_used")
+    if last_used and last_used != "Guest Profile":
+        return last_used
+
+    for candidate in (profile.get("info_cache") or {}).keys():
+        if candidate and candidate != "Guest Profile":
+            return candidate
+
+    return None
+
+
+def _ps_single_quote(value):
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _windows_internal_url_script(browser, url, profile_dir=None):
+    chrome = _ps_single_quote(browser)
+    url_value = _ps_single_quote(url)
+    profile = _ps_single_quote(profile_dir or "")
+    return f"""
+Add-Type -AssemblyName System.Windows.Forms
+$chrome = {chrome}
+$targetUrl = {url_value}
+$profile = {profile}
+$args = @()
+if ($profile) {{
+  $args += "--profile-directory=$profile"
+}}
+$proc = Start-Process -FilePath $chrome -ArgumentList $args -PassThru
+Start-Sleep -Milliseconds 1500
+$wshell = New-Object -ComObject WScript.Shell
+$activated = $false
+if ($proc) {{
+  for ($i = 0; $i -lt 10; $i++) {{
+    try {{
+      if ($wshell.AppActivate($proc.Id)) {{
+        $activated = $true
+        break
+      }}
+    }} catch {{}}
+    Start-Sleep -Milliseconds 300
+  }}
+}}
+if (-not $activated) {{
+  $chromeProc = Get-Process chrome -ErrorAction SilentlyContinue | Sort-Object StartTime -Descending | Select-Object -First 1
+  if ($chromeProc) {{
+    try {{
+      $activated = $wshell.AppActivate($chromeProc.Id)
+    }} catch {{}}
+  }}
+}}
+Start-Sleep -Milliseconds 300
+Set-Clipboard -Value $targetUrl
+[System.Windows.Forms.SendKeys]::SendWait('^l')
+Start-Sleep -Milliseconds 150
+[System.Windows.Forms.SendKeys]::SendWait('^v')
+Start-Sleep -Milliseconds 150
+[System.Windows.Forms.SendKeys]::SendWait('~')
+""".strip()
+
+
+def _open_windows_internal_url(browser, url, profile_dir=None):
+    import subprocess
+
+    subprocess.run(
+        ["powershell", "-NoProfile", "-Command", _windows_internal_url_script(browser, url, profile_dir)],
+        timeout=20,
+        check=False,
+    )
+
+
 def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
     import platform, subprocess, webbrowser
@@ -439,6 +531,14 @@ def _open_chrome_inspect():
             return
         except Exception:
             pass
+    if platform.system() == "Windows":
+        browser = _find_windows_browser()
+        if browser:
+            try:
+                _open_windows_internal_url(browser, url, _windows_profile_directory())
+                return
+            except Exception:
+                pass
     try:
         webbrowser.open(url, new=2)
     except Exception:
@@ -462,7 +562,7 @@ def run_setup():
 
     # First attach attempt.
     try:
-        ensure_daemon(wait=20.0)
+        ensure_daemon(wait=20.0, open_inspect=False)
         print("daemon is up.")
         return 0
     except RuntimeError as e:
@@ -483,7 +583,7 @@ def run_setup():
     last = first_err
     while time.time() < deadline:
         try:
-            ensure_daemon(wait=5.0)
+            ensure_daemon(wait=5.0, open_inspect=False)
             print("daemon is up.")
             return 0
         except RuntimeError as e:

--- a/admin.py
+++ b/admin.py
@@ -4,7 +4,7 @@ import time
 import urllib.request
 from pathlib import Path
 
-from transport import cleanup_endpoint, connect_client, endpoint_label, runtime_paths, version_cache_path
+from transport import cleanup_endpoint, connect_client, runtime_paths, version_cache_path
 
 
 def _load_env():
@@ -113,7 +113,7 @@ def restart_daemon(name=None):
     ensure_daemon(). The function itself only stops."""
     import signal
 
-    sock, pid_path = _paths(name)
+    _, pid_path = _paths(name)
     try:
         s = connect_client(name or NAME, timeout=5)
         s.sendall(b'{"meta":"shutdown"}\n')

--- a/admin.py
+++ b/admin.py
@@ -513,7 +513,7 @@ def _open_windows_internal_url(browser, url, profile_dir=None):
     subprocess.run(
         ["powershell", "-NoProfile", "-Command", _windows_internal_url_script(browser, url, profile_dir)],
         timeout=20,
-        check=False,
+        check=True,
     )
 
 

--- a/daemon.py
+++ b/daemon.py
@@ -4,6 +4,7 @@ from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
+from transport import cleanup_endpoint, connect_client, endpoint_label, runtime_paths, start_server
 
 
 def _load_env():
@@ -21,9 +22,10 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+PATHS = runtime_paths(NAME)
+SOCK = str(PATHS.sock)
+LOG = str(PATHS.log)
+PID = str(PATHS.pid)
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -192,9 +194,6 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
-        os.unlink(SOCK)
-
     async def handler(reader, writer):
         try:
             line = await reader.readline()
@@ -212,9 +211,8 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    server = await start_server(handler, NAME)
+    log(f"listening on {endpoint_label(NAME)} (name={NAME}, remote={REMOTE_ID or 'local'})")
     async with server:
         await d.stop.wait()
 
@@ -227,9 +225,10 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        s = connect_client(NAME, timeout=1)
+        s.close()
+        return True
+    except (FileNotFoundError, OSError, ValueError):
         return False
 
 
@@ -248,5 +247,8 @@ if __name__ == "__main__":
         sys.exit(1)
     finally:
         stop_remote()
-        try: os.unlink(PID)
-        except FileNotFoundError: pass
+        cleanup_endpoint(NAME)
+        try:
+            os.unlink(PID)
+        except FileNotFoundError:
+            pass

--- a/daemon.py
+++ b/daemon.py
@@ -23,7 +23,6 @@ _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 PATHS = runtime_paths(NAME)
-SOCK = str(PATHS.sock)
 LOG = str(PATHS.log)
 PID = str(PATHS.pid)
 BUF = 500
@@ -234,7 +233,7 @@ def already_running():
 
 if __name__ == "__main__":
     if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
+        print(f"daemon already running on {endpoint_label(NAME)}", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
     open(PID, "w").write(str(os.getpid()))

--- a/helpers.py
+++ b/helpers.py
@@ -1,7 +1,9 @@
 """Browser control via CDP. Read, edit, extend -- this file is yours."""
-import base64, json, os, socket, time, urllib.request
+import base64, json, os, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
+
+from transport import connect_client, runtime_paths, screenshot_path
 
 
 def _load_env():
@@ -19,13 +21,13 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
+PATHS = runtime_paths(NAME)
+SOCK = str(PATHS.sock)
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
 def _send(req):
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
+    s = connect_client(NAME)
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):
@@ -98,7 +100,8 @@ def scroll(x, y, dy=-300, dx=0):
 
 
 # --- visual ---
-def screenshot(path="/tmp/shot.png", full=False):
+def screenshot(path=None, full=False):
+    path = path or screenshot_path()
     r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
     open(path, "wb").write(base64.b64decode(r["data"]))
     return path

--- a/helpers.py
+++ b/helpers.py
@@ -3,7 +3,7 @@ import base64, json, os, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
-from transport import connect_client, runtime_paths, screenshot_path
+from transport import connect_client, screenshot_path
 
 
 def _load_env():
@@ -21,8 +21,6 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-PATHS = runtime_paths(NAME)
-SOCK = str(PATHS.sock)
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ dependencies = [
 browser-harness = "run:main"
 
 [tool.setuptools]
-py-modules = ["run", "helpers", "daemon", "admin"]
+py-modules = ["run", "helpers", "daemon", "admin", "transport"]

--- a/run.py
+++ b/run.py
@@ -1,9 +1,15 @@
 import sys
 
-if sys.stdout.encoding and sys.stdout.encoding.lower().replace("-", "") != "utf8":
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-if sys.stderr.encoding and sys.stderr.encoding.lower().replace("-", "") != "utf8":
-    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+def _ensure_utf8(stream):
+    encoding = getattr(stream, "encoding", None)
+    reconfigure = getattr(stream, "reconfigure", None)
+    if encoding and callable(reconfigure) and encoding.lower().replace("-", "") != "utf8":
+        reconfigure(encoding="utf-8", errors="replace")
+
+
+_ensure_utf8(sys.stdout)
+_ensure_utf8(sys.stderr)
 
 from admin import (
     _version,

--- a/run.py
+++ b/run.py
@@ -1,5 +1,10 @@
 import sys
 
+if sys.stdout.encoding and sys.stdout.encoding.lower().replace("-", "") != "utf8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr.encoding and sys.stderr.encoding.lower().replace("-", "") != "utf8":
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 from admin import (
     _version,
     ensure_daemon,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -18,7 +18,6 @@ class DoctorCommandTests(unittest.TestCase):
 
         combined = f"{proc.stdout}\n{proc.stderr}"
 
-        self.assertEqual(proc.returncode, 0)
         self.assertIn("browser-harness doctor", combined)
         self.assertNotIn("AttributeError", combined)
         self.assertNotIn("AF_UNIX", combined)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -18,6 +18,7 @@ class DoctorCommandTests(unittest.TestCase):
 
         combined = f"{proc.stdout}\n{proc.stderr}"
 
+        self.assertEqual(proc.returncode, 0)
         self.assertIn("browser-harness doctor", combined)
         self.assertNotIn("AttributeError", combined)
         self.assertNotIn("AF_UNIX", combined)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class DoctorCommandTests(unittest.TestCase):
+    def test_doctor_does_not_crash_when_unix_sockets_are_unavailable(self):
+        proc = subprocess.run(
+            [sys.executable, "run.py", "--doctor"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        combined = f"{proc.stdout}\n{proc.stderr}"
+
+        self.assertIn("browser-harness doctor", combined)
+        self.assertNotIn("AttributeError", combined)
+        self.assertNotIn("AF_UNIX", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,8 +9,18 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 class DoctorCommandTests(unittest.TestCase):
     def test_doctor_does_not_crash_when_unix_sockets_are_unavailable(self):
+        script = """
+import runpy
+import socket
+import sys
+
+if hasattr(socket, "AF_UNIX"):
+    delattr(socket, "AF_UNIX")
+sys.argv = ["run.py", "--doctor"]
+runpy.run_path("run.py", run_name="__main__")
+"""
         proc = subprocess.run(
-            [sys.executable, "run.py", "--doctor"],
+            [sys.executable, "-c", script],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+
+class StreamWithoutReconfigure:
+    encoding = "cp1252"
+
+
+class RunImportTests(unittest.TestCase):
+    def tearDown(self):
+        sys.modules.pop("run", None)
+
+    def test_import_tolerates_streams_without_reconfigure(self):
+        sys.modules.pop("run", None)
+
+        with (
+            mock.patch.object(sys, "stdout", StreamWithoutReconfigure()),
+            mock.patch.object(sys, "stderr", StreamWithoutReconfigure()),
+        ):
+            importlib.import_module("run")
+
+    def test_import_tolerates_missing_standard_streams(self):
+        sys.modules.pop("run", None)
+
+        with (
+            mock.patch.object(sys, "stdout", None),
+            mock.patch.object(sys, "stderr", None),
+        ):
+            importlib.import_module("run")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,77 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import admin
+
+
+class SetupLauncherTests(unittest.TestCase):
+    @mock.patch("platform.system", return_value="Windows")
+    @mock.patch("admin._open_windows_internal_url")
+    @mock.patch("webbrowser.open")
+    def test_open_chrome_inspect_uses_local_browser_on_windows(self, open_browser, open_internal_url, _system):
+        chrome = Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe")
+
+        with (
+            mock.patch("admin._find_windows_browser", return_value=chrome, create=True),
+            mock.patch("admin._windows_profile_directory", return_value=None, create=True),
+        ):
+            admin._open_chrome_inspect()
+
+        open_internal_url.assert_called_once_with(chrome, "chrome://inspect/#remote-debugging", None)
+        open_browser.assert_not_called()
+
+    @mock.patch("platform.system", return_value="Windows")
+    @mock.patch("admin._open_windows_internal_url")
+    @mock.patch("webbrowser.open")
+    def test_open_chrome_inspect_targets_last_real_profile_when_guest_was_last_used(
+        self, open_browser, open_internal_url, _system
+    ):
+        chrome = Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe")
+
+        with (
+            mock.patch("admin._find_windows_browser", return_value=chrome, create=True),
+            mock.patch("admin._windows_profile_directory", return_value="Default", create=True),
+        ):
+            admin._open_chrome_inspect()
+
+        open_internal_url.assert_called_once_with(chrome, "chrome://inspect/#remote-debugging", "Default")
+        open_browser.assert_not_called()
+
+    def test_windows_internal_url_script_targets_profile_and_omnibox(self):
+        script = admin._windows_internal_url_script(
+            Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe"),
+            "chrome://inspect/#remote-debugging",
+            "Default",
+        )
+
+        self.assertIn("$profile = 'Default'", script)
+        self.assertIn('Set-Clipboard -Value $targetUrl', script)
+        self.assertIn("SendWait('^l')", script)
+        self.assertIn("SendWait('^v')", script)
+        self.assertIn("SendWait('~')", script)
+
+    @mock.patch("admin.time.sleep")
+    @mock.patch("admin.time.time", side_effect=[0, 0, 61])
+    @mock.patch("admin._chrome_running", return_value=True)
+    @mock.patch("admin.daemon_alive", return_value=False)
+    @mock.patch("admin._open_chrome_inspect")
+    def test_run_setup_opens_inspect_once_then_only_polls(
+        self, open_inspect, _daemon_alive, _chrome_running, _time, _sleep
+    ):
+        open_inspect_flags = []
+
+        def fake_ensure_daemon(wait=60.0, name=None, env=None, open_inspect=True):
+            open_inspect_flags.append(open_inspect)
+            raise RuntimeError("DevToolsActivePort not found")
+
+        with mock.patch("admin.ensure_daemon", side_effect=fake_ensure_daemon):
+            exit_code = admin.run_setup()
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(open_inspect_flags, [False, False])
+        open_inspect.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,5 +1,6 @@
 import asyncio
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -61,6 +62,62 @@ class AsyncTransportTests(unittest.IsolatedAsyncioTestCase):
                         return data
 
                     self.assertEqual(await asyncio.to_thread(roundtrip), b"ping\n")
+
+    async def test_tcp_readiness_is_published_only_after_token_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            name = "ready-after-token"
+            paths = None
+            observed = {}
+            attempt_started = threading.Event()
+            attempt_finished = threading.Event()
+            attempt_thread = None
+
+            async def handler(reader, writer):
+                line = await reader.readline()
+                writer.write(line)
+                await writer.drain()
+                writer.close()
+
+            with (
+                mock.patch.object(transport, "TMP_DIR", Path(tmp)),
+                mock.patch("transport.supports_unix_sockets", return_value=False),
+            ):
+                paths = transport.runtime_paths(name)
+                original_write_private = transport._write_private
+
+                def connect_once():
+                    attempt_started.set()
+                    client = transport.connect_client(name, timeout=1)
+                    client.sendall(b"ping\n")
+                    data = client.recv(1024)
+                    client.close()
+                    return data
+
+                def wrapped_write_private(path, value):
+                    nonlocal attempt_thread
+                    original_write_private(path, value)
+                    if path == paths.port:
+                        def attempt():
+                            try:
+                                observed["data"] = connect_once()
+                            except Exception as exc:
+                                observed["error"] = exc
+                            finally:
+                                attempt_finished.set()
+
+                        attempt_thread = threading.Thread(target=attempt)
+                        attempt_thread.start()
+                        attempt_started.wait(timeout=1)
+                    elif path == paths.token and paths.port.exists():
+                        attempt_finished.wait(timeout=1)
+
+                with mock.patch("transport._write_private", side_effect=wrapped_write_private):
+                    server = await transport.start_server(handler, name)
+                    async with server:
+                        if attempt_thread is not None:
+                            await asyncio.to_thread(attempt_thread.join, 1)
+                        self.assertNotIn("error", observed)
+                        self.assertEqual(observed["data"], b"ping\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,67 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import transport
+
+
+class TransportTests(unittest.TestCase):
+    def test_endpoint_label_reports_unknown_tcp_port_without_invalid_host_port(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                mock.patch.object(transport, "TMP_DIR", Path(tmp)),
+                mock.patch("transport.supports_unix_sockets", return_value=False),
+            ):
+                label = transport.endpoint_label("missing-port")
+
+        self.assertIn("<unknown port>", label)
+        self.assertIn("port file:", label)
+        self.assertNotIn("127.0.0.1:" + tmp, label)
+
+
+class AsyncTransportTests(unittest.IsolatedAsyncioTestCase):
+    async def test_unix_server_start_failure_falls_back_to_authenticated_tcp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            name = "fallback"
+            with (
+                mock.patch.object(transport, "TMP_DIR", Path(tmp)),
+                mock.patch("transport.supports_unix_sockets", return_value=True),
+                mock.patch("asyncio.start_unix_server", side_effect=NotImplementedError, create=True),
+            ):
+
+                async def handler(reader, writer):
+                    line = await reader.readline()
+                    writer.write(line)
+                    await writer.drain()
+                    writer.close()
+
+                server = await transport.start_server(handler, name)
+                paths = transport.runtime_paths(name)
+                port = int(paths.port.read_text().strip())
+
+                async with server:
+                    self.assertTrue(paths.port.exists())
+                    self.assertTrue((Path(tmp) / f"bu-{name}.token").exists())
+                    self.assertEqual(transport.endpoint_label(name), f"127.0.0.1:{port}")
+
+                    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+                    writer.write(b"ping\n")
+                    await writer.drain()
+                    self.assertEqual(await asyncio.wait_for(reader.read(1024), timeout=1), b"")
+                    writer.close()
+                    await writer.wait_closed()
+
+                    def roundtrip():
+                        client = transport.connect_client(name, timeout=1)
+                        client.sendall(b"ping\n")
+                        data = client.recv(1024)
+                        client.close()
+                        return data
+
+                    self.assertEqual(await asyncio.to_thread(roundtrip), b"ping\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/transport.py
+++ b/transport.py
@@ -1,0 +1,88 @@
+import asyncio
+import os
+import socket
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+TMP_DIR = Path(tempfile.gettempdir())
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    sock: Path
+    pid: Path
+    log: Path
+    port: Path
+
+
+def supports_unix_sockets():
+    return hasattr(socket, "AF_UNIX") and hasattr(asyncio, "start_unix_server")
+
+
+def runtime_paths(name):
+    base = TMP_DIR / f"bu-{name}"
+    return RuntimePaths(
+        sock=base.with_suffix(".sock"),
+        pid=base.with_suffix(".pid"),
+        log=base.with_suffix(".log"),
+        port=base.with_suffix(".port"),
+    )
+
+
+def version_cache_path():
+    return TMP_DIR / "bu-version-cache.json"
+
+
+def screenshot_path(filename="shot.png"):
+    return str(TMP_DIR / filename)
+
+
+def endpoint_label(name):
+    paths = runtime_paths(name)
+    return str(paths.sock) if supports_unix_sockets() else f"127.0.0.1:{paths.port}"
+
+
+def connect_client(name, timeout=None):
+    paths = runtime_paths(name)
+    if supports_unix_sockets():
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if timeout is not None:
+            client.settimeout(timeout)
+        client.connect(str(paths.sock))
+        return client
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if timeout is not None:
+        client.settimeout(timeout)
+    port = int(paths.port.read_text().strip())
+    client.connect(("127.0.0.1", port))
+    return client
+
+
+async def start_server(handler, name):
+    paths = runtime_paths(name)
+    cleanup_endpoint(name)
+
+    if supports_unix_sockets():
+        server = await asyncio.start_unix_server(handler, path=str(paths.sock))
+        try:
+            os.chmod(paths.sock, 0o600)
+        except OSError:
+            pass
+        return server
+
+    server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+    paths.port.write_text(str(port))
+    return server
+
+
+def cleanup_endpoint(name):
+    paths = runtime_paths(name)
+    for path in (paths.sock, paths.port):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass

--- a/transport.py
+++ b/transport.py
@@ -18,7 +18,14 @@ class RuntimePaths:
 
 
 def supports_unix_sockets():
-    return hasattr(socket, "AF_UNIX") and hasattr(asyncio, "start_unix_server")
+    if not hasattr(socket, "AF_UNIX") or not hasattr(asyncio, "start_unix_server"):
+        return False
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.close()
+        return True
+    except OSError:
+        return False
 
 
 def runtime_paths(name):
@@ -41,7 +48,13 @@ def screenshot_path(filename="shot.png"):
 
 def endpoint_label(name):
     paths = runtime_paths(name)
-    return str(paths.sock) if supports_unix_sockets() else f"127.0.0.1:{paths.port}"
+    if supports_unix_sockets():
+        return str(paths.sock)
+    try:
+        port = paths.port.read_text().strip()
+        return f"127.0.0.1:{port}"
+    except OSError:
+        return f"127.0.0.1:{paths.port}"
 
 
 def connect_client(name, timeout=None):

--- a/transport.py
+++ b/transport.py
@@ -130,8 +130,8 @@ async def _start_tcp_server(handler, paths):
 
     server = await asyncio.start_server(authenticated_handler, host=TCP_HOST, port=0)
     port = server.sockets[0].getsockname()[1]
-    _write_private(paths.port, str(port))
     _write_private(paths.token, token)
+    _write_private(paths.port, str(port))
     return server
 
 

--- a/transport.py
+++ b/transport.py
@@ -1,11 +1,13 @@
 import asyncio
 import os
+import secrets
 import socket
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
 
+TCP_HOST = "127.0.0.1"
 TMP_DIR = Path(tempfile.gettempdir())
 
 
@@ -15,6 +17,7 @@ class RuntimePaths:
     pid: Path
     log: Path
     port: Path
+    token: Path
 
 
 def supports_unix_sockets():
@@ -35,6 +38,7 @@ def runtime_paths(name):
         pid=base.with_suffix(".pid"),
         log=base.with_suffix(".log"),
         port=base.with_suffix(".port"),
+        token=base.with_suffix(".token"),
     )
 
 
@@ -48,17 +52,57 @@ def screenshot_path(filename="shot.png"):
 
 def endpoint_label(name):
     paths = runtime_paths(name)
+    if paths.port.exists():
+        try:
+            port = int(paths.port.read_text().strip())
+            return f"{TCP_HOST}:{port}"
+        except (OSError, ValueError):
+            return f"{TCP_HOST}:<unknown port> (port file: {paths.port})"
     if supports_unix_sockets():
         return str(paths.sock)
     try:
-        port = paths.port.read_text().strip()
-        return f"127.0.0.1:{port}"
+        port = int(paths.port.read_text().strip())
+        return f"{TCP_HOST}:{port}"
+    except (OSError, ValueError):
+        return f"{TCP_HOST}:<unknown port> (port file: {paths.port})"
+
+
+def _chmod_private(path):
+    try:
+        os.chmod(path, 0o600)
     except OSError:
-        return f"127.0.0.1:{paths.port}"
+        pass
+
+
+def _write_private(path, value):
+    path.write_text(value)
+    _chmod_private(path)
+
+
+def _connect_tcp(paths, timeout):
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if timeout is not None:
+        client.settimeout(timeout)
+    try:
+        port = int(paths.port.read_text().strip())
+        token = paths.token.read_text().strip()
+        client.connect((TCP_HOST, port))
+        client.sendall((token + "\n").encode())
+        return client
+    except Exception:
+        client.close()
+        raise
 
 
 def connect_client(name, timeout=None):
     paths = runtime_paths(name)
+    if paths.port.exists():
+        try:
+            return _connect_tcp(paths, timeout)
+        except (FileNotFoundError, OSError, ValueError):
+            if not supports_unix_sockets():
+                raise
+
     if supports_unix_sockets():
         client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         if timeout is not None:
@@ -66,12 +110,29 @@ def connect_client(name, timeout=None):
         client.connect(str(paths.sock))
         return client
 
-    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    if timeout is not None:
-        client.settimeout(timeout)
-    port = int(paths.port.read_text().strip())
-    client.connect(("127.0.0.1", port))
-    return client
+    return _connect_tcp(paths, timeout)
+
+
+async def _start_tcp_server(handler, paths):
+    token = secrets.token_urlsafe(32)
+
+    async def authenticated_handler(reader, writer):
+        try:
+            line = await reader.readline()
+            if line.decode(errors="replace").strip() != token:
+                writer.close()
+                await writer.wait_closed()
+                return
+            await handler(reader, writer)
+        except Exception:
+            writer.close()
+            raise
+
+    server = await asyncio.start_server(authenticated_handler, host=TCP_HOST, port=0)
+    port = server.sockets[0].getsockname()[1]
+    _write_private(paths.port, str(port))
+    _write_private(paths.token, token)
+    return server
 
 
 async def start_server(handler, name):
@@ -79,22 +140,19 @@ async def start_server(handler, name):
     cleanup_endpoint(name)
 
     if supports_unix_sockets():
-        server = await asyncio.start_unix_server(handler, path=str(paths.sock))
         try:
-            os.chmod(paths.sock, 0o600)
-        except OSError:
-            pass
-        return server
+            server = await asyncio.start_unix_server(handler, path=str(paths.sock))
+            _chmod_private(paths.sock)
+            return server
+        except (AttributeError, NotImplementedError, OSError):
+            cleanup_endpoint(name)
 
-    server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
-    port = server.sockets[0].getsockname()[1]
-    paths.port.write_text(str(port))
-    return server
+    return await _start_tcp_server(handler, paths)
 
 
 def cleanup_endpoint(name):
     paths = runtime_paths(name)
-    for path in (paths.sock, paths.port):
+    for path in (paths.sock, paths.port, paths.token):
         try:
             path.unlink()
         except FileNotFoundError:


### PR DESCRIPTION
## Summary
- add a cross-platform daemon transport layer with a TCP fallback when Unix sockets are unavailable
- move runtime temp files and default screenshot paths onto platform-appropriate temp directories
- fix the Windows setup flow so it targets a real Chrome profile, opens `chrome://inspect/#remote-debugging` through the omnibox, and avoids reopening the setup tab on every retry
- add regression coverage for the Windows `--doctor` and `--setup` flows

## Root cause
The harness assumed Unix sockets and `/tmp` paths everywhere, which broke the control channel on Windows Python builds without `socket.AF_UNIX`. The setup flow also relied on launching `chrome://` URLs directly, which did not reliably reach the inspect page on Windows Chrome.

## Validation
- `python -m unittest tests.test_setup tests.test_doctor`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the harness work on Windows with a cross‑platform transport (authenticated TCP fallback), a reliable Chrome setup in a real profile, and UTF‑8 console encoding. Runtime files now live in the OS temp dir; also fixes a TCP startup readiness race and adds targeted tests.

- **New Features**
  - Cross‑platform transport with authenticated TCP fallback when Unix sockets are unavailable (`transport.py`).
  - Runtime paths for sock/pid/log/port/token and default screenshot now use the OS temp directory.

- **Bug Fixes**
  - Windows setup opens chrome://inspect via the omnibox in a real Chrome profile; PowerShell runs with `check=True` so failures fall back to `webbrowser`; avoids reopening the setup tab on retries.
  - Transport robustness: probe Unix socket support by actually creating a socket; fix endpoint labels by reading the `.port` file; publish TCP readiness only after the token exists; clean up endpoints; daemon/admin use transport helpers.
  - Prevent Windows console crashes by forcing UTF‑8 encoding for stdout/stderr (`run.py`).
  - Tests: add `--doctor`, `--setup`, transport fallback/readiness, and run import robustness tests; fix doctor test expectation.

<sup>Written for commit 5fbf27f170c49d9c2a38f838340a2634803c74e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

