### PR TITLE
fix(daemon): fire-and-forget mark_js in tap handler (fixes #136)

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -154,8 +154,7 @@ class Daemon:
             elif method == "Page.javascriptDialogClosed":
                 self.dialog = None
             elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-                try: await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session), timeout=2)
-                except Exception: pass
+                asyncio.create_task(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session))
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 

--- a/daemon.py
+++ b/daemon.py
@@ -154,7 +154,10 @@ class Daemon:
             elif method == "Page.javascriptDialogClosed":
                 self.dialog = None
             elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-                asyncio.create_task(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session))
+                async def _mark():
+                    try: await self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session)
+                    except Exception: pass
+                asyncio.create_task(_mark())
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 


### PR DESCRIPTION
## Summary

The `tap` event handler in `daemon.py` `await`s the `Runtime.evaluate` call that adds the 🟢 tab marker on every `Page.loadEventFired` and `Page.domContentEventFired`. Because `cdp-use` dispatches events sequentially, this await blocks the event queue — `domContentEventFired` holds up `loadEventFired`, and both evals queue in Chrome's V8 thread ahead of the user's next `js(...)` call. Two ~2s timeouts compound to ~4s per navigation.

Switching to `asyncio.create_task()` makes the mark_js eval fire-and-forget. The 🟢 title still appears, just a moment later. The event queue is no longer blocked.

## Before / after (9 navigations, 3 URLs × 3 rounds)

| | Before | After |
|---|---|---|
| Median | 4.136s | **0.278s** |
| Mean | 4.266s | **0.287s** |
| Min | 4.032s | **0.126s** |

**~15× improvement.**

## Test plan

- [x] Benchmark before/after with `goto → wait_for_load → js` loop
- [x] Tab marking still works — `page_info()["title"]` contains 🟢
- [x] Screenshot, `js()`, `drain_events()` all functional
- [x] 10 rapid tab create/navigate/close cycles — no race conditions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the tap handler to fire-and-forget the `mark_js` Runtime.evaluate via `asyncio.create_task` so CDP events don’t block on 2s timeouts, and guard the task with try/except to avoid unhandled exceptions. Navigation is ~15× faster (median 4.1s → 0.28s) and the 🟢 tab title still appears.

<sup>Written for commit 97790342cafed5c11029a1a1df5ff6577949f71f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

