### PR TITLE
fix(helpers): resolve domain skills for subdomains and hyphenated hosts

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -47,10 +47,29 @@ def drain_events():  return _send({"meta": "drain_events"})["events"]
 
 
 # --- navigation / page ---
+def _skill_dir(url):
+    """Resolve URL to domain-skills/ subdirectory.
+
+    Tries progressively shorter hostname segments, then the full hostname
+    hyphenated, so ``booking.com`` → ``booking-com``, ``old.reddit.com`` → ``reddit``,
+    ``itch.io`` → ``itch-io``."""
+    host = (urlparse(url).hostname or "").removeprefix("www.")
+    base = Path(__file__).parent / "domain-skills"
+    # Try each segment of the hostname: old.reddit.com → old, reddit, com
+    parts = host.split(".")
+    for i in range(len(parts)):
+        d = base / parts[i]
+        if d.is_dir(): return d
+    # Try full hostname hyphenated: booking.com → booking-com
+    d = base / host.replace(".", "-")
+    if d.is_dir(): return d
+    return None
+
+
 def goto(url):
     r = cdp("Page.navigate", url=url)
-    d = (Path(__file__).parent / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0])
-    return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]} if d.is_dir() else r
+    d = _skill_dir(url)
+    return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]} if d else r
 
 def page_info():
     """{url, title, w, h, sx, sy, pw, ph} — viewport + scroll + page size.


### PR DESCRIPTION
## Summary

`goto()` extracts domain skills by taking the first segment of the hostname (`booking.com` → `booking`). This misses:

- **Hyphenated folders:** `booking.com` → folder is `booking-com`, not `booking`
- **Subdomains:** `old.reddit.com` → looks for `old`, should find `reddit`
- **Multi-segment hosts:** `itch.io` → folder is `itch-io`, `archive.org` → folder is `archive-org`

Added `_skill_dir()` which tries a fallback chain:
1. Each hostname segment left-to-right (`old.reddit.com` → try `old`, then `reddit`, then `com`)
2. Full hostname hyphenated (`booking.com` → `booking-com`)

## Before / after

| URL | Before | After |
|---|---|---|
| `booking.com` | ❌ `booking` (missing) | ✅ `booking-com` |
| `old.reddit.com` | ❌ `old` (missing) | ✅ `reddit` |
| `itch.io` | ❌ `itch` (missing) | ✅ `itch-io` |
| `archive.org` | ❌ `archive` (missing) | ✅ `archive-org` |
| `reddit.com` | ✅ `reddit` | ✅ `reddit` (unchanged) |
| `github.com` | ✅ `github` | ✅ `github` (unchanged) |

## Test plan

- [x] Unit-tested `_skill_dir()` against 11 URLs covering all cases
- [x] Live-tested with `goto("https://www.booking.com")` — returns `domain_skills: ["scraping.md"]`
- [x] Live-tested with `goto("https://old.reddit.com")` — returns `domain_skills: ["scraping.md"]`
- [x] Existing matches (`github.com`, `reddit.com`, `stackoverflow.com`) still resolve correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes domain-skill resolution in `goto()` to correctly handle subdomains and hyphenated or multi-segment hosts. Adds `_skill_dir()` with a fallback search over hostname segments and the hyphenated full host.

- **Bug Fixes**
  - Subdomains now resolve to the main domain folder (e.g., `old.reddit.com` → `reddit`).
  - Hyphenated and multi-segment hosts resolve to the hyphenated folder (e.g., `booking.com` → `booking-com`, `itch.io` → `itch-io`).
  - Returns `domain_skills` only when a matching folder exists; otherwise response is unchanged.

<sup>Written for commit a9299f716b3bdb372ed63d3cff97b41d29b7c675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

