### PR TITLE
fix(admin): auto-launch Chrome 147+ with debug profile on cold start

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -85,8 +85,9 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             time.sleep(0.2)
         msg = _log_tail(name) or ""
         if local and attempt == 0 and ("DevToolsActivePort not found" in msg or "not live yet" in msg or ("WS handshake failed" in msg and "403" in msg)):
-            _launch_chrome_debug()
-            print("browser-harness: launched Chrome with remote debugging on port 9222", file=sys.stderr)
+            launched = _launch_chrome_debug()
+            if launched:
+                print("browser-harness: launched Chrome with remote debugging on port 9222", file=sys.stderr)
             restart_daemon(name)
             continue
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
@@ -446,7 +447,7 @@ def _launch_chrome_debug():
         profile = os.path.expanduser("~/.local/share/browser-harness/chrome-debug-profile")
     if not chrome or not os.path.exists(chrome):
         _open_chrome_inspect()
-        return
+        return False
     os.makedirs(profile, exist_ok=True)
     subprocess.Popen(
         [chrome, "--remote-debugging-port=9222", f"--user-data-dir={profile}"],
@@ -459,7 +460,7 @@ def _launch_chrome_debug():
         try:
             sock.connect(("127.0.0.1", 9222))
             sock.close()
-            return
+            return True
         except OSError:
             pass
         finally:

--- a/admin.py
+++ b/admin.py
@@ -455,17 +455,13 @@ def _launch_chrome_debug():
     )
     import time as _t, socket as _s
     for _ in range(30):
-        sock = _s.socket(_s.AF_INET, _s.SOCK_STREAM)
-        sock.settimeout(1)
         try:
-            sock.connect(("127.0.0.1", 9222))
-            sock.close()
+            urllib.request.urlopen("http://127.0.0.1:9222/json/version", timeout=2)
             return True
-        except OSError:
+        except Exception:
             pass
-        finally:
-            sock.close()
         _t.sleep(1)
+    return False
 
 
 def _open_chrome_inspect():

--- a/admin.py
+++ b/admin.py
@@ -85,8 +85,8 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             time.sleep(0.2)
         msg = _log_tail(name) or ""
         if local and attempt == 0 and ("DevToolsActivePort not found" in msg or "not live yet" in msg or ("WS handshake failed" in msg and "403" in msg)):
-            _open_chrome_inspect()
-            print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
+            _launch_chrome_debug()
+            print("browser-harness: launched Chrome with remote debugging on port 9222", file=sys.stderr)
             restart_daemon(name)
             continue
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
@@ -423,6 +423,48 @@ def _chrome_running():
         return any(n.lower() in out.lower() for n in names)
     except Exception:
         return False
+
+
+def _launch_chrome_debug():
+    """Launch Chrome with remote debugging on a persistent profile.
+
+    Chrome 147+ blocks remote debugging on the default user data directory.
+    This launches Chrome with a separate profile and --remote-debugging-port=9222.
+    The profile persists across sessions so cookies and logins survive.
+    """
+    import platform, shutil, subprocess
+    if platform.system() == "Darwin":
+        chrome = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        profile = os.path.expanduser("~/Library/Application Support/browser-harness/chrome-debug-profile")
+    elif platform.system() == "Windows":
+        chrome = os.path.expandvars(r"%ProgramFiles%\Google\Chrome\Application\chrome.exe")
+        if not os.path.exists(chrome):
+            chrome = os.path.expandvars(r"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe")
+        profile = os.path.expandvars(r"%LOCALAPPDATA%\browser-harness\chrome-debug-profile")
+    else:
+        chrome = shutil.which("google-chrome") or shutil.which("chromium") or shutil.which("chromium-browser")
+        profile = os.path.expanduser("~/.local/share/browser-harness/chrome-debug-profile")
+    if not chrome or not os.path.exists(chrome):
+        _open_chrome_inspect()
+        return
+    os.makedirs(profile, exist_ok=True)
+    subprocess.Popen(
+        [chrome, "--remote-debugging-port=9222", f"--user-data-dir={profile}"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+    )
+    import time as _t, socket as _s
+    for _ in range(30):
+        sock = _s.socket(_s.AF_INET, _s.SOCK_STREAM)
+        sock.settimeout(1)
+        try:
+            sock.connect(("127.0.0.1", 9222))
+            sock.close()
+            return
+        except OSError:
+            pass
+        finally:
+            sock.close()
+        _t.sleep(1)
 
 
 def _open_chrome_inspect():

--- a/daemon.py
+++ b/daemon.py
@@ -58,6 +58,18 @@ def log(msg):
     open(LOG, "a").write(f"{msg}\n")
 
 
+def _probe_port(port):
+    """Probe a local CDP port for a websocket URL. Returns ws:// URL or None."""
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=2) as r:
+            info = json.loads(r.read())
+            ws = info.get("webSocketDebuggerUrl")
+            if ws: log(f"probed CDP on port {port}: {ws}")
+            return ws
+    except Exception:
+        return None
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
@@ -82,7 +94,17 @@ def get_ws_url():
             finally:
                 probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
-    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
+    # Chrome 147+ blocks remote debugging on the default user data directory.
+    # Probe the default port — a previous `ensure_daemon` may have launched
+    # Chrome with --remote-debugging-port=9222 and a temp profile.
+    ws = _probe_port(9222)
+    if ws: return ws
+    raise RuntimeError(
+        "DevToolsActivePort not found — "
+        "Chrome 147+ blocks remote debugging on the default profile. "
+        "Launch Chrome with --remote-debugging-port=9222 --user-data-dir=/tmp/bu-chrome-profile, "
+        "or set BU_CDP_WS for a remote browser."
+    )
 
 
 def stop_remote():


### PR DESCRIPTION
## Summary

Chrome 147+ blocks `--remote-debugging-port` on the default user data directory. The daemon's `get_ws_url()` fails with "DevToolsActivePort not found", and `ensure_daemon()` currently opens `chrome://inspect/#remote-debugging` — but ticking that checkbox on Chrome 147 still doesn't work because the default profile is blocked.

This PR makes `ensure_daemon` auto-launch Chrome with a separate persistent profile and `--remote-debugging-port=9222` when `DevToolsActivePort` is missing. The daemon's `get_ws_url()` now probes port 9222 as a fallback before raising, so it picks up the auto-launched Chrome instance.

**Result:** A bare `browser-harness <<PY ... PY` on a cold machine with Chrome 147 works in one invocation — no manual steps.

## Changes

**`admin.py`** — new `_launch_chrome_debug()`:
- Detects Chrome binary per platform (macOS, Windows, Linux)
- Creates a persistent profile directory (`~/Library/Application Support/browser-harness/chrome-debug-profile` on macOS)
- Launches Chrome with `--remote-debugging-port=9222 --user-data-dir=<profile>`
- Waits up to 30s for port 9222 to bind
- Falls back to `_open_chrome_inspect()` if Chrome binary not found

**`daemon.py`** — new `_probe_port()` + updated `get_ws_url()`:
- `_probe_port(port)` probes `http://127.0.0.1:<port>/json/version` for a websocket URL
- `get_ws_url()` calls `_probe_port(9222)` before raising — catches the auto-launched Chrome
- Error message updated to mention Chrome 147 profile requirement

## Before / after

| | Before | After |
|---|---|---|
| Cold start (Chrome 147) | ❌ RuntimeError — manual fix needed | ✅ Works in one invocation |
| Existing Chrome with DevToolsActivePort | ✅ | ✅ (unchanged) |
| Remote browsers (`BU_CDP_WS`) | ✅ | ✅ (unchanged) |

## Test plan

- [x] Cold start with Chrome dead + no daemon → auto-launches Chrome, connects, runs commands
- [x] Domain skill discovery, screenshots, js(), tab marking all work with auto-launched Chrome
- [x] Existing Chrome with `DevToolsActivePort` present → still uses old path (no regression)
- [x] `BU_CDP_WS` set → skips all local detection (no regression)
- [x] Falls back to `_open_chrome_inspect()` when Chrome binary not found

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-launch Chrome 147+ with a dedicated debug profile on cold start to bypass the DevToolsActivePort block. The daemon now validates CDP via `/json/version` on port 9222 and connects automatically, so a bare run works without manual steps.

- **Bug Fixes**
  - In `admin.py`, `ensure_daemon` calls `_launch_chrome_debug()` when DevToolsActivePort is missing (also handles “not live yet” and WS 403); launches Chrome with `--remote-debugging-port=9222` and a persistent `--user-data-dir`, waits up to 30s by probing `/json/version`, then restarts the daemon. `_launch_chrome_debug()` returns a bool and only prints success when Chrome actually starts; if the binary isn’t found, it opens `chrome://inspect` instead.
  - In `daemon.py`, adds `_probe_port()` and updates `get_ws_url()` to query `http://127.0.0.1:9222/json/version` before failing; the error explains the Chrome 147 profile requirement.
  - Existing flows remain: if DevToolsActivePort exists or `BU_CDP_WS` is set, behavior is unchanged; if Chrome isn’t found, fallback to `chrome://inspect`.

<sup>Written for commit 2ba0829fa135c20bd925c2fcf375632bee4b7482. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

