### PR TITLE
feat(domain-skills/x): X.com post domain skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -35,6 +35,7 @@ Available interaction skills:
 
 Available domain skills:
 - `tiktok/upload.md`
+- `domain-skills/x/post.md` — post text + image(s) or video(s) to X.com (auto-converts non-H.264 video, supports multiple media)
 
 ## Tool call shape
 

--- a/domain-skills/x/post.md
+++ b/domain-skills/x/post.md
@@ -1,0 +1,86 @@
+# X / Twitter — Post with Image(s) or Video(s)
+
+Post text + image(s) and/or video(s) to X.com using the browser harness. Assumes user is already logged in.
+
+## Media Requirements
+
+**Images:** PNG, JPG, WebP, GIF — uploaded as-is.
+
+**Video:** Must be H.264 codec (libx264) + AAC audio. The skill auto-converts non-H.264 video using ffmpeg before uploading. HEVC (ProRes, etc.) files will be rejected by X with "Your video file could not be processed."
+
+## API Design
+
+### Module usage
+
+```python
+from x_post import post_to_x
+
+# Single image
+result = post_to_x(text="...", media=[{"path": "/path/to/img.png", "type": "image"}])
+
+# Multiple images
+result = post_to_x(text="...", media=[
+    {"path": "/path/to/img1.png", "type": "image"},
+    {"path": "/path/to/img2.jpg", "type": "image"},
+])
+
+# Mix of images and video
+result = post_to_x(text="...", media=[
+    {"path": "/path/to/img.png", "type": "image"},
+    {"path": "/path/to/video.mp4", "type": "video"},
+])
+```
+
+### Script usage
+
+```bash
+# Auto-detect type from file extension
+uv run python3 x_post.py "text" /path/to/img.png
+uv run python3 x_post.py "text" /path/to/video.mp4
+
+# Explicit type prefix (img: / vid:)
+uv run python3 x_post.py "text" img:/path/to/img.png vid:/path/to/video.mp4
+
+# Multiple items
+uv run python3 x_post.py "text" /path/to/img1.png /path/to/img2.jpg
+```
+
+## Selectors
+
+| Element | Selector |
+|---------|----------|
+| Compose textarea | `[data-testid="tweetTextarea_0_label"]` |
+| Post button | `[data-testid="tweetButtonInline"]` |
+| Media file input | `[data-testid="fileInput"]` |
+
+## Workflow
+
+```
+1. navigate to https://x.com/home
+2. wait_for_load()
+3. click compose textarea center (coordinate click)
+4. type_text(text)       — fills the compose box
+5. upload each media item to '[data-testid="fileInput"]'
+   — images uploaded first, then videos
+   — videos are pre-converted to H.264 if needed (auto-detected by extension)
+6. wait 3 seconds (buffer for media to start processing)
+7. poll until Post button is enabled (aria-disabled != 'true')
+   — for video, this wait is longer since X disables the button during processing
+8. js click the Post button (coordinate click fails after media attachment)
+9. wait 5s, verify post appears in feed
+```
+
+## Key Gotchas
+
+- **Video codec must be H.264** — X rejects HEVC, VP9, ProRes. The skill auto-converts these.
+- **Coordinate click on Post button fails** — X re-renders the button after media is attached. Always use JS `.click()` for the Post button.
+- **Post button is disabled during video processing** — the button stays `aria-disabled="true"` until the video finishes processing. The polling loop handles this naturally.
+- **3-second fixed wait before polling** — ensures media upload starts before we start checking button state.
+- **Upload is sequential** — images then videos, 0.5s between each upload call.
+- **Auto-detect by extension** — `.mp4/.mov/.avi/.mkv/.webm/.m4v` are treated as video; everything else as image. Use `img:` / `vid:` prefix to override.
+- **Verify with JS** — look for `[data-testid="tweet"]` element containing the posted text.
+
+## Files
+
+- `x/x_post.py` — standalone script with `post_to_x()` function
+- `x/post.md` — this documentation

--- a/domain-skills/x/x_post.py
+++ b/domain-skills/x/x_post.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+X Post with Image(s) or Video(s) — browser-harness domain skill
+
+Usage as script:
+    uv run python3 x_post.py "text here" /path/to/media.png
+    uv run python3 x_post.py "text here" /path/to/img1.png /path/to/img2.png
+    uv run python3 x_post.py "text here" /path/to/video.mp4
+    uv run python3 x_post.py "text here" img:/path/to/img.png vid:/path/to/video.mp4
+
+Usage as module:
+    from x_post import post_to_x
+
+    # Single image
+    result = post_to_x(text="...", media=[{"path": "/path/to/img.png", "type": "image"}])
+
+    # Multiple images
+    result = post_to_x(text="...", media=[
+        {"path": "/path/to/img1.png", "type": "image"},
+        {"path": "/path/to/img2.jpg", "type": "image"},
+    ])
+
+    # Mix of images and video
+    result = post_to_x(text="...", media=[
+        {"path": "/path/to/img.png", "type": "image"},
+        {"path": "/path/to/video.mp4", "type": "video"},
+    ])
+"""
+import sys, subprocess, os, tempfile
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).parent
+sys.path.insert(0, str(SKILL_DIR.parent.parent))
+from helpers import *
+from admin import ensure_daemon
+
+
+def _is_video(path):
+    """Check if a file is a video based on extension."""
+    video_exts = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v", ".flv", ".wmv"}
+    return Path(path).suffix.lower() in video_exts
+
+
+def _ensure_h264(path):
+    """
+    Check if a video file is H.264. If not, convert to H.264 using ffmpeg.
+    Returns the path to use (original if already H.264, or a temp converted file).
+    Skips non-video files and returns them unchanged.
+    """
+    if not _is_video(path):
+        return path
+
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "quiet", "-show_streams", path],
+            capture_output=True, text=True, timeout=10
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("codec_name="):
+                if line.split("=", 1)[1] == "h264":
+                    return path
+                break
+    except Exception:
+        pass
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    tmp.close()
+    out_path = tmp.name
+    try:
+        subprocess.run(
+            ["ffmpeg", "-i", path, "-c:v", "libx264", "-c:a", "aac",
+             "-movflags", "+faststart", out_path, "-y"],
+            capture_output=True, timeout=300
+        )
+        return out_path
+    except Exception:
+        try:
+            os.unlink(out_path)
+        except Exception:
+            pass
+        return path
+
+
+def _parse_media_arg(arg):
+    """
+    Parse a media argument that may be:
+      - a bare path (auto-detected as image or video by extension)
+      - "img:/path/to/file.png"  (explicit image)
+      - "vid:/path/to/file.mp4"  (explicit video)
+    Returns {"path": str, "type": "image"|"video"}
+    """
+    if arg.startswith("img:") or arg.startswith("vid:"):
+        prefix, rest = arg.split(":", 1)
+        media_type = "image" if prefix == "img" else "video"
+        return {"path": rest, "type": media_type}
+
+    # Auto-detect by extension
+    if _is_video(arg):
+        return {"path": arg, "type": "video"}
+    return {"path": arg, "type": "image"}
+
+
+def post_to_x(text, media, screenshot_dir=None):
+    """
+    Post text with image(s) and/or video(s) to X.com.
+
+    Args:
+        text:          post body text (with or without hashtags)
+        media:         a single path str, or a list of dicts [{"path": str, "type": "image"|"video"}].
+                       Type is auto-detected from extension if not specified.
+        screenshot_dir: absolute path for verification screenshot (optional)
+
+    Returns:
+        {"success": bool, "post_in_feed": bool, "url": str}
+    """
+    ensure_daemon(wait=60)
+    ensure_real_tab()
+
+    try:
+        cdp("Page.handleJavaScriptDialog", accept=True)
+    except Exception:
+        pass
+
+    # Normalize media to list of dicts
+    if isinstance(media, str):
+        media = [_parse_media_arg(media)]
+    else:
+        media = [_parse_media_arg(m) if isinstance(m, str) else m for m in media]
+
+    # Separate images and videos
+    images = [m["path"] for m in media if m["type"] == "image"]
+    videos = [m["path"] for m in media if m["type"] == "video"]
+
+    # Pre-convert videos to H.264 if needed
+    videos = [_ensure_h264(v) for v in videos]
+
+    goto("https://x.com/home")
+    wait_for_load()
+
+    compose = js("""
+        (() => {
+            const el = document.querySelector('[data-testid="tweetTextarea_0_label"]');
+            if (!el) return null;
+            const r = el.getBoundingClientRect();
+            return { x: Math.round(r.left + r.width/2), y: Math.round(r.top + r.height/2) };
+        })()
+    """)
+    if not compose:
+        return {"success": False, "post_in_feed": False, "error": "compose textarea not found"}
+
+    click(compose["x"], compose["y"])
+    wait(0.3)
+    type_text(text)
+    wait(0.2)
+
+    # Upload images first, then videos
+    all_media = images + videos
+    for m in all_media:
+        upload_file('[data-testid="fileInput"]', m)
+        wait(0.5)
+
+    wait(3.0)
+
+    for _ in range(60):
+        wait(0.2)
+        btn = js("""
+            (() => {
+                const el = document.querySelector('[data-testid="tweetButtonInline"]');
+                if (!el) return null;
+                return el.getAttribute('aria-disabled') !== 'true';
+            })()
+        """)
+        if btn:
+            break
+    else:
+        return {"success": False, "post_in_feed": False, "error": "Post button never enabled"}
+
+    js("""(() => { const btn = document.querySelector('[data-testid="tweetButtonInline"]'); if (btn) btn.click(); })()""")
+
+    wait(5)
+
+    if screenshot_dir:
+        Path(screenshot_dir).mkdir(parents=True, exist_ok=True)
+        screenshot(f"{screenshot_dir}/x_post_result.png")
+
+    posted = js("""
+        (() => {
+            const posts = document.querySelectorAll('[data-testid="tweet"]');
+            for (const p of posts) {
+                if (p.textContent.includes(%s)) return true;
+            }
+            return false;
+        })()
+    """ % json.dumps(text[:40]))
+
+    return {
+        "success": True,
+        "post_in_feed": bool(posted),
+        "url": page_info().get("url", ""),
+    }
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: uv run python3 x_post.py \"post text\" <media paths or prefixed paths>")
+        print("  Bare paths auto-detect type from extension:")
+        print("    uv run python3 x_post.py \"text\" /path/to/img.png")
+        print("    uv run python3 x_post.py \"text\" /path/to/video.mp4")
+        print("  Explicit types with prefix (img: / vid:):")
+        print("    uv run python3 x_post.py \"text\" img:/path/to/img.png vid:/path/to/video.mp4")
+        print("  Multiple items:")
+        print("    uv run python3 x_post.py \"text\" /path/to/img1.png /path/to/img2.jpg")
+        sys.exit(1)
+
+    text_arg = sys.argv[1]
+    media_args = sys.argv[2:]
+
+    media = [_parse_media_arg(m) for m in media_args]
+
+    ss_dir = str(SKILL_DIR / "screenshots")
+
+    result = post_to_x(text=text_arg, media=media, screenshot_dir=ss_dir)
+
+    print(f"success: {result['success']}, post_in_feed: {result.get('post_in_feed', False)}")
+    if not result["success"]:
+        sys.exit(1)

--- a/domain-skills/x/x_post.py
+++ b/domain-skills/x/x_post.py
@@ -26,13 +26,28 @@ Usage as module:
         {"path": "/path/to/video.mp4", "type": "video"},
     ])
 """
-import sys, subprocess, os, tempfile
+import sys, subprocess, os, tempfile, atexit
 from pathlib import Path
 
 SKILL_DIR = Path(__file__).parent
 sys.path.insert(0, str(SKILL_DIR.parent.parent))
 from helpers import *
 from admin import ensure_daemon
+
+# Temp video files created by _ensure_h264 that need cleanup after the post
+_TEMP_FILES = []
+
+
+def _cleanup_temp_files():
+    for f in _TEMP_FILES:
+        try:
+            os.unlink(f)
+        except Exception:
+            pass
+    _TEMP_FILES.clear()
+
+
+atexit.register(_cleanup_temp_files)
 
 
 def _is_video(path):
@@ -70,8 +85,9 @@ def _ensure_h264(path):
         subprocess.run(
             ["ffmpeg", "-i", path, "-c:v", "libx264", "-c:a", "aac",
              "-movflags", "+faststart", out_path, "-y"],
-            capture_output=True, timeout=300
+            check=True, capture_output=True, timeout=300
         )
+        _TEMP_FILES.append(out_path)
         return out_path
     except Exception:
         try:
@@ -192,6 +208,8 @@ def post_to_x(text, media, screenshot_dir=None):
             return false;
         })()
     """ % json.dumps(text[:40]))
+
+    _cleanup_temp_files()
 
     return {
         "success": True,

--- a/domain-skills/x/x_post.py
+++ b/domain-skills/x/x_post.py
@@ -150,72 +150,73 @@ def post_to_x(text, media, screenshot_dir=None):
     # Pre-convert videos to H.264 if needed
     videos = [_ensure_h264(v) for v in videos]
 
-    goto("https://x.com/home")
-    wait_for_load()
+    try:
+        goto("https://x.com/home")
+        wait_for_load()
 
-    compose = js("""
-        (() => {
-            const el = document.querySelector('[data-testid="tweetTextarea_0_label"]');
-            if (!el) return null;
-            const r = el.getBoundingClientRect();
-            return { x: Math.round(r.left + r.width/2), y: Math.round(r.top + r.height/2) };
-        })()
-    """)
-    if not compose:
-        return {"success": False, "post_in_feed": False, "error": "compose textarea not found"}
-
-    click(compose["x"], compose["y"])
-    wait(0.3)
-    type_text(text)
-    wait(0.2)
-
-    # Upload images first, then videos
-    all_media = images + videos
-    for m in all_media:
-        upload_file('[data-testid="fileInput"]', m)
-        wait(0.5)
-
-    wait(3.0)
-
-    for _ in range(60):
-        wait(0.2)
-        btn = js("""
+        compose = js("""
             (() => {
-                const el = document.querySelector('[data-testid="tweetButtonInline"]');
+                const el = document.querySelector('[data-testid="tweetTextarea_0_label"]');
                 if (!el) return null;
-                return el.getAttribute('aria-disabled') !== 'true';
+                const r = el.getBoundingClientRect();
+                return { x: Math.round(r.left + r.width/2), y: Math.round(r.top + r.height/2) };
             })()
         """)
-        if btn:
-            break
-    else:
-        return {"success": False, "post_in_feed": False, "error": "Post button never enabled"}
+        if not compose:
+            return {"success": False, "post_in_feed": False, "error": "compose textarea not found"}
 
-    js("""(() => { const btn = document.querySelector('[data-testid="tweetButtonInline"]'); if (btn) btn.click(); })()""")
+        click(compose["x"], compose["y"])
+        wait(0.3)
+        type_text(text)
+        wait(0.2)
 
-    wait(5)
+        # Upload images first, then videos
+        all_media = images + videos
+        for m in all_media:
+            upload_file('[data-testid="fileInput"]', m)
+            wait(0.5)
 
-    if screenshot_dir:
-        Path(screenshot_dir).mkdir(parents=True, exist_ok=True)
-        screenshot(f"{screenshot_dir}/x_post_result.png")
+        wait(3.0)
 
-    posted = js("""
-        (() => {
-            const posts = document.querySelectorAll('[data-testid="tweet"]');
-            for (const p of posts) {
-                if (p.textContent.includes(%s)) return true;
-            }
-            return false;
-        })()
-    """ % json.dumps(text[:40]))
+        for _ in range(60):
+            wait(0.2)
+            btn = js("""
+                (() => {
+                    const el = document.querySelector('[data-testid="tweetButtonInline"]');
+                    if (!el) return null;
+                    return el.getAttribute('aria-disabled') !== 'true';
+                })()
+            """)
+            if btn:
+                break
+        else:
+            return {"success": False, "post_in_feed": False, "error": "Post button never enabled"}
 
-    _cleanup_temp_files()
+        js("""(() => { const btn = document.querySelector('[data-testid="tweetButtonInline"]'); if (btn) btn.click(); })()""")
 
-    return {
-        "success": True,
-        "post_in_feed": bool(posted),
-        "url": page_info().get("url", ""),
-    }
+        wait(5)
+
+        if screenshot_dir:
+            Path(screenshot_dir).mkdir(parents=True, exist_ok=True)
+            screenshot(f"{screenshot_dir}/x_post_result.png")
+
+        posted = js("""
+            (() => {
+                const posts = document.querySelectorAll('[data-testid="tweet"]');
+                for (const p of posts) {
+                    if (p.textContent.includes(%s)) return true;
+                }
+                return false;
+            })()
+        """ % json.dumps(text[:40]))
+
+        return {
+            "success": True,
+            "post_in_feed": bool(posted),
+            "url": page_info().get("url", ""),
+        }
+    finally:
+        _cleanup_temp_files()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `domain-skills/x/x_post.py` — post text + image(s) and/or video(s) to X.com
- `domain-skills/x/post.md` — full documentation
- `SKILL.md` — updated to list the new domain skill

## Features
- **Single or multiple images** — auto-detected by extension, or use `img:` prefix
- **Video with auto H.264 conversion** — non-H.264 video is converted via ffmpeg before upload
- **Mixed media** — images + video in one post, sequential upload
- **Explicit type override** — `img:` or `vid:` prefix when extension isn't reliable
- **JS click on Post button** — coordinate click fails after media attachment (X re-renders button position)
- **Polling loop** — waits for `aria-disabled != 'true'` to handle slow video processing

## Test Results
All three modes verified on X.com:
- Image only ✅
- Video only ✅
- Image + Video mixed ✅

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an X.com posting domain skill to publish text with image(s) and/or video via the browser harness. Includes `domain-skills/x/post.md` and updates `SKILL.md` to list the skill.

- **New Features**
  - Post text with images and/or video; supports multiple and mixed media with auto-detect and `img:`/`vid:` overrides.
  - Converts non-H.264 video to H.264/AAC (ffmpeg); uses JS click + polling until Post is enabled to handle video processing.

- **Bug Fixes**
  - Detects ffmpeg conversion failures (`check=True`) and avoids returning bad temp paths.
  - Always cleans up converted temp files, including early-return paths (wrapped in `try/finally`), with an `atexit` safety net.

<sup>Written for commit 6655b394808ce78954718b29bfe2f9a054135d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

