### PR TITLE
domain-skills: amazon — cart.md, orders.md

### DIFF
--- a/domain-skills/amazon/cart.md
+++ b/domain-skills/amazon/cart.md
@@ -1,0 +1,54 @@
+# Amazon — Shopping Cart
+
+Field-tested against amazon.com on 2026-04-22 using a logged-in Chrome session.
+
+## URL
+
+```
+https://www.amazon.com/gp/cart/view.html
+```
+
+## Empty-cart trap
+
+**Do not use `[data-asin]` to detect whether the cart has items.** The cart page renders an "Items you may like" recommendation strip and other widgets that also carry `data-asin` attributes — a naive scrape returns 8–12 ASINs even on a fully empty cart.
+
+Check the empty-state string first:
+
+```python
+empty = js("""
+  document.body.innerText.includes('Your Amazon Cart is empty')
+""")
+```
+
+If `empty` is true, stop — do not enumerate items.
+
+## Subtotal
+
+When the cart has items, the active subtotal lives at:
+
+```
+#sc-subtotal-amount-activecart   (or)   #sc-subtotal-amount-buybox
+```
+
+These elements are **absent from the DOM entirely on an empty cart** (not just empty-string). A `null` here is consistent with the empty-state check above; do not treat it as "subtotal hidden."
+
+## Price-change banners
+
+Amazon renders an "Important messages about items in your Cart" panel above the cart contents whenever a watched item's price has moved (up or down). The panel includes Saved-for-later items, not just active cart items. The text format is stable:
+
+```
+... has increased from $X to $Y
+... has decreased from $X to $Y
+```
+
+These are worth surfacing to the user on every cart visit — they are not redundant with the cart contents themselves.
+
+## Saved for later
+
+The "Saved for later" section is on the same URL as the cart, rendered below the active cart. Item count is shown as `Saved for later (N items)` in the section header. For a user with many saved items this can be hundreds — do not assume the section is small.
+
+## Gotchas
+
+- **`[data-asin]` ≠ cart contents.** Recommendations and "Items you may like" carry `data-asin` too. Always anchor cart-item scrapes inside `[data-name="Active Items"]` (or check the empty string first), never on the bare attribute.
+- **Subtotal selectors are absent, not empty, when the cart is empty.** `querySelector(...)` returns `null`, which is the correct signal.
+- **The page is logged-in only.** If a non-cart "Sign in to see your cart" page appears, treat as auth wall and stop.

--- a/domain-skills/amazon/orders.md
+++ b/domain-skills/amazon/orders.md
@@ -1,0 +1,151 @@
+# Amazon — Orders, Search & Tracking
+
+Field-tested against amazon.com on 2026-04-22 using a logged-in Chrome session.
+
+## Order list
+
+```
+https://www.amazon.com/gp/your-account/order-history    (legacy, still works)
+https://www.amazon.com/your-orders/orders               (current)
+```
+
+Both render the same DOM. Default view is the last ~10 orders.
+
+### Order card selector
+
+`.js-order-card` (or `.order-card` / `.a-box-group.order` — all three match). Each card's `innerText` contains a stable, line-broken block:
+
+```
+ORDER PLACED
+April 20, 2026
+TOTAL
+$51.57
+SHIP TO
+<recipient name>
+ORDER # 113-0977973-5845019
+View order details  View invoice
+Arriving April 24 - April 28
+<item title>
+Buy it again
+Track package
+...
+```
+
+For each card you can pull:
+- **Order date**: line after `ORDER PLACED`.
+- **Total**: line after `TOTAL` (absent on cancelled orders — those carry `Cancelled` instead).
+- **Order #**: regex `ORDER # (\d{3}-\d{7}-\d{7})` against the card text.
+- **ETA / status**: the `Arriving …` / `Delivered …` / `Picked up …` / `Cancelled` line.
+- **Item title(s)**: line(s) following the ETA.
+- **Track-package URL**: the `<a>` whose visible text is exactly `Track package` — its `href` goes straight to the tracking page.
+
+```python
+url = js("""
+  (() => {
+    const cards = document.querySelectorAll('.js-order-card');
+    for (const c of cards) {
+      if (c.innerText.includes('113-0977973-5845019')) {
+        const links = Array.from(c.querySelectorAll('a'));
+        const trk = links.find(a => a.innerText.trim().toLowerCase() === 'track package');
+        return trk ? trk.href : null;
+      }
+    }
+    return null;
+  })()
+""")
+```
+
+## Order search
+
+**The `?search=` URL parameter alone does not filter the order list.** Hitting `/your-orders/orders?search=calvin+klein` directly returns the unfiltered last ~10 orders.
+
+To actually search, submit the search form:
+
+```python
+goto("https://www.amazon.com/your-orders/orders")
+wait_for_load()
+js("""
+  (() => {
+    const input = document.querySelector('#searchOrdersInput');
+    const form  = input.closest('form');
+    input.value = 'calvin klein';
+    form.submit();
+  })()
+""")
+wait_for_load()
+```
+
+The submit redirects to `/your-orders/search/ref=ppx_yo2ov_dt_b_search?opt=ab&search=<query>`. That URL **does** filter when navigated to directly — the trick is the `opt=ab` param + the `/your-orders/search/` path (not `/your-orders/orders`).
+
+### Search results page DOM differs
+
+The search results page is **not** a list of `.js-order-card` elements. `document.querySelectorAll('.js-order-card').length === 1` regardless of how many matches there are. All matched orders are rendered into a single container as plain text, repeating the block:
+
+```
+View order details Ordered on March 25, 2026
+
+<item title>
+
+Buy it again
+View your item
+```
+
+Extract by walking `body.innerText` from the first occurrence of "calvin klein" (case-insensitive, or your search term). Product links to the matched items are `<a href="/dp/{ASIN}?...">` whose closest enclosing `div` contains the search term — useful for jumping to a product PDP for current pricing.
+
+## Tracking page
+
+URL pattern returned by the order-card "Track package" link:
+
+```
+/gp/your-account/ship-track?itemId=...&packageIndex=0&orderId=...&shipmentId=...
+```
+
+### Structured selectors are unreliable
+
+Selectors like `[data-test-id="primary-status-eta"]`, `[data-test-id="tracking-number"]`, `[data-test-id="carrier-name"]` all return `null` on this page. The text is rendered into generic containers that don't expose stable test IDs.
+
+**Extract from `body.innerText` anchored at "Arriving":**
+
+```python
+chunk = js("""
+  (() => {
+    const t = document.body.innerText;
+    const i = t.indexOf('Arriving');
+    return i >= 0 ? t.slice(i, i + 1500) : null;
+  })()
+""")
+```
+
+The chunk has a stable shape:
+
+```
+Arriving April 24 - April 28
+Shipped
+Package arrived at a carrier facility.
+Ordered
+Shipped
+Out for delivery
+Delivered
+...
+Shipped with USPS
+Tracking ID: 9300110990513346924683
+...
+Tracking info provided by <seller name>
+```
+
+Pull individual fields with regexes against that chunk:
+- ETA: `^Arriving (.+)$` (first line).
+- Carrier: `Shipped with (\w+)`.
+- Tracking #: `Tracking ID:\s*(\S+)`.
+- Seller (if 3P): `Tracking info provided by (.+)`.
+
+The milestone words (`Ordered` / `Shipped` / `Out for delivery` / `Delivered`) are always present as a static legend regardless of how far the package has actually moved — they are not a source of truth for current status. Use the line **above** the legend (e.g. `Package arrived at a carrier facility.`) for the live carrier message.
+
+## Gotchas
+
+- **`?search=` alone does nothing on `/your-orders/orders`.** You must submit the form, or hit the post-submit URL `/your-orders/search/ref=...?opt=ab&search=<query>` directly.
+- **Search results page has only one `.js-order-card`.** Don't iterate cards; walk `body.innerText`.
+- **Tracking page `data-test-id` selectors are null.** Anchor on the `"Arriving"` line in `body.innerText`.
+- **The milestone words on the tracking page are a static legend**, not progress. Read the line above them for the live status.
+- **Cancelled orders have no `TOTAL` line.** They carry the literal word `Cancelled` plus `Your order was cancelled. You have not been charged for this order.` instead.
+- **Order # regex**: Amazon order numbers are always `\d{3}-\d{7}-\d{7}` (17 digits + 2 hyphens).


### PR DESCRIPTION
## Summary

Two new amazon.com domain skills derived from a logged-in session, capturing traps that cost real round-trips to figure out:

- **`cart.md`** — the cart page renders `[data-asin]` elements (recommendation strips, "Items you may like") even when the cart is empty, so a naive ASIN scrape returns 8–12 items on an empty cart. Documents the `Your Amazon Cart is empty` text check as the correct signal, plus the active-subtotal selectors and the price-change banner format.

- **`orders.md`** — three things that aren't obvious:
  1. The order-list card shape (`.js-order-card`, with stable `innerText` blocks).
  2. **The order-search URL param `?search=` does not filter** on `/your-orders/orders` — you have to submit the form (or hit the post-submit URL `/your-orders/search/ref=...?opt=ab&search=<query>`). The search-results page also collapses to a single `.js-order-card` regardless of match count, so you have to walk `body.innerText` instead of iterating cards.
  3. The tracking page's `data-test-id` selectors (`primary-status-eta`, `tracking-number`, `carrier-name`) all return `null`. The reliable extraction is anchored on the `Arriving …` line in `body.innerText`, with a stable downstream shape that exposes carrier, tracking number, and seller via simple regexes. Also notes that the `Ordered / Shipped / Out for delivery / Delivered` words on the page are a **static legend**, not a progress indicator — easy to mistake for live status.

Both files follow the durability guidance from `SKILL.md` ("the map, not the diary"): no pixel coordinates, no run narration, no user-specific state.

## Test plan

- [ ] Open `/gp/cart/view.html` on an empty cart, verify `[data-asin]` returns >0 ASINs and the empty-state string check correctly returns `true`.
- [ ] Search for an item in `/your-orders/orders` via the URL param alone; confirm it does not filter.
- [ ] Submit the search form and confirm the post-submit URL renders the filtered view with a single `.js-order-card`.
- [ ] Open a `Track package` link and confirm `[data-test-id="primary-status-eta"]` is `null` while `body.innerText.indexOf('Arriving')` returns a usable chunk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two amazon.com domain skills to reliably read Cart and Orders/Tracking, avoiding common traps that cause false positives and extra requests. Improves selector guidance for empty carts, order search, and tracking details.

- **New Features**
  - `cart.md`: Use the "Your Amazon Cart is empty" string to detect emptiness; do not rely on `[data-asin]`. Document subtotal selectors (`#sc-subtotal-amount-activecart` / `#sc-subtotal-amount-buybox`), stable price-change banner phrases, and "Saved for later" behavior. Scope item scrapes inside `[data-name="Active Items"]`.
  - `orders.md`: Define `.js-order-card` fields (order date, total, order #, ETA, item titles) and how to grab the "Track package" link. Explain that `?search=` on `/your-orders/orders` doesn’t filter; submit the form or use `/your-orders/search/ref=...?opt=ab&search=<query>`. Note search results collapse into one card. On tracking pages, `[data-test-id]` selectors are unreliable; extract from `body.innerText` anchored at "Arriving" and parse carrier, tracking ID, and seller. The milestone legend is static and not live status.

<sup>Written for commit 17e88b4e468274946f9830afd58e136a3fb50379. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

