### PR TITLE
Domain skill/linkedin messaging

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,0 +1,1 @@
+{"last_synced": "2026-04-23", "synced_prs": []}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md — browser-harness
+
+## Documentation
+
+All project documentation, planning, and AI workflow instructions live in the Obsidian vault.
+
+**Project root**:
+`/Users/ahmedfareed/___all_data/___projects/utilities_/browser-harness/browser-harness`
+
+**Obsidian documentation root**:
+`/Users/ahmedfareed/___all_data/___projects/techchaps_/_obsidian_vault/Projects/Utilities/browser-harness/`
+
+**AI workflow instructions**:
+`/Users/ahmedfareed/___all_data/___projects/techchaps_/_obsidian_vault/ai-instructions/ai.md`
+
+**Workflow type**: browser-task
+
+---
+
+## Before Starting Any Work
+
+1. Read the AI workflow instructions at the path above
+2. Follow the workflow file it routes you to (`ai-instructions/workflows/browser-task.md`)
+3. Read `SKILL.md` in this repo root before every browser session
+4. Check `domain-skills/<target-site>/` before inventing new approaches
+
+## PR Policy
+
+- All PRs target `afareed007/browser-harness:main` only
+- Never open PRs to upstream `browser-use/browser-harness`
+- Branch naming: `domain-skill/<site>-<feature>` or `upstream-sync/<pr-number>`

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,6 +35,7 @@ Available interaction skills:
 
 Available domain skills:
 - `tiktok/upload.md`
+- `linkedin/messaging.md`
 
 ## Tool call shape
 

--- a/domain-skills/linkedin/messaging.md
+++ b/domain-skills/linkedin/messaging.md
@@ -1,0 +1,50 @@
+# LinkedIn — Messaging
+
+## URL
+
+Direct route: `https://www.linkedin.com/messaging/`
+
+No required query params. Loads the full inbox list immediately.
+
+## Navigation
+
+Use `goto("https://www.linkedin.com/messaging/")` on an existing tab — `new_tab()` hangs on LinkedIn (see `interaction-skills/connection.md` for the general rule).
+
+## Stable selectors
+
+| Target | Selector |
+|---|---|
+| Conversation card (each row) | `.msg-conversation-card__content--selectable` |
+| Sender name | `.msg-conversation-card__participant-names` |
+| Timestamp | `time.msg-conversation-card__time-stamp` (or `time[datetime]` inside the card) |
+| Message preview snippet | `.msg-conversation-card__message-snippet` |
+
+## Extracting the inbox via JS
+
+```python
+cards = js("""
+Array.from(document.querySelectorAll('.msg-conversation-card__content--selectable')).map(c => ({
+    name: c.querySelector('.msg-conversation-card__participant-names')?.innerText?.trim(),
+    ts:   c.querySelector('time')?.getAttribute('datetime'),
+    preview: c.querySelector('.msg-conversation-card__message-snippet')?.innerText?.trim()
+}))
+""")
+```
+
+The `datetime` attribute on `time` is ISO 8601 (e.g. `2026-04-22T14:30:00.000Z`) — use it for date filtering instead of the display text.
+
+## Invocation note
+
+When calling the harness from a background or sub-agent context, use:
+
+```bash
+uv run python -c "
+import sys; sys.path.insert(0, '.')
+from helpers import *
+goto('https://www.linkedin.com/messaging/')
+wait_for_load()
+# ...
+"
+```
+
+The `browser-harness <<'PY' ... PY` heredoc form hangs in background invocations on this repo.

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -45,3 +45,16 @@ Prefer navigating an existing tab over `new_tab()`. Tabs created via CDP's `Targ
 tab = ensure_real_tab()
 goto("https://example.com")
 ```
+
+## Heredoc hang in background invocations
+
+The `browser-harness <<'PY' ... PY` heredoc form hangs when the harness is called from a background or sub-agent context (e.g. a spawned Claude sub-agent). Use the inline form instead:
+
+```bash
+uv run python -c "
+import sys; sys.path.insert(0, '.')
+from helpers import *
+goto('https://example.com')
+wait_for_load()
+"
+```

--- a/run.py
+++ b/run.py
@@ -5,7 +5,6 @@ from admin import (
     ensure_daemon,
     list_cloud_profiles,
     list_local_profiles,
-    print_update_banner,
     restart_daemon,
     run_doctor,
     run_setup,
@@ -58,7 +57,6 @@ def main():
             "  print(page_info())\n"
             "  PY"
         )
-    print_update_banner()
     ensure_daemon()
     exec(sys.stdin.read())
 


### PR DESCRIPTION
add linkedin messaging skill

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a LinkedIn messaging domain skill with stable selectors, navigation guidance, and a JS snippet for reliable inbox extraction. Also documents a heredoc hang workaround for background runs and removes a deprecated update banner from the harness.

- **New Features**
  - LinkedIn messaging skill: stable CSS selectors, inbox extraction JS, and use `goto()` on an existing tab instead of `new_tab()`.
  - Connection skill: document heredoc hang in background contexts; recommend `uv run python -c`.
  - Register skill in `SKILL.md`.

- **Refactors**
  - Remove `print_update_banner()` from `run.py`.
  - Add `CLAUDE.md` (workflow/PR policy) and initialize `.github/upstream-sync-state.json`.

<sup>Written for commit f68f5dbae660bbecdeef2605076f55366e4a7831. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

