### PR TITLE
docs: lead README with first-buyer job

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Browser Harness ♞
 
-The simplest, thinnest, **self-healing** harness that gives LLM **complete freedom** to complete any browser task. Built directly on CDP.
+Connect an LLM directly to your real browser with a thin, editable CDP harness. For browser tasks where you need freedom, not another framework.
 
-The agent writes what's missing, mid-task. No framework, no recipes, no rails. One websocket to Chrome, nothing between.
+One websocket to Chrome, nothing between. The agent writes what's missing, mid-task; the harness heals itself when it doesn't.
 
 ```
   ● agent: wants to upload a file


### PR DESCRIPTION
Per #90, reframe the README opener to name the job (thin, editable CDP harness, freedom over framework) before claiming outcomes. Self-healing stays as a one-liner under the lede so the ASCII demo that follows reads as proof.

@sauravpanda invited this on the issue.

Fixes #90


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the README intro to lead with the job: a thin, editable CDP harness that connects an LLM to a real browser and favors freedom over frameworks. Self-healing is now a one‑liner under the lede so the ASCII demo reads as proof.

<sup>Written for commit 5d4ae44fdc833b569552494393c460c4f6a05ac1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

