### PR TITLE
fix(daemon): fire-and-forget mark-title eval so load events don't stall

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -58,6 +58,13 @@ def log(msg):
     open(LOG, "a").write(f"{msg}\n")
 
 
+async def _silent(coro):
+    try:
+        await coro
+    except Exception:
+        pass
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
@@ -154,8 +161,7 @@ class Daemon:
             elif method == "Page.javascriptDialogClosed":
                 self.dialog = None
             elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-                try: await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session), timeout=2)
-                except Exception: pass
+                asyncio.create_task(_silent(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session)))
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 

--- a/daemon.py
+++ b/daemon.py
@@ -161,7 +161,7 @@ class Daemon:
             elif method == "Page.javascriptDialogClosed":
                 self.dialog = None
             elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-                asyncio.create_task(_silent(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session)))
+                asyncio.create_task(_silent(asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session), timeout=2)))
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 


### PR DESCRIPTION
Per #136, the `tap` handler awaits `Runtime.evaluate` on both `Page.loadEventFired` and `Page.domContentEventFired`. Because `cdp-use` dispatches events one at a time, the await on `domContentEventFired` holds up `loadEventFired` in the queue, and Chrome's V8 thread is busy so the eval doesn't return in time. The user's next `js(...)` then queues behind the second eval on V8. Two ~2s waits compound per navigation.

Reporter measured the median iteration time at 4.595s with the current double-await, dropping to 1.060s with fire-and-forget. Playwright baseline on the same browser is ~0.9s.

## Change

Module-level `_silent(coro)` wrapper preserves the current `except Exception: pass` behavior (the `set_session` branch at line 172 has the same pattern around the same `send_raw` call, and the generic `handle()` path explicitly handles `"Session with given id not found"`, so the existing suppression is load-bearing, not cosmetic). The `loadEventFired` / `domContentEventFired` branch uses `asyncio.create_task(_silent(...))` to fire-and-forget. The title mark still lands a moment later, just off the critical path.

## Scope

- `daemon.py` only, +8 / -2
- `mark_js` definition unchanged
- `set_session` branch at line 172 intentionally NOT touched (runs per session-switch, not per navigation)
- No test suite in repo, verified with `python3 -m py_compile daemon.py`

Fixes #136

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the mark-title eval fire-and-forget in `daemon.py` so `Page.loadEventFired` / `Page.domContentEventFired` don’t stall the event queue, and keep a 2s timeout to avoid leaking tasks on hung V8. Removes ~2s per navigation and drops median iteration time from ~4.6s to ~1.06s (fixes #136).

- **Bug Fixes**
  - Replace awaited `Runtime.evaluate` with `asyncio.create_task(_silent(asyncio.wait_for(..., timeout=2)))` in the `tap` handler for load/DOMContent events.
  - Preserve prior exception suppression via `_silent`; `mark_js` and the `set_session` path remain unchanged.

<sup>Written for commit dc4da479c7eb12335d6b118570e0d938a2e14ccd. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/171?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

