### PR TITLE
fix(deps): pin websockets==15.0.1 to unblock Chrome 147 CDP handshake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "cdp-use==1.4.5",
     "fetch-use==0.4.0",
-    "websockets==16.0",
+    "websockets==15.0.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Per #106, `websockets==16.0` sends `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits` during the WebSocket upgrade. Chrome 147's CDP endpoint rejects this header and closes the connection (EOF after ~7 bytes). Browser-harness becomes unusable out of the box on Chrome 147 as a result.

## Change

`pyproject.toml`: `websockets==16.0` -> `websockets==15.0.1`. That is the full diff.

## Why 15.0.1 is safe

- `cdp-use==1.4.5` declares `Requires-Dist: websockets>=15.0.1`, so the floor is satisfied. No cdp-use API is dropped.
- 15.0.1 is the highest release on PyPI before the 16.0 handshake change.
- OSV database: all published `websockets` CVEs (GHSA-6g87-ff9q-v847, GHSA-8ch4-58qp-g3mp, PYSEC-2018-79, PYSEC-2021-95) were fixed at or before version 9.1. Rolling back from 16.0 to 15.0.1 drops no security fix.

## What this does NOT do

- Does NOT touch `cdp-use==1.4.5` or `fetch-use==0.4.0` pins
- Does NOT pursue the upstream fix (cdp-use passing `compression=None` to `websockets.connect()`). That belongs in cdp-use, not here.
- Does NOT add a raw-socket fallback. Larger change, not needed once the pin is rolled.

## Relationship to #142 and #102

PR #142 is fixing `Fixes #107, #123` and is `Related to #106`, but #142 addresses the Chrome 147 profile-directory block, not the handshake-header path. Both land on the same "Chrome 147 breaks this" symptom from different root causes. This PR is the complementary fix. Both can merge independently.

## Local verification

Fresh venv, install from this branch:

```
$ python3 -m venv /tmp/bh-test && source /tmp/bh-test/bin/activate
$ pip install -e .
$ pip show websockets | grep Version
Version: 15.0.1
$ pip show cdp-use | grep Version
Version: 1.4.5
$ python3 -c "import websockets, cdp_use; from cdp_use.client import CDPClient; print(websockets.__version__)"
15.0.1
```

`uv.lock` is gitignored upstream, so no lock-file diff lands in this PR.

Fixes #106


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `websockets` to `15.0.1` to restore the Chrome 147 CDP handshake by avoiding the `permessage-deflate` header sent by `16.0`. Unblocks the browser harness on Chrome 147. Fixes #106.

- **Dependencies**
  - `pyproject.toml`: change `websockets` from `16.0` to `15.0.1`.
  - Compatible with `cdp-use==1.4.5`; no other pins changed.

<sup>Written for commit 4faf1d7414f12e62a5cdfc58b0d37de60c7a6ba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

