### PR TITLE
Add macOS Brave profile path + port-9222/9223 CDP probe fallback

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -31,6 +31,7 @@ PROFILES = [
     Path.home() / "Library/Application Support/Microsoft Edge Beta",
     Path.home() / "Library/Application Support/Microsoft Edge Dev",
     Path.home() / "Library/Application Support/Microsoft Edge Canary",
+    Path.home() / "Library/Application Support/BraveSoftware/Brave-Browser",
     Path.home() / ".config/google-chrome",
     Path.home() / ".config/chromium",
     Path.home() / ".config/chromium-browser",
@@ -82,6 +83,12 @@ def get_ws_url():
             finally:
                 probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+    for probe_port in (9222, 9223):
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{probe_port}/json/version", timeout=1) as r:
+                return json.loads(r.read())["webSocketDebuggerUrl"]
+        except (OSError, KeyError, ValueError):
+            continue
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 


### PR DESCRIPTION
## Summary

Two small additive fixes in `daemon.py` so macOS users running Brave (or any Chromium variant launched with `--remote-debugging-port`) can attach without manual `BU_CDP_WS` wiring.

1. **Add macOS Brave profile path to `PROFILES`.** The list previously only had the Linux Flatpak path for Brave (`~/.var/app/com.brave.Browser/...`), so macOS Brave users hit `DevToolsActivePort not found` even with the sticky inspect checkbox enabled. Adds `~/Library/Application Support/BraveSoftware/Brave-Browser`.

2. **Probe `127.0.0.1:9222` / `:9223` `/json/version` as a final fallback in `get_ws_url()`.** When Chromium is launched with an explicit `--remote-debugging-port` flag, `DevToolsActivePort` is not always written to the profile dir — CDP is fully live but the existing scan misses it. The fallback runs only after the profile-dir scan fails, and is gated to the standard debugging ports, so the normal sticky-checkbox flow is unaffected.

Both changes are additive — no existing behavior is altered.

## Test plan

- [x] On macOS with Brave launched via `open -a "Brave Browser" --args --remote-debugging-port=9222` and no `DevToolsActivePort` file present, `browser-harness <<<'print(page_info())'` attaches to the running browser via the new probe fallback.
- [ ] Sanity-check on Chrome with the sticky inspect checkbox (existing flow) still works unchanged.
- [ ] Linux/Windows users unaffected (paths and probe are macOS/Linux-friendly; probe is universal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable automatic CDP attachment for macOS Brave and Chromium launched with `--remote-debugging-port`, removing the need to set `BU_CDP_WS`. Adds a macOS Brave profile path and a last-resort probe of ports 9222/9223; existing flows stay the same.

- **Bug Fixes**
  - Added macOS Brave profile path: `~/Library/Application Support/BraveSoftware/Brave-Browser`.
  - If no `DevToolsActivePort` is found, probe `http://127.0.0.1:9222/json/version` and `:9223` and use `webSocketDebuggerUrl`.

<sup>Written for commit 704b1d41b7fcee033073df153c6432f70cd222d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

