### PR TITLE
feat(transport): cross-platform IPC with TCP loopback on Windows

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -154,7 +154,7 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 ## Architecture
 
 ```text
-Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.py
+Chrome / Browser Use cloud -> CDP WS -> daemon.py -> local IPC (UDS on POSIX, TCP loopback on Windows) -> run.py
 ```
 
 - Protocol is one JSON line each way.
@@ -182,7 +182,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
   `restart_daemon()`
   `PY`
   before assuming setup is wrong.
-- If `restart_daemon()` also hangs, kill Chrome entirely (`pkill -9 -f "Google Chrome"`), clean sockets (`rm -f /tmp/bu-default.sock /tmp/bu-default.pid`), reopen Chrome (`open -a "Google Chrome"`), wait 5s, then reconnect. This resets all CDP state.
+- If `restart_daemon()` also hangs, kill Chrome entirely (POSIX: `pkill -9 -f "Google Chrome"`; Windows: `taskkill /F /IM chrome.exe`), clean stale state in `$TMPDIR`/`%TEMP%` (`bu-default.endpoint`, `bu-default.sock` on POSIX, `bu-default.pid`), reopen Chrome, wait 5s, then reconnect. This resets all CDP state.
 - Browser Use API is camelCase on the wire. `cdpUrl`, `proxyCountryCode`, etc.
 - Remote `cdpUrl` is HTTPS, not ws. Resolve the websocket URL via `/json/version`.
 - Stop cloud browsers with `PATCH /browsers/{id}` + `{\"action\":\"stop\"}`.

--- a/admin.py
+++ b/admin.py
@@ -5,6 +5,8 @@ import time
 import urllib.request
 from pathlib import Path
 
+import transport
+
 
 def _load_env():
     p = Path(__file__).parent / ".env"
@@ -23,73 +25,66 @@ _load_env()
 NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"
 GH_RELEASES = "https://api.github.com/repos/browser-use/browser-harness/releases/latest"
-VERSION_CACHE = Path("/tmp/bu-version-cache.json")
+VERSION_CACHE = transport.version_cache_path()
 VERSION_CACHE_TTL = 24 * 3600
 
 
-def _paths(name):
-    n = name or NAME
-    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
-
-
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
     try:
-        return Path(p).read_text().strip().splitlines()[-1]
+        return transport.log_path(name or NAME).read_text().strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
         return None
 
 
 def daemon_alive(name=None):
-    try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(1)
-        s.connect(_paths(name)[0])
-        s.close()
-        return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
-        return False
+    return transport.is_alive(name or NAME, timeout=1.0)
 
 
 def ensure_daemon(wait=60.0, name=None, env=None):
     """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
-    if daemon_alive(name):
+    n = name or NAME
+    if daemon_alive(n):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
         try:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
-            s.connect(_paths(name)[0])
+            s = transport.open_client_sync(n, timeout=3)
             s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
             data = b""
             while not data.endswith(b"\n"):
                 chunk = s.recv(1 << 16)
                 if not chunk: break
                 data += chunk
+            s.close()
             if b'"result"' in data: return
         except Exception: pass
-        restart_daemon(name)
+        restart_daemon(n)
+    else:
+        # Clean up any stale endpoint file so the fresh daemon gets a clean bind.
+        transport.cleanup_endpoint(n)
+        transport.cleanup_server_files(n)
 
     import subprocess, sys
     local = not (env or {}).get("BU_CDP_WS") and not os.environ.get("BU_CDP_WS")
     for attempt in (0, 1):
-        e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
+        e = {**os.environ, **({"BU_NAME": n} if n else {}), **(env or {})}
         p = subprocess.Popen(
             ["uv", "run", "daemon.py"],
             cwd=os.path.dirname(os.path.abspath(__file__)),
-            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            **transport.popen_detach_kwargs(),
         )
         deadline = time.time() + wait
         while time.time() < deadline:
-            if daemon_alive(name): return
+            if daemon_alive(n): return
             if p.poll() is not None: break
             time.sleep(0.2)
-        msg = _log_tail(name) or ""
+        msg = _log_tail(n) or ""
         if local and attempt == 0 and ("DevToolsActivePort not found" in msg or "not live yet" in msg or ("WS handshake failed" in msg and "403" in msg)):
             _open_chrome_inspect()
             print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
-            restart_daemon(name)
+            restart_daemon(n)
             continue
-        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+        raise RuntimeError(msg or f"daemon {n} didn't come up -- check {transport.log_path(n)}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -107,25 +102,24 @@ def stop_remote_daemon(name="remote"):
 
 
 def restart_daemon(name=None):
-    """Best-effort daemon shutdown + socket/pid cleanup.
+    """Best-effort daemon shutdown + endpoint/socket/pid cleanup.
 
     Name is historical: callers typically follow this with another
     `browser-harness` invocation, which auto-spawns a fresh daemon via
     ensure_daemon(). The function itself only stops."""
     import signal
 
-    sock, pid_path = _paths(name)
+    n = name or NAME
+    pid_path = transport.pid_path(n)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(5)
-        s.connect(sock)
+        s = transport.open_client_sync(n, timeout=5)
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
         s.close()
     except Exception:
         pass
     try:
-        pid = int(open(pid_path).read())
+        pid = int(pid_path.read_text())
     except (FileNotFoundError, ValueError):
         pid = None
     if pid:
@@ -133,18 +127,19 @@ def restart_daemon(name=None):
             try:
                 os.kill(pid, 0)
                 time.sleep(0.2)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 break
         else:
             try:
                 os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 pass
-    for f in (sock, pid_path):
-        try:
-            os.unlink(f)
-        except FileNotFoundError:
-            pass
+    transport.cleanup_endpoint(n)
+    transport.cleanup_server_files(n)
+    try:
+        pid_path.unlink()
+    except FileNotFoundError:
+        pass
 
 
 def _browser_use(path, method, body=None):
@@ -509,6 +504,8 @@ def run_doctor():
     # for display would otherwise be parsed as (0,) and flag every latest as newer.
     newer = bool(cur and latest and _version_tuple(latest) > _version_tuple(cur))
     cur_display = cur or "(unknown)"
+    transport_kind = "tcp" if transport.is_tcp() else "uds"
+    endpoint_desc = transport.read_endpoint(NAME)
 
     def row(label, ok, detail=""):
         mark = "ok  " if ok else "FAIL"
@@ -522,6 +519,12 @@ def run_doctor():
         print(f"  latest release    {latest}" + (" (update available)" if newer else ""))
     else:
         print("  latest release    (could not reach github)")
+    if endpoint_desc and endpoint_desc.get("kind") == "tcp":
+        print(f"  transport         tcp {endpoint_desc['host']}:{endpoint_desc['port']} (name={NAME})")
+    elif endpoint_desc and endpoint_desc.get("kind") == "uds":
+        print(f"  transport         uds {endpoint_desc['path']} (name={NAME})")
+    else:
+        print(f"  transport         {transport_kind} (name={NAME}, no endpoint file — daemon not running)")
     row("chrome running", chrome, "" if chrome else "start chrome/edge and rerun `browser-harness --setup`")
     row("daemon alive", daemon, "" if daemon else "run `browser-harness --setup` to attach")
     row("profile-use installed", profile_use, "" if profile_use else "optional: curl -fsSL https://browser-use.com/profile.sh | sh")

--- a/daemon.py
+++ b/daemon.py
@@ -1,9 +1,15 @@
-"""CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
+"""CDP WS holder + local IPC relay. One daemon per BU_NAME.
+
+The IPC endpoint is a Unix Domain Socket on POSIX and a loopback-only TCP
+listener on Windows; ``transport.py`` owns the OS detection.
+"""
 import asyncio, json, os, socket, sys, time, urllib.request
 from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
+
+import transport
 
 
 def _load_env():
@@ -21,9 +27,8 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+LOG = str(transport.log_path(NAME))
+PID = str(transport.pid_path(NAME))
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -192,9 +197,6 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
-        os.unlink(SOCK)
-
     async def handler(reader, writer):
         try:
             line = await reader.readline()
@@ -212,11 +214,16 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
-    async with server:
-        await d.stop.wait()
+    server = await transport.start_ipc_server(NAME, handler)
+    desc = transport.read_endpoint(NAME)
+    endpoint = desc.get("path") if desc.get("kind") == "uds" else f"{desc['host']}:{desc['port']}"
+    log(f"listening on {desc['kind']}:{endpoint} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    try:
+        async with server:
+            await d.stop.wait()
+    finally:
+        transport.cleanup_endpoint(NAME)
+        transport.cleanup_server_files(NAME)
 
 
 async def main():
@@ -226,16 +233,12 @@ async def main():
 
 
 def already_running():
-    try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
-        return False
+    return transport.is_alive(NAME)
 
 
 if __name__ == "__main__":
     if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
+        print(f"daemon already running for {NAME!r}", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
     open(PID, "w").write(str(os.getpid()))

--- a/helpers.py
+++ b/helpers.py
@@ -1,7 +1,9 @@
 """Browser control via CDP. Read, edit, extend -- this file is yours."""
-import base64, json, os, socket, time, urllib.request
+import base64, json, os, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
+
+import transport
 
 
 def _load_env():
@@ -19,13 +21,11 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
 def _send(req):
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
+    s = transport.open_client_sync(NAME)
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):
@@ -98,7 +98,10 @@ def scroll(x, y, dy=-300, dx=0):
 
 
 # --- visual ---
-def screenshot(path="/tmp/shot.png", full=False):
+def screenshot(path=None, full=False):
+    """Default path is OS-specific: /tmp/shot.png on POSIX, %TEMP%\\shot.png on Windows."""
+    if path is None:
+        path = str(transport.state_dir() / "shot.png")
     r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
     open(path, "wb").write(base64.b64decode(r["data"]))
     return path

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -16,9 +16,8 @@ The daemon's `attach_first_page()` handles this by creating an `about:blank` tab
 
 ```python
 if not daemon_alive():
-    import os
-    for f in ["/tmp/bu-default.sock", "/tmp/bu-default.pid"]:
-        if os.path.exists(f): os.unlink(f)
+    # ensure_daemon() cleans up stale endpoint / pid files internally
+    # across POSIX (UDS) and Windows (TCP loopback).
     ensure_daemon()
 
 tabs = list_tabs()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ dependencies = [
 browser-harness = "run:main"
 
 [tool.setuptools]
-py-modules = ["run", "helpers", "daemon", "admin"]
+py-modules = ["run", "helpers", "daemon", "admin", "transport"]

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,292 @@
+"""Cross-platform IPC transport tests.
+
+Logic tests use monkeypatch for sys.platform, so both OS branches
+are covered on any host. Tests that actually bind a socket use the
+host's real OS — we just ensure UDS/TCP behavior is equivalent.
+"""
+import asyncio
+import json
+import os
+import socket
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import transport
+
+
+# --- state_dir --------------------------------------------------------------
+
+def test_state_dir_posix_returns_tmp(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert transport.state_dir() == Path("/tmp")
+
+
+def test_state_dir_windows_uses_temp_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    assert transport.state_dir() == tmp_path
+
+
+def test_state_dir_windows_falls_back_to_gettempdir(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("TEMP", raising=False)
+    monkeypatch.delenv("TMP", raising=False)
+    # gettempdir always returns something even without TEMP/TMP
+    assert transport.state_dir() == Path(tempfile.gettempdir())
+
+
+# --- path helpers -----------------------------------------------------------
+
+def test_endpoint_path_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert transport.endpoint_path("default") == Path("/tmp/bu-default.endpoint")
+    assert transport.endpoint_path("work") == Path("/tmp/bu-work.endpoint")
+
+
+def test_endpoint_path_windows_under_temp(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    assert transport.endpoint_path("default") == tmp_path / "bu-default.endpoint"
+
+
+def test_pid_path_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert transport.pid_path("default") == Path("/tmp/bu-default.pid")
+
+
+def test_log_path_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert transport.log_path("default") == Path("/tmp/bu-default.log")
+
+
+def test_version_cache_path_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert transport.version_cache_path() == Path("/tmp/bu-version-cache.json")
+
+
+def test_version_cache_path_windows(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    assert transport.version_cache_path() == tmp_path / "bu-version-cache.json"
+
+
+# --- kind / is_tcp ----------------------------------------------------------
+
+def test_is_tcp_false_on_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert transport.is_tcp() is False
+
+
+def test_is_tcp_true_on_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert transport.is_tcp() is True
+
+
+# --- endpoint descriptor I/O ------------------------------------------------
+
+def test_write_endpoint_atomic_uses_replace(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    desc = {"v": 1, "kind": "tcp", "host": "127.0.0.1", "port": 12345}
+    transport.write_endpoint("default", desc)
+    on_disk = json.loads((tmp_path / "bu-default.endpoint").read_text())
+    assert on_disk == desc
+    # no orphan .tmp file left behind
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_read_endpoint_returns_none_when_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    assert transport.read_endpoint("default") is None
+
+
+def test_read_endpoint_round_trips(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    desc = {"v": 1, "kind": "uds", "path": "/tmp/bu-foo.sock"}
+    transport.write_endpoint("foo", desc)
+    assert transport.read_endpoint("foo") == desc
+
+
+def test_read_endpoint_returns_none_for_malformed_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    (tmp_path / "bu-broken.endpoint").write_text("not json")
+    assert transport.read_endpoint("broken") is None
+
+
+def test_cleanup_endpoint_removes_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    transport.write_endpoint("x", {"v": 1, "kind": "tcp", "host": "127.0.0.1", "port": 1})
+    assert (tmp_path / "bu-x.endpoint").exists()
+    transport.cleanup_endpoint("x")
+    assert not (tmp_path / "bu-x.endpoint").exists()
+
+
+def test_cleanup_endpoint_is_idempotent(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    transport.cleanup_endpoint("never-existed")  # must not raise
+
+
+# --- popen detach kwargs ----------------------------------------------------
+
+def test_popen_detach_kwargs_posix(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    kw = transport.popen_detach_kwargs()
+    assert kw == {"start_new_session": True}
+
+
+def test_popen_detach_kwargs_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    import subprocess
+    kw = transport.popen_detach_kwargs()
+    assert "creationflags" in kw
+    assert kw["creationflags"] & subprocess.DETACHED_PROCESS
+    assert kw["creationflags"] & subprocess.CREATE_NEW_PROCESS_GROUP
+    assert "start_new_session" not in kw
+
+
+# --- real-socket integration (uses host OS) --------------------------------
+# These don't monkeypatch — they exercise the REAL transport against the
+# REAL operating system. On Linux/macOS this drives the UDS branch; on
+# Windows it drives the TCP branch. Both must work end-to-end.
+
+
+def test_is_alive_false_when_no_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    assert transport.is_alive("ghost") is False
+
+
+def test_is_alive_false_when_port_not_listening(tmp_path, monkeypatch):
+    """Endpoint file points at 127.0.0.1:port but nothing is listening."""
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    # grab + release a port to get a guaranteed-free number
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    free_port = s.getsockname()[1]
+    s.close()
+    transport.write_endpoint("dead", {"v": 1, "kind": "tcp",
+                                      "host": "127.0.0.1", "port": free_port})
+    assert transport.is_alive("dead") is False
+
+
+def _run_server_and_connect(tmp_path, name):
+    """Helper: spin up transport.start_ipc_server, connect via
+    open_client_sync on an executor thread (sync calls would otherwise
+    deadlock the event loop that's running the handler), assert echo."""
+    async def handler(reader, writer):
+        line = await reader.readline()
+        writer.write(line)  # echo
+        await writer.drain()
+        writer.close()
+
+    def sync_client():
+        s = transport.open_client_sync(name, timeout=5)
+        try:
+            s.sendall(b'{"hello":1}\n')
+            data = b""
+            while not data.endswith(b"\n"):
+                chunk = s.recv(1024)
+                if not chunk:
+                    break
+                data += chunk
+            return data
+        finally:
+            s.close()
+
+    async def driver():
+        server = await transport.start_ipc_server(name, handler)
+        async with server:
+            assert transport.is_alive(name) is True
+            loop = asyncio.get_running_loop()
+            data = await loop.run_in_executor(None, sync_client)
+            assert data == b'{"hello":1}\n'
+            server.close()
+            await server.wait_closed()
+        transport.cleanup_endpoint(name)
+        transport.cleanup_server_files(name)
+
+    asyncio.run(driver())
+
+
+def test_roundtrip_client_server_local_os(tmp_path, monkeypatch):
+    """Full integration on the current OS — UDS on POSIX, TCP on Windows."""
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+    _run_server_and_connect(tmp_path, "default")
+
+
+def test_descriptor_has_version_field(tmp_path, monkeypatch):
+    """Forward-compat: descriptor always carries `v: 1`."""
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+
+    async def handler(reader, writer):
+        writer.close()
+
+    async def driver():
+        server = await transport.start_ipc_server("vtest", handler)
+        try:
+            desc = transport.read_endpoint("vtest")
+            assert desc is not None
+            assert desc["v"] == 1
+            assert desc["kind"] in ("uds", "tcp")
+        finally:
+            server.close()
+            await server.wait_closed()
+            transport.cleanup_endpoint("vtest")
+            transport.cleanup_server_files("vtest")
+
+    asyncio.run(driver())
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="UDS chmod only meaningful on POSIX")
+def test_uds_socket_file_is_0600_on_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+
+    async def handler(reader, writer):
+        writer.close()
+
+    async def driver():
+        server = await transport.start_ipc_server("perms", handler)
+        try:
+            desc = transport.read_endpoint("perms")
+            assert desc["kind"] == "uds"
+            mode = os.stat(desc["path"]).st_mode & 0o777
+            assert mode == 0o600, f"expected 0o600 got {oct(mode)}"
+        finally:
+            server.close()
+            await server.wait_closed()
+            transport.cleanup_endpoint("perms")
+            transport.cleanup_server_files("perms")
+
+    asyncio.run(driver())
+
+
+@pytest.mark.skipif(sys.platform != "win32",
+                    reason="TCP loopback bind only exercised on Windows branch")
+def test_tcp_binds_loopback_only_on_windows(tmp_path, monkeypatch):
+    monkeypatch.setattr(transport, "state_dir", lambda: tmp_path)
+
+    async def handler(reader, writer):
+        writer.close()
+
+    async def driver():
+        server = await transport.start_ipc_server("wintcp", handler)
+        try:
+            desc = transport.read_endpoint("wintcp")
+            assert desc["kind"] == "tcp"
+            assert desc["host"] == "127.0.0.1"  # NEVER 0.0.0.0
+            assert isinstance(desc["port"], int) and desc["port"] > 0
+        finally:
+            server.close()
+            await server.wait_closed()
+            transport.cleanup_endpoint("wintcp")
+            transport.cleanup_server_files("wintcp")
+
+    asyncio.run(driver())

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -144,11 +144,14 @@ def test_popen_detach_kwargs_posix(monkeypatch):
 
 def test_popen_detach_kwargs_windows(monkeypatch):
     monkeypatch.setattr(sys, "platform", "win32")
-    import subprocess
     kw = transport.popen_detach_kwargs()
     assert "creationflags" in kw
-    assert kw["creationflags"] & subprocess.DETACHED_PROCESS
-    assert kw["creationflags"] & subprocess.CREATE_NEW_PROCESS_GROUP
+    # Numeric flags per MSDN so this test works on POSIX runners too
+    # (subprocess module there has no DETACHED_PROCESS attribute).
+    DETACHED_PROCESS = 0x00000008
+    CREATE_NEW_PROCESS_GROUP = 0x00000200
+    assert kw["creationflags"] & DETACHED_PROCESS
+    assert kw["creationflags"] & CREATE_NEW_PROCESS_GROUP
     assert "start_new_session" not in kw
 
 

--- a/transport.py
+++ b/transport.py
@@ -93,10 +93,18 @@ def cleanup_server_files(name: str) -> None:
 
 # --- Popen detach ----------------------------------------------------------
 
+# subprocess.DETACHED_PROCESS / CREATE_NEW_PROCESS_GROUP are Windows-only
+# attributes. We look them up defensively so this module imports cleanly on
+# POSIX (where the values are never actually used at runtime, but are still
+# reachable via the monkeypatched cross-platform tests).
+_WIN_DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+_WIN_CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+
+
 def popen_detach_kwargs() -> dict:
     """Kwargs so subprocess.Popen spawns a detached daemon on this OS."""
     if sys.platform == "win32":
-        return {"creationflags": subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP}
+        return {"creationflags": _WIN_DETACHED_PROCESS | _WIN_CREATE_NEW_PROCESS_GROUP}
     return {"start_new_session": True}
 
 

--- a/transport.py
+++ b/transport.py
@@ -1,0 +1,166 @@
+"""Cross-platform IPC transport for the browser-harness daemon.
+
+POSIX : Unix Domain Socket at <state_dir>/bu-<NAME>.sock
+Windows: TCP on 127.0.0.1 with a kernel-assigned port (bind is loopback-only).
+
+Callers never check ``sys.platform`` themselves — everything OS-specific is
+behind this module. Both the daemon and the clients read the endpoint
+descriptor (``<state_dir>/bu-<NAME>.endpoint``, JSON with a ``v`` version
+field) to discover where to connect.
+"""
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+# --- state directory + path helpers ----------------------------------------
+
+def state_dir() -> Path:
+    if sys.platform == "win32":
+        return Path(os.environ.get("TEMP") or os.environ.get("TMP") or tempfile.gettempdir())
+    return Path("/tmp")
+
+
+def endpoint_path(name: str) -> Path:
+    return state_dir() / f"bu-{name}.endpoint"
+
+
+def pid_path(name: str) -> Path:
+    return state_dir() / f"bu-{name}.pid"
+
+
+def log_path(name: str) -> Path:
+    return state_dir() / f"bu-{name}.log"
+
+
+def version_cache_path() -> Path:
+    return state_dir() / "bu-version-cache.json"
+
+
+def _sock_path(name: str) -> Path:
+    # Internal: the UDS socket file lives next to the endpoint file.
+    return state_dir() / f"bu-{name}.sock"
+
+
+# --- kind ------------------------------------------------------------------
+
+def is_tcp() -> bool:
+    return sys.platform == "win32"
+
+
+# --- endpoint descriptor I/O -----------------------------------------------
+
+def write_endpoint(name: str, descriptor: dict) -> None:
+    """Atomic: write to a sibling .tmp file, then os.replace()."""
+    target = endpoint_path(name)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(descriptor))
+    os.replace(tmp, target)
+
+
+def read_endpoint(name: str) -> dict | None:
+    try:
+        raw = endpoint_path(name).read_text()
+    except FileNotFoundError:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def cleanup_endpoint(name: str) -> None:
+    try:
+        endpoint_path(name).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def cleanup_server_files(name: str) -> None:
+    """Also remove the UDS socket file (no-op on TCP)."""
+    if is_tcp():
+        return
+    try:
+        _sock_path(name).unlink()
+    except FileNotFoundError:
+        pass
+
+
+# --- Popen detach ----------------------------------------------------------
+
+def popen_detach_kwargs() -> dict:
+    """Kwargs so subprocess.Popen spawns a detached daemon on this OS."""
+    if sys.platform == "win32":
+        return {"creationflags": subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+# --- async server ----------------------------------------------------------
+
+async def start_ipc_server(name: str, handler) -> asyncio.Server:
+    """Start the IPC listener and publish its endpoint descriptor.
+
+    On POSIX this creates an AF_UNIX server chmod'd to 0o600; on Windows a
+    loopback-only TCP server. The endpoint file is written *after* the
+    listener is up and the real port (TCP) or socket path (UDS) is known.
+    Callers should ``async with server: ...`` and call
+    ``cleanup_endpoint(name)`` + ``cleanup_server_files(name)`` on shutdown.
+    """
+    if is_tcp():
+        server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
+        host, port = server.sockets[0].getsockname()[:2]
+        descriptor = {"v": 1, "kind": "tcp", "host": host, "port": int(port)}
+    else:
+        sock = _sock_path(name)
+        if sock.exists():
+            sock.unlink()
+        server = await asyncio.start_unix_server(handler, path=str(sock))
+        os.chmod(sock, 0o600)
+        descriptor = {"v": 1, "kind": "uds", "path": str(sock)}
+
+    write_endpoint(name, descriptor)
+    return server
+
+
+# --- sync client (mirrors helpers.py / admin.py usage) ---------------------
+
+def open_client_sync(name: str, timeout: float | None = None) -> socket.socket:
+    """Open + connect a blocking socket to the daemon. Raises if no endpoint
+    file exists or the daemon isn't accepting connections."""
+    desc = read_endpoint(name)
+    if desc is None:
+        raise FileNotFoundError(f"no endpoint for {name!r} at {endpoint_path(name)}")
+    kind = desc.get("kind")
+    if kind == "tcp":
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if timeout is not None:
+            s.settimeout(timeout)
+        s.connect((desc["host"], int(desc["port"])))
+        return s
+    if kind == "uds":
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if timeout is not None:
+            s.settimeout(timeout)
+        s.connect(desc["path"])
+        return s
+    raise ValueError(f"unknown endpoint kind {kind!r} for {name!r}")
+
+
+def is_alive(name: str, timeout: float = 1.0) -> bool:
+    """True if a client can connect to the endpoint right now.
+
+    False for: no endpoint file, malformed descriptor, refused/timeout/missing
+    target. Stale endpoint files (descriptor present, nothing listening) are
+    also False — callers handle the unlink.
+    """
+    try:
+        s = open_client_sync(name, timeout=timeout)
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError, ValueError):
+        return False
+    s.close()
+    return True


### PR DESCRIPTION
## Summary

Native Windows support for the daemon. Today `asyncio.start_unix_server` raises `NotImplementedError` on Windows and every path is hardcoded under `/tmp/`, so the daemon crashes before listening and `browser-harness --doctor` traceback's out. This PR:

- adds `transport.py` — a small module that owns OS-specific state paths and IPC server/client creation. AF_UNIX on POSIX, AF_INET on `127.0.0.1:<kernel-assigned-port>` on Windows (loopback-only bind — no new deps, no named pipes, no pywin32).
- routes `daemon.py`, `admin.py`, `helpers.py` through it. **Zero `sys.platform` checks outside `transport.py`.**
- writes an atomic endpoint descriptor (`%TEMP%\bu-<NAME>.endpoint` / `/tmp/bu-<NAME>.endpoint`):
  ```json
  {""v"": 1, ""kind"": ""tcp"", ""host"": ""127.0.0.1"", ""port"": 52137}
  ```
  `v: 1` keeps the shape forward-compatible (named pipes, per-name tokens, etc. can opt-in without breaking clients). Written after the listener binds, cleaned up in `finally` and on stale-daemon detection.
- migrates `log` / `pid` / `version-cache` paths to `transport.state_dir()` — they were hardcoded `/tmp/bu-*`, which meant the daemon crashed on Windows at `open(LOG, 'w')` before it even tried to listen.
- detaches `subprocess.Popen` correctly per OS: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows, `start_new_session=True` on POSIX.
- guards `os.chmod(SOCK, 0o600)` (no-op on TCP — there's no file, and loopback-only bind IS the access control).
- `--doctor` gains a `transport` row:
  ```
  transport         tcp 127.0.0.1:52137 (name=default)
  ```
  or, on POSIX with the daemon running:
  ```
  transport         uds /tmp/bu-default.sock (name=default)
  ```
- `helpers.screenshot()` default path moves from `/tmp/shot.png` to `transport.state_dir() / 'shot.png'` so it doesn't crash on Windows.

`run.py` is not touched (per the design constraint in `SKILL.md`).

### Security

TCP listener binds to `127.0.0.1`, not `0.0.0.0`. Same threat model as Jupyter / ADB / Selenium Grid when run locally. No token in the endpoint file — happy to add one in a follow-up if you'd prefer explicit auth.

### Acceptance — verified on Windows 10 x64 + Python 3.13 + Chrome 147

```
$ browser-harness --doctor
browser-harness doctor
  platform          Windows 10
  python            3.13.12
  version           0.1.0 (git)
  transport         tcp 127.0.0.1:52137 (name=default)
  [ok  ] chrome running
  [ok  ] daemon alive

$ browser-harness <<'PY'
print(page_info())
PY
{'url': 'about:blank', 'title': '', 'w': 929, 'h': 925, 'sx': 0, 'sy': 0, 'pw': 929, 'ph': 925}
```

### Test plan

- [x] `uv run --with pytest pytest tests/` — 24 passed, 1 skipped (UDS chmod test skipped on Windows by design). Logic tests cover both OS branches via `monkeypatch.setattr(sys, 'platform', ...)` so Linux CI also exercises the Windows branch.
- [x] `browser-harness --doctor` on Windows (no daemon) — no traceback, transport row reads `tcp (name=default, no endpoint file — daemon not running)`.
- [x] `browser-harness --doctor` on Windows (daemon alive) — `daemon alive = ok`, endpoint descriptor on disk with `v: 1`, `kind: tcp`, `host: 127.0.0.1`, kernel-assigned port.
- [x] Full heredoc `page_info()` round-trip on Windows returns the expected dict (exit 0).
- [x] `restart_daemon()` cleans up endpoint + socket + pid files cross-platform.
- [ ] macOS / Linux smoke — untouched code path; the AF_UNIX branch is exercised by `test_roundtrip_client_server_local_os` which on POSIX CI will hit `start_unix_server` + UDS client (currently only verified via monkeypatch).

### Files changed

| File | Δ |
|---|---|
| `transport.py` (new) | +160 |
| `tests/test_transport.py` (new) | +245 |
| `tests/__init__.py` (new) | 0 |
| `daemon.py` | +20 / -20 |
| `admin.py` | +40 / -40 |
| `helpers.py` | +7 / -7 |
| `SKILL.md` | +2 / -2 |
| `interaction-skills/connection.md` | +2 / -3 |
| `pyproject.toml` | +1 / -1 (add `transport` to `py-modules`) |

Net: +534 / -68 across 9 files. Tests + new module are the bulk of the line count; behavioral delta on existing files is roughly 70 lines on each side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross‑platform IPC so the daemon runs on Windows: UDS on POSIX, loopback TCP on Windows, with OS paths and startup centralized in `transport.py`. This unblocks `browser-harness` on Windows and adds a transport row to `--doctor` for visibility.

- New Features
  - `transport.py` centralizes state paths and IPC: AF_UNIX on POSIX, TCP `127.0.0.1:<port>` on Windows; writes an atomic endpoint descriptor (`v: 1`).
  - `daemon.py`, `admin.py`, and `helpers.py` now use `transport` (no `sys.platform` checks); `--doctor` shows transport; `helpers.screenshot()` defaults to `transport.state_dir()`.
  - Correct daemon detachment per OS: `start_new_session=True` on POSIX; `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows. Tests cover both OS branches and a real local round‑trip.

- Bug Fixes
  - Windows: no more crashes from `/tmp`/UDS; daemon starts and clients connect over TCP loopback.
  - Stale endpoint/socket files are cleaned up on ensure/restart; `chmod` on UDS is guarded (no‑op on TCP).
  - POSIX CI: guard Windows‑only `subprocess` flags in `transport.popen_detach_kwargs()` so monkeypatched tests pass on Linux/macOS.

<sup>Written for commit 391faa3c4ff40450905a60ddc0ecb33627843e0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

