### PR TITLE
fix(helpers): short timeout on switch_tab unmark to avoid stale-session hang

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -23,8 +23,10 @@ SOCK = f"/tmp/bu-{NAME}.sock"
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
-def _send(req):
+def _send(req, timeout=None):
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    if timeout is not None:
+        s.settimeout(timeout)
     s.connect(SOCK)
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
@@ -38,9 +40,11 @@ def _send(req):
     return r
 
 
-def cdp(method, session_id=None, **params):
-    """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1)."""
-    return _send({"method": method, "params": params, "session_id": session_id}).get("result", {})
+def cdp(method, session_id=None, timeout=None, **params):
+    """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1).
+    Pass timeout=<seconds> for best-effort calls that shouldn't block forever
+    (e.g. touching a possibly-stale session — see switch_tab's unmark step)."""
+    return _send({"method": method, "params": params, "session_id": session_id}, timeout=timeout).get("result", {})
 
 
 def drain_events():  return _send({"meta": "drain_events"})["events"]
@@ -124,8 +128,10 @@ def _mark_tab():
     except Exception: pass
 
 def switch_tab(target_id):
-    # Unmark old tab
-    try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F7E2 '))document.title=document.title.slice(2)")
+    # Unmark old tab. Short timeout: if the attached session's target is gone
+    # (tab closed, crashed, never woken), the daemon has nothing to reply with
+    # and this cosmetic call would otherwise hang forever, wedging switch_tab.
+    try: cdp("Runtime.evaluate", timeout=2, expression="if(document.title.startsWith('\U0001F7E2 '))document.title=document.title.slice(2)")
     except Exception: pass
     cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]


### PR DESCRIPTION
## Problem

`switch_tab()` can hang indefinitely when the daemon's currently-attached
session points at a target that isn't actually live anymore (tab closed,
crashed, or a stale session left over after a Chrome restart).

The first line of `switch_tab` runs a cosmetic `Runtime.evaluate` on that
session to strip the 🟢 title marker from the old tab. If the target is
gone, CDP never answers, and `_send`'s blocking `recv()` loop waits forever.
The `try/except` around the call catches exceptions, not hangs — so the
whole function wedges, and everything layered on top of it (`new_tab`,
`ensure_real_tab`, the autoswitch inside `new_tab`, …) wedges with it.

Hit this today setting up the harness against a Chrome instance that had
been restarted mid-session: `daemon.py` reattached cleanly (port, ws URL,
`/json/version` all good), `list_tabs` worked, but every `new_tab` or
`switch_tab` call never returned. Had to bypass `switch_tab` with raw CDP
to make progress.

## Fix

Add an optional `timeout` kwarg to `_send`/`cdp` (default `None` — existing
callers unchanged), and pass `timeout=2` on the unmark call in `switch_tab`.
The unmark is best-effort cosmetic — when the current session is dead we
want to swallow the timeout and move straight to the real `activateTarget`
+ `attachToTarget`, not wait forever.

## Diff

- `_send(req)` → `_send(req, timeout=None)` — sets `socket.settimeout` only
  when a timeout is provided.
- `cdp(method, session_id=None, **params)` → `cdp(method, session_id=None, timeout=None, **params)` — threads it through.
- `switch_tab`: `cdp("Runtime.evaluate", …)` → `cdp("Runtime.evaluate", timeout=2, …)`.

Two lines of real behaviour change, one added kwarg, one sentence of
docstring. Nothing that existing call sites need to know about.

## Testing

Reproduced on macOS / Chrome 147 by restarting Chrome with the daemon
still running and then calling `new_tab(...)` — hangs on main, returns
promptly on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent hangs in tab switching when the attached session is stale by adding an optional timeout to CDP calls and using a 2s timeout on the unmark step. `switch_tab` (and callers like `new_tab`) now proceeds instead of blocking forever.

- **Bug Fixes**
  - Added optional `timeout` to `_send` and `cdp` (default `None`).
  - Applied `timeout=2` to `Runtime.evaluate` in `switch_tab` to unmark the old tab without blocking.
  - No behavior changes for other callers.

<sup>Written for commit cb1cd9a1051809f7da4ec68c45732ecdfa42e958. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

