### PR TITLE
docs: move setup/maintenance content from SKILL.md to install.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,17 +5,9 @@ description: Direct browser control via CDP. Use when the user wants to automate
 
 # browser-harness
 
-Easiest and most powerful way to interact with the browser. Read this file in full before using or editing the harness — it has to be in context.
+Direct browser control via CDP. Read helpers.py — that's where the functions live. For setup, install, or connection problems, read install.md.
 
-## Fast start
-
-Read helpers.py first. For first-time install or reconnect/bootstrap, read install.md first.
-
-## Self-maintenance
-
-- browser-harness --doctor — diagnose install, daemon, browser, and whether an update is available.
-- browser-harness --setup — re-run the interactive browser-attach flow (equivalent to the bootstrap in install.md).
-- browser-harness --update -y — pull the latest version and restart the daemon without prompting. If you see a banner like `[browser-harness] update available: X -> Y` at the top of a run, run this yourself — don't ask the user first. The banner is rate-limited to once per day.
+## Usage
 
 ```bash
 browser-harness <<'PY'
@@ -27,8 +19,6 @@ PY
 
 - Invoke as browser-harness — it's on $PATH. No cd, no uv run.
 - First navigation is new_tab(url), not goto_url(url) — goto runs in the user's active tab and clobbers their work.
-
-The code is the doc.
 
 Available interaction skills:
 - interaction-skills/connection.md — startup sequence, tab visibility, omnibox popup fix
@@ -71,7 +61,7 @@ Profiles (cookies-only login state) live in interaction-skills/profile-sync.md �
 
 ## Search first
 
-After cloning the repo, search domain-skills/ first for the domain you are working on before inventing a new approach.
+Search domain-skills/ first for the domain you are working on before inventing a new approach.
 
 Only if you start struggling with a specific mechanic while navigating, look in interaction-skills/ for helpers. The available interaction skills are:
 - cookies.md
@@ -151,40 +141,11 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 - Helpers stay short. Browser primitives in helpers.py; daemon/bootstrap and remote session admin live in admin.py.
 - Don't add a manager layer. No retries framework, session manager, daemon supervisor, config system, or logging framework.
 
-## Architecture
-
-```text
-Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.py
-```
-
-- Protocol is one JSON line each way.
-- Requests are {method, params, session_id} for CDP or {meta: ...} for daemon control.
-- Responses are {result} / {error} / {events} / {session_id}.
-- BU_NAME namespaces socket, pid, and log files.
-- BU_CDP_WS overrides local Chrome discovery for remote browsers.
-- BU_BROWSER_ID + BROWSER_USE_API_KEY lets the daemon stop a Browser Use cloud browser on shutdown.
-
 ## Gotchas (field-tested)
 
-- Chrome 144+ chrome://inspect/#remote-debugging does NOT serve /json/version. Read DevToolsActivePort instead.
-- Try attaching before asking for setup. If uv run browser-harness already works, skip the remote-debugging instructions entirely. Decide what to escalate from the harness's error message, not from whether Chrome is visibly running.
-- The remote-debugging checkbox is per-profile sticky in Chrome. Once ticked on a profile, every future Chrome launch auto-enables CDP — only navigate to chrome://inspect/#remote-debugging when DevToolsActivePort is genuinely missing on a fresh profile.
-- The first connect may block on Chrome's Allow dialog. If setup hangs, explicitly tell the user to click Allow in Chrome if it appears, then keep polling for up to 30 seconds instead of treating follow-on errors as a new failure.
-- DevToolsActivePort can exist before the port is actually listening. Treat connection refused as "still enabling" and keep polling for up to 30 seconds.
-- Chrome may open the profile picker before any real tab exists. If Chrome opens both a profile picker and the remote-debugging page, tell the user to choose their normal profile first, then tick the checkbox and click Allow if shown.
-- On macOS, if Chrome is already running, prefer AppleScript open location over open -a ... URL. It reuses the current profile and avoids creating an extra startup path through the profile picker.
 - Omnibox popups are fake page targets. Filter chrome://omnibox-popup... and other internals when you need a real tab.
 - CDP target order != Chrome's visible tab-strip order. Use UI automation when the user means "the first/second tab I can see"; Target.activateTarget only shows a known target.
 - Default daemon sessions can go stale. ensure_real_tab() re-attaches to a real page.
-- "no close frame received or sent" usually means a stale daemon / websocket. Restart the daemon once with:
-  ```
-  uv run python - <<'PY'
-  from admin import restart_daemon
-  restart_daemon()
-  PY
-  ```
-  before assuming setup is wrong.
-- If restart_daemon() also hangs, kill Chrome entirely (pkill -9 -f "Google Chrome"), clean sockets (rm -f /tmp/bu-default.sock /tmp/bu-default.pid), reopen Chrome (open -a "Google Chrome"), wait 5s, then reconnect. This resets all CDP state.
 - Browser Use API is camelCase on the wire. cdpUrl, proxyCountryCode, etc.
 - Remote cdpUrl is HTTPS, not ws. Resolve the websocket URL via /json/version.
 - Stop cloud browsers with PATCH /browsers/{id} + {"action":"stop"}.

--- a/install.md
+++ b/install.md
@@ -93,7 +93,36 @@ restart_daemon()
 PY
 ```
 
+If restart_daemon() also hangs, kill Chrome entirely, clean sockets, and reopen:
+
+```bash
+pkill -9 -f "Google Chrome"
+rm -f /tmp/bu-default.sock /tmp/bu-default.pid
+open -a "Google Chrome"
+```
+
+Wait 5 seconds, then reconnect. This resets all CDP state.
+
 8. After install and browser bootstrap succeed, navigate to `https://github.com/browser-use/browser-harness` so the user can see the harness has attached to their browser. If the user is logged in to GitHub, **ask the user whether you should star the repo for them** as a quick demo that the interaction works — only click the star if they say yes. Then ask the user what they want to do next.
+
+## Maintenance commands
+
+- browser-harness --doctor — show version, install mode, daemon and Chrome state, and whether an update is pending.
+- browser-harness --setup — re-run the full interactive browser-attach flow.
+- browser-harness --update -y — pull the latest version and restart the daemon. Run this yourself when you see the `[browser-harness] update available: X -> Y` banner — don't ask the user. The banner is rate-limited to once per day.
+
+## Architecture
+
+```text
+Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.py
+```
+
+- Protocol is one JSON line each way.
+- Requests are {method, params, session_id} for CDP or {meta: ...} for daemon control.
+- Responses are {result} / {error} / {events} / {session_id}.
+- BU_NAME namespaces socket, pid, and log files.
+- BU_CDP_WS overrides local Chrome discovery for remote browsers.
+- BU_BROWSER_ID + BROWSER_USE_API_KEY lets the daemon stop a Browser Use cloud browser on shutdown.
 
 ## Keeping the harness current
 


### PR DESCRIPTION
## Summary

- SKILL.md now covers day-to-day usage only — no setup, maintenance, or architecture content
- Maintenance commands (--doctor, --setup, --update) moved to install.md under a new "Maintenance commands" section
- Architecture section moved to install.md
- Single reference line at the top of SKILL.md points to install.md for setup/connection problems
- Dropped stale "after cloning the repo" phrasing

## Why

The split between SKILL.md and install.md was intentional (commit 3193531) but incomplete — setup/maintenance content had accumulated back in SKILL.md over time. This finishes the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved setup, maintenance, and architecture docs from SKILL.md to install.md so SKILL.md focuses on day-to-day usage. Adds a clear link from SKILL.md to install.md for setup/connection issues.

- **Refactors**
  - Moved `browser-harness` maintenance commands (`--doctor`, `--setup`, `--update`) into a new “Maintenance commands” section in install.md.
  - Relocated Architecture details to install.md and added a hard reset path (kill Chrome, clean sockets, reopen).
  - Simplified SKILL.md intro and usage notes; dropped stale “after cloning the repo” phrasing.

<sup>Written for commit 197283bc55e06cd8db84dc5650a33a5a7f3f650b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

