### PR TITLE
fix(js): auto-wrap top-level return expressions in an IIFE

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -178,8 +178,14 @@ def wait_for_load(timeout=15.0):
     return False
 
 def js(expression, target_id=None):
-    """Run JS in the attached tab (default) or inside an iframe target (via iframe_target())."""
+    """Run JS in the attached tab (default) or inside an iframe target (via iframe_target()).
+
+    Expressions with top-level `return` are automatically wrapped in an IIFE, so both
+    `document.title` and `const x = 1; return x` are valid inputs.
+    """
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
+    if "return " in expression:
+        expression = f"(function(){{{expression}}})()"
     r = cdp("Runtime.evaluate", session_id=sid, expression=expression, returnByValue=True, awaitPromise=True)
     return r.get("result", {}).get("value")
 

--- a/test_js.py
+++ b/test_js.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+import helpers
+
+
+def _capture_cdp():
+    captured = []
+    def fake_cdp(method, **kwargs):
+        captured.append((method, kwargs))
+        return {"result": {"value": None}}
+    return fake_cdp, captured
+
+
+def _evaluated_expression(captured):
+    return next(kw["expression"] for m, kw in captured if m == "Runtime.evaluate")
+
+
+def test_simple_expression_passes_through():
+    fake_cdp, captured = _capture_cdp()
+    with patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.js("document.title")
+    assert _evaluated_expression(captured) == "document.title"
+
+
+def test_return_statement_gets_wrapped():
+    fake_cdp, captured = _capture_cdp()
+    with patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.js("const x = 1; return x")
+    assert _evaluated_expression(captured) == "(function(){const x = 1; return x})()"


### PR DESCRIPTION
## Summary

- `js()` now detects top-level `return` in the expression and wraps it in `(function(){...})()` before passing to `Runtime.evaluate`
- Simple expressions like `document.title` pass through unchanged
- Adds `test_js.py` with two tests (red → green via TDD)

## Test plan

- [x] `test_simple_expression_passes_through` — verifies no wrapping for plain expressions
- [x] `test_return_statement_gets_wrapped` — verifies IIFE wrapping when `return` is present
- [x] Both tests pass (`uv run pytest test_js.py -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `js()` to auto-wrap expressions with a top-level `return` in an IIFE before calling `Runtime.evaluate`, preventing CDP syntax errors. Simple expressions (e.g., `document.title`) pass through unchanged; adds tests for both paths.

<sup>Written for commit 0b1ba8e4ff9126ae41dc532ba3740bea02cc9313. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

