### PR TITLE
refactor(run): replace heredoc stdin with -c flag

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -178,8 +178,14 @@ def wait_for_load(timeout=15.0):
     return False
 
 def js(expression, target_id=None):
-    """Run JS in the attached tab (default) or inside an iframe target (via iframe_target())."""
+    """Run JS in the attached tab (default) or inside an iframe target (via iframe_target()).
+
+    Expressions with top-level `return` are automatically wrapped in an IIFE, so both
+    `document.title` and `const x = 1; return x` are valid inputs.
+    """
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
+    if "return " in expression:
+        expression = f"(function(){{{expression}}})()"
     r = cdp("Runtime.evaluate", session_id=sid, expression=expression, returnByValue=True, awaitPromise=True)
     return r.get("result", {}).get("value")
 

--- a/run.py
+++ b/run.py
@@ -51,16 +51,11 @@ def main():
     if args and args[0] == "--update":
         yes = any(a in {"-y", "--yes"} for a in args[1:])
         sys.exit(run_update(yes=yes))
-    if sys.stdin.isatty():
-        sys.exit(
-            "browser-harness reads Python from stdin. Use:\n"
-            "  browser-harness <<'PY'\n"
-            "  print(page_info())\n"
-            "  PY"
-        )
+    if not args or args[0] != "-c":
+        sys.exit("Usage: browser-harness -c \"print(page_info())\"")
     print_update_banner()
     ensure_daemon()
-    exec(sys.stdin.read(), globals())
+    exec(args[1], globals())
 
 
 if __name__ == "__main__":

--- a/test_js.py
+++ b/test_js.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+import helpers
+
+
+def _capture_cdp():
+    captured = []
+    def fake_cdp(method, **kwargs):
+        captured.append((method, kwargs))
+        return {"result": {"value": None}}
+    return fake_cdp, captured
+
+
+def _evaluated_expression(captured):
+    return next(kw["expression"] for m, kw in captured if m == "Runtime.evaluate")
+
+
+def test_simple_expression_passes_through():
+    fake_cdp, captured = _capture_cdp()
+    with patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.js("document.title")
+    assert _evaluated_expression(captured) == "document.title"
+
+
+def test_return_statement_gets_wrapped():
+    fake_cdp, captured = _capture_cdp()
+    with patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.js("const x = 1; return x")
+    assert _evaluated_expression(captured) == "(function(){const x = 1; return x})()"

--- a/test_run.py
+++ b/test_run.py
@@ -1,0 +1,28 @@
+import sys
+from io import StringIO
+from unittest.mock import patch
+import run
+
+
+def test_c_flag_executes_code():
+    stdout = StringIO()
+    with patch.object(sys, "argv", ["browser-harness", "-c", "print('hello from -c')"]), \
+         patch("run.ensure_daemon"), \
+         patch("run.print_update_banner"), \
+         patch("sys.stdout", stdout):
+        run.main()
+    assert stdout.getvalue().strip() == "hello from -c"
+
+
+def test_c_flag_does_not_read_stdin():
+    stdin_read = []
+    fake_stdin = StringIO("should not be read")
+    fake_stdin.read = lambda: stdin_read.append(True) or ""
+
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("run.ensure_daemon"), \
+         patch("run.print_update_banner"), \
+         patch("sys.stdin", fake_stdin):
+        run.main()
+
+    assert not stdin_read, "stdin should not be read when -c is passed"


### PR DESCRIPTION
## Summary

- Drops the `<<'PY' ... PY` heredoc pattern entirely — no backward compatibility shim
- `browser-harness -c "code"` is now the only invocation style
- Simpler for agents to construct programmatically; no heredoc quoting pitfalls
- Adds `test_run.py` with two tests covering the `-c` flag (red → green via TDD)

## Test plan

- [x] `test_c_flag_executes_code` — code passed via `-c` runs and produces output
- [x] `test_c_flag_does_not_read_stdin` — stdin is never touched when `-c` is used
- [x] All 4 tests pass (`uv run pytest test_js.py test_run.py -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `browser-harness` to use a `-c` flag instead of heredoc stdin, making invocation simpler and more reliable. Also updates `helpers.js()` to accept top‑level `return` by auto‑wrapping the expression in an IIFE.

- **Migration**
  - Use: `browser-harness -c "print(page_info())"`. Heredoc stdin is no longer supported.

- **Bug Fixes**
  - `helpers.js()` auto-wraps expressions containing `return` in an IIFE, so both `document.title` and `const x = 1; return x` work without CDP syntax errors.

<sup>Written for commit 0f20388303798d178826abb28b2d33cc2296f8f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

