### PR TITLE
feat(debug): add --debug-clicks mode with DPR-aware overlay

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -67,7 +67,27 @@ def page_info():
     return json.loads(r["result"]["value"])
 
 # --- input ---
+_debug_click_counter = 0
+
 def click_at_xy(x, y, button="left", clicks=1):
+    if os.environ.get("BH_DEBUG_CLICKS"):
+        global _debug_click_counter
+        try:
+            from PIL import Image, ImageDraw
+            dpr = js("window.devicePixelRatio") or 1
+            path = capture_screenshot(f"/tmp/debug_click_{_debug_click_counter}.png")
+            img = Image.open(path)
+            draw = ImageDraw.Draw(img)
+            px, py = int(x * dpr), int(y * dpr)
+            r = int(15 * dpr)
+            draw.ellipse([px - r, py - r, px + r, py + r], outline="red", width=int(3 * dpr))
+            draw.line([px - r - int(5 * dpr), py, px + r + int(5 * dpr), py], fill="red", width=int(2 * dpr))
+            draw.line([px, py - r - int(5 * dpr), px, py + r + int(5 * dpr)], fill="red", width=int(2 * dpr))
+            img.save(path)
+            print(f"[debug_click] saved {path} (x={x}, y={y}, dpr={dpr})")
+        except Exception as e:
+            print(f"[debug_click] overlay failed: {e}")
+        _debug_click_counter += 1
     cdp("Input.dispatchMouseEvent", type="mousePressed", x=x, y=y, button=button, clickCount=clicks)
     cdp("Input.dispatchMouseEvent", type="mouseReleased", x=x, y=y, button=button, clickCount=clicks)
 

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-import sys
+import os, sys
 
 from admin import (
     _version,
@@ -51,6 +51,9 @@ def main():
     if args and args[0] == "--update":
         yes = any(a in {"-y", "--yes"} for a in args[1:])
         sys.exit(run_update(yes=yes))
+    if args and args[0] == "--debug-clicks":
+        os.environ["BH_DEBUG_CLICKS"] = "1"
+        args = args[1:]
     if not args or args[0] != "-c":
         sys.exit("Usage: browser-harness -c \"print(page_info())\"")
     print_update_banner()


### PR DESCRIPTION
## Summary
- Adds `--debug-clicks` CLI flag (or `BH_DEBUG_CLICKS=1` env var) to enable click debugging
- Before each `click_at_xy` call, captures a screenshot and draws a red circle + crosshair at the exact click location
- Marker coordinates are scaled by `window.devicePixelRatio` so the overlay aligns correctly on HiDPI/Retina displays
- Sequential debug images saved to `/tmp/debug_click_<n>.png`

## Test plan
- [ ] Run `browser-harness --debug-clicks -c "new_tab('https://example.com'); wait_for_load(); click_at_xy(x, y)"` and verify `/tmp/debug_click_0.png` shows crosshair at correct location
- [ ] Verify normal usage without flag is completely unaffected
- [ ] Verify `BH_DEBUG_CLICKS=1 browser-harness -c "..."` also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--debug-clicks` mode to visualize click targets by saving screenshots with a DPR-aware red crosshair overlay. This makes it easy to debug misaligned clicks, especially on HiDPI/Retina displays.

- **New Features**
  - New `--debug-clicks` CLI flag (or `BH_DEBUG_CLICKS=1`) to enable click debugging.
  - Before each `click_at_xy`, captures a screenshot and draws a red circle + crosshair at the click coordinates.
  - Overlay scales with `window.devicePixelRatio` so markers align on HiDPI screens.
  - Saves sequential images to `/tmp/debug_click_<n>.png`. Normal runs are unchanged.

<sup>Written for commit 6c9ddf56fee9d5eee5d20ae2318b100c5938cbaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

