### PR TITLE
Update README footer Bitter Lesson and Skills links

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ If you're not sure where to start, open an issue and we'll point you somewhere u
 
 ---
 
-[Bitter lesson](https://browser-use.com/posts/bitter-lesson-agent-frameworks) · [Skills](https://browser-use.com/posts/web-agents-that-actually-learn)
+[The Bitter Lesson of Agent Harnesses](https://browser-use.com/posts/bitter-lesson-agent-harnesses) · [Web Agents That Actually Learn](https://browser-use.com/posts/web-agents-that-actually-learn)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the README footer Bitter Lesson link URL
- change the Bitter Lesson link text to "The Bitter Lesson of Agent Harnesses"
- change the Skills link text to "Web Agents That Actually Learn"

## Testing
- not applicable (documentation-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README footer links for clarity and accuracy. Renamed "Bitter lesson" to "The Bitter Lesson of Agent Harnesses" with the new URL, and "Skills" to "Web Agents That Actually Learn."

<sup>Written for commit ce35175b7890bdab90c9f606e4f858db87050a36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

