### PR TITLE
docs: refresh README for current domain skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The agent writes what's missing, mid-task. No framework, no recipes, no rails. O
 
 ## Setup prompt
 
-Paste into Claude Code or Codex:
+Paste into Codex or another human-spawned agent session:
 
 ```text
 Set up https://github.com/browser-use/browser-harness for me.
@@ -32,7 +32,7 @@ When this page appears, tick the checkbox so the agent can connect to your brows
 
 <img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />
 
-See [domain-skills/](domain-skills/) for example tasks.
+See [domain-skills/](domain-skills/) for example tasks. The library now includes browser-tested playbooks for common scraping targets plus action-oriented flows such as GitHub repo actions, Facebook groups/pages, Trello boards/lists, Framer editor work, Reddit JSON/DOM extraction, Medium article hydration, Atlas, and Centilebrain normative z-scores.
 
 ## Free remote browsers
 
@@ -42,13 +42,13 @@ Useful for stealth, sub-agents, or deployment.<br>
 - Grab a key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key)
 - Or let the agent sign up itself via [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt) (setup flow + challenge context included).
 
-## How simple is it? (~592 lines of Python)
+## How simple is it? (~816 lines of Python)
 
 - `install.md` — first-time install and browser bootstrap
 - `SKILL.md` — day-to-day usage
-- `run.py` (~36 lines) — runs plain Python with helpers preloaded
-- `helpers.py` (~195 lines) — starting tool calls; the agent edits these
-- `admin.py` + `daemon.py` (~361 lines) — daemon bootstrap plus the CDP websocket and socket bridge
+- `run.py` (~44 lines) — runs plain Python with helpers preloaded
+- `helpers.py` (~216 lines) — starting tool calls; the agent edits these
+- `admin.py` + `daemon.py` (~556 lines) — daemon bootstrap, profile detection, remote stop/restart helpers, plus the CDP websocket and socket bridge
 
 ## Contributing
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -88,6 +88,12 @@ rg --files domain-skills
 rg -n "tiktok|upload" domain-skills
 ```
 
+## Debugging helpers
+
+Use `browser-harness --debug-clicks` when coordinate clicks need a visual receipt. It draws a DPR-aware overlay for click debugging so retina and scaled displays do not mislead the next action.
+
+For JavaScript snippets, `run.py` sends code with Python's `-c` path rather than heredoc stdin. Top-level `return` expressions in JS snippets are auto-wrapped in an IIFE, so quick probes can stay terse without hand-writing wrapper functions.
+
 ## Always contribute back
 
 If you learned anything non-obvious about how a site works, open a PR to domain-skills/<site>/ before you finish. Default to contributing. The harness gets better only because agents file what they learn. If figuring something out cost you a few steps, the next run should not pay the same tax.


### PR DESCRIPTION
Refreshes the README to match the current harness size and domain-skill set, including newer GitHub/Facebook/Trello/Framer/Atlas/Reddit/Medium/CentileBrain skills and updated file-size notes.\n\nThis is docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh README and SKILL docs to reflect current domain skills and harness size.

Updates the setup prompt, lists new browser-tested playbooks (GitHub repo actions, Facebook groups/pages, Trello boards/lists, Framer editor work, Reddit JSON/DOM extraction, Medium article hydration, Atlas, Centilebrain z-scores), corrects approximate LOC for `run.py`/`helpers.py`/`admin.py`+`daemon.py`, and adds debugging notes for `browser-harness --debug-clicks` and JS snippet execution via `run.py` (IIFE-wrapped returns, `-c` path).

<sup>Written for commit 9381cd3324bc97fa363f6dd5bbb3c698e03fb98e. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

