### PR TITLE
docs(youtube): document watch-page DOM hydration wait

### DIFF
--- a/domain-skills/youtube/scraping.md
+++ b/domain-skills/youtube/scraping.md
@@ -66,6 +66,7 @@ with ThreadPoolExecutor(max_workers=5) as ex:
 ## Approach 2: Watch Page — Full Metadata via ytInitialPlayerResponse
 
 Every `youtube.com/watch?v={ID}` page embeds two JSON blobs in the HTML:
+
 - `ytInitialPlayerResponse` — video details, microformat, caption track list
 - `ytInitialData` — comments section structure, related videos
 
@@ -369,6 +370,19 @@ The following are **not accessible** via `http_get` and require the CDP browser 
 - **Channel Videos tab** — video list requires cookies for consistent results
 - **Caption text content** — `captionTracks[].baseUrl` URLs return empty bytes regardless of session state; use the browser's Show Transcript UI flow instead (see `playback.md`)
 - **Age-restricted videos** — oEmbed returns HTTP 401; `scrape_video()` raises `ValueError("LOGIN_REQUIRED")`
+
+### Watch-page DOM hydration — the wait you need
+
+When you do fall through to the browser for watch-page DOM (e.g. because you need a
+rendered UI state, not just metadata), `wait_for_load()` is **not** enough. The `load`
+event fires before YouTube's Polymer components hydrate — `h1.ytd-watch-metadata yt-formatted-string`,
+`ytd-video-owner-renderer #channel-name a`, and `ytd-watch-info-text` all return `null` for
+~2s after load. Add a `wait(3)` after `wait_for_load()` before querying any watch-page
+selector.
+
+Field-tested 2026-04-24 on Brave; same behavior observed on ungoogled-chromium. Prefer
+the `http_get` + `ytInitialPlayerResponse` path above — the browser path exists for flows
+that need live UI state, not for reading metadata.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a small note to `domain-skills/youtube/scraping.md` documenting the hydration gap on the YouTube watch page DOM. The HTTP-only path (via `ytInitialPlayerResponse`) is unaffected and remains the recommended approach for metadata — this note is for the cases that genuinely need the rendered DOM (live UI state, etc.).

## What

When falling through to the browser path, `wait_for_load()` is not enough. The `load` event fires before YouTube's Polymer components hydrate — `h1.ytd-watch-metadata yt-formatted-string`, `ytd-video-owner-renderer #channel-name a`, and `ytd-watch-info-text` all return `null` for ~2s after load. A `wait(3)` after `wait_for_load()` is required before querying any watch-page selector.

## How verified

Field-tested 2026-04-24 on Brave (Clawdia profile, CDP 9222); same hydration gap observed on ungoogled-chromium. Reproduced with three independent video IDs.

## Test plan

- [x] `wait_for_load()` alone returns `null` for the listed selectors
- [x] `wait_for_load()` + `wait(3)` returns expected values for title, channel, view count
- [x] Markdown lints clean (one MD032 fix in the same area)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a note about a ~2s DOM hydration delay on YouTube watch pages in `domain-skills/youtube/scraping.md`. For the browser path, `wait_for_load()` is not enough—add `wait(3)` before querying title/channel/view selectors; the `http_get` + `ytInitialPlayerResponse` path is unaffected and remains recommended.

<sup>Written for commit dafe832b6e72077ef68fae53ba369841cd10d113. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

