### PR TITLE
fix(js): don't double-wrap IIFEs that contain return

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -204,7 +204,7 @@ def js(expression, target_id=None):
     `document.title` and `const x = 1; return x` are valid inputs.
     """
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
-    if "return " in expression:
+    if "return " in expression and not expression.strip().startswith("("):
         expression = f"(function(){{{expression}}})()"
     r = cdp("Runtime.evaluate", session_id=sid, expression=expression, returnByValue=True, awaitPromise=True)
     return r.get("result", {}).get("value")

--- a/test_js.py
+++ b/test_js.py
@@ -26,3 +26,10 @@ def test_return_statement_gets_wrapped():
     with patch("helpers.cdp", side_effect=fake_cdp):
         helpers.js("const x = 1; return x")
     assert _evaluated_expression(captured) == "(function(){const x = 1; return x})()"
+
+
+def test_iife_with_internal_return_is_not_double_wrapped():
+    fake_cdp, captured = _capture_cdp()
+    with patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.js("(function(){ return document.title; })()")
+    assert _evaluated_expression(captured) == "(function(){ return document.title; })()"


### PR DESCRIPTION
## Summary
- `js()` used `"return " in expression` to decide whether to wrap in an IIFE, but this also matched expressions that already contained a pre-wrapped IIFE with an internal `return`
- Double-wrapping caused the outer IIFE to have no `return`, silently producing `None`
- Fix: add `and not expression.strip().startswith("(")` so pre-wrapped expressions pass through unchanged

## Test plan
- [ ] `test_simple_expression_passes_through` — plain expression, no wrapping
- [ ] `test_return_statement_gets_wrapped` — multi-statement block with `return`, gets wrapped
- [ ] `test_iife_with_internal_return_is_not_double_wrapped` — new test, IIFE passes through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `js()` so it doesn’t double-wrap IIFEs that contain `return`, preventing silent `None` results. Pre-wrapped expressions now pass through unchanged.

- **Bug Fixes**
  - Wrap only when `"return "` is present and the trimmed expression doesn’t start with `"("`.
  - Added `test_iife_with_internal_return_is_not_double_wrapped` to cover this case.

<sup>Written for commit e02a8db8320f5072441d3ed518aecb65f41cd562. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

