### PR TITLE
feat(cli): add --reload flag to restart the daemon

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -204,7 +204,7 @@ def js(expression, target_id=None):
     `document.title` and `const x = 1; return x` are valid inputs.
     """
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
-    if "return " in expression:
+    if "return " in expression and not expression.strip().startswith("("):
         expression = f"(function(){{{expression}}})()"
     r = cdp("Runtime.evaluate", session_id=sid, expression=expression, returnByValue=True, awaitPromise=True)
     return r.get("result", {}).get("value")

--- a/run.py
+++ b/run.py
@@ -33,6 +33,7 @@ Commands:
   browser-harness --doctor         diagnose install, daemon, and browser state
   browser-harness --setup          interactively attach to your running browser
   browser-harness --update [-y]    pull the latest version (agents: pass -y)
+  browser-harness --reload         stop the daemon so next call picks up code changes
 """
 
 
@@ -51,6 +52,10 @@ def main():
     if args and args[0] == "--update":
         yes = any(a in {"-y", "--yes"} for a in args[1:])
         sys.exit(run_update(yes=yes))
+    if args and args[0] == "--reload":
+        restart_daemon()
+        print("daemon stopped — will restart fresh on next call")
+        return
     if args and args[0] == "--debug-clicks":
         os.environ["BH_DEBUG_CLICKS"] = "1"
         args = args[1:]

--- a/test_js.py
+++ b/test_js.py
@@ -26,3 +26,10 @@ def test_return_statement_gets_wrapped():
     with patch("helpers.cdp", side_effect=fake_cdp):
         helpers.js("const x = 1; return x")
     assert _evaluated_expression(captured) == "(function(){const x = 1; return x})()"
+
+
+def test_iife_with_internal_return_is_not_double_wrapped():
+    fake_cdp, captured = _capture_cdp()
+    with patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.js("(function(){ return document.title; })()")
+    assert _evaluated_expression(captured) == "(function(){ return document.title; })()"


### PR DESCRIPTION
## Summary
- Adds `browser-harness --reload` which stops the running daemon
- Next `browser-harness -c "..."` call auto-starts a fresh daemon via the existing `ensure_daemon()` path, picking up any code changes
- Replaces the manual `pkill -f daemon.py` workflow after editing `helpers.py`

## Test plan
- [ ] `browser-harness --reload` prints confirmation and exits cleanly
- [ ] Subsequent `browser-harness -c "..."` call starts a fresh daemon and executes normally
- [ ] `browser-harness --help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--reload` flag to stop the running daemon so the next call restarts with fresh code. Also fixes `js()` to avoid double-wrapping IIFEs that already contain a return.

- **New Features**
  - `browser-harness --reload` stops the daemon and exits; the next `-c` run auto-starts a fresh daemon.
  - Help text updated; replaces the manual `pkill` workflow.

- **Bug Fixes**
  - `js()` now wraps only when the expression contains `return` and does not start with `(`.
  - Added a test to ensure IIFEs pass through unchanged.

<sup>Written for commit bd4f62c57ab3871ad8702fa326961cca3cf366d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

