### PR TITLE
docs: note device-pixel vs CSS-pixel mismatch in screenshots

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -70,6 +70,9 @@ def page_info():
 _debug_click_counter = 0
 
 def click_at_xy(x, y, button="left", clicks=1):
+    """Click at CSS pixel (x, y). capture_screenshot() saves at device pixels, so divide
+    image coordinates by window.devicePixelRatio before passing them here — see
+    interaction-skills/screenshots.md."""
     if os.environ.get("BH_DEBUG_CLICKS"):
         global _debug_click_counter
         try:

--- a/interaction-skills/screenshots.md
+++ b/interaction-skills/screenshots.md
@@ -1,3 +1,21 @@
 # Screenshots
 
-Separate full-page screenshots from targeted section screenshots, and note when screenshots are only for discovery versus verification.
+`capture_screenshot()` writes a PNG at **device pixels** (e.g. 4592×2286 on a 2× display), but `click_at_xy()` takes **CSS pixels** (e.g. 2296×1143). Reading a coordinate off the image and clicking it directly will miss by a factor of `window.devicePixelRatio` on any HiDPI / Retina display.
+
+```python
+from PIL import Image
+path = capture_screenshot()
+img = Image.open(path)
+dpr = js("window.devicePixelRatio") or 1
+# (px, py) read off the image in image pixels
+click_at_xy(px / dpr, py / dpr)
+```
+
+`page_info()` returns CSS dimensions (`w`, `h`) — compare against `img.size` to see the ratio for the current display.
+
+## Discovery vs verification
+
+- Discovery: `capture_screenshot(full=True)` captures the full scrollable page, including content below the fold. Use it to find a target before scrolling.
+- Verification: plain `capture_screenshot()` (viewport only) is enough to confirm a click landed, a menu opened, or a navigation completed.
+
+After every meaningful action, re-screenshot before assuming it worked.


### PR DESCRIPTION
## Summary
- `capture_screenshot()` writes PNGs at device pixels but `click_at_xy()` takes CSS pixels — on a 2x display, reading a coordinate off the image and clicking it directly misses by half.
- Flesh out `interaction-skills/screenshots.md` with the conversion recipe and the discovery-vs-verification distinction, and add a docstring to `click_at_xy` pointing at it.

## Verification
Confirmed the gap empirically before writing the doc:

```
screenshot pixels: (4592, 2286)
window: {"dpr":2,"iw":2296,"ih":1143}
```

Then dropped a 60×60 button at CSS (180,180) and clicked twice:
- `click_at_xy(210, 210)` → click registered (CSS coord inside button) ✅
- `click_at_xy(420, 420)` → no click (device-pixel coord, lands well outside) ❌

So `click_at_xy` definitively takes CSS pixels, and the previous `screenshots.md` (one sentence) didn't say so.

## Test plan
- [x] `browser-harness -c "print(click_at_xy.__doc__)"` shows the new docstring
- [x] Helpers still import and `page_info()` still works
- [ ] Reviewer skim of `interaction-skills/screenshots.md` for tone/scope


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify the device‑pixel vs CSS‑pixel mismatch between `capture_screenshot()` and `click_at_xy()`, and add a docstring that points to a short conversion recipe in `interaction-skills/screenshots.md`. This prevents off‑by‑DPR clicks on HiDPI/Retina displays and explains when to use full‑page vs viewport screenshots.

<sup>Written for commit dcd8137624901b274732c0211aaf70a9580d1ec2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

