### PR TITLE
fix(helpers): switch_tab accepts dict from current_tab()/list_tabs()

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -143,7 +143,10 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title")
     except Exception: pass
 
-def switch_tab(target_id):
+def switch_tab(target):
+    # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
+    # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
+    target_id = target.get("targetId") if isinstance(target, dict) else target
     # Unmark old tab
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F7E2 '))document.title=document.title.slice(2)")
     except Exception: pass


### PR DESCRIPTION
## Summary

`current_tab()` and `list_tabs()` both return dicts shaped `{"targetId": ..., "url": ..., "title": ...}`, but `switch_tab()` only accepted the bare string. The natural pattern of "save the active tab, do work, restore it" raises `InvalidParameters` from CDP:

```python
original = current_tab()         # → {"targetId": "...", "url": "...", "title": "..."}
new_tab("https://example.com")
switch_tab(original)             # ❌ RuntimeError from CDP — string expected
```

The error message (`Failed to deserialize params.targetId - BINDINGS: string value expected at position 17`) is opaque enough that I lost a few minutes to it before noticing the shape mismatch in `helpers.py`.

This patch makes `switch_tab` tolerant of either shape: pull `targetId` from the dict if one is passed, otherwise treat the input as the id string. The fix is one line and preserves the existing `switch_tab("<raw-id>")` call shape.

## Test plan

- [x] `switch_tab(current_tab())` no longer raises
- [x] `switch_tab("<raw-id-string>")` still works (back-compat)
- [x] `_mark_tab` / `_send` flow unchanged

```python
from helpers import current_tab, switch_tab

t = current_tab()
sid = switch_tab(t)            # dict form ✓
sid2 = switch_tab(t["targetId"])  # string form still ✓
```

## Why this matters for self-healing flows

The pattern this enables — *grab the user's active tab, do agent work in a new tab, restore the user's view* — is one of the most common shapes for non-disruptive automation. Catching this single mismatch makes that pattern just-work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated switch_tab to accept either the dict returned by current_tab()/list_tabs() or a raw targetId string, fixing the shape mismatch that caused CDP InvalidParameters errors. This lets callers save/restore the active tab without manually extracting ["targetId"] while keeping existing string-based calls working.

<sup>Written for commit 192f99251bad1da37833f9ff8ac87ebf0cad2944. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

