### PR TITLE
fix: scan Chrome profile subdirs for DevToolsActivePort

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -62,26 +62,35 @@ def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
     for base in PROFILES:
+        candidates = [base]
         try:
-            port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
-        except (FileNotFoundError, NotADirectoryError):
-            continue
-        deadline = time.time() + 30
-        while True:
-            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            probe.settimeout(1)
+            # Chrome often writes DevToolsActivePort inside profile dirs
+            # (Default, Profile 1, etc.) rather than directly under User Data.
+            candidates.extend(p for p in base.iterdir() if p.is_dir())
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            pass
+
+        for candidate in candidates:
             try:
-                probe.connect(("127.0.0.1", int(port.strip())))
-                break
-            except OSError:
-                if time.time() >= deadline:
-                    raise RuntimeError(
-                        f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
-                    )
-                time.sleep(1)
-            finally:
-                probe.close()
-        return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+                port, path = (candidate / "DevToolsActivePort").read_text().strip().split("\n", 1)
+            except (FileNotFoundError, NotADirectoryError):
+                continue
+            deadline = time.time() + 30
+            while True:
+                probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                probe.settimeout(1)
+                try:
+                    probe.connect(("127.0.0.1", int(port.strip())))
+                    break
+                except OSError:
+                    if time.time() >= deadline:
+                        raise RuntimeError(
+                            f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
+                        )
+                    time.sleep(1)
+                finally:
+                    probe.close()
+            return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 


### PR DESCRIPTION
## Summary
- Scans Chrome profile subdirectories like `Default` and `Profile 1` for `DevToolsActivePort`
- Keeps the existing top-level User Data lookup as a candidate
- Handles missing, non-directory, or permission-denied profile paths without aborting the scan

## Why
Chrome can write `DevToolsActivePort` inside an active profile directory instead of directly under the User Data root. When that happens, browser-harness cannot attach even though Chrome remote debugging is available.

## Verification
- `python3 -m py_compile daemon.py`
- Tested in a fork where Chrome profile subdirectory scanning was needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Chrome attach by scanning profile subdirectories (Default, Profile 1, etc.) for `DevToolsActivePort` instead of only the User Data root. Avoids failures when Chrome writes the port file inside a profile.

- **Bug Fixes**
  - Add candidate search across profile dirs; keep root as a candidate.
  - Treat missing, non-directory, and permission-denied paths as skippable.
  - Probe each candidate port and return the first live `ws://` URL.

<sup>Written for commit 4f15173c777b2617011c7b7f278f3559c3f4cb0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

