### PR TITLE
fix(setup): retry Chrome handshake timeouts

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -40,6 +40,30 @@ def _log_tail(name):
         return None
 
 
+def _needs_chrome_remote_debugging_prompt(msg):
+    """True when Chrome needs the inspect-page permission/profile flow."""
+    lower = (msg or "").lower()
+    return (
+        "devtoolsactiveport not found" in lower
+        or "enable chrome://inspect" in lower
+        or "not live yet" in lower
+        or (
+            "ws handshake failed" in lower
+            and (
+                "403" in lower
+                or "opening handshake" in lower
+                or "timed out" in lower
+                or "timeout" in lower
+            )
+        )
+    )
+
+
+def _is_local_chrome_mode(env=None):
+    """True when the daemon discovers a local Chrome instead of a remote CDP WS."""
+    return not (env or {}).get("BU_CDP_WS") and not os.environ.get("BU_CDP_WS")
+
+
 def daemon_alive(name=None):
     try:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -70,7 +94,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         restart_daemon(name)
 
     import subprocess, sys
-    local = not (env or {}).get("BU_CDP_WS") and not os.environ.get("BU_CDP_WS")
+    local = _is_local_chrome_mode(env)
     for attempt in (0, 1):
         e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
         p = subprocess.Popen(
@@ -84,7 +108,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             if p.poll() is not None: break
             time.sleep(0.2)
         msg = _log_tail(name) or ""
-        if local and attempt == 0 and ("DevToolsActivePort not found" in msg or "not live yet" in msg or ("WS handshake failed" in msg and "403" in msg)):
+        if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
             _open_chrome_inspect()
             print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
             restart_daemon(name)
@@ -468,7 +492,7 @@ def run_setup():
     except RuntimeError as e:
         first_err = str(e)
 
-    needs_inspect = "DevToolsActivePort not found" in first_err or "enable chrome://inspect" in first_err
+    needs_inspect = _is_local_chrome_mode() and _needs_chrome_remote_debugging_prompt(first_err)
     if needs_inspect:
         print("chrome remote-debugging is not enabled on the current profile.")
         print("opening chrome://inspect/#remote-debugging -- in the tab that opens:")

--- a/test_admin.py
+++ b/test_admin.py
@@ -1,0 +1,29 @@
+import admin
+
+
+def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():
+    assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
+
+
+def test_local_chrome_mode_is_false_when_process_env_provides_remote_cdp(monkeypatch):
+    monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/1")
+
+    assert not admin._is_local_chrome_mode()
+
+
+def test_handshake_timeout_needs_chrome_remote_debugging_prompt():
+    msg = "CDP WS handshake failed: timed out during opening handshake"
+
+    assert admin._needs_chrome_remote_debugging_prompt(msg)
+
+
+def test_handshake_403_needs_chrome_remote_debugging_prompt():
+    msg = "CDP WS handshake failed: server rejected WebSocket connection: HTTP 403"
+
+    assert admin._needs_chrome_remote_debugging_prompt(msg)
+
+
+def test_stale_websocket_does_not_open_chrome_inspect():
+    msg = "no close frame received or sent"
+
+    assert not admin._needs_chrome_remote_debugging_prompt(msg)


### PR DESCRIPTION
## Summary
- classify CDP websocket opening-handshake timeouts as Chrome remote-debugging prompt/stall cases
- reuse that classifier in `ensure_daemon()` and `--setup`
- add regression coverage for timeout, 403, and stale websocket classifications

## Testing
- `uv run pytest`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Chrome setup by treating CDP WebSocket opening-handshake timeouts and 403s as remote-debugging permission cases, and retrying. Applies only to local Chrome; skips when a remote `BU_CDP_WS` is configured.

- **Bug Fixes**
  - Added `_needs_chrome_remote_debugging_prompt()` and `_is_local_chrome_mode()`; used in `ensure_daemon()` and `run_setup()` to gate the local-only inspect flow.
  - Auto-opens chrome://inspect and retries on timeout/403/opening-handshake errors; ignores stale WebSocket errors.
  - Added tests for local/remote CDP detection and for timeout, 403, and stale cases.

<sup>Written for commit a53071551cfee827ad7ecf339367c1b28a958eea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

