### PR TITLE
fix(daemon): skip discarded tabs when attaching to first page

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -189,21 +189,55 @@ class Daemon:
         self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self):
-        """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
+        """Attach to a real, responsive page. Sets self.session. Returns attached target."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         pages = [t for t in targets if is_real_page(t)]
-        if not pages:
-            # No real pages — create one instead of attaching to omnibox popup
+
+        chosen = None
+        for p in pages:
+            try:
+                sid = (await self.cdp.send_raw(
+                    "Target.attachToTarget", {"targetId": p["targetId"], "flatten": True}
+                ))["sessionId"]
+            except Exception as e:
+                log(f"failed to attach to target {p['targetId']} ({p.get('url','')[:80]}) — {e}")
+                continue
+            # Page.enable doubles as a liveness probe: discarded tabs (Memory Saver)
+            # leave the target attachable but the renderer is gone, so it never returns.
+            try:
+                await asyncio.wait_for(
+                    self.cdp.send_raw("Page.enable", session_id=sid), timeout=2
+                )
+            except Exception as e:
+                log(f"skipping unresponsive target {p['targetId']} ({p.get('url','')[:80]}) — {e or 'likely discarded'}")
+                try:
+                    await self.cdp.send_raw("Target.detachFromTarget", {"sessionId": sid})
+                except Exception:
+                    pass
+                continue
+            chosen = p
+            self.session = sid
+            break
+
+        if chosen is None:
+            # No real pages, or all unresponsive — fall back to a fresh blank tab
             tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
-            log(f"no real pages found, created about:blank ({tid})")
-            pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
-        self.session = (await self.cdp.send_raw(
-            "Target.attachToTarget", {"targetId": pages[0]["targetId"], "flatten": True}
-        ))["sessionId"]
-        self.target_id = pages[0]["targetId"]
-        log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
+            log(f"no live real pages, created about:blank ({tid})")
+            chosen = {"targetId": tid, "url": "about:blank", "type": "page"}
+            self.session = (await self.cdp.send_raw(
+                "Target.attachToTarget", {"targetId": tid, "flatten": True}
+            ))["sessionId"]
+            try:
+                await asyncio.wait_for(
+                    self.cdp.send_raw("Page.enable", session_id=self.session), timeout=5
+                )
+            except Exception as e:
+                raise RuntimeError(f"failed to enable Page on fresh about:blank tab: {e}")
+
+        self.target_id = chosen["targetId"]
+        log(f"attached {chosen['targetId']} ({chosen.get('url','')[:80]}) session={self.session}")
         await self._enable_default_domains(self.session)
-        return pages[0]
+        return chosen
 
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.


### PR DESCRIPTION
## Summary

Disgusting Chrome tab user here.
<img width="1720" height="33" alt="Screen Shot 2026-04-26 at 11 41 20 AM" src="https://github.com/user-attachments/assets/c281d4cf-056b-4504-beb3-fbe8613c6a0b" />

TL;DR: The Chrome's memory save doesn't work well with browser harness daemon because it'll pick ["discarded" chrome tabs](https://developer.chrome.com/blog/tab-discarding) and hang.

### Fix

Treat `Page.enable` as a liveness probe inside `attach_first_page`. If it times out within 2s, detach and try the next real page. If all real pages fail, fall back to `about:blank` - same fallback #60 already added for the "no real pages at all" case.

### Issue Context

Chrome's Memory Saver discards a fair chunk of my tabs. After running `browser-harness --setup`, the very first `print(page_info())` hung indefinitely. So did `new_tab(...)`. `--reload` didn't help.

The daemon picks the first real page from `Target.getTargets` and binds `self.session` to it. If that page has been discarded, its renderer process is gone and any CDP call needing the renderer (`Page.enable`, `Runtime.evaluate`, …) never returns. The existing `enable` loop times out after 5s per call but only logs the timeout — `self.session` stays bound to the corpse. Every subsequent user call goes through `daemon.handle` which has no timeout, so it deadlocks.

## Test plan

- [x] Manual: `chrome://discards/` → urgent-discard a tab, `--reload`, run any
  command. Hangs on `main`; on this branch logs `skipping unresponsive
  target ...` and attaches to a different tab.
- [x] Existing `test_admin.py` / `test_run.py` / `test_js.py` still pass.
- No new automated test — a meaningful one needs a real Chrome with a   forced-discarded tab (integration scope, no infra in the repo today).  A mock-heavy unit test would just assert the loop iterates, which is  weaker evidence than the standalone repro below. Happy to add one if you'd prefer; happy to scope an integration fixture as a follow-up.

<details>
<summary>Standalone CDP reproduction (no harness)</summary>

Talks directly to Chrome's CDP. Discarded tab times out on `Page.enable`;
live tab returns in ms. Same WebSocket, same Chrome, only variable is
discard state — proves the underlying behaviour is in CDP, not in the
harness.

```python
"""Reproduce: discarded Chrome tabs don't respond to renderer-bound CDP commands.

Usage: python3 repro_discard.py <ws_url> <url_substring>
Get <ws_url> from the daemon log line: "connecting to ws://...".
"""
import asyncio, json, sys
import websockets


async def main(ws_url: str, url_substr: str):
    async with websockets.connect(ws_url, max_size=None) as ws:
        msg_id = 0

        async def send(method, **params):
            nonlocal msg_id
            msg_id += 1
            mid = msg_id
            await ws.send(json.dumps({"id": mid, "method": method, "params": params}))
            while True:
                resp = json.loads(await ws.recv())
                if resp.get("id") == mid:
                    return resp

        async def send_session(session_id, method, **params):
            nonlocal msg_id
            msg_id += 1
            mid = msg_id
            await ws.send(json.dumps({
                "id": mid, "sessionId": session_id, "method": method, "params": params,
            }))
            while True:
                resp = json.loads(await ws.recv())
                if resp.get("id") == mid:
                    return resp

        targets = (await send("Target.getTargets"))["result"]["targetInfos"]
        candidates = [t for t in targets if t.get("type") == "page" and url_substr in t.get("url", "")]
        if not candidates:
            print(f"no target matching {url_substr!r}")
            sys.exit(2)

        t = candidates[0]
        print(f"target: {t['targetId']}  url={t['url'][:80]}")
        attach = await send("Target.attachToTarget", targetId=t["targetId"], flatten=True)
        sid = attach["result"]["sessionId"]
        print(f"attached: session={sid}")

        print("calling Page.enable with 4s timeout...")
        try:
            r = await asyncio.wait_for(send_session(sid, "Page.enable"), timeout=4)
            print(f"Page.enable OK: {r}")
        except asyncio.TimeoutError:
            print("Page.enable TIMED OUT — target is discarded / renderer is dead")
            sys.exit(1)


if __name__ == "__main__":
    if len(sys.argv) != 3:
        print(__doc__); sys.exit(2)
    asyncio.run(main(sys.argv[1], sys.argv[2]))
```

Result against my Chrome:

| Target | URL | `Page.enable` (4s timeout) |
|---|---|---|
| `D91EC1C5...` | github.com (in `chrome://discards/`) | **TIMED OUT** |
| `3309C500...` | example.com (live) | OK (ms) |

</details>

<details>
<summary>Alternatives considered</summary>

- **Always create a fresh `about:blank` instead of attaching.** Sidesteps
  the bug entirely. Rejected: SKILL.md states `goto_url` runs in the
  user's active tab — that intent only works if the daemon attaches to an
  existing tab on startup. This would be a policy change, not a bug fix.
  If you'd actually prefer that, happy to swap to it — let me know.
- **Filter via a `discarded` field on `TargetInfo`.** No such field in CDP.
- **`Target.activateTarget` to un-discard before attaching.** Would change
  the user's active tab and reload pages without permission.
- **Defensive timeout in `daemon.handle`.** Complementary, not a
  replacement: turns the hang into "every call errors" but the session is
  still bound to a corpse. Worth a follow-up PR.

</details>

---

See also #182 (open) — switch_tab unmark hang. Different code path, same
family of "session attached to a dead renderer" issues.
