### PR TITLE
Fix resource leaks: unclosed file handles and sockets

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -80,6 +80,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
+        s = None
         try:
             s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
             s.connect(_paths(name)[0])
@@ -91,6 +92,8 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 data += chunk
             if b'"result"' in data: return
         except Exception: pass
+        finally:
+            if s: s.close()
         restart_daemon(name)
 
     import subprocess, sys
@@ -139,15 +142,17 @@ def restart_daemon(name=None):
     import signal
 
     sock, pid_path = _paths(name)
+    s = None
     try:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.settimeout(5)
         s.connect(sock)
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
-        s.close()
     except Exception:
         pass
+    finally:
+        if s: s.close()
     try:
         pid = int(open(pid_path).read())
     except (FileNotFoundError, ValueError):

--- a/daemon.py
+++ b/daemon.py
@@ -55,7 +55,8 @@ API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
 def log(msg):
-    open(LOG, "a").write(f"{msg}\n")
+    with open(LOG, "a") as f:
+        f.write(f"{msg}\n")
 
 
 def get_ws_url():
@@ -244,7 +245,8 @@ if __name__ == "__main__":
         print(f"daemon already running on {SOCK}", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
-    open(PID, "w").write(str(os.getpid()))
+    with open(PID, "w") as f:
+        f.write(str(os.getpid()))
     try:
         asyncio.run(main())
     except KeyboardInterrupt:

--- a/helpers.py
+++ b/helpers.py
@@ -25,14 +25,16 @@ INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension
 
 def _send(req):
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
-    s.sendall((json.dumps(req) + "\n").encode())
-    data = b""
-    while not data.endswith(b"\n"):
-        chunk = s.recv(1 << 20)
-        if not chunk: break
-        data += chunk
-    s.close()
+    try:
+        s.connect(SOCK)
+        s.sendall((json.dumps(req) + "\n").encode())
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = s.recv(1 << 20)
+            if not chunk: break
+            data += chunk
+    finally:
+        s.close()
     r = json.loads(data)
     if "error" in r: raise RuntimeError(r["error"])
     return r
@@ -120,7 +122,8 @@ def scroll(x, y, dy=-300, dx=0):
 # --- visual ---
 def capture_screenshot(path="/tmp/shot.png", full=False):
     r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
-    open(path, "wb").write(base64.b64decode(r["data"]))
+    with open(path, "wb") as f:
+        f.write(base64.b64decode(r["data"]))
     return path
 
 


### PR DESCRIPTION
## Summary
- Fix multiple resource leaks where file handles and sockets were never properly closed
- Use `with` statements for file operations and `try/finally` for socket cleanup

## Issues Fixed

**File handle leaks:**
- `helpers.py` `capture_screenshot()`: `open().write()` pattern never closed the file handle
- `daemon.py` `log()`: `open().write()` leaked a file descriptor on every log call — critical in a long-running daemon
- `daemon.py` `__main__`: PID file write leaked a file handle

**Socket leaks:**
- `helpers.py` `_send()`: socket leaked if an exception occurred before `s.close()`
- `admin.py` `ensure_daemon()`: stale-daemon probe socket never closed in any code path (success or exception)
- `admin.py` `restart_daemon()`: socket leaked if an exception occurred before `s.close()`

## Test plan
- [x] Existing tests still pass
- [ ] Manual verification: run the daemon and confirm no file descriptor growth over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file and socket resource leaks to stop file descriptor growth and improve daemon stability. All file handles and UNIX sockets are now properly closed.

- **Bug Fixes**
  - Use `with` for file writes in `daemon.log`, PID creation, and `helpers.capture_screenshot`.
  - Close sockets with `try/finally` in `helpers._send`, `admin.ensure_daemon`, and `admin.restart_daemon`.
  - No behavior changes; improves reliability under load.

<sup>Written for commit f04d753502c405f2b08fa237c4c0f12e0151a241. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

