### PR TITLE
Fix IndexError when -c flag is passed without code argument

### DIFF
--- a/run.py
+++ b/run.py
@@ -61,6 +61,8 @@ def main():
         args = args[1:]
     if not args or args[0] != "-c":
         sys.exit("Usage: browser-harness -c \"print(page_info())\"")
+    if len(args) < 2:
+        sys.exit("Usage: browser-harness -c \"print(page_info())\"")
     print_update_banner()
     ensure_daemon()
     exec(args[1], globals())


### PR DESCRIPTION
## Summary
- Running `browser-harness -c` without providing code crashed with an unhandled `IndexError` at `exec(args[1])`
- Added a length check to produce a proper usage message instead

## Before
```
$ browser-harness -c
Traceback (most recent call last):
  ...
IndexError: list index out of range
```

## After
```
$ browser-harness -c
Usage: browser-harness -c "print(page_info())"
```

## Test plan
- [x] Verified `browser-harness -c` now prints usage instead of crashing
- [x] Verified `browser-harness -c "print(1)"` still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Running `browser-harness -c` without a code argument no longer crashes; it now shows a clear usage message. Added a simple length check before calling `exec(args[1])`.

<sup>Written for commit 263de471922bf75ab3f5543f5ca4ba813642c5c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

