### PR TITLE
Validate hostname to prevent path traversal in domain-skills lookup

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -49,8 +49,12 @@ def drain_events():  return _send({"meta": "drain_events"})["events"]
 # --- navigation / page ---
 def goto_url(url):
     r = cdp("Page.navigate", url=url)
-    d = (Path(__file__).parent / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0])
-    return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]} if d.is_dir() else r
+    hostname = (urlparse(url).hostname or "").removeprefix("www.").split(".")[0]
+    if hostname and hostname.isalnum():
+        d = Path(__file__).parent / "domain-skills" / hostname
+        if d.is_dir():
+            return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]}
+    return r
 
 def page_info():
     """{url, title, w, h, sx, sy, pw, ph} — viewport + scroll + page size.


### PR DESCRIPTION
## Summary
- The hostname extracted from URLs in `goto_url()` was used directly in filesystem path construction without validation
- A crafted URL with a malicious hostname could potentially traverse outside the intended `domain-skills/` directory
- Added `isalnum()` validation on the hostname before using it in path construction

## Details

Before:
```python
d = Path(__file__).parent / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0]
```

The extracted hostname component was used directly as a path segment. While `urlparse` provides some natural protection, the hostname was never validated before being used in path construction.

After:
```python
hostname = (urlparse(url).hostname or "").removeprefix("www.").split(".")[0]
if hostname and hostname.isalnum():
    d = Path(__file__).parent / "domain-skills" / hostname
```

The hostname is now validated to contain only alphanumeric characters before being used in the path.

## Test plan
- [x] Valid URLs like `https://www.google.com/search` still resolve to `domain-skills/google`
- [x] URLs with unusual hostnames are safely skipped (returns CDP result without domain_skills)
- [ ] Verify existing domain-skills still load correctly for known domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent path traversal in domain-skills lookup by validating the URL hostname before using it in a filesystem path. Only alphanumeric hostnames are accepted; others skip domain-skills and return the normal navigate result.

- **Bug Fixes**
  - Validate hostname (strip `www`, take first label, require `isalnum()`) before constructing `domain-skills/<host>`.
  - Return `domain_skills` only if the directory exists; otherwise return the original CDP response.

<sup>Written for commit 85426689fcae3ae446366c8da85ac8f8591780c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

