### PR TITLE
daemon: add BU_CDP_URL for HTTP DevTools endpoint resolution

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -61,6 +61,19 @@ def log(msg):
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
+    if url := os.environ.get("BU_CDP_URL"):
+        # HTTP DevTools endpoint (e.g. http://127.0.0.1:9333) — resolve to ws via /json/version.
+        # Use this for a dedicated automation Chrome on a non-default profile, which avoids the
+        # M144 "Allow remote debugging" dialog and the M136 default-profile lockdown.
+        deadline = time.time() + 30
+        last_err = None
+        while time.time() < deadline:
+            try:
+                return json.loads(urllib.request.urlopen(f"{url}/json/version", timeout=5).read())["webSocketDebuggerUrl"]
+            except Exception as e:
+                last_err = e
+                time.sleep(1)
+        raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- is the dedicated automation Chrome running?")
     for base in PROFILES:
         try:
             port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)


### PR DESCRIPTION
## Summary
- Add `BU_CDP_URL` env var that takes a Chrome DevTools HTTP endpoint (e.g. `http://127.0.0.1:9333`) and resolves it to the WS URL via `/json/version`, mirroring how `start_remote_daemon` already handles cloud browsers.
- Resolution polls for up to 30 s so the harness can be invoked while Chrome is still booting (e.g. via a LaunchAgent on macOS).
- Existing setups are unaffected: if neither `BU_CDP_WS` nor `BU_CDP_URL` is set, behaviour falls through to the existing `DevToolsActivePort` discovery.

## Why
Chrome 144+ shows a per-connection "Allow remote debugging" consent dialog when CDP attaches to the **default** Chrome profile, and Chrome 136+ silently ignores `--remote-debugging-port` against the default `--user-data-dir`. The clean way around both, [recommended by the Chrome DevTools MCP team](https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/825), is to run a dedicated Chrome (Chrome for Testing works well, opt-out of both lockdowns) against a non-default `--user-data-dir` with `--remote-debugging-port=N`, then point clients at `http://127.0.0.1:N`.

`BU_CDP_WS` already supports this in principle, but the user has to manually resolve `/json/version` to get the WS URL, and the WS URL contains a session-specific UUID that changes on every Chrome restart - so it's not friendly as a static env var. `BU_CDP_URL` gives a stable URL that survives restarts.

## Example

```bash
# Launch Chrome for Testing with CDP on 9333 against an isolated profile
"/path/to/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
  --remote-debugging-port=9333 \
  --user-data-dir="$HOME/.chrome-automation-profile" \
  --headless=new &

# Tell the harness to attach to it
export BU_CDP_URL="http://127.0.0.1:9333"
browser-harness <<'PY'
new_tab("https://example.com")
print(page_info())
PY
```

No "Allow remote debugging" dialog, no fight with the user's regular Chrome.

## Test plan
- [x] `BU_CDP_URL` set: harness attaches and drives an isolated Chrome for Testing on port 9333; verified via `new_tab`, `page_info`, headless mode
- [x] Neither env var set: existing `DevToolsActivePort` discovery still works
- [x] `BU_CDP_URL` set but Chrome not yet up: polls for 30 s, then errors clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `BU_CDP_URL` to let the daemon accept a Chrome DevTools HTTP endpoint and auto-resolve it to the WebSocket URL. This supports dedicated automation Chrome profiles and avoids the default-profile lockdown and consent prompt.

- **New Features**
  - Resolve `BU_CDP_URL` via `/json/version` to get `webSocketDebuggerUrl`.
  - Poll up to 30s for the endpoint before failing with a clear error.
  - Preserve fallback: if neither `BU_CDP_WS` nor `BU_CDP_URL` is set, use `DevToolsActivePort`.

<sup>Written for commit 94897c7ae3ba7b9be7d38e201939848a68d1c401. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

