### PR TITLE
docs: replace heredoc stdin examples with -c flag

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -10,14 +10,22 @@ Direct browser control via CDP. Read helpers.py — that's where the functions l
 ## Usage
 
 ```bash
-browser-harness <<'PY'
+browser-harness -c "$(cat <<'PY'
 new_tab("https://docs.browser-use.com")
 wait_for_load()
 print(page_info())
 PY
+)"
+```
+
+For one-liners, just pass the code directly:
+
+```bash
+browser-harness -c 'print(page_info())'
 ```
 
 - Invoke as browser-harness — it's on $PATH. No cd, no uv run.
+- Pass Python via `-c` — the CLI does not read stdin. For multi-line scripts use the `-c "$(cat <<'PY' ... PY)"` form above.
 - First navigation is new_tab(url), not goto_url(url) — goto runs in the user's active tab and clobbers their work.
 
 Available interaction skills:
@@ -30,9 +38,16 @@ Available domain skills:
 ## Tool call shape
 
 ```bash
-browser-harness <<'PY'
+browser-harness -c "$(cat <<'PY'
 # any python. helpers pre-imported. daemon auto-starts.
 PY
+)"
+```
+
+For short scripts, single-quote the code after `-c`:
+
+```bash
+browser-harness -c 'ensure_real_tab(); print(page_info())'
 ```
 
 run.py calls ensure_daemon() before exec — you never start/stop manually unless you want to.
@@ -42,18 +57,20 @@ run.py calls ensure_daemon() before exec — you never start/stop manually unles
 Use remote for parallel sub-agents (each gets its own isolated browser via a distinct BU_NAME) or on a headless server. BROWSER_USE_API_KEY must be set. start_remote_daemon, list_cloud_profiles, list_local_profiles, sync_local_profile are pre-imported.
 
 ```bash
-browser-harness <<'PY'
+browser-harness -c "$(cat <<'PY'
 start_remote_daemon("work")                               # default — clean browser, no profile
 # start_remote_daemon("work", profileName="my-work")      # reuse a cloud profile (already logged in)
 # start_remote_daemon("work", profileId="<uuid>")         # same, but by UUID
 # start_remote_daemon("work", proxyCountryCode="de", timeout=120)   # DE proxy, 2-hour timeout
 # start_remote_daemon("work", proxyCountryCode=None)      # disable the Browser Use proxy
 PY
+)"
 
-BU_NAME=work browser-harness <<'PY'
+BU_NAME=work browser-harness -c "$(cat <<'PY'
 new_tab("https://example.com")
 print(page_info())
 PY
+)"
 ```
 
 start_remote_daemon prints liveUrl and auto-opens it in the local browser (if a GUI is detected) so the user can watch along. Headless servers print only — share the URL with the user. The daemon PATCHes the cloud browser to stop on shutdown, which persists profile state. Running remote daemons bill until timeout.

--- a/install.md
+++ b/install.md
@@ -48,9 +48,7 @@ Prefer `browser-harness --setup` — it runs the full attach-and-escalate flow b
 2. First try the harness directly. If this works, skip manual browser setup:
 
 ```bash
-uv run browser-harness <<'PY'
-print(page_info())
-PY
+uv run browser-harness -c 'print(page_info())'
 ```
 
    Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session.
@@ -77,11 +75,12 @@ osascript -e 'tell application "Google Chrome" to activate' \
 7. Verify with:
 
 ```bash
-uv run browser-harness <<'PY'
+uv run browser-harness -c "$(cat <<'PY'
 goto_url("https://github.com/browser-use/browser-harness")
 wait_for_load()
 print(page_info())
 PY
+)"
 ```
 
 If that fails with a stale websocket or stale socket, restart the daemon once and retry:

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -10,7 +10,7 @@ curl -fsSL https://browser-use.com/profile.sh | sh
 
 Downloads `profile-use` (macOS / Linux / Windows, x64 / arm64). The Python helpers shell out to it; you don't run `profile-use` directly.
 
-## Python API (pre-imported in `browser-harness <<'PY'`)
+## Python API (pre-imported in `browser-harness -c`)
 
 ```python
 list_cloud_profiles()

--- a/run.py
+++ b/run.py
@@ -21,10 +21,14 @@ HELP = """Browser Harness
 Read SKILL.md for the default workflow and examples.
 
 Typical usage:
-  uv run bh <<'PY'
+  browser-harness -c 'print(page_info())'
+
+  # multi-line:
+  browser-harness -c "$(cat <<'PY'
   ensure_real_tab()
   print(page_info())
   PY
+  )"
 
 Helpers are pre-imported. The daemon auto-starts and connects to the running browser.
 


### PR DESCRIPTION
Closes #213.

## Problem

The CLI switched to requiring `-c` in #188, but `SKILL.md`, `install.md`, `run.py`'s `HELP` string, and `interaction-skills/profile-sync.md` still documented the removed `<<'PY'` heredoc pattern. Running the examples verbatim errors out:

```console
$ browser-harness <<'PY'
print(page_info())
PY
Usage: browser-harness -c "print(page_info())"
```

## Change

Updated every example to use `-c`:

- **One-liners**: `browser-harness -c 'print(page_info())'`.
- **Multi-line**: `browser-harness -c "$(cat <<'PY' ... PY)"`. The single-quoted heredoc delimiter (`'PY'`) suppresses shell expansion, so embedded double quotes and `$` just work. Verified against a live browser:

```console
$ browser-harness -c "$(cat <<'PY'
new_tab("about:blank")
wait_for_load()
print(page_info())
PY
)"
{'url': 'about:blank', 'title': '🟢 about:blank', ...}
```

Also tightened the SKILL.md usage bullet to explicitly say the CLI does not read stdin, so the next agent reading it doesn't try a heredoc and hit the same wall.

## Files touched

- `SKILL.md` — Usage, Tool call shape, Remote browsers sections.
- `install.md` — step 2 attach probe, step 7 verify snippet.
- `run.py` — `HELP` string (shown on `--help`).
- `interaction-skills/profile-sync.md` — one-line section header.

## Scope

Kept narrowly to the paths called out in #213 plus the matching `HELP` string and the profile-sync cross-reference. Domain-skill scrape scripts (`domain-skills/**/*.md`) also still use heredocs in their narratives, but those are a separate cluster — happy to tackle them in a follow-up if you'd like.

## Test plan

- [x] `pytest test_run.py` — 2 passed (`test_c_flag_executes_code`, `test_c_flag_does_not_read_stdin`).
- [x] Ran the new multi-line `-c "$(cat <<'PY' ... PY)"` block against a real attached Chrome; got expected `page_info()` output.
- [x] Ran `browser-harness --help` after editing — `HELP` renders cleanly.

🤖 Authored with assistance from an automated agent; reviewed end-to-end against a live browser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced heredoc stdin examples with the required `-c` flag across the docs and `run.py` help so examples work with the current CLI (closes #213). Also clarifies that `browser-harness` does not read stdin.

- **Migration**
  - One-liners: `browser-harness -c 'print(page_info())'`
  - Multi-line: `browser-harness -c "$(cat <<'PY' ... PY)"` (use a single-quoted heredoc delimiter to avoid shell expansion)

<sup>Written for commit 64b9b6915ff9eee5c894b4de64282e80e679cff5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

