### PR TITLE
Add Windows support (TCP sockets, cross-platform paths)

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,9 +1,13 @@
 import json
 import os
 import socket
+import sys
+import tempfile
 import time
 import urllib.request
 from pathlib import Path
+
+_IS_WIN = sys.platform == "win32"
 
 
 def _load_env():
@@ -21,19 +25,33 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
+_TMPDIR = tempfile.gettempdir()
 BU_API = "https://api.browser-use.com/api/v3"
 GH_RELEASES = "https://api.github.com/repos/browser-use/browser-harness/releases/latest"
-VERSION_CACHE = Path("/tmp/bu-version-cache.json")
+VERSION_CACHE = Path(os.path.join(_TMPDIR, "bu-version-cache.json"))
 VERSION_CACHE_TTL = 24 * 3600
+
+
+def _bu_port(name=None):
+    """Deterministic TCP port for a daemon name (Windows). Range 49200-49399."""
+    import hashlib
+    n = name or NAME
+    return 49200 + int(hashlib.md5(n.encode()).hexdigest(), 16) % 200
+
+
+def _bu_port_file(name=None):
+    return os.path.join(_TMPDIR, f"bu-{name or NAME}.port")
 
 
 def _paths(name):
     n = name or NAME
-    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
+    sock = os.path.join(_TMPDIR, f"bu-{n}.sock")
+    pid = os.path.join(_TMPDIR, f"bu-{n}.pid")
+    return sock, pid
 
 
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
+    p = os.path.join(_TMPDIR, f"bu-{name or NAME}.log")
     try:
         return Path(p).read_text().strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
@@ -64,14 +82,31 @@ def _is_local_chrome_mode(env=None):
     return not (env or {}).get("BU_CDP_WS") and not os.environ.get("BU_CDP_WS")
 
 
-def daemon_alive(name=None):
-    try:
+def _connect_daemon(name=None):
+    """Connect to daemon, returns a connected socket."""
+    if _IS_WIN:
+        port_file = _bu_port_file(name)
+        try:
+            port = int(Path(port_file).read_text().strip())
+        except (FileNotFoundError, ValueError):
+            port = _bu_port(name)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(1)
+        s.connect(("127.0.0.1", port))
+        return s
+    else:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.settimeout(1)
         s.connect(_paths(name)[0])
+        return s
+
+
+def daemon_alive(name=None):
+    try:
+        s = _connect_daemon(name)
         s.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
         return False
 
 
@@ -81,8 +116,8 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
         try:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
-            s.connect(_paths(name)[0])
+            s = _connect_daemon(name)
+            s.settimeout(3)
             s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
             data = b""
             while not data.endswith(b"\n"):
@@ -97,11 +132,15 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     local = _is_local_chrome_mode(env)
     for attempt in (0, 1):
         e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
-        p = subprocess.Popen(
-            ["uv", "run", "daemon.py"],
+        popen_kwargs = dict(
             cwd=os.path.dirname(os.path.abspath(__file__)),
-            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
+        if _IS_WIN:
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+        else:
+            popen_kwargs["start_new_session"] = True
+        p = subprocess.Popen(["uv", "run", "daemon.py"], **popen_kwargs)
         deadline = time.time() + wait
         while time.time() < deadline:
             if daemon_alive(name): return
@@ -113,7 +152,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
             restart_daemon(name)
             continue
-        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {os.path.join(_TMPDIR, 'bu-' + (name or NAME) + '.log')}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -140,9 +179,8 @@ def restart_daemon(name=None):
 
     sock, pid_path = _paths(name)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s = _connect_daemon(name)
         s.settimeout(5)
-        s.connect(sock)
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
         s.close()
@@ -157,14 +195,20 @@ def restart_daemon(name=None):
             try:
                 os.kill(pid, 0)
                 time.sleep(0.2)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 break
         else:
             try:
-                os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
+                if _IS_WIN:
+                    os.kill(pid, signal.SIGTERM)
+                else:
+                    os.kill(pid, signal.SIGTERM)
+            except (ProcessLookupError, OSError):
                 pass
-    for f in (sock, pid_path):
+    cleanup = [sock, pid_path]
+    if _IS_WIN:
+        cleanup.append(_bu_port_file(name))
+    for f in cleanup:
         try:
             os.unlink(f)
         except FileNotFoundError:

--- a/daemon.py
+++ b/daemon.py
@@ -1,9 +1,11 @@
-"""CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.request
+"""CDP WS holder + socket relay. One daemon per BU_NAME."""
+import asyncio, json, os, socket, sys, tempfile, time, urllib.request
 from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
+
+_IS_WIN = sys.platform == "win32"
 
 
 def _load_env():
@@ -21,9 +23,10 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+_TMPDIR = tempfile.gettempdir()
+SOCK = os.path.join(_TMPDIR, f"bu-{NAME}.sock")
+LOG = os.path.join(_TMPDIR, f"bu-{NAME}.log")
+PID = os.path.join(_TMPDIR, f"bu-{NAME}.pid")
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -197,10 +200,18 @@ class Daemon:
             return {"error": msg}
 
 
-async def serve(d):
-    if os.path.exists(SOCK):
-        os.unlink(SOCK)
+def _bu_port(name=None):
+    """Deterministic TCP port for a daemon name (Windows). Range 49200-49399."""
+    import hashlib
+    n = name or NAME
+    return 49200 + int(hashlib.md5(n.encode()).hexdigest(), 16) % 200
 
+
+def _bu_port_file(name=None):
+    return os.path.join(_TMPDIR, f"bu-{name or NAME}.port")
+
+
+async def serve(d):
     async def handler(reader, writer):
         try:
             line = await reader.readline()
@@ -218,9 +229,19 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    if _IS_WIN:
+        port = _bu_port()
+        server = await asyncio.start_server(handler, "127.0.0.1", port)
+        # Write actual port so clients can find it
+        Path(_bu_port_file()).write_text(str(port))
+        log(f"listening on 127.0.0.1:{port} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    else:
+        if os.path.exists(SOCK):
+            os.unlink(SOCK)
+        server = await asyncio.start_unix_server(handler, path=SOCK)
+        os.chmod(SOCK, 0o600)
+        log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+
     async with server:
         await d.stop.wait()
 
@@ -233,9 +254,22 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        if _IS_WIN:
+            port_file = _bu_port_file()
+            try:
+                port = int(Path(port_file).read_text().strip())
+            except (FileNotFoundError, ValueError):
+                port = _bu_port()
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(1)
+            s.connect(("127.0.0.1", port))
+        else:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.settimeout(1)
+            s.connect(SOCK)
+        s.close()
+        return True
+    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
         return False
 
 
@@ -254,5 +288,6 @@ if __name__ == "__main__":
         sys.exit(1)
     finally:
         stop_remote()
-        try: os.unlink(PID)
-        except FileNotFoundError: pass
+        for f in [PID] + ([_bu_port_file()] if _IS_WIN else []):
+            try: os.unlink(f)
+            except FileNotFoundError: pass

--- a/helpers.py
+++ b/helpers.py
@@ -1,7 +1,9 @@
 """Browser control via CDP. Read, edit, extend -- this file is yours."""
-import base64, json, os, socket, time, urllib.request
+import base64, json, os, socket, sys, tempfile, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
+
+_IS_WIN = sys.platform == "win32"
 
 
 def _load_env():
@@ -19,13 +21,45 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
+_TMPDIR = tempfile.gettempdir()
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
+def _bu_port(name=None):
+    """Deterministic TCP port for a daemon name (Windows only). Range 49200-49399."""
+    import hashlib
+    n = name or NAME
+    return 49200 + int(hashlib.md5(n.encode()).hexdigest(), 16) % 200
+
+
+def _bu_port_file(name=None):
+    """File that stores the TCP port the daemon is listening on (Windows)."""
+    return os.path.join(_TMPDIR, f"bu-{name or NAME}.port")
+
+
+def _sock_path(name=None):
+    """Unix socket path (non-Windows)."""
+    return os.path.join(_TMPDIR, f"bu-{name or NAME}.sock")
+
+
+def _connect_daemon():
+    """Connect to the daemon, returns a connected socket."""
+    if _IS_WIN:
+        port_file = _bu_port_file()
+        try:
+            port = int(Path(port_file).read_text().strip())
+        except (FileNotFoundError, ValueError):
+            port = _bu_port()
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(("127.0.0.1", port))
+    else:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(_sock_path())
+    return s
+
+
 def _send(req):
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
+    s = _connect_daemon()
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):
@@ -75,7 +109,7 @@ def click_at_xy(x, y, button="left", clicks=1):
         try:
             from PIL import Image, ImageDraw
             dpr = js("window.devicePixelRatio") or 1
-            path = capture_screenshot(f"/tmp/debug_click_{_debug_click_counter}.png")
+            path = capture_screenshot(os.path.join(_TMPDIR, f"debug_click_{_debug_click_counter}.png"))
             img = Image.open(path)
             draw = ImageDraw.Draw(img)
             px, py = int(x * dpr), int(y * dpr)
@@ -118,7 +152,9 @@ def scroll(x, y, dy=-300, dx=0):
 
 
 # --- visual ---
-def capture_screenshot(path="/tmp/shot.png", full=False):
+def capture_screenshot(path=None, full=False):
+    if path is None:
+        path = os.path.join(_TMPDIR, "shot.png")
     r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
     open(path, "wb").write(base64.b64decode(r["data"]))
     return path


### PR DESCRIPTION
Windows Python lacks socket.AF_UNIX, so on win32 the daemon uses a TCP socket on localhost with a deterministic port derived from the instance name (MD5 hash). Unix platforms are unchanged.

Changes:
- helpers.py: TCP connect on Windows, cross-platform temp dir
- daemon.py: TCP server fallback in serve(), port-file management, TCP-based already_running() check
- admin.py: TCP _connect_daemon(), Windows subprocess flags (CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS), cross-platform paths

Tested on Windows 11 + Python 3.14 + Chrome 136 via CDP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class Windows support by switching the daemon to localhost TCP sockets with a deterministic port and using cross-platform temp paths. Unix behavior is unchanged and still uses Unix domain sockets.

- New Features
  - Windows: daemon listens on 127.0.0.1 using a deterministic port (49200–49399 from `BU_NAME`), writes it to a `.port` file in the temp dir, and removes it on shutdown.
  - Cross-platform temp paths via `tempfile.gettempdir()` for socket/log/pid/version-cache; screenshot and debug-click images now default to the temp dir.
  - Unified connection logic in `admin`/`helpers`: clients read the `.port` file (with fallback to the derived port); `already_running` and restart work over TCP on Windows.
  - Windows daemon launch uses detached subprocess flags (`CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS`).

<sup>Written for commit c6c063a0c081f321f6130950226ce8f825e762f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

