### PR TITLE
docs: add MiniMax-M2.7 setup guide for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,36 @@ The agent writes what's missing, mid-task. No framework, no recipes, no rails. O
 
 ## Setup prompt
 
-Paste into Claude Code or Codex:
+Paste into Claude Code or Codex (also works with [MiniMax-M2.7 in Claude Code](#minimax-m27)):
 
 ```text
 Set up https://github.com/browser-use/browser-harness for me.
 
 Read `install.md` first to install and connect this repo to my real browser. Then read `SKILL.md` for normal usage. Always read `helpers.py` because that is where the functions are. When you open a setup or verification tab, activate it so I can see the active browser tab. After it is installed, open this repository in my browser and, if I am logged in to GitHub, ask me whether you should star it for me as a quick demo that the interaction works — only click the star if I say yes. If I am not logged in, just go to browser-use.com.
 ```
+
+## MiniMax-M2.7
+
+browser-harness works with any AI coding agent that supports the Anthropic API. [MiniMax-M2.7](https://www.minimax.io/models/text/m27) is a cost-effective alternative that can power Claude Code via the MiniMax Anthropic-compatible endpoint.
+
+**Quick setup** — add to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "<YOUR_MINIMAX_API_KEY>",
+    "ANTHROPIC_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "MiniMax-M2.7",
+    "API_TIMEOUT_MS": "3000000",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  }
+}
+```
+
+Get your API key at [platform.minimax.io](https://platform.minimax.io/user-center/basic-information/interface-key). For users in China, replace the base URL with `https://api.minimaxi.com/anthropic`. See `install.md` for more details.
 
 When this page appears, tick the checkbox so the agent can connect to your browser:
 

--- a/install.md
+++ b/install.md
@@ -31,6 +31,60 @@ After the repo is installed, register this repo's `SKILL.md` with the agent you 
 - **Codex**: add this file as a global skill at `$CODEX_HOME/skills/browser-harness/SKILL.md` (often `~/.codex/skills/browser-harness/SKILL.md`). A symlink to this repo's `SKILL.md` is fine.
 - **Claude Code**: add an import to `~/.claude/CLAUDE.md` that points at this repo's `SKILL.md`, for example `@~/src/browser-harness/SKILL.md`.
 
+## Using MiniMax-M2.7 with Claude Code
+
+browser-harness works with any AI coding agent that speaks the Anthropic API. [MiniMax-M2.7](https://www.minimax.io/models/text/m27) is a cost-effective model that can back Claude Code via MiniMax's Anthropic-compatible endpoint — no separate agent installation required.
+
+**Step 1 — Get a MiniMax API key**
+
+Register at [platform.minimax.io](https://platform.minimax.io/login), then visit [API Keys → Create new secret key](https://platform.minimax.io/user-center/basic-information/interface-key). Export it:
+
+```bash
+export MINIMAX_API_KEY="your_key_here"
+```
+
+**Step 2 — Point Claude Code at MiniMax**
+
+Before configuring, clear any existing Anthropic variables to avoid conflicts:
+
+```bash
+unset ANTHROPIC_AUTH_TOKEN
+unset ANTHROPIC_BASE_URL
+```
+
+Then create or edit `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "<YOUR_MINIMAX_API_KEY>",
+    "ANTHROPIC_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "MiniMax-M2.7",
+    "API_TIMEOUT_MS": "3000000",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  }
+}
+```
+
+For users in China, replace `https://api.minimax.io/anthropic` with `https://api.minimaxi.com/anthropic`.
+
+**Step 3 — Verify**
+
+```bash
+claude --version          # confirm Claude Code is installed
+claude "print hello"      # first call — Claude Code will use MiniMax-M2.7
+```
+
+**Notes**
+
+- `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` set as process environment variables take priority over `settings.json`. If things aren't working, run `unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_BASE_URL` first.
+- `API_TIMEOUT_MS: 3000000` (50 minutes) prevents Claude Code from timing out on long browser sessions.
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: 1` skips Anthropic telemetry — required when using a third-party base URL.
+- The same `SKILL.md` setup steps apply: `@~/src/browser-harness/SKILL.md` in `~/.claude/CLAUDE.md`.
+
 Codex command:
 
 ```bash


### PR DESCRIPTION
## Summary

MiniMax-M2.7 is a coding-capable model that supports the Anthropic-compatible API, which means it can back Claude Code as a drop-in alternative to Anthropic models. Since browser-harness is primarily designed for Claude Code, this PR documents how to configure the pairing.

Changes:
- README.md: adds a MiniMax-M2.7 section with a minimal settings.json snippet
- install.md: adds a full step-by-step guide covering API key retrieval, environment variable cleanup, settings.json configuration, and a smoke-test. Covers both international and China endpoints.

No code changes — documentation only. All existing tests pass.

## Test plan

- Confirm all 10 existing unit tests pass (python -m pytest)
- Review README.md and install.md changes for accuracy against MiniMax docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs to use MiniMax-M2.7 with Claude Code via the Anthropic-compatible endpoint, so browser-harness can run with a lower-cost drop-in model. Adds a quick-start snippet in README and a step-by-step guide in install.md (API key, clear conflicting env vars, configure `~/.claude/settings.json`, verify; international and China endpoints).

<sup>Written for commit fc57f28640f793922ee0d513b5b0b9cf320d8a4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

