### PR TITLE
feat(helpers): add max_dim to capture_screenshot

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -118,9 +118,17 @@ def scroll(x, y, dy=-300, dx=0):
 
 
 # --- visual ---
-def capture_screenshot(path="/tmp/shot.png", full=False):
+def capture_screenshot(path="/tmp/shot.png", full=False, max_dim=None):
+    """Save a PNG of the current viewport. Set max_dim=1800 on a 2× display to
+    keep the file under the 2000px-per-side limit some image-aware LLMs enforce."""
     r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
     open(path, "wb").write(base64.b64decode(r["data"]))
+    if max_dim:
+        from PIL import Image
+        img = Image.open(path)
+        if max(img.size) > max_dim:
+            img.thumbnail((max_dim, max_dim))
+            img.save(path)
     return path
 
 

--- a/interaction-skills/screenshots.md
+++ b/interaction-skills/screenshots.md
@@ -1,3 +1,17 @@
 # Screenshots
 
-Separate full-page screenshots from targeted section screenshots, and note when screenshots are only for discovery versus verification.
+`capture_screenshot()` writes a PNG of the current viewport. The file is in **device pixels** — on a 2× display a 2296×1143 CSS viewport produces a 4592×2286 PNG.
+
+That matters for two reasons:
+
+1. **Click coordinates are CSS pixels.** Don't read a target off the image and pass it to `click_at_xy()` directly without dividing by `devicePixelRatio`. The simplest workflow is to take the screenshot, look at it in a viewer that shows CSS coordinates, or measure relative positions and use `js("window.devicePixelRatio")` to convert.
+
+2. **Some LLMs reject images > 2000 px per side.** Long sessions on 2× displays will eventually hit this. Pass `max_dim=1800` to downscale the file before it gets into the conversation:
+
+```python
+capture_screenshot("/tmp/shot.png", max_dim=1800)
+```
+
+The downscale only happens when the image actually exceeds `max_dim`, so it's safe to leave on for every shot.
+
+Use full-page screenshots (`full=True`) only when you need to see content below the fold — they are much larger and slower than viewport-only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "cdp-use==1.4.5",
     "fetch-use==0.4.0",
+    "pillow==12.2.0",
     "websockets==16.0",
 ]
 

--- a/test_screenshot.py
+++ b/test_screenshot.py
@@ -1,0 +1,41 @@
+import base64
+import io
+import tempfile
+from unittest.mock import patch
+
+from PIL import Image
+
+import helpers
+
+
+def _fake_png(width, height):
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), "white").save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_max_dim_downsizes_oversized_image():
+    fake = lambda method, **kwargs: {"data": _fake_png(4592, 2286)}
+    with patch("helpers.cdp", side_effect=fake), tempfile.NamedTemporaryFile(suffix=".png") as f:
+        helpers.capture_screenshot(f.name, max_dim=1800)
+        w, h = Image.open(f.name).size
+
+    assert max(w, h) == 1800
+
+
+def test_max_dim_skips_when_image_already_small():
+    fake = lambda method, **kwargs: {"data": _fake_png(800, 400)}
+    with patch("helpers.cdp", side_effect=fake), tempfile.NamedTemporaryFile(suffix=".png") as f:
+        helpers.capture_screenshot(f.name, max_dim=1800)
+        w, h = Image.open(f.name).size
+
+    assert (w, h) == (800, 400)
+
+
+def test_max_dim_default_is_no_resize():
+    fake = lambda method, **kwargs: {"data": _fake_png(4592, 2286)}
+    with patch("helpers.cdp", side_effect=fake), tempfile.NamedTemporaryFile(suffix=".png") as f:
+        helpers.capture_screenshot(f.name)
+        w, h = Image.open(f.name).size
+
+    assert (w, h) == (4592, 2286)

--- a/test_screenshot.py
+++ b/test_screenshot.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import os
 import tempfile
 from unittest.mock import patch
 
@@ -14,28 +15,21 @@ def _fake_png(width, height):
     return base64.b64encode(buf.getvalue()).decode()
 
 
-def test_max_dim_downsizes_oversized_image():
-    fake = lambda method, **kwargs: {"data": _fake_png(4592, 2286)}
-    with patch("helpers.cdp", side_effect=fake), tempfile.NamedTemporaryFile(suffix=".png") as f:
-        helpers.capture_screenshot(f.name, max_dim=1800)
-        w, h = Image.open(f.name).size
+def _run(width, height, **kwargs):
+    fake = lambda method, **_: {"data": _fake_png(width, height)}
+    with patch("helpers.cdp", side_effect=fake), tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "shot.png")
+        helpers.capture_screenshot(path, **kwargs)
+        return Image.open(path).size
 
-    assert max(w, h) == 1800
+
+def test_max_dim_downsizes_oversized_image():
+    assert max(_run(4592, 2286, max_dim=1800)) == 1800
 
 
 def test_max_dim_skips_when_image_already_small():
-    fake = lambda method, **kwargs: {"data": _fake_png(800, 400)}
-    with patch("helpers.cdp", side_effect=fake), tempfile.NamedTemporaryFile(suffix=".png") as f:
-        helpers.capture_screenshot(f.name, max_dim=1800)
-        w, h = Image.open(f.name).size
-
-    assert (w, h) == (800, 400)
+    assert _run(800, 400, max_dim=1800) == (800, 400)
 
 
 def test_max_dim_default_is_no_resize():
-    fake = lambda method, **kwargs: {"data": _fake_png(4592, 2286)}
-    with patch("helpers.cdp", side_effect=fake), tempfile.NamedTemporaryFile(suffix=".png") as f:
-        helpers.capture_screenshot(f.name)
-        w, h = Image.open(f.name).size
-
-    assert (w, h) == (4592, 2286)
+    assert _run(4592, 2286) == (4592, 2286)


### PR DESCRIPTION
## Summary
- Long agent sessions on 2× displays hit the **2000px-per-side image limit** that some image-aware LLMs enforce — a 2296×1143 CSS viewport produces a 4592×2286 PNG, and once one of those lands in conversation context, every follow-up call fails until the user runs `/compact`.
- `capture_screenshot()` now accepts an optional `max_dim` that thumbnails the file before save. Default behavior is unchanged.

## Why this is the smallest fix that works
- It's a single-line opt-in. Callers who don't pass `max_dim` get the original PNG bytes.
- The thumbnail only runs when the image actually exceeds `max_dim`, so leaving it on for every shot is safe and cheap.
- PR #201 documented the gotcha but added no code fix; this is the missing piece. The README and `interaction-skills/screenshots.md` now point at the new param.

## Verification
```
$ uv run pytest -q
.............
13 passed in 0.14s
```

## Test plan
- [x] `test_max_dim_downsizes_oversized_image` — 4592×2286 PNG → max(w,h) == 1800
- [x] `test_max_dim_skips_when_image_already_small` — 800×400 PNG stays 800×400
- [x] `test_max_dim_default_is_no_resize` — omitting `max_dim` returns the raw bytes unchanged
- [ ] Reviewer: confirm the doc tone in `interaction-skills/screenshots.md` matches the rest of the skill files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `max_dim` to `capture_screenshot()` to downscale large screenshots before save. This prevents 2000px-per-side rejections in some image-aware LLMs without changing default behavior.

- New Features
  - Added `max_dim` to `capture_screenshot(path, full=False, max_dim=None)`; downscales with `Pillow` only when the image exceeds the limit.
  - Updated `interaction-skills/screenshots.md` with guidance (e.g., use `max_dim=1800` on 2× displays).
  - Added tests for downscaling, skipping when small, and default no-resize.

- Bug Fixes
  - Declared `pillow==12.2.0` in `pyproject.toml` for the new resize path.
  - Made screenshot tests portable by using `tempfile.TemporaryDirectory` (avoids Windows file locking).

<sup>Written for commit 7d314748ee174fb7e6c55a7bcd3c786850f5e842. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

