### PR TITLE
daemon: discover DevToolsActivePort in Comet, Arc, Brave profiles on macOS

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -27,6 +27,9 @@ PID = f"/tmp/bu-{NAME}.pid"
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
+    Path.home() / "Library/Application Support/Comet",
+    Path.home() / "Library/Application Support/Arc/User Data",
+    Path.home() / "Library/Application Support/BraveSoftware/Brave-Browser",
     Path.home() / "Library/Application Support/Microsoft Edge",
     Path.home() / "Library/Application Support/Microsoft Edge Beta",
     Path.home() / "Library/Application Support/Microsoft Edge Dev",


### PR DESCRIPTION
## Summary

Three popular Chromium-based browsers on macOS use the same `DevToolsActivePort` discovery contract as Chrome and Edge, but their profile directories weren't in the harness's search list. Without `BU_CDP_WS` set manually, the harness fell back to:

> `fatal: DevToolsActivePort not found in [...] — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser`

This adds those three profile dirs so the harness "just works" against Comet, Arc, and Brave the same way it does against Chrome.

## Changes

`daemon.py` — append three macOS profile dirs to `PROFILES`:

- **Comet** (Perplexity): `~/Library/Application Support/Comet`
- **Arc** (The Browser Co): `~/Library/Application Support/Arc/User Data`
- **Brave**: `~/Library/Application Support/BraveSoftware/Brave-Browser`

## Behavior

- No change for Chrome/Edge users — entries are appended to the existing list and only matched when the dir exists.
- The `chrome://inspect/#remote-debugging` toggle (sticky per profile) works in Comet/Brave the same way it does in Chrome, so once enabled, the harness picks up `DevToolsActivePort` automatically.
- Verified locally on macOS: with Comet's profile dir created and the checkbox set, the harness attaches identically to how it does on Chrome.

## Test plan

- [x] Comet profile dir present + harness attaches via `DevToolsActivePort`
- [ ] Arc profile dir present + harness attaches (untested locally — listed by symmetry)
- [ ] Brave profile dir present + harness attaches (untested locally — listed by symmetry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds macOS profile discovery for Comet, Arc, and Brave so the harness finds DevToolsActivePort and auto-attaches without `BU_CDP_WS`. No change for Chrome/Edge; directories are only used when present.

- **New Features**
  - Comet: ~/Library/Application Support/Comet
  - Arc: ~/Library/Application Support/Arc/User Data
  - Brave: ~/Library/Application Support/BraveSoftware/Brave-Browser

<sup>Written for commit 02d0625cef5388aa0089d331ddc5f5bcf12592c5. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/223?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

