### PR TITLE
fix(windows): add cross-platform daemon transport fallback

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,9 +1,12 @@
 import json
 import os
 import socket
+import sys
 import time
 import urllib.request
 from pathlib import Path
+
+from transport import BASE, cleanup_endpoint, connect_socket, paths
 
 
 def _load_env():
@@ -23,19 +26,19 @@ _load_env()
 NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"
 GH_RELEASES = "https://api.github.com/repos/browser-use/browser-harness/releases/latest"
-VERSION_CACHE = Path("/tmp/bu-version-cache.json")
+VERSION_CACHE = BASE / "bu-version-cache.json"
 VERSION_CACHE_TTL = 24 * 3600
 
 
 def _paths(name):
-    n = name or NAME
-    return f"/tmp/bu-{n}.sock", f"/tmp/bu-{n}.pid"
+    sock, pid, _ = paths(name)
+    return str(sock), str(pid)
 
 
 def _log_tail(name):
-    p = f"/tmp/bu-{name or NAME}.log"
+    _, _, log_path = paths(name)
     try:
-        return Path(p).read_text().strip().splitlines()[-1]
+        return log_path.read_text().strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
         return None
 
@@ -66,12 +69,10 @@ def _is_local_chrome_mode(env=None):
 
 def daemon_alive(name=None):
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(1)
-        s.connect(_paths(name)[0])
+        s = connect_socket(name, timeout=1)
         s.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+    except OSError:
         return False
 
 
@@ -81,8 +82,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
         try:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
-            s.connect(_paths(name)[0])
+            s = connect_socket(name, timeout=3)
             s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
             data = b""
             while not data.endswith(b"\n"):
@@ -95,12 +95,25 @@ def ensure_daemon(wait=60.0, name=None, env=None):
 
     import subprocess, sys
     local = _is_local_chrome_mode(env)
+    # On Windows, start_new_session is silently ignored by subprocess and the
+    # daemon dies with its parent. DETACHED_PROCESS + CREATE_NEW_PROCESS_GROUP
+    # gives the same "fully detached" semantics as setsid() on POSIX.
+    if sys.platform == "win32":
+        spawn_kwargs = {
+            "creationflags": (
+                getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+            ),
+            "close_fds": True,
+        }
+    else:
+        spawn_kwargs = {"start_new_session": True}
     for attempt in (0, 1):
         e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
         p = subprocess.Popen(
             ["uv", "run", "daemon.py"],
             cwd=os.path.dirname(os.path.abspath(__file__)),
-            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **spawn_kwargs,
         )
         deadline = time.time() + wait
         while time.time() < deadline:
@@ -113,7 +126,8 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
             restart_daemon(name)
             continue
-        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check /tmp/bu-{name or NAME}.log")
+        _, _, log_path = paths(name)
+        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {log_path}")
 
 
 def stop_remote_daemon(name="remote"):
@@ -140,9 +154,7 @@ def restart_daemon(name=None):
 
     sock, pid_path = _paths(name)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(5)
-        s.connect(sock)
+        s = connect_socket(name, timeout=5)
         s.sendall(b'{"meta":"shutdown"}\n')
         s.recv(1024)
         s.close()
@@ -153,22 +165,31 @@ def restart_daemon(name=None):
     except (FileNotFoundError, ValueError):
         pid = None
     if pid:
-        for _ in range(75):
-            try:
-                os.kill(pid, 0)
-                time.sleep(0.2)
-            except ProcessLookupError:
-                break
-        else:
+        if sys.platform == "win32":
+            # Windows os.kill(pid, 0) raises WinError 87 instead of acting as a ping.
+            # Give the daemon ~2s to honour the shutdown message, then TerminateProcess via SIGTERM.
+            time.sleep(2.0)
             try:
                 os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
+            except (ProcessLookupError, OSError):
                 pass
-    for f in (sock, pid_path):
-        try:
-            os.unlink(f)
-        except FileNotFoundError:
-            pass
+        else:
+            for _ in range(75):
+                try:
+                    os.kill(pid, 0)
+                    time.sleep(0.2)
+                except ProcessLookupError:
+                    break
+            else:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+    cleanup_endpoint(name)
+    try:
+        os.unlink(pid_path)
+    except FileNotFoundError:
+        pass
 
 
 def _browser_use(path, method, body=None):

--- a/daemon.py
+++ b/daemon.py
@@ -4,6 +4,7 @@ from collections import deque
 from pathlib import Path
 
 from cdp_use.client import CDPClient
+from transport import cleanup_endpoint, connect_socket, paths, start_server
 
 
 def _load_env():
@@ -21,9 +22,7 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
-LOG = f"/tmp/bu-{NAME}.log"
-PID = f"/tmp/bu-{NAME}.pid"
+SOCK, PID, LOG = paths()
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
@@ -55,7 +54,7 @@ API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
 def log(msg):
-    open(LOG, "a").write(f"{msg}\n")
+    LOG.open("a").write(f"{msg}\n")
 
 
 def get_ws_url():
@@ -198,8 +197,7 @@ class Daemon:
 
 
 async def serve(d):
-    if os.path.exists(SOCK):
-        os.unlink(SOCK)
+    cleanup_endpoint()
 
     async def handler(reader, writer):
         try:
@@ -218,9 +216,8 @@ async def serve(d):
         finally:
             writer.close()
 
-    server = await asyncio.start_unix_server(handler, path=SOCK)
-    os.chmod(SOCK, 0o600)
-    log(f"listening on {SOCK} (name={NAME}, remote={REMOTE_ID or 'local'})")
+    server, endpoint = await start_server(handler)
+    log(f"listening on {endpoint} (name={NAME}, remote={REMOTE_ID or 'local'})")
     async with server:
         await d.stop.wait()
 
@@ -233,18 +230,17 @@ async def main():
 
 def already_running():
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(1)
-        s.connect(SOCK); s.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout):
+        s = connect_socket(timeout=1); s.close(); return True
+    except OSError:
         return False
 
 
 if __name__ == "__main__":
     if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
+        print(f"daemon already running for BU_NAME={NAME}", file=sys.stderr)
         sys.exit(0)
-    open(LOG, "w").close()
-    open(PID, "w").write(str(os.getpid()))
+    LOG.write_text("")
+    PID.write_text(str(os.getpid()))
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
@@ -254,5 +250,5 @@ if __name__ == "__main__":
         sys.exit(1)
     finally:
         stop_remote()
-        try: os.unlink(PID)
+        try: PID.unlink()
         except FileNotFoundError: pass

--- a/helpers.py
+++ b/helpers.py
@@ -3,6 +3,8 @@ import base64, json, os, socket, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
+from transport import connect_socket, paths
+
 
 def _load_env():
     p = Path(__file__).parent / ".env"
@@ -19,13 +21,12 @@ def _load_env():
 _load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
-SOCK = f"/tmp/bu-{NAME}.sock"
+SOCK = paths()[0]
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 
 
 def _send(req):
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(SOCK)
+    s = connect_socket()
     s.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ dependencies = [
 browser-harness = "run:main"
 
 [tool.setuptools]
-py-modules = ["run", "helpers", "daemon", "admin"]
+py-modules = ["run", "helpers", "daemon", "admin", "transport"]

--- a/test_transport.py
+++ b/test_transport.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import transport
+
+
+def test_paths_default_to_tmp_for_posix_compatibility(monkeypatch):
+    monkeypatch.setattr(transport, "BASE", Path("/tmp"))
+
+    sock, pid, log = transport.paths("demo")
+
+    assert sock == Path("/tmp/bu-demo.sock")
+    assert pid == Path("/tmp/bu-demo.pid")
+    assert log == Path("/tmp/bu-demo.log")
+
+
+def test_connect_socket_uses_unix_socket_when_available(monkeypatch):
+    fake_socket = Mock()
+    socket_factory = Mock(return_value=fake_socket)
+    monkeypatch.setattr(transport, "BASE", Path("/tmp"))
+    monkeypatch.setattr(transport, "HAS_UNIX_SOCKET", True)
+    monkeypatch.setattr(transport.socket, "socket", socket_factory)
+    monkeypatch.setattr(transport.socket, "AF_UNIX", 1, raising=False)
+    monkeypatch.setattr(transport.socket, "SOCK_STREAM", 2)
+
+    result = transport.connect_socket("demo", timeout=3)
+
+    assert result is fake_socket
+    socket_factory.assert_called_once_with(1, 2)
+    fake_socket.settimeout.assert_called_once_with(3)
+    fake_socket.connect.assert_called_once_with(str(Path("/tmp/bu-demo.sock")))
+
+
+def test_connect_socket_uses_tcp_when_unix_socket_unavailable(monkeypatch):
+    fake_socket = Mock()
+    socket_factory = Mock(return_value=fake_socket)
+    monkeypatch.setattr(transport, "HAS_UNIX_SOCKET", False)
+    monkeypatch.setattr(transport.socket, "socket", socket_factory)
+    monkeypatch.setattr(transport.socket, "AF_INET", 1)
+    monkeypatch.setattr(transport.socket, "SOCK_STREAM", 2)
+
+    result = transport.connect_socket("demo", timeout=3)
+
+    assert result is fake_socket
+    socket_factory.assert_called_once_with(1, 2)
+    fake_socket.settimeout.assert_called_once_with(3)
+    fake_socket.connect.assert_called_once_with(("127.0.0.1", transport._tcp_port("demo")))

--- a/transport.py
+++ b/transport.py
@@ -1,0 +1,61 @@
+import hashlib
+import os
+import socket
+import sys
+from pathlib import Path
+
+
+NAME = os.environ.get("BU_NAME", "default")
+BASE = Path(os.environ.get("TEMP") or os.environ.get("TMP") or ".") if sys.platform == "win32" else Path("/tmp")
+HAS_UNIX_SOCKET = sys.platform != "win32" and hasattr(socket, "AF_UNIX")
+
+
+def _tcp_port(name=None):
+    n = name or os.environ.get("BU_NAME", NAME)
+    digest = hashlib.sha256(n.encode()).digest()
+    return 49152 + int.from_bytes(digest[:2], "big") % 10000
+
+
+def paths(name=None):
+    n = name or os.environ.get("BU_NAME", NAME)
+    return BASE / f"bu-{n}.sock", BASE / f"bu-{n}.pid", BASE / f"bu-{n}.log"
+
+
+def connect_socket(name=None, timeout=None):
+    if HAS_UNIX_SOCKET:
+        sock_path, _, _ = paths(name)
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if timeout is not None:
+            s.settimeout(timeout)
+        s.connect(str(sock_path))
+        return s
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if timeout is not None:
+        s.settimeout(timeout)
+    s.connect(("127.0.0.1", _tcp_port(name)))
+    return s
+
+
+async def start_server(handler, name=None):
+    if HAS_UNIX_SOCKET:
+        import asyncio
+        sock_path, _, _ = paths(name)
+        if sock_path.exists():
+            sock_path.unlink()
+        server = await asyncio.start_unix_server(handler, path=str(sock_path))
+        os.chmod(sock_path, 0o600)
+        return server, str(sock_path)
+    import asyncio
+    port = _tcp_port(name)
+    server = await asyncio.start_server(handler, host="127.0.0.1", port=port)
+    return server, f"127.0.0.1:{port}"
+
+
+def cleanup_endpoint(name=None):
+    if not HAS_UNIX_SOCKET:
+        return
+    sock_path, _, _ = paths(name)
+    try:
+        sock_path.unlink()
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
## Summary

This PR makes the daemon transport work on Windows while preserving the existing Unix domain socket behavior on macOS/Linux.

### Changes

- Add `transport.py` to centralize daemon socket handling.
- Keep POSIX behavior unchanged:
  - `/tmp/bu-{NAME}.sock`
  - Unix domain sockets via `AF_UNIX`
  - socket file permission `0o600`
- Add Windows fallback:
  - TCP loopback on `127.0.0.1`
  - deterministic port derived from `BU_NAME`
  - temp-dir based pid/log paths
- Update `admin.py`, `daemon.py`, and `helpers.py` to use the transport abstraction.
- Fix Windows daemon lifecycle issues:
  - use `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` instead of relying on POSIX-style `start_new_session`
  - avoid `os.kill(pid, 0)` on Windows, where it raises `WinError 87`
- Add transport unit tests to lock in both POSIX and Windows behavior.

## Testing

On Windows 10 / Python 3.11.13:

```text
uv run --with pytest pytest -v --tb=short
# 13 passed
```

Manual smoke tests:

```text
uv run browser-harness --reload
uv run browser-harness --setup
uv run browser-harness --doctor
uv run browser-harness -c print(page_info())
```

Observed:

- `--setup` starts the daemon successfully.
- `--doctor` reports both Chrome and daemon as OK.
- `page_info()` successfully returns the active browser page metadata through the daemon.

## Compatibility notes

This intentionally keeps macOS/Linux on the original Unix socket path. The new tests assert that POSIX-style usage still calls `AF_UNIX` and connects to `/tmp/bu-{name}.sock`.

On Windows, the fallback listens only on `127.0.0.1`. This is a pragmatic replacement for Unix domain sockets, but unlike the POSIX `0o600` socket file, TCP loopback does not provide per-user filesystem permissions. This should be fine for the common single-user desktop workflow, but it is worth noting for multi-user Windows hosts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross‑platform daemon transport that keeps Unix sockets on macOS/Linux and falls back to TCP loopback on Windows. Also fixes Windows daemon start/stop behavior.

- **Bug Fixes**
  - Added `transport.py` to centralize endpoints and cleanup; updated `admin.py`, `daemon.py`, and `helpers.py` to use it; added unit tests.
  - POSIX unchanged: `/tmp/bu-{NAME}.sock` via `AF_UNIX` with `0o600` perms.
  - Windows fallback: TCP `127.0.0.1` with a deterministic port from `BU_NAME`, PID/log in temp dir, proper detach flags (`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`), and no `os.kill(pid, 0)` probe.

- **Migration**
  - No action needed on macOS/Linux.
  - On Windows the daemon listens on `127.0.0.1:PORT`; per‑user file permissions are not enforced on TCP, which may matter on multi‑user hosts.

<sup>Written for commit bbf41c138487be2c48430025a4f2240efe2e1716. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/227?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

