### PR TITLE
fix(js): raise RuntimeError on JS evaluation errors instead of returning None

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -234,7 +234,24 @@ def js(expression, target_id=None):
     if "return " in expression and not expression.strip().startswith("("):
         expression = f"(function(){{{expression}}})()"
     r = cdp("Runtime.evaluate", session_id=sid, expression=expression, returnByValue=True, awaitPromise=True)
-    return r.get("result", {}).get("value")
+    result = r.get("result", {})
+    details = r.get("exceptionDetails")
+    if details or result.get("subtype") == "error":
+        desc = result.get("description")
+        if not desc and details:
+            desc = details.get("text")
+        desc = desc or "JavaScript evaluation failed"
+        if details:
+            line = details.get("lineNumber")
+            col = details.get("columnNumber")
+            loc = f" at line {line}, column {col}" if line is not None and col is not None else ""
+        else:
+            loc = ""
+        snippet = expression.strip().replace("\n", "\\n")
+        if len(snippet) > 160:
+            snippet = snippet[:157] + "..."
+        raise RuntimeError(f"JavaScript evaluation failed{loc}: {desc}; expression: {snippet}")
+    return result.get("value")
 
 
 _KC = {"Enter": 13, "Tab": 9, "Escape": 27, "Backspace": 8, " ": 32, "ArrowLeft": 37, "ArrowUp": 38, "ArrowRight": 39, "ArrowDown": 40}

--- a/tests/integration/test_js.py
+++ b/tests/integration/test_js.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from browser_harness import helpers
 
 
@@ -34,3 +36,58 @@ def test_iife_with_internal_return_is_not_double_wrapped():
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
         helpers.js("(function(){ return document.title; })()")
     assert _evaluated_expression(captured) == "(function(){ return document.title; })()"
+
+
+def test_js_raises_on_syntax_error_exception_details():
+    def fake_cdp(method, **kwargs):
+        return {
+            "result": {
+                "type": "object",
+                "subtype": "error",
+                "description": "SyntaxError: Invalid or unexpected token",
+            },
+            "exceptionDetails": {
+                "text": "Uncaught",
+                "lineNumber": 1,
+                "columnNumber": 12,
+            },
+        }
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        with pytest.raises(RuntimeError, match="SyntaxError"):
+            helpers.js('return "a\n\nb";')
+
+
+def test_js_raises_on_runtime_error_exception_details():
+    def fake_cdp(method, **kwargs):
+        return {
+            "result": {
+                "type": "object",
+                "subtype": "error",
+                "description": "ReferenceError: missing is not defined",
+            },
+            "exceptionDetails": {
+                "text": "Uncaught",
+                "lineNumber": 0,
+                "columnNumber": 17,
+            },
+        }
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        with pytest.raises(RuntimeError, match="ReferenceError"):
+            helpers.js("return missing.value")
+
+
+def test_js_raises_on_error_result_without_exception_details():
+    def fake_cdp(method, **kwargs):
+        return {
+            "result": {
+                "type": "object",
+                "subtype": "error",
+                "description": "Error: evaluation failed",
+            }
+        }
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        with pytest.raises(RuntimeError, match="evaluation failed"):
+            helpers.js("throw new Error('evaluation failed')")


### PR DESCRIPTION
## Summary
- `js()` previously swallowed Chrome's `exceptionDetails` and returned `None` silently on both syntax errors and runtime errors
- Now raises `RuntimeError` with the error description, line/column location, and a truncated snippet of the failing expression
- Added 3 unit tests covering syntax errors, runtime errors, and error results without exception details

## Test plan
- [ ] `pytest tests/integration/test_js.py` — all 6 pass
- [ ] `pytest` — all 16 pass
- [ ] Live: bad JS (literal newline in string) raises `RuntimeError: JavaScript evaluation failed at line 1, column 7: SyntaxError: Invalid or unexpected token`
- [ ] Live: raw-string JS works and returns correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `helpers.js()` raise `RuntimeError` on JavaScript evaluation failures instead of returning `None`. This surfaces syntax and runtime errors with clear messages and locations.

- **Bug Fixes**
  - Raise `RuntimeError` when Chrome reports `exceptionDetails` or the result `subtype` is `error`.
  - Include error description, line/column (when available), and a truncated expression snippet.
  - Added integration tests for syntax errors, runtime errors, and error results without exception details.

- **Migration**
  - If you relied on `None` for failures, wrap `helpers.js()` calls in `try/except RuntimeError`.

<sup>Written for commit 5748035bb1c3b9b35194004dc98f5b655c2ebcbd. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/230?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

