### PR TITLE
refactor(js): proper return-statement parsing, unserializable value decoding, unified eval helpers

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, os, tempfile, time, urllib.request
+import base64, importlib.util, json, math, os, tempfile, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -61,6 +61,104 @@ def cdp(method, session_id=None, **params):
 def drain_events():  return _send({"meta": "drain_events"})["events"]
 
 
+def _js_snippet(expression, limit=160):
+    snippet = expression.strip().replace("\n", "\\n")
+    return snippet[:limit - 3] + "..." if len(snippet) > limit else snippet
+
+
+def _js_exception_description(result, details):
+    desc = result.get("description")
+    exc = details.get("exception") if details else None
+    if not desc and isinstance(exc, dict):
+        desc = exc.get("description")
+        if desc is None and "value" in exc:
+            desc = str(exc["value"])
+        if desc is None:
+            desc = exc.get("className")
+    if not desc and details:
+        desc = details.get("text")
+    return desc or "JavaScript evaluation failed"
+
+
+def _decode_unserializable_js_value(value):
+    if value == "NaN":
+        return math.nan
+    if value == "Infinity":
+        return math.inf
+    if value == "-Infinity":
+        return -math.inf
+    if value == "-0":
+        return -0.0
+    if value.endswith("n"):
+        return int(value[:-1])
+    return value
+
+
+def _runtime_value(response, expression):
+    result = response.get("result", {})
+    details = response.get("exceptionDetails")
+    if details or result.get("subtype") == "error":
+        desc = _js_exception_description(result, details)
+        if details:
+            line = details.get("lineNumber")
+            col = details.get("columnNumber")
+            loc = f" at line {line}, column {col}" if line is not None and col is not None else ""
+        else:
+            loc = ""
+        raise RuntimeError(f"JavaScript evaluation failed{loc}: {desc}; expression: {_js_snippet(expression)}")
+    if "value" in result:
+        return result["value"]
+    if "unserializableValue" in result:
+        return _decode_unserializable_js_value(result["unserializableValue"])
+    return None
+
+
+def _runtime_evaluate(expression, session_id=None, await_promise=False):
+    try:
+        r = cdp("Runtime.evaluate", session_id=session_id, expression=expression, returnByValue=True, awaitPromise=await_promise)
+    except TimeoutError as e:
+        raise RuntimeError(f"Runtime.evaluate timed out; expression: {_js_snippet(expression)}") from e
+    return _runtime_value(r, expression)
+
+
+def _has_return_statement(expression):
+    i = 0
+    n = len(expression)
+    state = "code"
+    quote = ""
+    while i < n:
+        ch = expression[i]
+        nxt = expression[i + 1] if i + 1 < n else ""
+        if state == "code":
+            if ch in ("'", '"', "`"):
+                state = "string"; quote = ch; i += 1; continue
+            if ch == "/" and nxt == "/":
+                state = "line_comment"; i += 2; continue
+            if ch == "/" and nxt == "*":
+                state = "block_comment"; i += 2; continue
+            if expression.startswith("return", i):
+                before = expression[i - 1] if i > 0 else ""
+                after = expression[i + 6] if i + 6 < n else ""
+                if not (before == "_" or before.isalnum()) and not (after == "_" or after.isalnum()):
+                    return True
+            i += 1; continue
+        if state == "line_comment":
+            if ch == "\n":
+                state = "code"
+            i += 1; continue
+        if state == "block_comment":
+            if ch == "*" and nxt == "/":
+                state = "code"; i += 2; continue
+            i += 1; continue
+        if state == "string":
+            if ch == "\\":
+                i += 2; continue
+            if ch == quote:
+                state = "code"; quote = ""
+            i += 1; continue
+    return False
+
+
 # --- navigation / page ---
 def goto_url(url):
     r = cdp("Page.navigate", url=url)
@@ -76,10 +174,8 @@ def page_info():
     dialog = _send({"meta": "pending_dialog"}).get("dialog")
     if dialog:
         return {"dialog": dialog}
-    r = cdp("Runtime.evaluate",
-            expression="JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})",
-            returnByValue=True)
-    return json.loads(r["result"]["value"])
+    expression = "JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})"
+    return json.loads(_runtime_evaluate(expression))
 
 # --- input ---
 _debug_click_counter = 0
@@ -231,27 +327,9 @@ def js(expression, target_id=None):
     `document.title` and `const x = 1; return x` are valid inputs.
     """
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
-    if "return " in expression and not expression.strip().startswith("("):
+    if _has_return_statement(expression) and not expression.strip().startswith("("):
         expression = f"(function(){{{expression}}})()"
-    r = cdp("Runtime.evaluate", session_id=sid, expression=expression, returnByValue=True, awaitPromise=True)
-    result = r.get("result", {})
-    details = r.get("exceptionDetails")
-    if details or result.get("subtype") == "error":
-        desc = result.get("description")
-        if not desc and details:
-            desc = details.get("text")
-        desc = desc or "JavaScript evaluation failed"
-        if details:
-            line = details.get("lineNumber")
-            col = details.get("columnNumber")
-            loc = f" at line {line}, column {col}" if line is not None and col is not None else ""
-        else:
-            loc = ""
-        snippet = expression.strip().replace("\n", "\\n")
-        if len(snippet) > 160:
-            snippet = snippet[:157] + "..."
-        raise RuntimeError(f"JavaScript evaluation failed{loc}: {desc}; expression: {snippet}")
-    return result.get("value")
+    return _runtime_evaluate(expression, session_id=sid, await_promise=True)
 
 
 _KC = {"Enter": 13, "Tab": 9, "Escape": 27, "Backspace": 8, " ": 32, "ArrowLeft": 37, "ArrowUp": 38, "ArrowRight": 39, "ArrowDown": 40}

--- a/tests/integration/test_js.py
+++ b/tests/integration/test_js.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import math
+
 import pytest
 
 from browser_harness import helpers
@@ -91,3 +93,79 @@ def test_js_raises_on_error_result_without_exception_details():
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
         with pytest.raises(RuntimeError, match="evaluation failed"):
             helpers.js("throw new Error('evaluation failed')")
+
+
+def test_return_word_inside_string_does_not_trigger_wrapping():
+    fake_cdp, captured = _capture_cdp()
+    expr = 'document.body.innerText.includes("return ")'
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        helpers.js(expr)
+    assert _evaluated_expression(captured) == expr
+
+
+def test_return_word_inside_comment_does_not_trigger_wrapping():
+    fake_cdp, captured = _capture_cdp()
+    expr = "// return comment\n1 + 1"
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        helpers.js(expr)
+    assert _evaluated_expression(captured) == expr
+
+
+@pytest.mark.parametrize("expr", ["return\t1", "return\n1"])
+def test_top_level_return_with_whitespace_gets_wrapped(expr):
+    fake_cdp, captured = _capture_cdp()
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        helpers.js(expr)
+    assert _evaluated_expression(captured) == f"(function(){{{expr}}})()"
+
+
+@pytest.mark.parametrize(
+    ("unserializable", "expected"),
+    [
+        ("NaN", math.nan),
+        ("Infinity", math.inf),
+        ("-Infinity", -math.inf),
+        ("-0", -0.0),
+        ("1n", 1),
+    ],
+)
+def test_js_returns_unserializable_values(unserializable, expected):
+    def fake_cdp(method, **kwargs):
+        return {"result": {"type": "number", "unserializableValue": unserializable, "description": unserializable}}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        value = helpers.js(unserializable)
+
+    if isinstance(expected, float) and math.isnan(expected):
+        assert math.isnan(value)
+    elif expected == 0:
+        assert value == 0
+        assert math.copysign(1, value) == math.copysign(1, expected)
+    else:
+        assert value == expected
+
+
+def test_js_primitive_exception_message_uses_exception_value():
+    def fake_cdp(method, **kwargs):
+        return {
+            "result": {"type": "string", "value": "boom"},
+            "exceptionDetails": {
+                "text": "Uncaught",
+                "lineNumber": 0,
+                "columnNumber": 9,
+                "exception": {"type": "string", "value": "boom"},
+            },
+        }
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        with pytest.raises(RuntimeError, match="boom"):
+            helpers.js("throw value")
+
+
+def test_js_timeout_error_includes_expression_context():
+    def fake_cdp(method, **kwargs):
+        raise TimeoutError("timed out")
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        with pytest.raises(RuntimeError, match="Runtime.evaluate.*document.title"):
+            helpers.js("document.title")

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from unittest.mock import patch
 
+import pytest
 from PIL import Image
 
 from browser_harness import helpers
@@ -25,3 +26,27 @@ def test_max_dim_skips_when_image_already_small(fake_png):
 
 def test_max_dim_default_is_no_resize(fake_png):
     assert _run(fake_png, 4592, 2286) == (4592, 2286)
+
+
+def test_page_info_raises_clear_error_on_js_exception():
+    def fake_send(req):
+        return {}
+
+    def fake_cdp(method, **kwargs):
+        return {
+            "result": {
+                "type": "object",
+                "subtype": "error",
+                "description": "ReferenceError: location is not defined",
+            },
+            "exceptionDetails": {
+                "text": "Uncaught",
+                "lineNumber": 0,
+                "columnNumber": 16,
+            },
+        }
+
+    with patch("browser_harness.helpers._send", side_effect=fake_send), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        with pytest.raises(RuntimeError, match="ReferenceError"):
+            helpers.page_info()


### PR DESCRIPTION
## Summary

- Replace naive `"return " in expression` string check with a character-level parser (`_has_return_statement`) that correctly ignores `return` inside strings, line comments, and block comments
- Add `_decode_unserializable_js_value` to handle values CDP can't serialize as JSON: `NaN`, `±Infinity`, `-0`, and BigInt literals
- Extract `_runtime_value` and `_runtime_evaluate` shared helpers to unify error handling across `js()` and `page_info()`; wrap `TimeoutError` from `Runtime.evaluate` in `RuntimeError` with expression context

## Test plan

- [ ] `test_return_word_inside_string_does_not_trigger_wrapping` — ensures string-embedded `return` is not treated as a return statement
- [ ] `test_return_word_inside_comment_does_not_trigger_wrapping` — same for line comments
- [ ] `test_top_level_return_with_whitespace_gets_wrapped` — `return\t1` and `return\n1` still trigger wrapping
- [ ] `test_js_returns_unserializable_values` — NaN, Infinity, -Infinity, -0, BigInt round-trip correctly
- [ ] `test_js_primitive_exception_message_uses_exception_value` — thrown primitive strings surface in RuntimeError
- [ ] `test_js_timeout_error_includes_expression_context` — TimeoutError becomes RuntimeError with snippet
- [ ] `test_page_info_raises_clear_error_on_js_exception` — page_info propagates JS errors cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors JS evaluation to safely detect top‑level returns, decode CDP unserializable values, and unify error handling in `js()` and `page_info()`. This fixes false wrapping, improves value round‑trips, and makes errors clearer.

- **Refactors**
  - Replace naive `"return "` check with a character-level parser that ignores strings and comments.
  - Extract `_runtime_value` and `_runtime_evaluate` to share evaluation/exception logic across `js()` and `page_info()`.
  - Wrap `TimeoutError` from `Runtime.evaluate` in `RuntimeError` with an expression snippet.

- **Bug Fixes**
  - Decode `unserializableValue` from CDP: `NaN`, `±Infinity`, `-0`, and BigInt literals return correct Python values.
  - Improve exception messages to surface thrown primitive values and error descriptions.

<sup>Written for commit b6f62f9ab0b17624e78d11637c737ac6db5cb052. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/231?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

