### PR TITLE
fix: prevent chrome://inspect tab flooding during setup

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -79,7 +79,7 @@ def daemon_alive(name=None):
         return False
 
 
-def ensure_daemon(wait=60.0, name=None, env=None):
+def ensure_daemon(wait=60.0, name=None, env=None, _open_inspect=True):
     """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
@@ -112,7 +112,8 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             time.sleep(0.2)
         msg = _log_tail(name) or ""
         if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
-            _open_chrome_inspect()
+            if _open_inspect:
+                _open_chrome_inspect()
             print("browser-harness: click Allow on chrome://inspect (and tick the checkbox if shown)", file=sys.stderr)
             restart_daemon(name)
             continue
@@ -510,7 +511,7 @@ def run_setup():
     last = first_err
     while time.time() < deadline:
         try:
-            ensure_daemon(wait=5.0)
+            ensure_daemon(wait=5.0, _open_inspect=False)
             print("daemon is up.")
             return 0
         except RuntimeError as e:


### PR DESCRIPTION
## Summary

- When `browser-harness --setup` detects that remote-debugging is not enabled, it opens `chrome://inspect/#remote-debugging` and then retries `ensure_daemon` in a loop every ~7 seconds
- `ensure_daemon` itself also calls `_open_chrome_inspect()` on each failed attempt, opening a **new tab every iteration** and flooding the browser with dozens of `chrome://inspect` tabs
- Added `_open_inspect` parameter to `ensure_daemon` so `run_setup`'s retry loop suppresses redundant tab opens after the initial one

## Reproduction

1. Start Chrome without remote-debugging enabled
2. Run `browser-harness --setup`
3. Don't click "Allow" — observe a new `chrome://inspect` tab opening every few seconds

## Test plan

- [ ] Run `browser-harness --setup` with remote-debugging disabled — only one `chrome://inspect` tab should open
- [ ] Verify `ensure_daemon()` still opens the tab when called standalone (default `_open_inspect=True`)
- [ ] Verify setup completes normally once the user clicks Allow

<img width="2112" height="1544" alt="image" src="https://github.com/user-attachments/assets/7e964c5f-c80f-4027-961d-d095f0ffd6fe" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a new chrome://inspect tab from opening on every retry during `browser-harness --setup` by gating when the tab opens. Setup now opens the tab once, then retries without flooding.

- **Bug Fixes**
  - Added `_open_inspect` (default `True`) to `ensure_daemon` to gate `_open_chrome_inspect()`.
  - Updated `run_setup` to call `ensure_daemon(wait=5.0, _open_inspect=False)` in the retry loop.
  - Direct `ensure_daemon()` calls keep existing behavior and open the tab once if needed.

<sup>Written for commit d1c7d80c0460e962b553fc7e93058d857143b059. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/232?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

