### PR TITLE
feat(doctor): show live browser connections and attached pages in run_doctor

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -34,6 +34,7 @@ BU_API = "https://api.browser-use.com/api/v3"
 GH_RELEASES = "https://api.github.com/repos/browser-use/browser-harness/releases/latest"
 VERSION_CACHE = Path(tempfile.gettempdir()) / "bu-version-cache.json"
 VERSION_CACHE_TTL = 24 * 3600
+DOCTOR_TEXT_LIMIT = 140
 
 
 def _paths(name):
@@ -77,6 +78,69 @@ def daemon_alive(name=None):
         c = ipc.connect(name or NAME, timeout=1.0); c.close(); return True
     except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
         return False
+
+
+def _daemon_endpoint_names():
+    pattern = "bu-*.port" if ipc.IS_WINDOWS else "bu-*.sock"
+    suffix = ".port" if ipc.IS_WINDOWS else ".sock"
+    names = []
+    for p in sorted(ipc._TMP.glob(pattern)):
+        name = p.name
+        if not name.startswith("bu-") or not name.endswith(suffix):
+            continue
+        raw = name[3:-len(suffix)]
+        try:
+            ipc._check(raw)
+        except ValueError:
+            continue
+        names.append(raw)
+    return names
+
+
+def _daemon_browser_connection(name):
+    c = None
+    try:
+        c = ipc.connect(name, timeout=1.0)
+        c.sendall(b'{"meta":"connection_status"}\n')
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = c.recv(1 << 16)
+            if not chunk:
+                break
+            data += chunk
+        response = json.loads(data)
+        if "error" in response:
+            return None
+        page = response.get("page")
+        if page:
+            page = {"title": page.get("title") or "(untitled)", "url": page.get("url") or ""}
+        return {"name": name, "page": page}
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError, KeyError, ValueError, json.JSONDecodeError):
+        return None
+    finally:
+        if c:
+            c.close()
+
+
+def browser_connections():
+    """Live browser-harness daemons with healthy CDP browser connections and their attached page."""
+    out = []
+    for name in _daemon_endpoint_names():
+        conn = _daemon_browser_connection(name)
+        if conn:
+            out.append(conn)
+    return out
+
+
+def active_browser_connections():
+    """Count live browser-harness daemons with a healthy CDP browser connection."""
+    return len(browser_connections())
+
+
+def _doctor_short_text(value, limit=None):
+    limit = limit or DOCTOR_TEXT_LIMIT
+    value = str(value)
+    return value if len(value) <= limit else value[:limit - 3] + "..."
 
 
 def ensure_daemon(wait=60.0, name=None, env=None):
@@ -529,6 +593,7 @@ def run_doctor():
     mode = _install_mode()
     chrome = _chrome_running()
     daemon = daemon_alive()
+    connections = browser_connections()
     profile_use = shutil.which("profile-use") is not None
     api_key = bool(os.environ.get("BROWSER_USE_API_KEY"))
     latest = _latest_release_tag()
@@ -551,6 +616,15 @@ def run_doctor():
         print("  latest release    (could not reach github)")
     row("chrome running", chrome, "" if chrome else "start chrome/edge and rerun `browser-harness --setup`")
     row("daemon alive", daemon, "" if daemon else "run `browser-harness --setup` to attach")
+    row("active browser connections", bool(connections), str(len(connections)))
+    for conn in connections:
+        page = conn.get("page")
+        if page:
+            title = _doctor_short_text(page["title"])
+            url = _doctor_short_text(page["url"])
+            print(f"        {conn['name']} — active page: {title} — {url}")
+        else:
+            print(f"        {conn['name']} — active page: (no real page)")
     row("profile-use installed", profile_use, "" if profile_use else "optional: curl -fsSL https://browser-use.com/profile.sh | sh")
     row("BROWSER_USE_API_KEY set", api_key, "" if api_key else "optional: needed only for cloud browsers / profile sync")
     # Core health = chrome + daemon. Profile-use/api-key are optional.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -142,6 +142,7 @@ class Daemon:
     def __init__(self):
         self.cdp = None
         self.session = None
+        self.target_id = None
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
@@ -158,6 +159,7 @@ class Daemon:
         self.session = (await self.cdp.send_raw(
             "Target.attachToTarget", {"targetId": pages[0]["targetId"], "flatten": True}
         ))["sessionId"]
+        self.target_id = pages[0]["targetId"]
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
         for d in ("Page", "DOM", "Runtime", "Network"):
             try:
@@ -204,8 +206,23 @@ class Daemon:
             out = list(self.events); self.events.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
+        if meta == "connection_status":
+            page = None
+            if self.target_id:
+                try:
+                    info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
+                    if is_real_page(info):
+                        page = {
+                            "targetId": info.get("targetId"),
+                            "title": info.get("title") or "(untitled)",
+                            "url": info.get("url") or "",
+                        }
+                except Exception:
+                    page = None
+            return {"target_id": self.target_id, "session_id": self.session, "page": page}
         if meta == "set_session":
             self.session = req.get("session_id")
+            self.target_id = req.get("target_id") or self.target_id
             try:
                 await asyncio.wait_for(self.cdp.send_raw("Page.enable", session_id=self.session), timeout=3)
                 await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"}, session_id=self.session), timeout=2)

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -272,7 +272,7 @@ def switch_tab(target):
     except Exception: pass
     cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
-    _send({"meta": "set_session", "session_id": sid})
+    _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
     return sid
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,6 +1,23 @@
 from browser_harness import admin
 
 
+class FakeSocket:
+    def __init__(self, response=b'{"target_id":"target-1","session_id":"session-1","page":null}\n'):
+        self.response = response
+        self.closed = False
+        self.sent = b""
+
+    def sendall(self, data):
+        self.sent += data
+
+    def recv(self, _size):
+        out, self.response = self.response, b""
+        return out
+
+    def close(self):
+        self.closed = True
+
+
 def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():
     assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
 
@@ -27,3 +44,95 @@ def test_stale_websocket_does_not_open_chrome_inspect():
     msg = "no close frame received or sent"
 
     assert not admin._needs_chrome_remote_debugging_prompt(msg)
+
+
+def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):
+    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
+    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
+    (tmp_path / "bu-default.sock").touch()
+    (tmp_path / "bu-remote_1.sock").touch()
+    (tmp_path / "bu-invalid.name.sock").touch()
+    (tmp_path / "not-bu-default.sock").touch()
+
+    assert admin._daemon_endpoint_names() == ["default", "remote_1"]
+
+
+def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "stale", "remote"])
+
+    def fake_connect(name, timeout=1.0):
+        if name == "stale":
+            raise ConnectionRefusedError()
+        if name == "remote":
+            return FakeSocket(b'{"error":"no close frame received or sent"}\n')
+        return FakeSocket()
+
+    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+
+    assert admin.active_browser_connections() == 1
+
+
+def test_browser_connections_returns_attached_page(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default"])
+    response = (
+        b'{"target_id":"target-1","session_id":"session-1",'
+        b'"page":{"targetId":"target-1","title":"Cat - Wikipedia","url":"https://en.wikipedia.org/wiki/Cat"}}\n'
+    )
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: FakeSocket(response))
+
+    assert admin.browser_connections() == [
+        {
+            "name": "default",
+            "page": {"title": "Cat - Wikipedia", "url": "https://en.wikipedia.org/wiki/Cat"},
+        }
+    ]
+
+
+def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypatch, capsys):
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [
+        {
+            "name": "default",
+            "page": {"title": "Example", "url": "https://example.test"},
+        },
+        {
+            "name": "cats",
+            "page": {"title": "Cat - Wikipedia", "url": "https://en.wikipedia.org/wiki/Cat"},
+        },
+    ])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+    assert admin.run_doctor() == 0
+
+    out = capsys.readouterr().out
+    assert "[ok  ] active browser connections — 2" in out
+    assert "        default — active page: Example — https://example.test" in out
+    assert "        cats — active page: Cat - Wikipedia — https://en.wikipedia.org/wiki/Cat" in out
+
+
+def test_doctor_page_output_truncates_long_text(monkeypatch, capsys):
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "DOCTOR_TEXT_LIMIT", 20)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [
+        {
+            "name": "default",
+            "page": {"title": "A very long page title", "url": "https://example.test/very/long/path"},
+        }
+    ])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+    assert admin.run_doctor() == 0
+
+    out = capsys.readouterr().out
+    assert "A very long page ..." in out
+    assert "https://example.t..." in out


### PR DESCRIPTION
## Summary

- Add `browser_connections()` and `active_browser_connections()` to `admin.py` — probe each daemon socket via a new `connection_status` meta message and return the live page title/URL
- Add `connection_status` meta handler in `daemon.py` — daemon now tracks `target_id` (set on attach and on `set_session`) and returns the live page info via `Target.getTargetInfo`
- `switch_tab` in `helpers.py` now forwards `target_id` in `set_session` so the daemon stays in sync after tab switches
- `run_doctor` shows connection count, each daemon name, and truncated active-page title and URL

## Test plan

- [ ] `test_daemon_endpoint_names_discovers_valid_socket_names` — filters invalid socket names correctly
- [ ] `test_active_browser_connections_counts_only_healthy_daemons` — stale/error daemons not counted
- [ ] `test_browser_connections_returns_attached_page` — page title/URL round-trips correctly
- [ ] `test_run_doctor_prints_active_browser_connections_and_active_pages` — doctor output contains count and per-daemon lines
- [ ] `test_doctor_page_output_truncates_long_text` — long titles/URLs are truncated with `...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show live browser connections in `run_doctor`, including the active page title and URL for each daemon. Adds a new daemon meta message to probe connections and keeps `target_id` in sync on tab switches.

- **New Features**
  - Added `browser_connections()` and `active_browser_connections()` in `admin.py` to probe each daemon socket and return live page info.
  - Added `connection_status` meta handler in `daemon.py`; daemon now tracks `target_id` and returns active page via `Target.getTargetInfo`.
  - `switch_tab` now forwards `target_id` in `set_session` to keep the daemon synced after tab changes.
  - `run_doctor` prints the active connection count and per-daemon active page (title and URL), with long text truncated.

<sup>Written for commit 8120c68d6d07ee45404c1589a497d9b7b693f0d0. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/234?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

