### PR TITLE
Fix Windows daemon probing and CLI docs

### DIFF
--- a/agent-workspace/domain-skills/facebook/groups.md
+++ b/agent-workspace/domain-skills/facebook/groups.md
@@ -171,7 +171,7 @@ print(js("""
 ## Full example — mine one group, emit JSON for downstream tools
 
 ```bash
-cd ~/Developer/browser-harness && uv run browser-harness <<'PY'
+cd ~/Developer/browser-harness && uv run browser-harness -c "$(cat <<'PY'
 import json, sys
 from urllib.parse import urlparse, parse_qs, unquote
 
@@ -223,6 +223,7 @@ print(json.dumps({
     "external_urls": all_externals,
 }, ensure_ascii=False))
 PY
+)"
 ```
 
 The JSON on stdout is the handoff payload — parse it in the calling agent and

--- a/agent-workspace/domain-skills/facebook/pages.md
+++ b/agent-workspace/domain-skills/facebook/pages.md
@@ -197,7 +197,7 @@ print(js("""
 ## Full example — mine one Page, emit JSON for downstream tools
 
 ```bash
-cd ~/Developer/browser-harness && uv run browser-harness <<'PY'
+cd ~/Developer/browser-harness && uv run browser-harness -c "$(cat <<'PY'
 import json, sys
 from urllib.parse import urlparse, parse_qs, unquote
 
@@ -267,6 +267,7 @@ print(json.dumps({
     "external_urls": all_externals,
 }, ensure_ascii=False))
 PY
+)"
 ```
 
 The stdout JSON is the handoff payload — parse it in the calling agent and

--- a/agent-workspace/domain-skills/medium/article-hydration.md
+++ b/agent-workspace/domain-skills/medium/article-hydration.md
@@ -33,7 +33,7 @@ Safe pattern: take the extracted markdown, then drop leading paragraphs that are
 ## Extractor
 
 ````bash
-browser-harness <<'PY'
+browser-harness -c "$(cat <<'PY'
 new_tab("https://medium.com/@user/slug-abc123")
 wait_for_load()
 wait(2.0)  # Medium hydrates more UI after readyState=complete
@@ -87,6 +87,7 @@ while paras and len(paras[0]) < 12:
 md = '\n\n'.join(paras)
 print(md)
 PY
+)"
 ````
 
 The `seen` set avoids double-emitting when an `<li>` matches the block query inside its `<ul>`.

--- a/agent-workspace/domain-skills/polymarket/scraping.md
+++ b/agent-workspace/domain-skills/polymarket/scraping.md
@@ -129,7 +129,7 @@ Polymarket's event page renders every outcome row inside nested `<div>`s with **
 **Only emit text from DOM leaves** — elements with `children.length === 0`. A leaf node's `innerText` is precisely what it renders, never a concatenation of siblings. Then group adjacent leaves by their **nearest common ancestor** to assemble rows.
 
 ```bash
-browser-harness <<'PY'
+browser-harness -c "$(cat <<'PY'
 new_tab("https://polymarket.com/event/iran-x-israelus-conflict-ends-by")
 wait_for_load()
 wait(3.0)   # SPA hydration
@@ -175,6 +175,7 @@ labels = js(r"""
 """)
 print(labels)
 PY
+)"
 ```
 
 Then assemble rows in Python by matching fingerprints:

--- a/agent-workspace/domain-skills/reddit/scraping.md
+++ b/agent-workspace/domain-skills/reddit/scraping.md
@@ -35,7 +35,7 @@ Fails on:
 Core selector: every post renders inside a single `<shreddit-post>` custom element. Top-level comments are `<shreddit-comment depth="0">`.
 
 ```bash
-browser-harness <<'PY'
+browser-harness -c "$(cat <<'PY'
 new_tab("https://www.reddit.com/r/vibecoding/comments/1kwuqpz/")
 wait_for_load()
 wait(3.0)  # SPA still hydrating after readyState=complete
@@ -73,6 +73,7 @@ data = js(r"""
 """)
 print(data["title"], "·", len(data["body"]), "chars ·", len(data["comments"]), "comments")
 PY
+)"
 ```
 
 ### Key selectors

--- a/install.md
+++ b/install.md
@@ -48,9 +48,9 @@ Prefer `browser-harness --setup` — it runs the full attach-and-escalate flow b
 2. First try the harness directly. If this works, skip manual browser setup:
 
 ```bash
-uv run browser-harness <<'PY'
+uv run browser-harness -c '
 print(page_info())
-PY
+'
 ```
 
    Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session.
@@ -77,11 +77,11 @@ osascript -e 'tell application "Google Chrome" to activate' \
 7. Verify with:
 
 ```bash
-uv run browser-harness <<'PY'
+uv run browser-harness -c '
 goto_url("https://github.com/browser-use/browser-harness")
 wait_for_load()
 print(page_info())
-PY
+'
 ```
 
 If that fails with a stale websocket or stale socket, restart the daemon once and retry:
@@ -114,7 +114,8 @@ Wait 5 seconds, then reconnect. This resets all CDP state.
 ## Architecture
 
 ```text
-Chrome / Browser Use cloud -> CDP WS -> browser_harness.daemon -> /tmp/bu-<NAME>.sock -> browser_harness.run
+POSIX:   Chrome / Browser Use cloud -> CDP WS -> browser_harness.daemon -> /tmp/bu-<NAME>.sock -> browser_harness.run
+Windows: Chrome / Browser Use cloud -> CDP WS -> browser_harness.daemon -> 127.0.0.1:<ephemeral> (+ temp bu-<NAME>.port) -> browser_harness.run
 ```
 
 - Protocol is one JSON line each way.

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -10,7 +10,7 @@ curl -fsSL https://browser-use.com/profile.sh | sh
 
 Downloads `profile-use` (macOS / Linux / Windows, x64 / arm64). The Python helpers shell out to it; you don't run `profile-use` directly.
 
-## Python API (pre-imported in `browser-harness <<'PY'`)
+## Python API (pre-imported in `browser-harness -c '...'`)
 
 ```python
 list_cloud_profiles()

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -10,7 +10,7 @@ curl -fsSL https://browser-use.com/profile.sh | sh
 
 Downloads `profile-use` (macOS / Linux / Windows, x64 / arm64). The Python helpers shell out to it; you don't run `profile-use` directly.
 
-## Python API (pre-imported in `browser-harness -c '...'`)
+## Python API (pre-imported in `browser-harness <<'PY'`)
 
 ```python
 list_cloud_profiles()

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -148,9 +148,9 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
+        s = None
         try:
-            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(3)
-            s.connect(_paths(name)[0])
+            s = ipc.connect(name or NAME, timeout=3.0)
             s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
             data = b""
             while not data.endswith(b"\n"):
@@ -159,6 +159,10 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 data += chunk
             if b'"result"' in data: return
         except Exception: pass
+        finally:
+            if s:
+                try: s.close()
+                except Exception: pass
         restart_daemon(name)
 
     import subprocess, sys
@@ -506,7 +510,7 @@ def _chrome_running():
     system = platform.system()
     try:
         if system == "Windows":
-            out = subprocess.check_output(["tasklist"], text=True, timeout=5)
+            out = subprocess.check_output(["tasklist"], text=True, timeout=15)
             names = ("chrome.exe", "msedge.exe")
         else:
             out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, timeout=5)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -40,6 +40,20 @@ def test_handshake_403_needs_chrome_remote_debugging_prompt():
     assert admin._needs_chrome_remote_debugging_prompt(msg)
 
 
+def test_chrome_running_allows_slow_windows_tasklist(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+
+    def fake_check_output(cmd, text=True, timeout=None):
+        assert cmd == ["tasklist"]
+        assert text is True
+        assert timeout == 15
+        return "chrome.exe"
+
+    monkeypatch.setattr("subprocess.check_output", fake_check_output)
+
+    assert admin._chrome_running()
+
+
 def test_stale_websocket_does_not_open_chrome_inspect():
     msg = "no close frame received or sent"
 
@@ -70,6 +84,22 @@ def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch):
     monkeypatch.setattr(admin.ipc, "connect", fake_connect)
 
     assert admin.active_browser_connections() == 1
+
+
+def test_ensure_daemon_probes_live_daemon_through_ipc(monkeypatch):
+    monkeypatch.setattr(admin, "daemon_alive", lambda name=None: True)
+
+    class ProbeSocket(FakeSocket):
+        def __init__(self):
+            super().__init__(b'{"result":{"targetInfos":[]}}\n')
+
+    def fail_restart(_name=None):
+        raise AssertionError("live daemon should not be restarted")
+
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: ProbeSocket())
+    monkeypatch.setattr(admin, "restart_daemon", fail_restart)
+
+    admin.ensure_daemon()
 
 
 def test_browser_connections_returns_attached_page(monkeypatch):


### PR DESCRIPTION
## Root Cause

The latest `src/browser_harness` layout moved the CLI to `browser-harness -c`, but several setup/domain examples still used the removed stdin heredoc invocation. On Windows, the daemon health probe in `ensure_daemon()` still attempted a POSIX socket connection, so a healthy Windows daemon could be treated as stale and restarted on every call.

## Fix Summary

- Probe live daemons through the shared IPC abstraction so Windows TCP loopback daemons are recognized as healthy.
- Give the Windows `tasklist` check more time before declaring Chrome absent.
- Update setup/profile-sync/domain-skill examples to use the current `browser-harness -c` invocation.
- Add unit coverage for the Windows daemon probe and slower `tasklist` path.

## Verification

- `git diff --check` -> passed
- `uv run --with pytest pytest` -> 35 passed
- `browser-harness --doctor` -> core health OK: Chrome running, daemon alive, 1 active browser connection
- `browser-harness -c "print(page_info())"` -> succeeded against the attached Chrome tab

## Notes

`profile-use` and `BROWSER_USE_API_KEY` remain optional and were not configured in the local environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows daemon health checks by probing over the shared IPC so healthy loopback daemons aren’t restarted. Updates examples to use `browser-harness -c` and clarifies Windows TCP architecture; improves Chrome detection reliability on Windows.

- **Bug Fixes**
  - Probe daemons via `ipc.connect(...)` instead of a POSIX socket so Windows TCP daemons are treated as healthy; close the probe socket cleanly.
  - Increase Windows `tasklist` timeout to 15s to avoid false “Chrome not running” results.
  - Add unit tests for the IPC probe and the slower Windows `tasklist` path.

- **Migration**
  - Use `browser-harness -c '...'` (or `-c "$(cat <<'PY' ... )"`) in scripts; examples and install docs were updated, including a note that Windows uses 127.0.0.1:<ephemeral> with a temp `bu-<NAME>.port` file.

<sup>Written for commit d41b87e4ea65b542803d40bf4edba9d592c846b6. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/236?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

