### PR TITLE
Clarify browser harness session routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ Useful for stealth, sub-agents, or deployment.<br>
 - Grab a key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key)
 - Or let the agent sign up itself via [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt) (setup flow + challenge context included).
 
+## Parallel agents and `BU_NAME`
+
+Multiple agents can use the same local Chrome if each one runs with a distinct `BU_NAME`. That isolates the harness daemon/session state, not the whole browser.
+
+```bash
+BU_NAME=alpha browser-harness -c 'new_tab("https://example.com"); print(page_info())'
+BU_NAME=beta browser-harness -c 'new_tab("https://example.org"); print(page_info())'
+```
+
+What `BU_NAME` isolates:
+- socket, pid, and daemon state
+- attached target/session inside the harness
+
+What it does not isolate on local Chrome:
+- the visible Chrome window
+- profile cookies/login state
+- accidental interaction with the same site or tab flow
+
+Use Browser Use remote browsers only when explicitly requested or when the task genuinely requires a separate cloud browser.
+
+Remote access is opt-in per daemon. Setting `BROWSER_USE_API_KEY` or having Browser Use cloud enabled is not enough: `BU_NAME=alpha browser-harness ...` still attaches to local Chrome unless `alpha` was started with `start_remote_daemon("alpha")` or a remote `BU_CDP_WS` / `BU_CDP_URL`. When Chrome remote debugging shows `Server running at: 127.0.0.1:9222`, local daemons will prefer that local browser unless you explicitly point them elsewhere.
+
 ## How simple is it? (~592 lines of Python)
 
 - `install.md` — first-time install and browser bootstrap

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,6 +89,27 @@ Having `BROWSER_USE_API_KEY` set or remote browser access available does not mak
 
 Use remote only when the user explicitly asks for a Browser Use cloud browser, a non-local browser, or a headless/deployment browser. BROWSER_USE_API_KEY must be set. start_remote_daemon, list_cloud_profiles, list_local_profiles, sync_local_profile are pre-imported.
 
+Baseline remote run:
+
+```bash
+browser-harness -c '
+start_remote_daemon("remote", timeout=5)
+'
+
+BU_NAME=remote browser-harness -c '
+new_tab("https://example.com")
+wait_for_load()
+print(current_tab())
+print(page_info())
+'
+
+browser-harness -c '
+stop_remote_daemon("remote")
+'
+```
+
+`start_remote_daemon(...)` prints and opens a `live.browser-use.com` viewer in the local Chrome. That tab is only the viewer; the controlled page runs in the Browser Use cloud browser.
+
 ```bash
 browser-harness -c '
 start_remote_daemon("work")                               # default — clean browser, no profile

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,6 +20,34 @@ print(page_info())
 - Invoke as browser-harness — it's on $PATH. No cd, no uv run.
 - First navigation is new_tab(url), not goto_url(url) — goto runs in the user's active tab and clobbers their work.
 
+## Use local Chrome by default
+
+Always use the user's local Chrome for browser-harness work unless the user explicitly asks for a remote Browser Use cloud browser. When local Chrome remote debugging is enabled at `127.0.0.1:9222`, plain `browser-harness` and plain `BU_NAME=<name> browser-harness ...` should attach there.
+
+Do not start a remote daemon just because the user asks for parallel work, a fresh `BU_NAME`, or a new browser-harness session. `BU_NAME` only selects the harness daemon namespace. If the command calls `new_tab(...)`, it opens a tab in the local Chrome unless that specific daemon was explicitly created as remote.
+
+Local parallel pattern:
+
+```bash
+BU_NAME=work browser-harness -c '
+new_tab("https://example.com")
+print(page_info())
+'
+```
+
+Remote pattern, only when explicitly requested:
+
+```bash
+browser-harness -c '
+start_remote_daemon("work")
+'
+
+BU_NAME=work browser-harness -c '
+new_tab("https://example.com")
+print(page_info())
+'
+```
+
 Available interaction skills:
 - interaction-skills/connection.md — startup sequence, tab visibility, omnibox popup fix
 
@@ -37,9 +65,29 @@ browser-harness -c '
 
 run.py calls ensure_daemon() before exec — you never start/stop manually unless you want to.
 
+### Parallel agents on local Chrome
+
+You can run multiple agents against the same local Chrome as long as each one uses a distinct `BU_NAME`.
+
+```bash
+BU_NAME=alpha browser-harness -c '
+new_tab("https://example.com")
+print(page_info())
+'
+
+BU_NAME=beta browser-harness -c '
+new_tab("https://example.org")
+print(page_info())
+'
+```
+
+`BU_NAME` isolates the harness session and daemon state (`/tmp/bu-<NAME>.sock`, pid, attached target). It does **not** give each agent a separate local browser profile or independent visible window. Agents with different `BU_NAME`s still share the same real Chrome and can interfere with each other if they touch the same site, account, or active tab flow. Use remote browsers when you need real isolation.
+
+Having `BROWSER_USE_API_KEY` set or remote browser access available does not make plain `BU_NAME=<name> browser-harness ...` remote. A new `BU_NAME` defaults to local Chrome unless that daemon was created with `start_remote_daemon("<name>")` or an explicit remote CDP endpoint (`BU_CDP_WS` / `BU_CDP_URL`). If Chrome's remote debugging page says `Server running at: 127.0.0.1:9222`, new local daemons can attach there immediately. If your command calls `new_tab(...)`, it opens a new tab in whichever browser that daemon is attached to.
+
 ### Remote browsers
 
-Use remote for parallel sub-agents (each gets its own isolated browser via a distinct BU_NAME) or on a headless server. BROWSER_USE_API_KEY must be set. start_remote_daemon, list_cloud_profiles, list_local_profiles, sync_local_profile are pre-imported.
+Use remote only when the user explicitly asks for a Browser Use cloud browser, a non-local browser, or a headless/deployment browser. BROWSER_USE_API_KEY must be set. start_remote_daemon, list_cloud_profiles, list_local_profiles, sync_local_profile are pre-imported.
 
 ```bash
 browser-harness -c '

--- a/install.md
+++ b/install.md
@@ -53,7 +53,7 @@ print(page_info())
 PY
 ```
 
-   Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session.
+   Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session. Distinct `BU_NAME`s isolate harness sessions, not the local Chrome itself: separate agents can still affect the same tabs, profile state, or logged-in sites unless you move them to remote browsers.
 
 3. If it failed, **read the error and escalate from there — do not assume you need `chrome://inspect`**. The remote-debugging checkbox is per-profile sticky in Chrome, so any profile that has had it toggled on once will auto-enable CDP on every future launch; the inspect page is only needed the first time per profile.
 
@@ -121,7 +121,11 @@ Chrome / Browser Use cloud -> CDP WS -> browser_harness.daemon -> /tmp/bu-<NAME>
 - Requests are {method, params, session_id} for CDP or {meta: ...} for daemon control.
 - Responses are {result} / {error} / {events} / {session_id}.
 - BU_NAME namespaces socket, pid, and log files.
+- Different `BU_NAME`s can point at the same local Chrome while keeping separate daemon/session state.
+- Different `BU_NAME`s do not create separate local Chrome profiles or windows; use remote browsers only when explicitly requested or when true cloud-browser isolation is required.
 - BU_CDP_WS overrides local Chrome discovery for remote browsers.
+- BROWSER_USE_API_KEY enables remote browser creation, but does not make ordinary BU_NAME daemons remote by default.
+- When local Chrome remote debugging is enabled and serving on 127.0.0.1:9222, plain BU_NAME daemons attach there unless BU_CDP_WS or BU_CDP_URL points them elsewhere.
 - BU_BROWSER_ID + BROWSER_USE_API_KEY lets the daemon stop a Browser Use cloud browser on shutdown.
 
 ## Keeping the harness current

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -110,6 +110,8 @@ def _daemon_browser_connection(name):
             data += chunk
         response = json.loads(data)
         if "error" in response:
+            if response.get("error") == "'method'":
+                return _legacy_daemon_browser_connection(name)
             return None
         page = response.get("page")
         if page:
@@ -120,6 +122,28 @@ def _daemon_browser_connection(name):
     finally:
         if c:
             c.close()
+
+
+def _legacy_daemon_browser_connection(name):
+    c = None
+    try:
+        c = ipc.connect(name, timeout=1.0)
+        c.sendall(b'{"method":"Target.getTargets","params":{}}\n')
+        data = b""
+        while not data.endswith(b"\n"):
+            chunk = c.recv(1 << 16)
+            if not chunk:
+                break
+            data += chunk
+        response = json.loads(data)
+        if "result" in response:
+            return {"name": name, "page": None}
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError, KeyError, ValueError, json.JSONDecodeError):
+        return None
+    finally:
+        if c:
+            c.close()
+    return None
 
 
 def browser_connections():

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -3,6 +3,7 @@ import os
 import socket
 import tempfile
 import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -470,20 +471,35 @@ def _cache_write(data):
         pass
 
 
-def _latest_release_tag(force=False):
-    """Return latest release tag from GitHub, or None. Cached for 24h to avoid hammering the API."""
+def _latest_release_lookup(force=False):
+    """Return (latest release tag, status). Cached for 24h to avoid hammering the API."""
     cache = _cache_read()
     now = time.time()
-    if not force and cache.get("tag") and now - cache.get("fetched_at", 0) < VERSION_CACHE_TTL:
-        return cache["tag"]
+    if not force and now - cache.get("fetched_at", 0) < VERSION_CACHE_TTL:
+        if cache.get("tag"):
+            return cache["tag"], "ok"
+        if cache.get("release_status") == "no_release":
+            return None, "no_release"
     try:
         req = urllib.request.Request(GH_RELEASES, headers={"Accept": "application/vnd.github+json"})
         tag = json.loads(urllib.request.urlopen(req, timeout=5).read()).get("tag_name") or ""
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            _cache_write({**cache, "tag": "", "release_status": "no_release", "fetched_at": now})
+            return None, "no_release"
+        return cache.get("tag"), "ok" if cache.get("tag") else "unreachable"
     except Exception:
-        return cache.get("tag")  # fall back to last known
+        return cache.get("tag"), "ok" if cache.get("tag") else "unreachable"
     tag = tag.lstrip("v")
-    _cache_write({**cache, "tag": tag, "fetched_at": now})
-    return tag or None
+    release_status = "ok" if tag else "no_release"
+    _cache_write({**cache, "tag": tag, "release_status": release_status, "fetched_at": now})
+    return tag or None, release_status
+
+
+def _latest_release_tag(force=False):
+    """Return latest release tag from GitHub, or None."""
+    tag, _status = _latest_release_lookup(force=force)
+    return tag
 
 
 def _version_tuple(v):
@@ -620,7 +636,7 @@ def run_doctor():
     connections = browser_connections()
     profile_use = shutil.which("profile-use") is not None
     api_key = bool(os.environ.get("BROWSER_USE_API_KEY"))
-    latest = _latest_release_tag()
+    latest, latest_status = _latest_release_lookup()
     # Only claim an update when we know the installed version — `cur or "(unknown)"`
     # for display would otherwise be parsed as (0,) and flag every latest as newer.
     newer = bool(cur and latest and _version_tuple(latest) > _version_tuple(cur))
@@ -636,6 +652,8 @@ def run_doctor():
     print(f"  version           {cur_display} ({mode})")
     if latest:
         print(f"  latest release    {latest}" + (" (update available)" if newer else ""))
+    elif latest_status == "no_release":
+        print("  latest release    (none published)")
     else:
         print("  latest release    (could not reach github)")
     row("chrome running", chrome, "" if chrome else "start chrome/edge and rerun `browser-harness --setup`")

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -255,6 +255,25 @@ def list_tabs(include_chrome=True):
     return out
 
 def current_tab():
+    try:
+        status = _send({"meta": "connection_status"})
+        page = status.get("page")
+        if page:
+            return {
+                "targetId": page.get("targetId"),
+                "url": page.get("url", ""),
+                "title": page.get("title", ""),
+            }
+        target_id = status.get("target_id")
+        if target_id:
+            t = cdp("Target.getTargetInfo", targetId=target_id).get("targetInfo", {})
+            return {
+                "targetId": t.get("targetId"),
+                "url": t.get("url", ""),
+                "title": t.get("title", ""),
+            }
+    except Exception:
+        pass
     t = cdp("Target.getTargetInfo").get("targetInfo", {})
     return {"targetId": t.get("targetId"), "url": t.get("url", ""), "title": t.get("title", "")}
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -88,6 +88,21 @@ def test_browser_connections_returns_attached_page(monkeypatch):
     ]
 
 
+def test_browser_connections_counts_legacy_daemon_that_still_answers_cdp(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default"])
+    responses = [
+        b'{"error":"\'method\'"}\n',
+        b'{"result":{"targetInfos":[]}}\n',
+    ]
+
+    def fake_connect(name, timeout=1.0):
+        return FakeSocket(responses.pop(0))
+
+    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+
+    assert admin.browser_connections() == [{"name": "default", "page": None}]
+
+
 def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypatch, capsys):
     monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
     monkeypatch.setattr(admin, "_install_mode", lambda: "git")

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -118,7 +118,7 @@ def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypat
             "page": {"title": "Cat - Wikipedia", "url": "https://en.wikipedia.org/wiki/Cat"},
         },
     ])
-    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_latest_release_lookup", lambda: ("0.1.0", "ok"))
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
     monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
 
@@ -142,7 +142,7 @@ def test_doctor_page_output_truncates_long_text(monkeypatch, capsys):
             "page": {"title": "A very long page title", "url": "https://example.test/very/long/path"},
         }
     ])
-    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_latest_release_lookup", lambda: ("0.1.0", "ok"))
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
     monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
 
@@ -151,3 +151,19 @@ def test_doctor_page_output_truncates_long_text(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "A very long page ..." in out
     assert "https://example.t..." in out
+
+
+def test_run_doctor_reports_when_no_release_is_published(monkeypatch, capsys):
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr(admin, "_latest_release_lookup", lambda: (None, "no_release"))
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+    assert admin.run_doctor() == 0
+
+    out = capsys.readouterr().out
+    assert "latest release    (none published)" in out

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -50,3 +50,50 @@ def test_page_info_raises_clear_error_on_js_exception():
          patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
         with pytest.raises(RuntimeError, match="ReferenceError"):
             helpers.page_info()
+
+
+def test_current_tab_uses_daemon_connection_status_page():
+    def fake_send(req):
+        assert req == {"meta": "connection_status"}
+        return {
+            "target_id": "browser-target",
+            "session_id": "session-1",
+            "page": {
+                "targetId": "page-target",
+                "title": "Example",
+                "url": "https://example.test",
+            },
+        }
+
+    with patch("browser_harness.helpers._send", side_effect=fake_send):
+        assert helpers.current_tab() == {
+            "targetId": "page-target",
+            "title": "Example",
+            "url": "https://example.test",
+        }
+
+
+def test_current_tab_falls_back_to_target_id_from_connection_status():
+    def fake_send(req):
+        assert req == {"meta": "connection_status"}
+        return {"target_id": "page-target", "session_id": "session-1", "page": None}
+
+    def fake_cdp(method, **kwargs):
+        assert method == "Target.getTargetInfo"
+        assert kwargs == {"targetId": "page-target"}
+        return {
+            "targetInfo": {
+                "targetId": "page-target",
+                "type": "page",
+                "title": "Example",
+                "url": "https://example.test",
+            }
+        }
+
+    with patch("browser_harness.helpers._send", side_effect=fake_send), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        assert helpers.current_tab() == {
+            "targetId": "page-target",
+            "title": "Example",
+            "url": "https://example.test",
+        }


### PR DESCRIPTION
## Summary

- Clarify that `BU_NAME` selects a harness daemon namespace and does not make a session remote by itself.
- Document local Chrome parallel usage versus explicitly requested Browser Use cloud sessions.
- Add a baseline remote Browser Use cloud run with `start_remote_daemon(...)`, `BU_NAME=...`, and `stop_remote_daemon(...)`.
- Make `current_tab()` use daemon `connection_status` so it reports the attached page instead of the browser target.
- Let `doctor` count legacy daemons that still answer CDP, instead of omitting them from active browser connections.
- Distinguish a repository with no published GitHub release from an unreachable GitHub API in `doctor` output.

## Why

While testing multiple `BU_NAME` sessions, a fresh local daemon attached to Chrome remote debugging at `127.0.0.1:9222`, which can be surprising when Browser Use cloud credentials are configured. The docs now make local versus remote routing explicit.

The same testing showed `current_tab()` returning an empty `url`/`title` because `Target.getTargetInfo` without a `targetId` can return the browser target. The daemon already tracks the attached target, so `current_tab()` now asks the daemon first and falls back to the existing behavior for compatibility.

Follow-up verification showed `doctor` printed `latest release (could not reach github)` even though GitHub was reachable and the repository simply had no published release. That output is now specific: `latest release (none published)`.

## Verification

- `python3 -m py_compile src/browser_harness/admin.py tests/unit/test_admin.py`
- `python3 -m py_compile src/browser_harness/admin.py src/browser_harness/helpers.py src/browser_harness/daemon.py src/browser_harness/run.py`
- `git diff --check`
- Manual local smoke: `BU_NAME=moderninstall browser-harness -c 'new_tab("https://example.com/?moderninstall=2"); wait_for_load(); print(current_tab()); print(page_info())'` returned the expected page URL/title.
- Manual doctor smoke: `browser-harness --doctor` listed active daemons and printed `latest release (none published)`.
- Manual remote smoke: `start_remote_daemon("remotecheck", timeout=5)` followed by `BU_NAME=remotecheck ...` navigated to `https://example.com/?remotecheck=1`; `stop_remote_daemon("remotecheck")` removed it from `doctor` output.
