### PR TITLE
fix(admin): catch SystemError raised by os.kill on Windows

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -223,12 +223,12 @@ def restart_daemon(name=None):
             try:
                 os.kill(pid, 0)
                 time.sleep(0.2)
-            except (ProcessLookupError, OSError):
+            except (ProcessLookupError, OSError, SystemError):
                 break
         else:
             try:
                 os.kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
+            except (ProcessLookupError, OSError, SystemError):
                 pass
     ipc.cleanup_endpoint(name or NAME)
     try:


### PR DESCRIPTION
## Bug

On Windows, `os.kill(pid, 0)` does not behave like its POSIX counterpart. Instead of returning silently when the process exists or raising `ProcessLookupError` when it doesn't, CPython on Windows raises:

```
SystemError: <built-in function kill> returned a result with an exception set
```

This happens because the underlying Win32 `TerminateProcess` API does not accept signal `0` as an "is alive?" probe — Python's C implementation hits an internal error path that doesn't set a proper exception, and the interpreter surfaces `SystemError` (which is *not* a subclass of `OSError`).

`restart_daemon()` already wraps both `os.kill(pid, 0)` and `os.kill(pid, signal.SIGTERM)` in `except (ProcessLookupError, OSError)`, so on Linux/macOS this works fine — but on Windows the `SystemError` slips through and crashes every second invocation of the harness, because by then the previous daemon's pid in `/tmp/bu-default.pid` points at a process that no longer exists.

## Repro (Windows 11, Python 3.12.7, browser-harness 0.1.0)

```bash
browser-harness --reload                  # ok — daemon stopped
browser-harness -c 'print(page_info())'   # ok — daemon spawns, page_info returns
browser-harness -c 'print(page_info())'   # CRASH
```

Stack trace from the second call:

```
File ".../browser_harness/run.py", line 74, in main
    ensure_daemon()
File ".../browser_harness/admin.py", line 162, in ensure_daemon
    restart_daemon(name)
File ".../browser_harness/admin.py", line 224, in restart_daemon
    os.kill(pid, 0)
SystemError: <built-in function kill> returned a result with an exception set
```

## Fix

Add `SystemError` to the two existing except clauses in `restart_daemon()`. Two-word change, matches the intent of the existing handlers — treat any "couldn't probe/signal the pid" failure as "process is gone, move on."

```diff
-            except (ProcessLookupError, OSError):
+            except (ProcessLookupError, OSError, SystemError):
```

## Verification

After the patch, on the same Windows machine:

```bash
browser-harness --reload                                                # ok
browser-harness -c 'print(page_info())'                                 # ok
browser-harness -c 'new_tab("https://github.com/browser-use/browser-harness"); wait_for_load(); print(page_info())'   # ok
browser-harness -c 'print(page_info())'                                 # ok
```

Successive calls return clean `page_info()` output with no traceback.

## Notes

- No behavior change on POSIX systems — `SystemError` is never raised by `os.kill` there.
- Companion to recent Windows-IPC work (#225). Surfaced while running the harness against a dedicated `--user-data-dir` Chrome on Windows 11.
- I'm happy to add a test if you have a preferred way to mock the Windows-specific `os.kill` quirk; the existing test layout in `tests/unit` doesn't seem to mock `os.kill` yet, so I left this as a fix-only PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catch `SystemError` from `os.kill` on Windows to prevent crashes when probing or terminating a stale daemon pid. No behavior change on Linux/macOS.

- **Bug Fixes**
  - Add `SystemError` to the existing handlers around `os.kill(pid, 0)` and `os.kill(pid, signal.SIGTERM)` in `restart_daemon()`.

<sup>Written for commit 06aad12d91d1eb5029af8f88412ac3e1859cf326. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/241?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

