### PR TITLE
Rename skill command from /browser-harness to /browser

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: browser-harness
+name: browser
 description: Direct browser control via CDP. Use when the user wants to automate, scrape, test, or interact with web pages. Connects to the user's already-running Chrome.
 ---
 

--- a/install.md
+++ b/install.md
@@ -1,5 +1,5 @@
 ---
-name: browser-harness-install
+name: browser-install
 description: Install and bootstrap browser-harness into the current agent, then connect it to the user's real Chrome with minimal prompting.
 ---
 


### PR DESCRIPTION
## Summary
- Renames the skill command from `/browser-harness` to `/browser` for a cleaner invocation
- Also renames the install skill from `/browser-harness-install` to `/browser-install` for consistency

## Test plan
- [ ] Verify `/browser` command loads the skill correctly
- [ ] Verify `/browser-install` command loads the install instructions

Slack thread: https://browser-use.slack.com/archives/C084NF0JMPT/p1777414723787169?thread_ts=1777414678.638439&cid=C084NF0JMPT

https://claude.ai/code/session_014BWe8AkViicHviYPP843t5

---
_Generated by [Claude Code](https://claude.ai/code/session_014BWe8AkViicHviYPP843t5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the browser skill commands to shorter names for easier invocation. `/browser-harness` -> `/browser` and `/browser-harness-install` -> `/browser-install`.

<sup>Written for commit ee1ff81eac1f7d6f2a27b39ecea73c8a5d9fe09c. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/242?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

