### PR TITLE
fix(_ipc): mkdir -p _TMP at module load

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -8,6 +8,7 @@ IS_WINDOWS = sys.platform == "win32"
 # /tmp on POSIX (gettempdir() returns long /var/folders/... on macOS); tempdir on Windows.
 # Caller picking BH_TMP_DIR is responsible for keeping <dir>/bu-<NAME>.sock under 104 chars.
 _TMP = Path(os.environ.get("BH_TMP_DIR") or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
+_TMP.mkdir(parents=True, exist_ok=True)  # caller-supplied BH_TMP_DIR may not exist yet
 _NAME_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
 
 


### PR DESCRIPTION
## Summary

Ensure `_TMP` exists at module load so `BH_TMP_DIR` can point at a directory that doesn't exist yet.

## Why

Without this, a caller passing `BH_TMP_DIR=<custom dir>` to a non-existent path causes the first write (sock / port / pid / log / screenshot) to fail with `FileNotFoundError`. The default `_TMP` (`/tmp` on POSIX, `tempfile.gettempdir()` on Windows) always exists, so this is latent today. It surfaces with per-session scratch dirs that the consumer creates on the fly — exactly the use case browsercode is about to introduce.

Single root cause -> single fix in `_ipc.py`: covers screenshots, sock, port, pid, and log paths uniformly.

## Change

```python
_TMP = Path(os.environ.get("BH_TMP_DIR") or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
_TMP.mkdir(parents=True, exist_ok=True)  # caller-supplied BH_TMP_DIR may not exist yet
```

## Test

```
$env:BH_TMP_DIR="...nested/dir/that/does/not/exist"
uv run python -c "from browser_harness import _ipc; assert _ipc._TMP.exists()"
# OK
```
