### PR TITLE
fix(_ipc): drop bu-<NAME> filename prefix when BH_TMP_DIR is set

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -3,12 +3,13 @@ import asyncio, os, re, socket, subprocess, sys, tempfile
 from pathlib import Path
 
 IS_WINDOWS = sys.platform == "win32"
-# Override via BH_TMP_DIR for sock/port/pid/log + screenshot output (e.g. per-session
-# scratch dir). Default keeps AF_UNIX paths under sun_path limits (104 macOS, 108 Linux):
-# /tmp on POSIX (gettempdir() returns long /var/folders/... on macOS); tempdir on Windows.
-# Caller picking BH_TMP_DIR is responsible for keeping <dir>/bu-<NAME>.sock under 104 chars.
-_TMP = Path(os.environ.get("BH_TMP_DIR") or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
-_TMP.mkdir(parents=True, exist_ok=True)  # caller-supplied BH_TMP_DIR may not exist yet
+# BH_TMP_DIR set → caller-isolated dir, bare filenames (avoids AF_UNIX sun_path
+# overrun: 104 macOS / 108 Linux). Unset → shared tmpdir, "bu-<NAME>" prefix
+# disambiguates daemons. POSIX default is /tmp (gettempdir() returns long
+# /var/folders/... on macOS); Windows uses TCP so any tempdir is fine.
+BH_TMP_DIR = os.environ.get("BH_TMP_DIR")
+_TMP = Path(BH_TMP_DIR or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
+_TMP.mkdir(parents=True, exist_ok=True)
 _NAME_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
 
 
@@ -18,16 +19,21 @@ def _check(name):  # path-traversal guard for BU_NAME
     return name
 
 
-def log_path(name):   return _TMP / f"bu-{_check(name)}.log"
-def pid_path(name):   return _TMP / f"bu-{_check(name)}.pid"
-def port_path(name):  return _TMP / f"bu-{_check(name)}.port"  # Windows-only: holds the daemon's TCP port
-def _sock_path(name): return _TMP / f"bu-{_check(name)}.sock"
+def _stem(name):  # "bu" when BH_TMP_DIR isolates us, else "bu-<NAME>"
+    _check(name)
+    return "bu" if BH_TMP_DIR else f"bu-{name}"
+
+
+def log_path(name):   return _TMP / f"{_stem(name)}.log"
+def pid_path(name):   return _TMP / f"{_stem(name)}.pid"
+def port_path(name):  return _TMP / f"{_stem(name)}.port"  # Windows-only: holds the daemon's TCP port
+def _sock_path(name): return _TMP / f"{_stem(name)}.sock"
 
 
 def sock_addr(name):  # display-only, used in log lines
     if not IS_WINDOWS: return str(_sock_path(name))
     try: return f"127.0.0.1:{port_path(name).read_text().strip()}"
-    except FileNotFoundError: return f"tcp:bu-{_check(name)}"
+    except FileNotFoundError: return f"tcp:{_stem(name)}"
 
 
 def spawn_kwargs():  # subprocess.Popen flags so the daemon detaches from this terminal

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -76,14 +76,16 @@ def daemon_alive(name=None):
 
 
 def _daemon_endpoint_names():
-    pattern = "bu-*.port" if ipc.IS_WINDOWS else "bu-*.sock"
+    # BH_TMP_DIR isolates one daemon per dir → no filename-prefix discovery,
+    # just check whether our local endpoint exists. Without BH_TMP_DIR, _TMP
+    # is the shared default (`/tmp` etc.) and we glob `bu-*.<suffix>` to find
+    # every daemon on the machine.
     suffix = ".port" if ipc.IS_WINDOWS else ".sock"
+    if ipc.BH_TMP_DIR:
+        return [NAME] if (ipc._TMP / f"bu{suffix}").exists() else []
     names = []
-    for p in sorted(ipc._TMP.glob(pattern)):
-        name = p.name
-        if not name.startswith("bu-") or not name.endswith(suffix):
-            continue
-        raw = name[3:-len(suffix)]
+    for p in sorted(ipc._TMP.glob(f"bu-*{suffix}")):
+        raw = p.name[3:-len(suffix)]
         try:
             ipc._check(raw)
         except ValueError:

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -48,6 +48,7 @@ def test_stale_websocket_does_not_open_chrome_inspect():
 
 def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
+    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", None)  # shared-tmpdir mode
     monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
     (tmp_path / "bu-default.sock").touch()
     (tmp_path / "bu-remote_1.sock").touch()
@@ -55,6 +56,25 @@ def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatc
     (tmp_path / "not-bu-default.sock").touch()
 
     assert admin._daemon_endpoint_names() == ["default", "remote_1"]
+
+
+def test_daemon_endpoint_names_with_bh_tmp_dir_returns_local_name_when_sock_exists(tmp_path, monkeypatch):
+    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
+    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
+    monkeypatch.setattr(admin, "NAME", "session-xyz")
+    (tmp_path / "bu.sock").touch()
+
+    assert admin._daemon_endpoint_names() == ["session-xyz"]
+
+
+def test_daemon_endpoint_names_with_bh_tmp_dir_returns_empty_when_sock_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
+    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
+    monkeypatch.setattr(admin, "NAME", "session-xyz")
+
+    assert admin._daemon_endpoint_names() == []
 
 
 def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch):


### PR DESCRIPTION
## The bug

`AF_UNIX` `sun_path` is 104 bytes on macOS / 108 on Linux. With `BH_TMP_DIR` set to a per-daemon directory (introduced in #225) and a long `BU_NAME` (e.g. an opencode-style session id of `ses_` + 26 chars = 30 chars), the resulting socket path easily overruns the limit.

Concrete example reported by a downstream tester (browsercode, on macOS):

```
/Users/alexanderyue/.local/share/bcode/sessions/ses_2286e3c64ffeQfk5GNhqjKEslW/bu-ses_2286e3c64ffeQfk5GNhqjKEslW.sock
len = 117  (limit = 104)
```

The daemon attaches to Chrome successfully, then dies trying to bind its IPC socket. Every `browser_execute` call short-circuits with `RuntimeError: fatal: AF_UNIX path too long`.

## The structural issue

The `<sessionID>` appears in the path twice:

1. The directory leaf (chosen by the caller, browsercode in this case).
2. The filename prefix `bu-<NAME>` (chosen by the harness via `_sock_path`).

The harness's filename prefix exists for **shared-tmpdir** disambiguation — when multiple daemons sit in `/tmp`, `bu-<NAME>` keeps them apart. But once the caller sets `BH_TMP_DIR` and gives each daemon its own dir, the prefix is redundant.

## The fix

When `BH_TMP_DIR` is set, drop the `bu-<NAME>` prefix. Filenames become bare:

```
<BH_TMP_DIR>/bu.sock
<BH_TMP_DIR>/bu.log
<BH_TMP_DIR>/bu.pid
<BH_TMP_DIR>/bu.port    # Windows-only
```

Saves ~30 chars on the AF_UNIX path. The same downstream example becomes:

```
/Users/alexanderyue/.local/share/bcode/sessions/ses_2286e3c64ffeQfk5GNhqjKEslW/bu.sock
len = 88   (limit = 104)  ✓
```

When `BH_TMP_DIR` is unset, `_TMP` is the shared default (`/tmp` on POSIX, `gettempdir()` on Windows) and the `bu-<NAME>` prefix is kept to disambiguate. **Backward compatible by default** — only opting into per-daemon dirs changes the layout.

## Diff summary

- `src/browser_harness/_ipc.py` — extract `_stem(name)` helper that returns `"bu"` when `BH_TMP_DIR` is set, else `"bu-<NAME>"`. Path validation (`_check`) still runs in both modes to catch garbage names early.
- `src/browser_harness/admin.py` — `_daemon_endpoint_names`: when `BH_TMP_DIR` is set, the dir is per-daemon so glob discovery doesn't apply; just check whether the local endpoint exists. Falls back to the existing shared-dir glob otherwise.
- `tests/unit/test_admin.py` — pin `BH_TMP_DIR=None` on the existing shared-dir test (would otherwise be sensitive to the env at test-run time), add two cases for the BH_TMP_DIR-set behavior.

## Verification

- `uv run pytest tests/unit -x -q` → 18 passed (16 existing + 2 new).
- Manual smoke (`BH_TMP_DIR` set vs unset):
  - set → `_stem('foo') == 'bu'`, sock = `<BH_TMP_DIR>/bu.sock`
  - unset → `_stem('foo') == 'bu-foo'`, sock = `/tmp/bu-foo.sock`
- Path-traversal validation still triggers in both modes (`_check('../../etc/passwd')` raises).

## Backward compatibility

- Existing callers (no `BH_TMP_DIR`): zero behavior change.
- Callers using `BH_TMP_DIR` per-daemon (browsercode is the first I'm aware of): filenames change from `bu-<NAME>.*` to `bu.*`. They were broken before this PR on macOS for any normal-length username, so any working state needs to be re-tested anyway.
