### PR TITLE
daemon: discover DevToolsActivePort in Comet and Arc profiles on macOS

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -34,6 +34,8 @@ PID = str(ipc.pid_path(NAME))
 BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
+    Path.home() / "Library/Application Support/Comet",
+    Path.home() / "Library/Application Support/Arc/User Data",
     Path.home() / "Library/Application Support/Microsoft Edge",
     Path.home() / "Library/Application Support/Microsoft Edge Beta",
     Path.home() / "Library/Application Support/Microsoft Edge Dev",


### PR DESCRIPTION
Adds Comet and Arc to the macOS profile search list in `daemon.py` so `DevToolsActivePort` is discovered for those Chromium-based browsers.

Rebased version of #223. Brave is already covered by #173, so only Comet and Arc are added here.