### PR TITLE
Fix remote browser cleanup when daemon startup fails

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -253,7 +253,7 @@ def _stop_cloud_browser(browser_id):
         return
     try:
         _browser_use(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
-    except Exception:
+    except BaseException:
         pass
 
 
@@ -352,7 +352,7 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
             name=name,
             env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
         )
-    except Exception:
+    except BaseException:
         _stop_cloud_browser(browser.get("id"))
         raise
     _show_live_url(browser.get("liveUrl"))

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -248,6 +248,15 @@ def _browser_use(path, method, body=None):
     return json.loads(urllib.request.urlopen(req, timeout=60).read() or b"{}")
 
 
+def _stop_cloud_browser(browser_id):
+    if not browser_id:
+        return
+    try:
+        _browser_use(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
+    except Exception:
+        pass
+
+
 def _cdp_ws_from_url(cdp_url):
     return json.loads(urllib.request.urlopen(f"{cdp_url}/json/version", timeout=15).read())["webSocketDebuggerUrl"]
 
@@ -338,10 +347,14 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
             raise RuntimeError("pass profileName OR profileId, not both")
         create_kwargs["profileId"] = _resolve_profile_name(profileName)
     browser = _browser_use("/browsers", "POST", create_kwargs)
-    ensure_daemon(
-        name=name,
-        env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
-    )
+    try:
+        ensure_daemon(
+            name=name,
+            env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
+        )
+    except Exception:
+        _stop_cloud_browser(browser.get("id"))
+        raise
     _show_live_url(browser.get("liveUrl"))
     return browser
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -185,6 +185,40 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monke
         ("/browsers/browser-123", "PATCH", {"action": "stop"}),
     ]
 
+
+@pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
+def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrupted(monkeypatch, exc_type):
+    calls = []
+    browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
+
+    def fake_browser_use(path, method, body=None):
+        calls.append((path, method, body))
+        if (path, method) == ("/browsers", "POST"):
+            return browser
+        if (path, method) == ("/browsers/browser-123", "PATCH"):
+            return {}
+        raise AssertionError((path, method, body))
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
+    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: (_ for _ in ()).throw(exc_type()))
+
+    with pytest.raises(exc_type):
+        admin.start_remote_daemon()
+
+    assert calls == [
+        ("/browsers", "POST", {}),
+        ("/browsers/browser-123", "PATCH", {"action": "stop"}),
+    ]
+
+
+@pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
+def test_stop_cloud_browser_swallows_baseexception_from_stop_request(monkeypatch, exc_type):
+    monkeypatch.setattr(admin, "_browser_use", lambda *args, **kwargs: (_ for _ in ()).throw(exc_type()))
+
+    admin._stop_cloud_browser("browser-123")
+
 def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatch):
     calls = []
     browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,3 +1,5 @@
+import pytest
+
 from browser_harness import admin
 
 
@@ -156,3 +158,50 @@ def test_doctor_page_output_truncates_long_text(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "A very long page ..." in out
     assert "https://example.t..." in out
+
+
+def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monkeypatch):
+    calls = []
+    browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
+
+    def fake_browser_use(path, method, body=None):
+        calls.append((path, method, body))
+        if (path, method) == ("/browsers", "POST"):
+            return browser
+        if (path, method) == ("/browsers/browser-123", "PATCH"):
+            return {}
+        raise AssertionError((path, method, body))
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
+    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        admin.start_remote_daemon()
+
+    assert calls == [
+        ("/browsers", "POST", {}),
+        ("/browsers/browser-123", "PATCH", {"action": "stop"}),
+    ]
+
+def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatch):
+    calls = []
+    browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
+
+    def fake_browser_use(path, method, body=None):
+        calls.append((path, method, body))
+        if (path, method) == ("/browsers", "POST"):
+            return browser
+        raise AssertionError((path, method, body))
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
+    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: None)
+    monkeypatch.setattr(admin, "_show_live_url", lambda url: None)
+
+    assert admin.start_remote_daemon() == browser
+    assert calls == [
+        ("/browsers", "POST", {}),
+    ]


### PR DESCRIPTION
## Summary

This fixes a remote startup cleanup bug in `start_remote_daemon()`.

If a cloud browser is created successfully but daemon startup fails afterward, the remote browser could be left running because cleanup depended on daemon shutdown, which never happens in that failure path.

## What changed

- stop the created cloud browser when `ensure_daemon()` fails after browser creation
- add unit tests for the failure and success paths

## Why

This avoids leaving cloud browser sessions alive when remote initialization does not complete.

## Testing

```bash
uv run --with pytest pytest tests/unit/test_admin.py -q
```

Passed:
- `14 passed in 0.40s`

Closes #250

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote startup cleanup: if a cloud browser is created but the daemon start fails or is interrupted, we stop the browser to avoid orphaned sessions.

- **Bug Fixes**
  - Wrap `ensure_daemon()` in `start_remote_daemon()` with try/except `BaseException` and call `_stop_cloud_browser()` on error (covers `KeyboardInterrupt`/`SystemExit`).
  - Add `_stop_cloud_browser()` that ignores stop errors and unit tests for failure, interruption, and success paths.

<sup>Written for commit 08fd2494cf2750d69ef405811bea5d12f2d88da1. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/251?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

