### PR TITLE
Fix: doctor health reporting for stale browser connections

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -94,24 +94,31 @@ def _daemon_endpoint_names():
     return names
 
 
+def _read_daemon_response(c):
+    data = b""
+    while not data.endswith(b"\n"):
+        chunk = c.recv(1 << 16)
+        if not chunk:
+            break
+        data += chunk
+    return json.loads(data)
+
+
+def _healthy_connection_status(name, response):
+    if "error" in response or not response.get("browser_connected"):
+        return None
+    page = response.get("page")
+    if page:
+        page = {"title": page.get("title") or "(untitled)", "url": page.get("url") or ""}
+    return {"name": name, "page": page}
+
+
 def _daemon_browser_connection(name):
     c = None
     try:
         c = ipc.connect(name, timeout=1.0)
         c.sendall(b'{"meta":"connection_status"}\n')
-        data = b""
-        while not data.endswith(b"\n"):
-            chunk = c.recv(1 << 16)
-            if not chunk:
-                break
-            data += chunk
-        response = json.loads(data)
-        if "error" in response:
-            return None
-        page = response.get("page")
-        if page:
-            page = {"title": page.get("title") or "(untitled)", "url": page.get("url") or ""}
-        return {"name": name, "page": page}
+        return _healthy_connection_status(name, _read_daemon_response(c))
     except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError, KeyError, ValueError, json.JSONDecodeError):
         return None
     finally:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -202,26 +202,30 @@ class Daemon:
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 
+    async def connection_status(self):
+        page = None
+        browser_connected = self.session is not None and self.target_id is not None
+        if self.target_id:
+            try:
+                info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
+            except Exception:
+                browser_connected = False
+            else:
+                if is_real_page(info):
+                    page = {
+                        "targetId": info.get("targetId"),
+                        "title": info.get("title") or "(untitled)",
+                        "url": info.get("url") or "",
+                    }
+        return {"target_id": self.target_id, "session_id": self.session, "browser_connected": browser_connected, "page": page}
+
     async def handle(self, req):
         meta = req.get("meta")
         if meta == "drain_events":
             out = list(self.events); self.events.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
-        if meta == "connection_status":
-            page = None
-            if self.target_id:
-                try:
-                    info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
-                    if is_real_page(info):
-                        page = {
-                            "targetId": info.get("targetId"),
-                            "title": info.get("title") or "(untitled)",
-                            "url": info.get("url") or "",
-                        }
-                except Exception:
-                    page = None
-            return {"target_id": self.target_id, "session_id": self.session, "page": page}
+        if meta == "connection_status": return await self.connection_status()
         if meta == "set_session":
             self.session = req.get("session_id")
             self.target_id = req.get("target_id") or self.target_id

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -4,7 +4,7 @@ from browser_harness import admin
 
 
 class FakeSocket:
-    def __init__(self, response=b'{"target_id":"target-1","session_id":"session-1","page":null}\n'):
+    def __init__(self, response=b'{"target_id":"target-1","session_id":"session-1","browser_connected":true,"page":null}\n'):
         self.response = response
         self.closed = False
         self.sent = b""
@@ -94,10 +94,23 @@ def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch):
     assert admin.active_browser_connections() == 1
 
 
+def test_active_browser_connections_skips_daemons_without_live_browser_connection(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "dead"])
+
+    def fake_connect(name, timeout=1.0):
+        if name == "dead":
+            return FakeSocket(b'{"target_id":"target-2","session_id":"session-2","browser_connected":false,"page":null}\n')
+        return FakeSocket()
+
+    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+
+    assert admin.active_browser_connections() == 1
+
+
 def test_browser_connections_returns_attached_page(monkeypatch):
     monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default"])
     response = (
-        b'{"target_id":"target-1","session_id":"session-1",'
+        b'{"target_id":"target-1","session_id":"session-1","browser_connected":true,'
         b'"page":{"targetId":"target-1","title":"Cat - Wikipedia","url":"https://en.wikipedia.org/wiki/Cat"}}\n'
     )
     monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: FakeSocket(response))
@@ -106,6 +119,19 @@ def test_browser_connections_returns_attached_page(monkeypatch):
         {
             "name": "default",
             "page": {"title": "Cat - Wikipedia", "url": "https://en.wikipedia.org/wiki/Cat"},
+        }
+    ]
+
+
+def test_browser_connections_keeps_live_daemon_without_real_page(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default"])
+    response = b'{"target_id":"target-1","session_id":"session-1","browser_connected":true,"page":null}\n'
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: FakeSocket(response))
+
+    assert admin.browser_connections() == [
+        {
+            "name": "default",
+            "page": None,
         }
     ]
 


### PR DESCRIPTION
Closes #252

## Summary

This fixes a correctness bug in doctor connection health reporting.

`browser_connections()`, `active_browser_connections()`, and `browser-harness --doctor` could count a daemon as having a healthy browser connection even when its CDP browser connection was already stale.

## Root cause

On the daemon side, `connection_status` could swallow `Target.getTargetInfo` failures and return `page: null` instead of an error.

On the admin side, `_daemon_browser_connection()` treated any non-error response as healthy, so stale connections could still be counted.

## What changed

- `connection_status` now reports explicit browser connection health
- admin-side connection parsing only counts daemons with a live browser connection as healthy
- healthy daemons with no real page are still represented with `page: None`
- added unit tests for stale connections, healthy no-page daemons, and attached real pages

## Why

This makes doctor output more accurate and prevents stale browser connections from being reported as healthy.

## Testing

```bash
uv run --with pytest pytest tests/unit/test_admin.py -q


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect doctor connection health reporting so stale CDP browser connections are not counted as healthy in `browser-harness --doctor` and admin stats. Doctor output and counts now reflect only live browser connections.

- **Bug Fixes**
  - Daemon `connection_status` now includes `browser_connected`; treats `Target.getTargetInfo` failures as disconnected and only returns page data for real pages.
  - Admin only counts daemons with `browser_connected: true`; keeps healthy daemons without a real page as `page: None`.
  - Added unit tests for stale connections, healthy no-page daemons, and attached real pages.

<sup>Written for commit 921108b04a356301f5ebb0f108e07059951bdefa. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/253?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

