### PR TITLE
fix(daemon): report error on stale CDP in connection_status

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -209,18 +209,19 @@ class Daemon:
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
         if meta == "connection_status":
+            if not self.target_id:
+                return {"error": "not_attached"}
+            try:
+                info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
+            except Exception:
+                return {"error": "cdp_disconnected"}
             page = None
-            if self.target_id:
-                try:
-                    info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
-                    if is_real_page(info):
-                        page = {
-                            "targetId": info.get("targetId"),
-                            "title": info.get("title") or "(untitled)",
-                            "url": info.get("url") or "",
-                        }
-                except Exception:
-                    page = None
+            if is_real_page(info):
+                page = {
+                    "targetId": info.get("targetId"),
+                    "title": info.get("title") or "(untitled)",
+                    "url": info.get("url") or "",
+                }
             return {"target_id": self.target_id, "session_id": self.session, "page": page}
         if meta == "set_session":
             self.session = req.get("session_id")

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -94,6 +94,19 @@ def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch):
     assert admin.active_browser_connections() == 1
 
 
+def test_active_browser_connections_skips_daemons_reporting_cdp_disconnected(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "stale"])
+
+    def fake_connect(name, timeout=1.0):
+        if name == "stale":
+            return FakeSocket(b'{"error":"cdp_disconnected"}\n')
+        return FakeSocket()
+
+    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+
+    assert admin.active_browser_connections() == 1
+
+
 def test_browser_connections_returns_attached_page(monkeypatch):
     monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default"])
     response = (


### PR DESCRIPTION
Fixes the doctor false-positive that PR #253 was after, with a smaller surface.

## Symptom

If the browser dies but the daemon survives (Chrome force-quit, remote CDP socket dropped, etc.), `target_id` and `session` stay cached on the `Bridge` and are never cleared. `bh doctor` then reports the daemon as a live connection.

## Root cause

`connection_status` swallowed the `Target.getTargetInfo` failure and returned `{target_id, session_id, page: null}`. `admin._daemon_browser_connection` only treats a response as unhealthy when it contains an `error` key, so the daemon was always counted.

## Fix

Have the daemon emit `{error: cdp_disconnected}` when the CDP probe fails, and `{error: not_attached}` when `target_id` is unset. Admin's existing `if error in response: return None` then handles both cases. No admin.py change, no new wire field, no helper extraction.

## vs #253

|  | #253 | this PR |
|---|---|---|
| Files | 3 | 2 |
| +/- | +66 / -29 | +25 / -11 |
| New wire field | `browser_connected` | none |
| admin.py changes | yes | none |
| Old daemon + new admin | reports false-dead | unchanged |

Closes #253.