### PR TITLE
docs: lead README with first-buyer job (rebased from #170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Browser Harness ♞
 
-The simplest, thinnest, **self-healing** harness that gives LLM **complete freedom** to complete any browser task. Built directly on CDP.
+Connect an LLM directly to your real browser with a thin, editable CDP harness. For browser tasks where you need **complete freedom**.
 
-The agent writes what's missing, mid-task, inside `agent-workspace/`. No framework, no recipes, no rails. One websocket to Chrome, nothing between.
+One websocket to Chrome, nothing between. The agent writes what's missing during execution. The harness improves itself every run.
 
 ```
   ● agent: wants to upload a file


### PR DESCRIPTION
Reapplies @mvanhorn's README rewrite from #170 onto current main.

The original branch was based on a stale README (pre-`agent-workspace/` rename, old links, etc.), so cherry-picking it whole would drag in unrelated changes. This PR contains only the two lines that were the actual point of #170 — the new opener and the self-healing tagline — with @mvanhorn preserved as the commit author so the merge credits them.

Closes #170.