### PR TITLE
docs: replace remaining heredoc examples with -c flag

### DIFF
--- a/install.md
+++ b/install.md
@@ -48,9 +48,7 @@ Prefer `browser-harness --setup` — it runs the full attach-and-escalate flow b
 2. First try the harness directly. If this works, skip manual browser setup:
 
 ```bash
-uv run browser-harness <<'PY'
-print(page_info())
-PY
+uv run browser-harness -c 'print(page_info())'
 ```
 
    Reuse an existing healthy daemon if it is already responding. Do not kill it during setup unless the attach is clearly stale and you are confident no other agent is using the same `BU_NAME`. For parallel agents, use distinct `BU_NAME`s so they do not fight over the same default session.
@@ -77,11 +75,12 @@ osascript -e 'tell application "Google Chrome" to activate' \
 7. Verify with:
 
 ```bash
-uv run browser-harness <<'PY'
+uv run browser-harness -c "$(cat <<'PY'
 goto_url("https://github.com/browser-use/browser-harness")
 wait_for_load()
 print(page_info())
 PY
+)"
 ```
 
 If that fails with a stale websocket or stale socket, restart the daemon once and retry:

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -10,7 +10,7 @@ curl -fsSL https://browser-use.com/profile.sh | sh
 
 Downloads `profile-use` (macOS / Linux / Windows, x64 / arm64). The Python helpers shell out to it; you don't run `profile-use` directly.
 
-## Python API (pre-imported in `browser-harness <<'PY'`)
+## Python API (pre-imported in `browser-harness -c`)
 
 ```python
 list_cloud_profiles()


### PR DESCRIPTION
Cleans up the heredoc examples that PR #229 missed when the CLI dropped stdin support.

#215 (thanks @FVTVLIX) caught all four locations, but #229 (src layout refactor) independently fixed `SKILL.md` and `run.py` and is now merged. The other two locations are still stale on `main`:

- `install.md` step 2 (line 51) — attach probe
- `install.md` step 7 (line 80) — verify snippet
- `interaction-skills/profile-sync.md` line 13 — inline reference

This PR is just those three hunks, in the same `-c '...'` / `-c "$(cat <<'PY' ... PY)"` form already used by SKILL.md.

Closes #215, refs #213.
