### PR TITLE
fix(helpers): add fill_input, wait_for_element, wait_for_network_idle

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, time, urllib.request
+import base64, importlib.util, json, math, os, sys, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -214,7 +214,7 @@ def fill_input(selector, text, clear_first=True):
     """
     js(f"document.querySelector({json.dumps(selector)})?.focus()")
     if clear_first:
-        press_key("a", modifiers=2)  # Ctrl+A
+        press_key("a", modifiers=4 if sys.platform == "darwin" else 2)  # Cmd+A on macOS, Ctrl+A elsewhere
         press_key("Backspace")
     for ch in text:
         press_key(ch)
@@ -351,7 +351,9 @@ def wait_for_element(selector, timeout=10.0, visible=False):
     if visible:
         check = (
             f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
-            f"return !!(e&&e.offsetParent!==null&&getComputedStyle(e).visibility!=='hidden')}})()"
+            f"if(!e)return false;"
+            f"const s=getComputedStyle(e);"
+            f"return s.display!=='none'&&s.visibility!=='hidden'&&s.opacity!=='0'}})()"
         )
     else:
         check = f"!!document.querySelector({json.dumps(selector)})"
@@ -362,7 +364,7 @@ def wait_for_element(selector, timeout=10.0, visible=False):
     return False
 
 def wait_for_network_idle(timeout=10.0, idle_ms=500):
-    """Wait until no Network.* events arrive for idle_ms ms, then return True.
+    """Wait until all in-flight requests finish and no Network.* events arrive for idle_ms ms.
 
     Useful after form submits, SPA route transitions, and any action that triggers
     XHR/fetch without a visible DOM change. Builds on drain_events() — no daemon changes.
@@ -370,11 +372,20 @@ def wait_for_network_idle(timeout=10.0, idle_ms=500):
     """
     deadline = time.time() + timeout
     last_activity = time.time()
+    inflight = set()
     while time.time() < deadline:
-        events = drain_events()
-        if any(e.get("method", "").startswith("Network.") for e in events):
-            last_activity = time.time()
-        if (time.time() - last_activity) * 1000 >= idle_ms:
+        for e in drain_events():
+            method = e.get("method", "")
+            params = e.get("params", {})
+            if method == "Network.requestWillBeSent":
+                inflight.add(params.get("requestId"))
+                last_activity = time.time()
+            elif method in ("Network.loadingFinished", "Network.loadingFailed"):
+                inflight.discard(params.get("requestId"))
+                last_activity = time.time()
+            elif method.startswith("Network."):
+                last_activity = time.time()
+        if not inflight and (time.time() - last_activity) * 1000 >= idle_ms:
             return True
         time.sleep(0.1)
     return False

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -205,14 +205,25 @@ def click_at_xy(x, y, button="left", clicks=1):
 def type_text(text):
     cdp("Input.insertText", text=text)
 
-def fill_input(selector, text, clear_first=True):
+def fill_input(selector, text, clear_first=True, timeout=0.0):
     """Fill a framework-managed input (React controlled, Vue v-model, Ember tracked).
 
     type_text() uses Input.insertText which bypasses framework event listeners and leaves
     submit buttons disabled. This helper focuses the element, clears it, types via real
     key events, then fires synthetic input+change events so the framework sees the update.
+
+    Raises RuntimeError if the element is not found. Pass timeout>0 to wait for
+    late-rendered elements (e.g. after a route change) before typing.
     """
-    js(f"document.querySelector({json.dumps(selector)})?.focus()")
+    if timeout > 0:
+        if not wait_for_element(selector, timeout=timeout):
+            raise RuntimeError(f"fill_input: element not found: {selector!r}")
+    focused = js(
+        f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
+        f"if(!e)return false;e.focus();return true;}})()"
+    )
+    if not focused:
+        raise RuntimeError(f"fill_input: element not found: {selector!r}")
     if clear_first:
         press_key("a", modifiers=4 if sys.platform == "darwin" else 2)  # Cmd+A on macOS, Ctrl+A elsewhere
         press_key("Backspace")

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -360,9 +360,16 @@ def wait_for_element(selector, timeout=10.0, visible=False):
     Returns True if found, False on timeout.
     """
     if visible:
+        # checkVisibility walks the ancestor chain and respects display:none /
+        # visibility:hidden / opacity:0 on parents, which a getComputedStyle
+        # check on the element alone misses (it returns the descendant's own
+        # style, not the inherited "is this rendered" state). Falls back to
+        # the per-element CSS check on older Chrome that lacks checkVisibility.
         check = (
             f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
             f"if(!e)return false;"
+            f"if(typeof e.checkVisibility==='function')"
+            f"return e.checkVisibility({{checkOpacity:true,checkVisibilityCSS:true}});"
             f"const s=getComputedStyle(e);"
             f"return s.display!=='none'&&s.visibility!=='hidden'&&s.opacity!=='0'}})()"
         )

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -205,6 +205,26 @@ def click_at_xy(x, y, button="left", clicks=1):
 def type_text(text):
     cdp("Input.insertText", text=text)
 
+def fill_input(selector, text, clear_first=True):
+    """Fill a framework-managed input (React controlled, Vue v-model, Ember tracked).
+
+    type_text() uses Input.insertText which bypasses framework event listeners and leaves
+    submit buttons disabled. This helper focuses the element, clears it, types via real
+    key events, then fires synthetic input+change events so the framework sees the update.
+    """
+    js(f"document.querySelector({json.dumps(selector)})?.focus()")
+    if clear_first:
+        press_key("a", modifiers=2)  # Ctrl+A
+        press_key("Backspace")
+    for ch in text:
+        press_key(ch)
+    js(
+        f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
+        f"if(!e)return;"
+        f"e.dispatchEvent(new Event('input',{{bubbles:true}}));"
+        f"e.dispatchEvent(new Event('change',{{bubbles:true}}));}})();"
+    )
+
 _KEYS = {  # key → (windowsVirtualKeyCode, code, text)
     "Enter": (13, "Enter", "\r"), "Tab": (9, "Tab", "\t"), "Backspace": (8, "Backspace", ""),
     "Escape": (27, "Escape", ""), "Delete": (46, "Delete", ""), " ": (32, "Space", " "),
@@ -318,6 +338,45 @@ def wait_for_load(timeout=15.0):
     while time.time() < deadline:
         if js("document.readyState") == "complete": return True
         time.sleep(0.3)
+    return False
+
+def wait_for_element(selector, timeout=10.0, visible=False):
+    """Poll until querySelector(selector) exists in the DOM, or timeout.
+
+    wait_for_load() misses SPAs — the document is 'complete' before the framework renders.
+    Use this after actions that trigger async rendering (route changes, data fetches).
+    Set visible=True to also require the element to be non-hidden and in-layout.
+    Returns True if found, False on timeout.
+    """
+    if visible:
+        check = (
+            f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
+            f"return !!(e&&e.offsetParent!==null&&getComputedStyle(e).visibility!=='hidden')}})()"
+        )
+    else:
+        check = f"!!document.querySelector({json.dumps(selector)})"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if js(check): return True
+        time.sleep(0.3)
+    return False
+
+def wait_for_network_idle(timeout=10.0, idle_ms=500):
+    """Wait until no Network.* events arrive for idle_ms ms, then return True.
+
+    Useful after form submits, SPA route transitions, and any action that triggers
+    XHR/fetch without a visible DOM change. Builds on drain_events() — no daemon changes.
+    Returns True if idle window reached, False on timeout.
+    """
+    deadline = time.time() + timeout
+    last_activity = time.time()
+    while time.time() < deadline:
+        events = drain_events()
+        if any(e.get("method", "").startswith("Network.") for e in events):
+            last_activity = time.time()
+        if (time.time() - last_activity) * 1000 >= idle_ms:
+            return True
+        time.sleep(0.1)
     return False
 
 def js(expression, target_id=None):

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -225,7 +225,15 @@ def fill_input(selector, text, clear_first=True, timeout=0.0):
     if not focused:
         raise RuntimeError(f"fill_input: element not found: {selector!r}")
     if clear_first:
-        press_key("a", modifiers=4 if sys.platform == "darwin" else 2)  # Cmd+A on macOS, Ctrl+A elsewhere
+        # Dispatch select-all directly — NOT via press_key, which always emits a
+        # `char` event for single-char keys. With Ctrl/Cmd held, that `char`
+        # makes Chrome treat the input as a printable "a" instead of firing the
+        # select-all shortcut, leaving the field uncleared.
+        mods = 4 if sys.platform == "darwin" else 2  # Cmd on macOS, Ctrl elsewhere
+        select_all = {"key": "a", "code": "KeyA", "modifiers": mods,
+                      "windowsVirtualKeyCode": 65, "nativeVirtualKeyCode": 65}
+        cdp("Input.dispatchKeyEvent", type="rawKeyDown", **select_all)
+        cdp("Input.dispatchKeyEvent", type="keyUp", **select_all)
         press_key("Backspace")
     for ch in text:
         press_key(ch)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -142,7 +142,7 @@ def test_wait_for_element_returns_false_on_timeout():
         assert helpers.wait_for_element("#missing", timeout=1.0) is False
 
 
-def test_wait_for_element_visible_uses_different_check():
+def test_wait_for_element_visible_uses_computed_style_check():
     js_exprs = []
 
     def fake_js(expr, **kwargs):
@@ -152,7 +152,10 @@ def test_wait_for_element_visible_uses_different_check():
     with patch("browser_harness.helpers.js", side_effect=fake_js):
         helpers.wait_for_element("#btn", visible=True)
 
-    assert any("offsetParent" in e for e in js_exprs)
+    assert any("getComputedStyle" in e for e in js_exprs)
+    assert any("display" in e for e in js_exprs)
+    # must NOT use offsetParent (fails for position:fixed elements)
+    assert not any("offsetParent" in e for e in js_exprs)
 
 
 def test_wait_for_element_non_visible_uses_simple_check():
@@ -189,10 +192,15 @@ def test_wait_for_network_idle_returns_true_when_no_events():
     assert result is True
 
 
-def test_wait_for_network_idle_resets_on_network_event():
+def test_wait_for_network_idle_waits_for_inflight_request():
+    # Verifies inflight tracking: must not return True until loadingFinished,
+    # even though >idle_ms elapses between requestWillBeSent and loadingFinished.
+    # An event-silence-only implementation would return True at iter2 (wrong).
     events_seq = [
-        [{"method": "Network.requestWillBeSent", "params": {}}],
-        [],
+        [{"method": "Network.requestWillBeSent", "params": {"requestId": "req1"}}],
+        [],   # >500ms elapsed — old impl returns True here; new must NOT
+        [{"method": "Network.loadingFinished",   "params": {"requestId": "req1"}}],
+        [],   # idle_ms after loadingFinished → return True
     ]
     idx = 0
 
@@ -205,28 +213,42 @@ def test_wait_for_network_idle_resets_on_network_event():
     with patch("browser_harness.helpers._send", side_effect=fake_send), \
          patch("browser_harness.helpers.time") as mock_time:
         start = 1000.0
-        mock_time.time.side_effect = [start, start, start + 0.1, start + 0.1, start + 0.7, start + 0.7]
+        # inflight non-empty → short-circuit skips time.time() in idle check for iter1/iter2
+        mock_time.time.side_effect = [
+            start, start,       # deadline + last_activity init
+            start + 0.1,        # iter1 while-check
+            start + 0.1,        # iter1 rWS last_activity update
+                                # iter1 idle-check: inflight non-empty → short-circuit
+            start + 0.7,        # iter2 while-check (>500ms since rWS but request still in flight)
+                                # iter2 idle-check: inflight non-empty → short-circuit
+            start + 0.8,        # iter3 while-check
+            start + 0.8,        # iter3 lF last_activity update
+            start + 0.8,        # iter3 idle-check: 0ms < 500 → not idle
+            start + 1.4,        # iter4 while-check
+            start + 1.4,        # iter4 idle-check: 600ms >= 500 → True
+        ]
         mock_time.sleep = lambda _: None
         result = helpers.wait_for_network_idle(timeout=5.0, idle_ms=500)
 
     assert result is True
+    assert idx == 4  # did not short-circuit at iter2 despite silence > idle_ms
 
 
 def test_wait_for_network_idle_returns_false_on_timeout():
+    # Continuous rWS keeps inflight non-empty → idle check short-circuits every iteration.
+    # time.time() is only called for while-check and rWS last_activity (not idle check).
     def fake_send(req):
-        return {"events": [{"method": "Network.requestWillBeSent", "params": {}}]}
+        return {"events": [{"method": "Network.requestWillBeSent", "params": {"requestId": "r"}}]}
 
     with patch("browser_harness.helpers._send", side_effect=fake_send), \
          patch("browser_harness.helpers.time") as mock_time:
         start = 1000.0
-        # calls: deadline, last_activity, while-check, last_activity update,
-        #        idle-check, while-check (exceeds deadline → return False)
         mock_time.time.side_effect = [
-            start, start,           # deadline + last_activity init
-            start + 0.1,            # while check (within deadline)
-            start + 0.1,            # last_activity update (network event seen)
-            start + 0.1,            # idle check (0ms elapsed, not idle)
-            start + 20.0,           # while check (past deadline → exit)
+            start, start,       # deadline + last_activity init
+            start + 0.1,        # iter1 while-check (in deadline)
+            start + 0.1,        # iter1 rWS last_activity update
+                                # iter1 idle-check: inflight non-empty → short-circuit
+            start + 20.0,       # iter2 while-check (past deadline → exit)
         ]
         mock_time.sleep = lambda _: None
         result = helpers.wait_for_network_idle(timeout=10.0, idle_ms=500)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 from unittest.mock import patch
 
 import pytest
@@ -50,3 +51,185 @@ def test_page_info_raises_clear_error_on_js_exception():
          patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
         with pytest.raises(RuntimeError, match="ReferenceError"):
             helpers.page_info()
+
+
+# --- fill_input ---
+
+def test_fill_input_focuses_types_and_fires_events():
+    cdp_calls = []
+    js_calls = []
+
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        return {}
+
+    def fake_js(expr, **kwargs):
+        js_calls.append(expr)
+        return None
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.js", side_effect=fake_js):
+        helpers.fill_input("#my-input", "hello")
+
+    # focus call
+    assert any("#my-input" in e for e in js_calls)
+    # per-character key events dispatched
+    key_downs = [m for m, _ in cdp_calls if m == "Input.dispatchKeyEvent"]
+    assert len(key_downs) > 0
+    # input+change events dispatched at end
+    assert any("input" in e and "change" in e for e in js_calls)
+
+
+def test_fill_input_clear_first_sends_ctrl_a_backspace():
+    key_events = []
+
+    def fake_cdp(method, **kwargs):
+        if method == "Input.dispatchKeyEvent":
+            key_events.append(kwargs)
+        return {}
+
+    def fake_js(expr, **kwargs):
+        return None
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.js", side_effect=fake_js):
+        helpers.fill_input("#inp", "x", clear_first=True)
+
+    keys_seen = [e.get("key") for e in key_events if e.get("type") == "keyDown"]
+    assert "a" in keys_seen          # Ctrl+A
+    assert "Backspace" in keys_seen
+
+
+def test_fill_input_no_clear_skips_ctrl_a():
+    key_events = []
+
+    def fake_cdp(method, **kwargs):
+        if method == "Input.dispatchKeyEvent":
+            key_events.append(kwargs)
+        return {}
+
+    def fake_js(expr, **kwargs):
+        return None
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.js", side_effect=fake_js):
+        helpers.fill_input("#inp", "x", clear_first=False)
+
+    keys_seen = [e.get("key") for e in key_events if e.get("type") == "keyDown"]
+    assert "Backspace" not in keys_seen
+
+
+# --- wait_for_element ---
+
+def test_wait_for_element_returns_true_when_found_immediately():
+    def fake_js(expr, **kwargs):
+        return True
+
+    with patch("browser_harness.helpers.js", side_effect=fake_js):
+        assert helpers.wait_for_element("#target", timeout=2.0) is True
+
+
+def test_wait_for_element_returns_false_on_timeout():
+    def fake_js(expr, **kwargs):
+        return False
+
+    with patch("browser_harness.helpers.js", side_effect=fake_js), \
+         patch("browser_harness.helpers.time") as mock_time:
+        # simulate time advancing past the deadline immediately
+        start = time.time()
+        mock_time.time.side_effect = [start, start + 5.0]
+        mock_time.sleep = lambda _: None
+        assert helpers.wait_for_element("#missing", timeout=1.0) is False
+
+
+def test_wait_for_element_visible_uses_different_check():
+    js_exprs = []
+
+    def fake_js(expr, **kwargs):
+        js_exprs.append(expr)
+        return True
+
+    with patch("browser_harness.helpers.js", side_effect=fake_js):
+        helpers.wait_for_element("#btn", visible=True)
+
+    assert any("offsetParent" in e for e in js_exprs)
+
+
+def test_wait_for_element_non_visible_uses_simple_check():
+    js_exprs = []
+
+    def fake_js(expr, **kwargs):
+        js_exprs.append(expr)
+        return True
+
+    with patch("browser_harness.helpers.js", side_effect=fake_js):
+        helpers.wait_for_element("#btn", visible=False)
+
+    assert any("querySelector" in e and "offsetParent" not in e for e in js_exprs)
+
+
+# --- wait_for_network_idle ---
+
+def test_wait_for_network_idle_returns_true_when_no_events():
+    call_count = 0
+
+    def fake_send(req):
+        nonlocal call_count
+        call_count += 1
+        return {"events": []}
+
+    with patch("browser_harness.helpers._send", side_effect=fake_send), \
+         patch("browser_harness.helpers.time") as mock_time:
+        start = 1000.0
+        # first call: not idle yet; second call: idle window elapsed
+        mock_time.time.side_effect = [start, start, start, start + 0.6, start + 0.6]
+        mock_time.sleep = lambda _: None
+        result = helpers.wait_for_network_idle(timeout=5.0, idle_ms=500)
+
+    assert result is True
+
+
+def test_wait_for_network_idle_resets_on_network_event():
+    events_seq = [
+        [{"method": "Network.requestWillBeSent", "params": {}}],
+        [],
+    ]
+    idx = 0
+
+    def fake_send(req):
+        nonlocal idx
+        evs = events_seq[min(idx, len(events_seq) - 1)]
+        idx += 1
+        return {"events": evs}
+
+    with patch("browser_harness.helpers._send", side_effect=fake_send), \
+         patch("browser_harness.helpers.time") as mock_time:
+        start = 1000.0
+        mock_time.time.side_effect = [start, start, start + 0.1, start + 0.1, start + 0.7, start + 0.7]
+        mock_time.sleep = lambda _: None
+        result = helpers.wait_for_network_idle(timeout=5.0, idle_ms=500)
+
+    assert result is True
+
+
+def test_wait_for_network_idle_returns_false_on_timeout():
+    def fake_send(req):
+        return {"events": [{"method": "Network.requestWillBeSent", "params": {}}]}
+
+    with patch("browser_harness.helpers._send", side_effect=fake_send), \
+         patch("browser_harness.helpers.time") as mock_time:
+        start = 1000.0
+        # calls: deadline, last_activity, while-check, last_activity update,
+        #        idle-check, while-check (exceeds deadline → return False)
+        mock_time.time.side_effect = [
+            start, start,           # deadline + last_activity init
+            start + 0.1,            # while check (within deadline)
+            start + 0.1,            # last_activity update (network event seen)
+            start + 0.1,            # idle check (0ms elapsed, not idle)
+            start + 20.0,           # while check (past deadline → exit)
+        ]
+        mock_time.sleep = lambda _: None
+        result = helpers.wait_for_network_idle(timeout=10.0, idle_ms=500)
+
+    assert result is False
+

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -86,7 +86,9 @@ def test_fill_input_raises_when_element_not_found():
             helpers.fill_input("#missing", "hello")
 
 
-def test_fill_input_clear_first_sends_ctrl_a_backspace():
+def test_fill_input_clear_first_sends_select_all_then_backspace():
+    import sys
+
     key_events = []
 
     def fake_cdp(method, **kwargs):
@@ -101,9 +103,23 @@ def test_fill_input_clear_first_sends_ctrl_a_backspace():
          patch("browser_harness.helpers.js", side_effect=fake_js):
         helpers.fill_input("#inp", "x", clear_first=True)
 
-    keys_seen = [e.get("key") for e in key_events if e.get("type") == "keyDown"]
-    assert "a" in keys_seen
-    assert "Backspace" in keys_seen
+    # The "a" must be dispatched with the platform-correct modifier (Meta=4 on
+    # macOS, Ctrl=2 elsewhere). Without the modifier, the field would never get
+    # selected — it would just receive a literal "a".
+    expected_mod = 4 if sys.platform == "darwin" else 2
+    a_events = [e for e in key_events if e.get("key") == "a"]
+    assert a_events, "expected an 'a' key event for select-all"
+    assert all(e.get("modifiers") == expected_mod for e in a_events), \
+        f"select-all 'a' must carry modifiers={expected_mod}; got {[e.get('modifiers') for e in a_events]}"
+
+    # Crucial: no `char` event for the "a" — emitting one makes Chrome treat
+    # Cmd/Ctrl+A as a printable letter instead of a shortcut.
+    assert not any(e.get("type") == "char" and e.get("text") == "a" for e in key_events), \
+        "select-all must not emit a 'char' event with text='a' (would cancel the shortcut)"
+
+    # Backspace still fires (via press_key, which uses keyDown).
+    keys_down = [e.get("key") for e in key_events if e.get("type") in ("keyDown", "rawKeyDown")]
+    assert "Backspace" in keys_down
 
 
 def test_fill_input_no_clear_skips_ctrl_a():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -148,7 +148,7 @@ def test_wait_for_element_returns_false_on_timeout():
         assert helpers.wait_for_element("#missing", timeout=1.0) is False
 
 
-def test_wait_for_element_visible_uses_computed_style_check():
+def test_wait_for_element_visible_uses_check_visibility():
     js_exprs = []
 
     def fake_js(expr, **kwargs):
@@ -158,8 +158,10 @@ def test_wait_for_element_visible_uses_computed_style_check():
     with patch("browser_harness.helpers.js", side_effect=fake_js):
         helpers.wait_for_element("#btn", visible=True)
 
+    # Prefers checkVisibility (walks ancestor chain) with a computed-style
+    # fallback for older Chrome.
+    assert any("checkVisibility" in e for e in js_exprs)
     assert any("getComputedStyle" in e for e in js_exprs)
-    assert any("display" in e for e in js_exprs)
     # must NOT use offsetParent (fails for position:fixed elements)
     assert not any("offsetParent" in e for e in js_exprs)
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -65,19 +65,25 @@ def test_fill_input_focuses_types_and_fires_events():
 
     def fake_js(expr, **kwargs):
         js_calls.append(expr)
-        return None
+        return True  # focus call must return True (element found)
 
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
          patch("browser_harness.helpers.js", side_effect=fake_js):
         helpers.fill_input("#my-input", "hello")
 
-    # focus call
     assert any("#my-input" in e for e in js_calls)
-    # per-character key events dispatched
     key_downs = [m for m, _ in cdp_calls if m == "Input.dispatchKeyEvent"]
     assert len(key_downs) > 0
-    # input+change events dispatched at end
     assert any("input" in e and "change" in e for e in js_calls)
+
+
+def test_fill_input_raises_when_element_not_found():
+    def fake_js(expr, **kwargs):
+        return False  # element not found
+
+    with patch("browser_harness.helpers.js", side_effect=fake_js):
+        with pytest.raises(RuntimeError, match="element not found"):
+            helpers.fill_input("#missing", "hello")
 
 
 def test_fill_input_clear_first_sends_ctrl_a_backspace():
@@ -89,14 +95,14 @@ def test_fill_input_clear_first_sends_ctrl_a_backspace():
         return {}
 
     def fake_js(expr, **kwargs):
-        return None
+        return True  # element found
 
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
          patch("browser_harness.helpers.js", side_effect=fake_js):
         helpers.fill_input("#inp", "x", clear_first=True)
 
     keys_seen = [e.get("key") for e in key_events if e.get("type") == "keyDown"]
-    assert "a" in keys_seen          # Ctrl+A
+    assert "a" in keys_seen
     assert "Backspace" in keys_seen
 
 
@@ -109,7 +115,7 @@ def test_fill_input_no_clear_skips_ctrl_a():
         return {}
 
     def fake_js(expr, **kwargs):
-        return None
+        return True  # element found
 
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
          patch("browser_harness.helpers.js", side_effect=fake_js):


### PR DESCRIPTION
## Problem

Two core helpers silently fail on modern web apps:

**`type_text()` leaves submit buttons disabled on React / Vue / Ember** 
It calls `Input.insertText` which bypasses framework event listeners. The field looks filled but the framework's internal state never updates — submit stays disabled.

**`wait_for_load()` returns before SPAs are usable**
It polls `document.readyState == 'complete'`, which fires before any SPA framework renders content. 
Agents proceed to interact with elements that don't exist yet.

## Changes

Three new helpers in `helpers.py` — no daemon changes needed:

- **`fill_input(selector, text, clear_first=True)`** — focuses element, types  per-character via `press_key()` (dispatches real `keyDown`/`char`/`keyUp`),  then fires synthetic `input`+`change` events so React/Vue/Ember state updates
- **`wait_for_element(selector, timeout=10.0, visible=False)`** — polls  `querySelector` until element exists (and is visible if `visible=True`), returns `bool`
- **`wait_for_network_idle(timeout=10.0, idle_ms=500)`** — drains `drain_events()`  until no `Network.*` events arrive for `idle_ms` ms, useful after form submits  and SPA route transitions

## Tests

13 new unit tests covering all helpers and edge cases. 35 total, all passing.

## Closes: #257 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SPA-safe helpers to reliably fill inputs and wait for UI readiness. Fixes issues with React/Vue/Ember controlled inputs and premature interactions after navigation.

- **New Features**
  - `fill_input(selector, text, clear_first=True, timeout=0.0)` — focuses the input, optionally clears via Cmd/Ctrl+A, types per character with real key events, fires `input`/`change`, can wait for late-rendered elements, and raises if the element is missing.
  - `wait_for_element(selector, timeout=10.0, visible=False)` — polls until the element exists; if `visible=True`, uses `element.checkVisibility` with a computed-style fallback. Returns True/False.
  - `wait_for_network_idle(timeout=10.0, idle_ms=500)` — waits for no in-flight requests and no `Network.*` events for `idle_ms`. Useful after submits and SPA route changes.

- **Bug Fixes**
  - Dispatch select-all without a `char` event so Cmd/Ctrl+A reliably fires and clears inputs on all platforms.
  - Network idle detection tracks in-flight requests to prevent early returns.

<sup>Written for commit 4da0684eb2e4fa464338fb9e83b28159034e1b30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

