### PR TITLE
domain-skills: add ly.com, ctrip, wehotel (Chinese hotel sites)

### DIFF
--- a/agent-workspace/domain-skills/ctrip/hotels.md
+++ b/agent-workspace/domain-skills/ctrip/hotels.md
@@ -1,0 +1,278 @@
+# Ctrip (携程 / `ctrip.com`) — Hotel Scraping
+
+Field-tested 2026-04-29 against `hotels.ctrip.com` PC web. Domestic hotels.
+
+---
+
+## TL;DR
+
+**Prices are visible without login** — but only if you reach the list page
+through a "natural" navigation flow that produces a complete URL parameter
+schema. Direct GETs to a simplified URL get redirected to login.
+
+- Browser session required (the page shell is 144 KB, hotels are loaded by
+  XHR after hydration). `http_get` cannot retrieve hotel data.
+- Once on a valid list page, prices render as `¥<original> ¥<current> 起`
+  pairs. No `¥?` placeholders and no `请登录` interstitial.
+- Detail URL `https://hotels.ctrip.com/hotel/<hotelId>.html?checkin=...` works
+  pre-login and shows full room-rate breakdown.
+- Compared to ly.com (which hides every price behind login) ctrip is far more
+  scrape-friendly *if you respect the URL schema*.
+
+---
+
+## URL patterns
+
+```
+List page (canonical, anonymous-friendly):
+  https://hotels.ctrip.com/hotels/list
+    ?flexType=1
+    &cityId=<n>          # 2 = 上海, 1 = 北京, etc.
+    &provinceId=0
+    &districtId=0
+    &countryId=1         # 1 = 中国 domestic
+    &checkin=YYYY-MM-DD
+    &checkout=YYYY-MM-DD
+
+Hotel detail (canonical):
+  https://hotels.ctrip.com/hotel/<hotelId>.html?checkin=...&checkout=...
+  → server rewrites to /hotels/detail/?... — both work, same data
+
+Login page (when reached unintentionally):
+  https://passport.ctrip.com/user/login?backurl=<url-encoded-target>
+```
+
+**Critical:** the *simplified* form `https://hotels.ctrip.com/hotels/list?city=2&checkin=...&checkout=...`
+(note: `city`, not `cityId`, and missing `provinceId/districtId/countryId/flexType`)
+**redirects to login.** This is ctrip's signature anti-scrape gate — it
+distinguishes a "real" client (built the URL through the homepage form) from
+a scripted client (typed the URL by hand).
+
+---
+
+## How to land on the list page reliably
+
+### Path A — build the canonical URL (preferred when you know cityId)
+
+```python
+from browser_harness.helpers import new_tab, wait_for_load
+import time
+url = (
+    "https://hotels.ctrip.com/hotels/list"
+    "?flexType=1&cityId=2&provinceId=0&districtId=0&countryId=1"
+    "&checkin=2026-04-29&checkout=2026-04-30"
+)
+new_tab(url)
+wait_for_load(timeout=20)
+time.sleep(6)            # XHR hotel-list fetch
+```
+
+### Path B — simulate the homepage flow (when you only have a city name)
+
+If you only have a city name, drive the home-page form. The 搜索 button is
+a `<div>`, not `<button>` (same as ly.com — see "search button gotcha"
+below):
+
+```python
+from browser_harness.helpers import new_tab, wait_for_load, js, click_at_xy, type_text, press_key
+import time
+
+new_tab("https://hotels.ctrip.com/")
+wait_for_load(timeout=20)
+time.sleep(2)
+
+# Find destination input by placeholder
+inp = js("""
+  const i = Array.from(document.querySelectorAll("input"))
+    .find(i => i.placeholder && /目的地|城市|酒店/.test(i.placeholder));
+  if (!i) return null;
+  const r = i.getBoundingClientRect();
+  return {x: r.x+r.width/2, y: r.y+r.height/2};
+""")
+click_at_xy(inp["x"], inp["y"])
+time.sleep(0.4)
+type_text("上海")
+time.sleep(1.5)
+press_key("Enter")        # selects first autocomplete suggestion
+
+btn = js("""
+  const b = Array.from(document.querySelectorAll("button, div"))
+    .find(el => (el.innerText||"").trim() === "搜索"
+                && el.getBoundingClientRect().width > 60);
+  if (!b) return null;
+  const r = b.getBoundingClientRect();
+  return {x: r.x+r.width/2, y: r.y+r.height/2};
+""")
+click_at_xy(btn["x"], btn["y"])
+time.sleep(7)
+# now on /hotels/list?... with the full canonical schema
+```
+
+This is what the human would do, and it's what makes the parameter schema
+match. Cookies set during this flow help future direct-URL requests too.
+
+---
+
+## List page — extracting hotels
+
+Cards are `<div class="list-item">`. **No `data-id`, no `<a href=...>`.**
+The hotel ID lives only in the React component closure — to navigate to
+detail you either click the card visually (coordinate click) or scrape the
+hotel name and re-visit `/hotel/<id>.html` once you've resolved the ID by
+some other means (e.g. a mapping you build over time).
+
+```js
+// list extraction — runs in browser via js(...)
+return Array.from(document.querySelectorAll(".list-item")).slice(0, 30).map(card => {
+  const text = (card.innerText || "").replace(/\s+/g, " ");
+  const name = text.match(/^([^\s]{2,40}?(?:酒店|宾馆|公寓|民宿)(?:\([^)]*\))?)/)?.[1];
+  const score = text.match(/[1-5]\.\d/)?.[0];
+  // strip "1,234条点评" before grabbing prices, otherwise ¥1 from "1,234" leaks in
+  const priced = text.replace(/\d{1,3}(?:,\d{3})+/g, "").replace(/\d+条点评/g, "");
+  const prices = (priced.match(/¥\s*(\d{2,})/g) || []).map(s => parseInt(s.replace(/[^\d]/g, "")));
+  const [original, current] = prices;
+  return {name, score, price_original: original ?? null, price_current: current ?? null};
+});
+```
+
+**Trap:** review counts like `1,234条点评` and `5,678条点评` will match
+`¥\s*\d+` if you don't strip them first — `¥1` and `¥5` will appear as
+phantom prices. Always pre-strip thousand-separated numbers and review
+counts before the price regex.
+
+The text shape per card:
+```
+<name> [4.8] [超棒][1,994条点评] <tagline> 近<area> · <metro>查看地图 <room-type> 订单确认后30分钟内免费取消 ... ¥<original> ¥<current> 起 查看详情
+```
+
+The "起" suffix means "from"; the actual booked price can be higher
+depending on rate plan / breakfast / cancellation.
+
+---
+
+## Detail page
+
+```
+https://hotels.ctrip.com/hotel/<hotelId>.html?checkin=YYYY-MM-DD&checkout=YYYY-MM-DD
+```
+
+Works pre-login. Server normalizes to `/hotels/detail/?...` but the data is
+identical. Title format: `🟢 <hotelName>预订价格,联系电话位置地址【携程酒店】`
+(the 🟢 prefix is from `browser-harness`, not ctrip).
+
+Detail page renders multiple room-rate rows with the same `¥orig ¥current`
+shape as the list. Look for `<button>` or `<a>` whose text is exactly `预订`
+and walk up to the rate card.
+
+If you hit a hotel that no longer exists, the URL silently survives but
+shows a generic "预订价格,联系电话位置地址【携程酒店】" title with no
+prices — detect by `bodyText.match(/¥\s*\d+/) === null`.
+
+---
+
+## Login redirect signal
+
+When ctrip decides your session is suspicious it redirects to:
+
+```
+https://passport.ctrip.com/user/login?backurl=...
+```
+
+The login form pre-fills the last phone number from the user's Chrome
+form-fill. If you see this URL, **do not type credentials** — bail and
+either (a) restart the flow through the homepage form (Path B above), which
+fixes the URL schema mismatch, or (b) ask the user to log in interactively.
+
+Detection:
+```python
+if "passport.ctrip.com" in page_info()["url"]:
+    raise RuntimeError("ctrip wants login — restart from homepage")
+```
+
+In our test, redirect was triggered by:
+- Hitting `/hotels/list?city=2&...` (note: `city`, not `cityId`).
+- Direct GET without ever loading `hotels.ctrip.com/` first in the session.
+
+Conversely, *not* triggered by:
+- Hitting `/hotels/list?flexType=1&cityId=2&provinceId=0&districtId=0&countryId=1&...`
+  cold (zero ctrip cookies pre-set).
+- Hitting `/hotel/<id>.html?...` directly.
+
+So the gate is parameter-schema-based, not behavior-based. Get the schema
+right and you don't need a login flow.
+
+---
+
+## Global state — don't bother
+
+`window._objAllSearchResult` exists but is empty in the live session.
+Ctrip's hotel data lives in React component state, not on `window`.
+**Use DOM extraction.** No `__NEXT_DATA__`, no `__APOLLO_STATE__`, no
+`window.__INITIAL_STATE__`.
+
+---
+
+## Traps
+
+- **Simplified URL (`?city=`) redirects to login.** Use the canonical
+  six-param schema or drive the homepage form.
+- **Default homepage tab is 海外酒店 (overseas).** Featured hotels show
+  "暂无价格" and pre-select Singapore/Phuket dates. Don't read prices off
+  the homepage — go to `/hotels/list?...` instead.
+- **Phantom `¥1`, `¥5` prices** from review-count regex bleed-through.
+  Strip `\d+,\d+` and `\d+条点评` before applying `¥\d+`.
+- **No detail URL on cards.** No `data-id`, no `<a>`. Coordinate click is
+  the only reliable navigate-to-detail option without an external ID
+  source.
+- **`/hotel/{id}.html` for a non-existent ID returns 200** with the brand
+  chrome and no error — detect by absence of prices in body text.
+- **The 搜索 button is a `<div>`.** Same gotcha as ly.com — coordinate
+  click works, `el.click()` is unreliable.
+- **`hotels.ctrip.com` is the *domestic* host.** Title says "海外酒店预订"
+  on the homepage but `/hotels/list?countryId=1&...` is domestic. The
+  overseas equivalent uses `countryId` ≠ 1 (not yet mapped).
+
+---
+
+## Useful cityId values (observed)
+
+| 城市 | cityId |
+|------|--------|
+| 上海 | 2 |
+| 北京 | 1 |
+| 广州 | 32 |
+| 深圳 | 30 |
+
+Get more by driving the homepage flow once and reading the canonical URL.
+
+---
+
+## Quick start
+
+```python
+from browser_harness.helpers import new_tab, wait_for_load, js, cdp
+import time, json
+
+url = (
+    "https://hotels.ctrip.com/hotels/list"
+    "?flexType=1&cityId=2&provinceId=0&districtId=0&countryId=1"
+    "&checkin=2026-04-29&checkout=2026-04-30"
+)
+tid = new_tab(url)
+wait_for_load(timeout=20)
+time.sleep(6)
+
+hotels = js("""
+  return Array.from(document.querySelectorAll(".list-item")).slice(0, 20).map(card => {
+    const raw = (card.innerText || "").replace(/\\s+/g, " ");
+    const cleaned = raw.replace(/\\d{1,3}(?:,\\d{3})+/g, "").replace(/\\d+条点评/g, "");
+    const name = raw.match(/^([^\\s]{2,40}?(?:酒店|宾馆|公寓|民宿)(?:\\([^)]*\\))?)/)?.[1] || null;
+    const prices = (cleaned.match(/¥\\s*\\d{2,}/g) || [])
+                     .map(s => parseInt(s.replace(/[^\\d]/g, "")));
+    const score = raw.match(/[1-5]\\.\\d/)?.[0] || null;
+    return {name, score, price_original: prices[0] ?? null, price_current: prices[1] ?? null};
+  });
+""")
+print(json.dumps(hotels, indent=2, ensure_ascii=False))
+cdp("Target.closeTarget", targetId=tid)
+```

--- a/agent-workspace/domain-skills/ctrip/hotels.md
+++ b/agent-workspace/domain-skills/ctrip/hotels.md
@@ -89,6 +89,8 @@ inp = js("""
   const r = i.getBoundingClientRect();
   return {x: r.x+r.width/2, y: r.y+r.height/2};
 """)
+if not inp:
+    raise RuntimeError("ctrip homepage: destination input not found — page DOM may have changed")
 click_at_xy(inp["x"], inp["y"])
 time.sleep(0.4)
 type_text("上海")
@@ -103,6 +105,8 @@ btn = js("""
   const r = b.getBoundingClientRect();
   return {x: r.x+r.width/2, y: r.y+r.height/2};
 """)
+if not btn:
+    raise RuntimeError("ctrip homepage: 搜索 button not found — page DOM may have changed")
 click_at_xy(btn["x"], btn["y"])
 time.sleep(7)
 # now on /hotels/list?... with the full canonical schema

--- a/agent-workspace/domain-skills/ly-com/hotels.md
+++ b/agent-workspace/domain-skills/ly-com/hotels.md
@@ -1,0 +1,286 @@
+# Tongcheng (ly.com / 同程旅行) — Hotel Scraping
+
+Field-tested 2026-04-29 against the PC web (`www.ly.com`). Mobile H5 paths
+not yet mapped. All notes below are PC unless stated otherwise.
+
+---
+
+## TL;DR
+
+**Prices are gated behind login. Hotel metadata is not.**
+
+- List page returns `prc=null&cury=null` in the result URLs and renders every
+  price as the literal string `￥？` until the user is signed in.
+- After login (cookies persist in the user's Chrome), the same DOM nodes
+  render real numbers (`¥259 ¥200 ¥59` triplets — see *Price triplet shape*).
+- Hotel name / address / metro / star / English name / opening + decorate
+  dates are available pre-login from `window.__NUXT__` SSR state.
+
+**Practical implication:** `http_get` is useless for prices. You need a
+browser session AND a logged-in user. `browser-harness` connecting to the
+user's daily Chrome is the cheapest way — once they log in once via
+`passport.ly.com`, the cookie sticks across runs.
+
+---
+
+## URL patterns
+
+```
+List page:
+  https://www.ly.com/hotel/hotellist?city=<cityId>&inDate=YYYY-MM-DD&outDate=YYYY-MM-DD
+
+Hotel detail page:
+  https://www.ly.com/hotel/hoteldetail?hotelId=<hotelId>&inDate=YYYY-MM-DD&outDate=YYYY-MM-DD
+
+Login page (with return URL):
+  https://passport.ly.com/?pageurl=<urlencoded-target>
+```
+
+`cityId` is Tongcheng's internal id, not GB code. Shanghai = `321`. Get it by
+running a search via the home page — the redirect URL contains it.
+
+`hotelId` is per-property, stable. Range observed: 8-digit numerics
+(e.g. `92963586`, `50201258`, `93067902`).
+
+The list page also accepts `&keyword=`, `&star=`, etc., but the form fields
+on `/hotel/` are the canonical entry — fill them or click the search div and
+let the SPA build the URL.
+
+### Mobile H5 — DO NOT use these (404 in our test)
+
+- `https://m.ly.com/scenery/hotel/<hotelId>` — 404
+- `https://hotelh5.ly.com/...` — not yet mapped
+
+If you need a mobile path, search from `m.ly.com/` instead of guessing.
+
+---
+
+## Search button is NOT a `<button>`
+
+On `https://www.ly.com/hotel/`, the green "搜索" search button is a `<div>`,
+not `<button>` or `<a>`. JS click via `element.click()` does **not** fire the
+SPA handler reliably. Two patterns that work:
+
+1. **Coordinate click** (preferred — same shape as the rest of harness):
+   ```python
+   from browser_harness.helpers import js, click_at_xy
+   btns = js("""
+     return Array.from(document.querySelectorAll("div"))
+       .filter(el => (el.innerText||"").trim() === "搜索")
+       .map(el => { const r = el.getBoundingClientRect();
+                    return {x: r.x+r.width/2, y: r.y+r.height/2}; });
+   """)
+   click_at_xy(btns[0]["x"], btns[0]["y"])
+   ```
+
+2. **Direct URL navigation** (skip the form entirely): build the
+   `/hotel/hotellist?city=<id>&inDate=...&outDate=...` URL yourself.
+
+After clicking, the list renders via XHR. Page shows the loader text
+"正在搜寻更多住宿……" — wait ~5–7 s before extracting cards.
+
+---
+
+## List page — extracting hotels
+
+Hotel cards are `<a>` elements with class `listBox` (Tailwind-mangled, so
+the full class string is `mb-[20px] flow-root listBox` or similar — match by
+`a[class*=listBox]`).
+
+```js
+Array.from(document.querySelectorAll("a[class*=listBox]")).slice(0, 20).map(a => {
+  const href = a.href;
+  const m = href.match(/hotelId=(\d+)/);
+  return {
+    hotelId: m ? m[1] : null,
+    href,
+    text: (a.innerText || "").replace(/\s+/g, " ").slice(0, 200),
+  };
+});
+```
+
+The card `innerText` is pipe-separated and contains: hotel name, star tier,
+score (4.x), review count, amenity tags, area/metro, then `￥？ 查看详情`
+when not logged in (or `¥<n> 预订` after login from the list page — but the
+list page often still hides prices and only the detail page shows them
+reliably).
+
+The `href` carries a verbose `traceToken` query that's safe to drop when
+re-navigating; only `hotelId`, `inDate`, `outDate` matter.
+
+---
+
+## Detail page — Nuxt SSR state
+
+The site is built on Nuxt.js. Pre-login data lives at:
+
+```
+window.__NUXT__.data["$<random-hash>"]   // per-page-load, NOT stable
+```
+
+The data object contains exactly two keys per page load. The first
+(`$VKSoZS1qt0`-style) holds page chrome (header/footer/CSS); the second
+holds the actual hotel payload. Find it by shape, not by key:
+
+```js
+const dataMap = window.__NUXT__?.data || {};
+const hotelEntry = Object.values(dataMap).find(v => v && v.hotelData);
+const meta = hotelEntry?.hotelData?._rawValue;   // _rawValue is the resolved Vue ref
+// meta now has: hotelid, hotelName, hotelNameEn, hotelAddress,
+// nearestAreaPosition, hotelArea, starLevel, headPicUrl
+```
+
+`detailBaseInfo._rawValue` adds: `openDate`, `decorateDate`, `featureInfo`
+(prose paragraph), and the full address again.
+
+**Prices are NOT in `__NUXT__`.** They're loaded by a separate XHR after
+hydration. This is server-side gating, not a client-side hide — the price
+fields literally don't exist in the SSR payload until the user is
+authenticated.
+
+---
+
+## Price extraction (logged in)
+
+Each room/rate card contains a `预订` button (`<button>` or `<a>` —
+visibility is `offsetParent !== null`). Walk up to the smallest ancestor
+whose `innerText.length > 80` to get the card.
+
+### Price triplet shape
+
+Every visible price block is a 3-tuple in DOM order:
+
+```
+[¥<original>] [¥<member_price>] [¥<savings>]
+```
+
+For the room "至尊·大床房 (无餐食)" we observed `¥259 ¥200 ¥59`. The
+discount is always `original - member_price`, so use it as a sanity check
+when the regex catches stray `¥` from neighboring elements.
+
+```js
+const text = card.innerText.replace(/\s+/g, " ");
+const nums = (text.match(/¥\s*\d+(?:\.\d+)?/g) || [])
+              .map(s => parseFloat(s.replace(/[^\d.]/g, "")));
+const [original, current, saved] = nums;
+// validate: Math.abs((original - current) - saved) < 1
+```
+
+Other useful fields in the card text:
+- `无餐食` / `1份早餐` / `2份早餐` — meal plan
+- `订单确认30分钟内可免费取消` — cancellation policy
+- `可开专票` — VAT invoice
+- 房型名通常在卡片头部，跟在 `套餐` 之后；面积写作 `<n>-<m>㎡`
+
+The "房间" tab is the default landing tab. If the page lands somewhere else,
+scroll to ~`y=1400` (relative to a 6900-tall doc on a 720-viewport) or click
+the `房间` tab DOM element to bring rooms into view.
+
+---
+
+## Login flow
+
+Login URL takes a `pageurl` query so the user lands back where they started:
+
+```python
+new_tab(f"https://passport.ly.com/?pageurl={urllib.parse.quote(target_url)}")
+```
+
+Detection — login is complete when the active URL leaves the `passport.ly.com`
+host. Poll `page_info()` every 3 s; bail when:
+
+```python
+url = page_info()["url"]
+done = "passport.ly.com" not in url and "login" not in url.lower()
+```
+
+> Gotcha: while the user is on the login page (and especially when they
+> change tabs/swipe through QR steps), `page_info()` can momentarily error
+> with "Cannot read properties of null (reading 'scrollWidth')" — the
+> document body isn't ready. Wrap each poll in try/except and continue.
+
+Cookies set by `passport.ly.com` are scoped to `.ly.com` and persist in the
+user's Chrome profile. They survive across `browser-harness` runs and across
+Chrome restarts. There is no need to re-login per session.
+
+---
+
+## XHRs to watch (not yet reverse-engineered)
+
+We observed but did not capture:
+
+- A price-fetch XHR fires after Nuxt hydration on the detail page; it appears
+  to gate on the `.ly.com` auth cookie. Reverse-engineering this would let
+  you skip the browser entirely once you have a valid token, but the request
+  almost certainly carries an anti-replay signature.
+- A list-page price-fill XHR fires after the initial render (the `prc=null`
+  in the card URL is a placeholder for what would have been written here).
+
+Until one of these is mapped, **prefer DOM extraction over network sniffing.**
+
+---
+
+## Traps
+
+- **`￥？` is real DOM content, not a CSS placeholder.** Don't waste time
+  hunting for hidden elements or computed styles — the server simply doesn't
+  send a price for unauthenticated requests.
+- **`m.ly.com/scenery/hotel/<id>`** returns 404. Don't pattern-match mobile
+  URLs without verifying.
+- **`__NUXT__` data keys are randomized per page load** (`$VKSoZS1qt0`,
+  `$0GffEk0IYv`, ...). Iterate values and detect by shape (presence of
+  `hotelData`), don't hardcode the key.
+- **`__NUXT__.data.X.hotelData` is a Vue ref.** Read `_rawValue` (or
+  `_value`); both contain the same data. Don't try to `JSON.stringify` the
+  ref directly — circular refs blow up.
+- **The "搜索" search button is a `<div>`, not a button.** `el.click()`
+  doesn't trigger the SPA — use coordinate click or build the list URL
+  directly.
+- **`predict-future` dates** (e.g. `inDate=2099-01-01`) silently coerce to
+  the next available night — don't rely on echoing the input back.
+
+---
+
+## Quick start (logged-in user, harness attached)
+
+```python
+from urllib.parse import quote
+import time, json
+from browser_harness.helpers import new_tab, wait_for_load, js, page_info, cdp
+
+HOTEL_ID = "92963586"   # 和颐至尊酒店(上海新国际博览中心世博园店)
+url = f"https://www.ly.com/hotel/hoteldetail?hotelId={HOTEL_ID}&inDate=2026-04-29&outDate=2026-04-30"
+
+tid = new_tab(url)
+wait_for_load(timeout=20)
+time.sleep(4)            # XHR price fetch
+js("window.scrollTo(0, 1400)")
+time.sleep(2)
+
+rooms = js("""
+  const buttons = Array.from(document.querySelectorAll("button, a, div"))
+    .filter(el => (el.innerText||"").trim() === "预订" && el.offsetParent !== null);
+  const out = [], seen = new Set();
+  for (const btn of buttons) {
+    let card = btn.parentElement;
+    while (card && card.innerText.length < 80) card = card.parentElement;
+    if (!card) continue;
+    const k = card.innerText.slice(0, 50);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    const text = card.innerText.replace(/\\s+/g, " ");
+    const nums = (text.match(/¥\\s*\\d+(?:\\.\\d+)?/g) || [])
+                   .map(s => parseFloat(s.replace(/[^\\d.]/g, "")));
+    out.push({
+      summary: text.slice(0, 120),
+      price_original: nums[0] ?? null,
+      price_current:  nums[1] ?? null,
+      saved:          nums[2] ?? null,
+    });
+    if (out.length >= 10) break;
+  }
+  return out;
+""")
+print(json.dumps(rooms, indent=2, ensure_ascii=False))
+cdp("Target.closeTarget", targetId=tid)
+```

--- a/agent-workspace/domain-skills/ly-com/hotels.md
+++ b/agent-workspace/domain-skills/ly-com/hotels.md
@@ -125,12 +125,14 @@ holds the actual hotel payload. Find it by shape, not by key:
 ```js
 const dataMap = window.__NUXT__?.data || {};
 const hotelEntry = Object.values(dataMap).find(v => v && v.hotelData);
-const meta = hotelEntry?.hotelData?._rawValue;   // _rawValue is the resolved Vue ref
+// Prefer the public Vue ref API (`.value`); fall back to `_rawValue` only
+// if a future Vue/Nuxt build changes the unwrapping shape.
+const meta = hotelEntry?.hotelData?.value ?? hotelEntry?.hotelData?._rawValue;
 // meta now has: hotelid, hotelName, hotelNameEn, hotelAddress,
 // nearestAreaPosition, hotelArea, starLevel, headPicUrl
 ```
 
-`detailBaseInfo._rawValue` adds: `openDate`, `decorateDate`, `featureInfo`
+`detailBaseInfo.value` adds: `openDate`, `decorateDate`, `featureInfo`
 (prose paragraph), and the full address again.
 
 **Prices are NOT in `__NUXT__`.** They're loaded by a separate XHR after

--- a/agent-workspace/domain-skills/wehotel/hotels.md
+++ b/agent-workspace/domain-skills/wehotel/hotels.md
@@ -1,0 +1,266 @@
+# Jinjiang WeHotel (`bestwehotel.com`) — Hotel Scraping
+
+Field-tested 2026-04-29 against `www.bestwehotel.com` PC web. The official
+direct-booking portal of the Jin Jiang group, covering ~50 sub-brands
+(锦江/J酒店/昆仑/丽笙/丽筠/丽柏/维也纳/锦江都城/白玉兰/麗枫/喆啡/希岸/IU/7天/锦江之星 etc.).
+
+---
+
+## TL;DR
+
+**Most scrape-friendly of the three Chinese hotel portals tested**:
+
+- Anonymous works on both list and detail pages — no login wall, no
+  parameter-schema gate, no `¥?` placeholders.
+- `http_get` does not work (SPA shell only). Need a browser session.
+- Browser cookies aren't required either — a freshly-opened tab via
+  `browser-harness` immediately renders 200+ hotels with prices.
+- Detail pages show full rate-plan breakdown (multiple room types ×
+  breakfast/cancellation matrix) anonymously.
+- Compared to: ly.com forces login for every price; ctrip works only via a
+  canonical 6-param URL schema or homepage-driven flow; WeHotel just works.
+
+---
+
+## URL patterns
+
+```
+List page:
+  https://www.bestwehotel.com/HotelSearch/
+    ?checkinDate=YYYY-MM-DD            # NOTE: lower-case  i / d
+    &checkoutDate=YYYY-MM-DD            # NOTE: lower-case  o / d
+    &cityCode=AR04567                   # WeHotel internal alpha-numeric code
+    &cityName=<urlencoded-Chinese>
+    &queryWords=                        # optional keyword filter
+    &extend=1,2,0,0,0,0                 # rooms,adults,children,...
+
+Hotel detail page:
+  https://www.bestwehotel.com/HotelDetail/
+    ?hotelId=JJ1888                     # JJ<digits>; "JJ" prefix = Jin Jiang chain
+    &checkInDate=YYYY-MM-DD             # NOTE: capital  I and D
+    &checkOutDate=YYYY-MM-DD             # NOTE: capital  O and D
+    &extend=1,2,0,0,0,0
+```
+
+**Param-name capitalization is inconsistent between list and detail.**
+List uses `checkinDate/checkoutDate`; detail uses `checkInDate/checkOutDate`.
+Get this wrong and the page silently falls back to default dates.
+
+---
+
+## How to land on the list page
+
+The home-page form has 上海 as the default destination and reasonable default
+dates, so two equivalent paths work:
+
+### Path A — drive the homepage form
+
+```python
+from browser_harness.helpers import new_tab, wait_for_load, click_at_xy, js, type_text
+import time
+
+new_tab("https://www.bestwehotel.com/")
+wait_for_load(timeout=20)
+time.sleep(2)
+
+# Search button is a <div> (and a sibling <a> with same coords) — coordinate click works
+btn = js("""
+  const b = Array.from(document.querySelectorAll('button, div, a'))
+    .find(el => (el.innerText||'').trim() === '搜索' && el.offsetParent !== null);
+  const r = b.getBoundingClientRect();
+  return {x: r.x+r.width/2, y: r.y+r.height/2};
+""")
+click_at_xy(btn["x"], btn["y"])
+time.sleep(8)            # XHR list fetch
+```
+
+### Path B — build the canonical URL (preferred when you know `cityCode`)
+
+```python
+url = (
+    "https://www.bestwehotel.com/HotelSearch/"
+    "?checkinDate=2026-04-30&checkoutDate=2026-05-01"
+    "&cityCode=AR04567&cityName=%E4%B8%8A%E6%B5%B7"
+    "&queryWords=&extend=1,2,0,0,0,0"
+)
+new_tab(url)
+wait_for_load(timeout=20)
+time.sleep(8)
+```
+
+WeHotel does **not** redirect-to-login when you skip `provinceId/districtId/countryId`-style
+parameters (unlike ctrip). The `cityCode` alone is sufficient.
+
+---
+
+## List page — extracting hotels
+
+The reliable path: walk back from `查看详情` `<a>` tags. Each card emits
+**three** `<a>` with the same `hotelId` href but different innerText:
+empty, hotel-name, and `查看详情`. Walk up to the smallest ancestor
+containing all three.
+
+```js
+return Array.from(document.querySelectorAll("a[href*=HotelDetail]"))
+  .filter(a => (a.innerText || "").trim() === "查看详情")
+  .slice(0, 30)
+  .map(detailA => {
+    const id = (detailA.href.match(/hotelId=([A-Z]+\d+)/i) || [])[1];
+
+    // Walk up to the smallest container that includes the hotel name <a>
+    let card = detailA.parentElement;
+    while (card && !card.querySelector("a[href*='" + id + "']:not([href*=查看详情])")) {
+      card = card.parentElement;
+    }
+    if (!card) return null;
+
+    const text = (card.innerText || "").replace(/\s+/g, " ");
+    const name = text.match(/(?:\d+\s+)?([^\s]{2,40}?(?:酒店|宾馆|大酒店|饭店))/)?.[1] || null;
+    const score = text.match(/(\d\.\d)\s*\/\s*5/)?.[1] || null;
+    const grade = (text.match(/(豪华型|高档型|舒适型|经济型)/) || [])[1] || null;
+    const distance = (text.match(/距离市中心\s*([\d.]+)\s*km/) || [])[1] || null;
+    const fromPrice = (text.match(/(?:¥|￥)\s*(\d+)\s*起/) || [])[1] || null;
+    const address = (text.match(/地址：([^|]+?)距离/) || [])[1]?.trim() || null;
+    const amenities = (text.match(/(停车场|餐厅|新店|游泳池|健身房|wifi)/g) || []).slice(0, 5);
+
+    return {
+      hotelId: id,
+      name, score, grade, distance, address,
+      price_from: fromPrice ? parseInt(fromPrice) : null,
+      amenities,
+    };
+  })
+  .filter(x => x && x.hotelId);
+```
+
+The body shows total via `查询到 N 家酒店`.
+
+### Card field shape (observed)
+
+```
+<index>
+<hotel-name>
+地址：<full-address>
+距离市中心 X.X km
+<rating>/5分
+<grade>            # 豪华型/高档型/舒适型/经济型
+<amenity tags>     # 停车场/餐厅/新店/...
+￥<price>起
+查看详情
+```
+
+---
+
+## Detail page — extracting room rates
+
+Detail page shows a flat table: `房型 | 早餐 | 取消政策 | 人数上限 | 房价 | <book-button>`.
+Each row contains the rate plan and a single `¥<price>` (no original/discount
+triplet — list rates are already "from price").
+
+```js
+const rows = Array.from(document.querySelectorAll("[class*=room], [class*=Room]"))
+  .filter(el => (el.innerText || "").includes("立即预订") || (el.innerText || "").includes("￥"))
+  .slice(0, 30);
+
+return rows.map(row => {
+  const text = (row.innerText || "").replace(/\s+/g, " ");
+  return {
+    room_type: text.match(/^(\S+(?:大床房|双床房|套房|标间|双人房)\S*)/)?.[1] || null,
+    breakfast: text.match(/(无早餐|含早餐|含\d份早餐|\d份早餐)/)?.[1] || null,
+    cancel: text.match(/(限时取消|免费取消|不可取消|订单确认后\d+分钟内可免费取消)/)?.[1] || null,
+    price: parseInt((text.match(/(?:¥|￥)\s*(\d+)/) || [])[1] || "0"),
+    full: text.slice(0, 200),
+  };
+}).filter(r => r.price > 0);
+```
+
+Title pattern: stays `🟢 锦江酒店WeHotel官网` (the harness 🟢 prefix). The
+hotel name is in the page body, not the title — extract via the page header,
+which uses generic `[class*=name]` or `[class*=title]` selectors.
+
+---
+
+## Brand matrix (under the WeHotel umbrella)
+
+WeHotel covers all Jin Jiang group brands. Useful when filtering or guessing
+hotelId prefixes:
+
+```
+LUXURY (奢华尊选):    J酒店, 昆仑
+PREMIUM (高端甄选):   锦江, 丽笙精选, 丽笙, 丽筠, 丽芮, 暻阁, 郁锦香, 丽柏, Park Plaza
+QUALITY (精品优选):   维也纳国际/酒店/智好/3好, 非繁云居, Park Inn, Renjoy, 锦江都城, 凯里亚德, Lavande
+ESSENTIALS (舒适智选): 锦江之星(品尚/风尚), 7天酒店, 7天优品, IU酒店, 派酒店, 白玉兰, 康铂, 麗枫, 喆啡, 希岸, 潮漫
+```
+
+All of these are bookable through the same `/HotelDetail/?hotelId=JJ<n>` URL.
+
+---
+
+## Global state — none useful
+
+`window.__INITIAL_STATE__`, `__NUXT__`, `__NEXT_DATA__`, `__APOLLO_STATE__`
+are all absent. Hotel data is loaded into Vue/React component state via XHR,
+not exposed on `window`. **Use DOM extraction.**
+
+---
+
+## Traps
+
+- **`checkinDate` (lower-case) on list, `checkInDate` (capital I) on detail.**
+  Mixing them up causes silent fallback to default dates. Always copy from
+  this doc rather than typing.
+- **`cityCode` is alpha-numeric, not numeric.** Shanghai = `AR04567`. There's
+  no obvious mapping — get it once via the homepage form and cache.
+- **Card has 3 `<a>` with the same href.** First is empty (image link),
+  second is name, third is `查看详情`. Filter by inner text to dedup.
+- **Default dates on the homepage shift daily.** Don't trust the form's
+  pre-filled dates — set them explicitly via URL or fill the form before
+  clicking 搜索.
+- **"价格区间-" filter** in the body text is a UI element, not data —
+  don't accidentally extract `¥?` from it.
+
+---
+
+## Quick start
+
+```python
+import time, json
+from browser_harness.helpers import new_tab, wait_for_load, js, cdp
+
+url = (
+    "https://www.bestwehotel.com/HotelSearch/"
+    "?checkinDate=2026-04-30&checkoutDate=2026-05-01"
+    "&cityCode=AR04567&cityName=%E4%B8%8A%E6%B5%B7"
+    "&queryWords=&extend=1,2,0,0,0,0"
+)
+tid = new_tab(url)
+wait_for_load(timeout=20)
+time.sleep(8)
+
+hotels = js(r"""
+  return Array.from(document.querySelectorAll("a[href*=HotelDetail]"))
+    .filter(a => (a.innerText||"").trim() === "查看详情")
+    .slice(0, 30)
+    .map(detailA => {
+      const id = (detailA.href.match(/hotelId=([A-Z]+\d+)/i) || [])[1];
+      let card = detailA.parentElement;
+      while (card && !card.querySelector(`a[href*='${id}']:not(:where([href*='%E6%9F%A5%E7%9C%8B%E8%AF%A6%E6%83%85']))`)) {
+        card = card.parentElement;
+        if (!card) break;
+      }
+      if (!card) return null;
+      const text = (card.innerText || "").replace(/\s+/g, " ");
+      return {
+        hotelId: id,
+        name:  text.match(/(?:\d+\s+)?([^\s]{2,40}?(?:酒店|宾馆|大酒店|饭店))/)?.[1] || null,
+        score: text.match(/(\d\.\d)\s*\/\s*5/)?.[1] || null,
+        grade: (text.match(/(豪华型|高档型|舒适型|经济型)/) || [])[1] || null,
+        distance_km: parseFloat((text.match(/距离市中心\s*([\d.]+)/) || [])[1] || "0"),
+        price_from: parseInt((text.match(/(?:¥|￥)\s*(\d+)\s*起/) || [])[1] || "0") || null,
+      };
+    })
+    .filter(x => x && x.hotelId && x.name);
+""")
+print(json.dumps(hotels, indent=2, ensure_ascii=False))
+cdp("Target.closeTarget", targetId=tid)
+```

--- a/agent-workspace/domain-skills/wehotel/hotels.md
+++ b/agent-workspace/domain-skills/wehotel/hotels.md
@@ -107,9 +107,15 @@ return Array.from(document.querySelectorAll("a[href*=HotelDetail]"))
   .map(detailA => {
     const id = (detailA.href.match(/hotelId=([A-Z]+\d+)/i) || [])[1];
 
-    // Walk up to the smallest container that includes the hotel name <a>
+    // Walk up to the smallest container that includes the hotel-name <a>
+    // (an anchor sharing the same hotelId href but whose text is NOT
+    // "查看详情" — that text lives on the link body, not in the href, so
+    // we filter by anchor identity / innerText, not by attribute selector).
     let card = detailA.parentElement;
-    while (card && !card.querySelector("a[href*='" + id + "']:not([href*=查看详情])")) {
+    const hasNameAnchor = (el) =>
+      Array.from(el.querySelectorAll("a[href*='" + id + "']"))
+        .some(a => a !== detailA && (a.innerText || "").trim() && (a.innerText || "").trim() !== "查看详情");
+    while (card && !hasNameAnchor(card)) {
       card = card.parentElement;
     }
     if (!card) return null;


### PR DESCRIPTION
## Summary

First batch of domain skills for Chinese hotel-booking sites — fills a
gap in the existing 70+ skill set, which has none for Chinese travel /
e-commerce. Field-tested 2026-04-29 against the live PC web.

| Site | Anonymous price? | Trick |
|------|-----------------|-------|
| `ly-com` (同程旅行) | ❌ — login wall | Hotel metadata still readable from `window.__NUXT__` SSR state |
| `ctrip` (携程) | ✅ — but URL schema gated | Need full 6-param canonical URL or homepage flow |
| `wehotel` (锦江) | ✅ — fully open | 249 hotels in Shanghai with prices in one shot |

Each `hotels.md` follows the existing `SKILL.md` "durable site map"
guidance:

- URL patterns (list + detail + login redirect)
- Stable selectors / extraction JS
- Login-redirect detection (when relevant)
- Traps with reasons
- Self-contained quick-start snippet

## What's covered

### `agent-workspace/domain-skills/ly-com/hotels.md`
- Price-hidden behavior: `￥？` is real DOM content, not CSS placeholder
- Nuxt data-key randomization → match by shape (`hotelData`), not key
- `passport.ly.com` login flow + return-URL pattern
- Search button is a `<div>` (`el.click()` unreliable, coordinate click works)

### `agent-workspace/domain-skills/ctrip/hotels.md`
- Canonical schema: `flexType=1&cityId=N&provinceId=0&districtId=0&countryId=1&...`
- Direct simplified URL (`?city=N`) → login redirect
- Hotel cards have no `data-id` and no `<a href>` — hotelId only in React closure
- Phantom-`¥` trap from review-count regex bleed-through
- `/hotel/<id>.html` works pre-login as direct entry to detail

### `agent-workspace/domain-skills/wehotel/hotels.md`
- Most scrape-friendly of the three — direct URL works without any form drive
- Inconsistent `checkinDate` (list) vs `checkInDate` (detail) capitalization
- `cityCode` is alpha-numeric (e.g. Shanghai = `AR04567`), not pure numeric
- Brand matrix table for the ~50 Jin Jiang sub-brands under one URL

## Test plan

- [x] Each site reproduced end-to-end on a real Chrome with `browser-harness` attached.
- [x] Quick-start snippets verified to return non-empty results (where anonymous access is possible).
- [x] No secrets, cookies, or session tokens included anywhere.
- [x] No raw pixel coordinates — selectors and JS only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add domain skills for Chinese hotel sites `ly-com`, `ctrip`, and `wehotel` for reliable hotel list/detail extraction. Includes URL schemas, selectors, login/redirect handling, traps, and quick-start snippets, plus robustness fixes.

- **New Features**
  - `ly-com`: prices behind login; pre-login metadata from `window.__NUXT__`; search button is a `<div>`; documents login flow and the `￥？` placeholder vs. post-login price triplet.
  - `ctrip`: anonymous prices only with the canonical 6‑param list URL or homepage flow; simplified `?city=` redirects to login; detail pages work pre-login; notes the phantom ¥ trap and lack of global state.
  - `wehotel`: fully anonymous list/detail; `cityCode` is alphanumeric; `checkinDate` (list) vs `checkInDate` (detail) capitalization; includes brand matrix and robust selectors.

- **Bug Fixes**
  - `ly-com`: read Vue refs via `.value` with `_rawValue` fallback for stable Nuxt data access.
  - `wehotel`: fix ancestor walk to find the hotel-name anchor by identity/innerText, not href text, avoiding stops on `查看详情`.
  - `ctrip`: raise a clear error when the destination input or 搜索 button is missing instead of failing with a TypeError.

<sup>Written for commit 318e3f01ccc92cb4a8bb3df511784d23e3adcfb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

