### PR TITLE
fix(daemon): ignore stale DevToolsActivePort path; resolve WS via /json/version

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -93,25 +93,22 @@ def get_ws_url():
         raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- is the dedicated automation Chrome running?")
     for base in PROFILES:
         try:
-            port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
+            port = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)[0].strip()
         except (FileNotFoundError, NotADirectoryError):
             continue
+        # Resolve the live WS URL via /json/version instead of trusting the path stored
+        # alongside the port in DevToolsActivePort: if Chrome was previously launched
+        # with a different --user-data-dir on the same port, that file is left behind
+        # with a stale browser UUID and the WS upgrade returns 404.
         deadline = time.time() + 30
-        while True:
-            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            probe.settimeout(1)
+        while time.time() < deadline:
             try:
-                probe.connect(("127.0.0.1", int(port.strip())))
-                break
-            except OSError:
-                if time.time() >= deadline:
-                    raise RuntimeError(
-                        f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port.strip()} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
-                    )
+                return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1).read())["webSocketDebuggerUrl"]
+            except (OSError, KeyError, ValueError):
                 time.sleep(1)
-            finally:
-                probe.close()
-        return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+        raise RuntimeError(
+            f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
+        )
     for probe_port in (9222, 9223):
         try:
             with urllib.request.urlopen(f"http://127.0.0.1:{probe_port}/json/version", timeout=1) as r:


### PR DESCRIPTION
## Summary

Fixes `CDP WS handshake failed: server rejected WebSocket connection: HTTP 404` when `DevToolsActivePort` in a default Chrome profile dir is stale.

## Repro

1. Launch Chrome at some point with `--remote-debugging-port=9222` against the default user-data-dir. Close it. Chrome leaves a `DevToolsActivePort` file behind containing the old browser UUID.
2. Later, launch Chrome with `--remote-debugging-port=9222 --user-data-dir=<some other dir>`.
3. Run `browser-harness`. Daemon dies with `CDP WS handshake failed: server rejected WebSocket connection: HTTP 404`.

Daemon log:
```
connecting to ws://127.0.0.1:9222/devtools/browser/<stale-uuid>
fatal: CDP WS handshake failed: server rejected WebSocket connection: HTTP 404
```

## Why

`get_ws_url()` walks `PROFILES` and reads `DevToolsActivePort` to learn both the port and the WS path. The TCP probe on the port succeeds (the new Chrome listens there), so we return `ws://127.0.0.1:<port><stale-path>` and try to upgrade ? Chrome answers 404 because the UUID is dead.

The fallback at the bottom of the function (the `(9222, 9223)` HTTP probe via `/json/version`) handles this case correctly, but only fires when no `DevToolsActivePort` file is found at all.

## Fix

Read only the port from `DevToolsActivePort`, then resolve the live WS URL via `/json/version` on that port ? the same approach the function already uses for `BU_CDP_URL` and the 9222/9223 fallback. `/json/version` is authoritative for whatever Chrome is currently bound to that port, so stale paths no longer matter.

The 30s deadline-with-retry behaviour is preserved (replaces the old TCP-socket probe loop). One port per cycle keeps the deadline tight.

## Test

- Reproduced on Windows 11 (Chrome 147, `--user-data-dir=C:\Users\alexa\chrome-debug-profile`).
- Confirmed pre-fix: daemon connects to the stale UUID and gets 404; post-fix: it resolves the live UUID via `/json/version` and attaches cleanly.
- `uv run --with pytest python -m pytest tests/unit` ? 25 passed.