### PR TITLE
fix(daemon): fall back to DevToolsActivePort ws path when /json/version 404s

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -105,24 +105,17 @@ def get_ws_url():
         # with a different --user-data-dir on the same port, that file is left behind
         # with a stale browser UUID and the WS upgrade returns 404.
         deadline = time.time() + 30
-        saw_http_404 = False
         while time.time() < deadline:
             try:
                 return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1).read())["webSocketDebuggerUrl"]
             except urllib.error.HTTPError as e:
-                if e.code == 404:
-                    # Chrome 147+ disables /json/* HTTP discovery when remote debugging
-                    # runs on the default user-data-dir (IsUsingDefaultDataDirectory check).
-                    # The websocket itself still works; fall back to the path Chrome wrote
-                    # to DevToolsActivePort, which is fresh because Chrome rewrites it on
-                    # every launch.
-                    saw_http_404 = True
-                    break
+                # Chrome 147+ disables /json/* HTTP discovery on the default user-data-dir;
+                # the ws path Chrome wrote to DevToolsActivePort still works.
+                if e.code == 404 and ws_path:
+                    return f"ws://127.0.0.1:{port}{ws_path}"
                 time.sleep(1)
             except (OSError, KeyError, ValueError):
                 time.sleep(1)
-        if saw_http_404 and ws_path:
-            return f"ws://127.0.0.1:{port}{ws_path}"
         raise RuntimeError(
             f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
         )

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.request
+import asyncio, json, os, socket, sys, time, urllib.error, urllib.request
 from collections import deque
 from pathlib import Path
 
@@ -93,19 +93,36 @@ def get_ws_url():
         raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- is the dedicated automation Chrome running?")
     for base in PROFILES:
         try:
-            port = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)[0].strip()
+            active = (base / "DevToolsActivePort").read_text().splitlines()
         except (FileNotFoundError, NotADirectoryError):
+            continue
+        port = active[0].strip() if active else ""
+        ws_path = active[1].strip() if len(active) > 1 else ""
+        if not port:
             continue
         # Resolve the live WS URL via /json/version instead of trusting the path stored
         # alongside the port in DevToolsActivePort: if Chrome was previously launched
         # with a different --user-data-dir on the same port, that file is left behind
         # with a stale browser UUID and the WS upgrade returns 404.
         deadline = time.time() + 30
+        saw_http_404 = False
         while time.time() < deadline:
             try:
                 return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1).read())["webSocketDebuggerUrl"]
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    # Chrome 147+ disables /json/* HTTP discovery when remote debugging
+                    # runs on the default user-data-dir (IsUsingDefaultDataDirectory check).
+                    # The websocket itself still works; fall back to the path Chrome wrote
+                    # to DevToolsActivePort, which is fresh because Chrome rewrites it on
+                    # every launch.
+                    saw_http_404 = True
+                    break
+                time.sleep(1)
             except (OSError, KeyError, ValueError):
                 time.sleep(1)
+        if saw_http_404 and ws_path:
+            return f"ws://127.0.0.1:{port}{ws_path}"
         raise RuntimeError(
             f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
         )


### PR DESCRIPTION
## Summary

Fix CDP attach on Chrome 147+ when remote debugging runs on the **default** user data directory.

Closes #264.

## Problem

Chrome 147+ silently disables the `/json/*` HTTP discovery endpoints when `--remote-debugging-port` is used with the default user data directory (the `IsUsingDefaultDataDirectory()` lockdown — the same one PR #142 sidesteps by launching on a non-default profile). Verified locally on macOS Darwin 25.4 + Chrome 147.0.7727.137:

```text
GET /json/version → 404
GET /json         → 404
GET /json/list    → 404
```

`DevToolsActivePort` is still written, and `ws://127.0.0.1:9222/devtools/browser/<UUID>` still accepts CDP. But `get_ws_url()` reads only the *port* from `DevToolsActivePort` and resolves the WS URL via `/json/version` (intentional behavior introduced in #260). On a default-profile Chrome 147, `/json/version` 404s permanently — the 30s poll never recovers and dies with the misleading `DevTools is not live yet on 127.0.0.1:9222` error.

## Repro

1. Chrome 147 running on the default profile with remote debugging on (sticky checkbox from `chrome://inspect/#remote-debugging` after any prior `--remote-debugging-port=9222` launch).
2. Run any harness command:
   ```
   $ browser-harness -c 'print(page_info())'
   RuntimeError: fatal: Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:9222 — ...
   ```
3. Confirm the websocket itself is fine via `BU_CDP_WS` constructed from `DevToolsActivePort`.

## Why #260's concern still holds

PR #260 deliberately stopped trusting the path in `DevToolsActivePort` because a *stale* port file (left from a previous Chrome run with a different `--user-data-dir`) had a dead UUID, while `/json/version` had the live one. That's a real bug and this PR doesn't reintroduce it.

## Fix

Read both port and ws path from `DevToolsActivePort`. Try `/json/version` first — keeps #260's stale-UUID handling intact. On **HTTP 404 specifically** (distinct from connection-refused/timeout, which mean Chrome is still starting), fall back to `ws://127.0.0.1:{port}{ws_path}` from the file. The file's UUID is fresh because Chrome rewrites it on every launch, and the only persistent reason `/json/version` 404s on a live port is the default-profile lockdown. If the fallback path is somehow stale anyway, the existing CDP handshake error surfaces cleanly — no worse than today.

## Behavioral matrix

| Scenario | Before | After |
|---|---|---|
| Chrome 147 default profile (this PR) | ❌ 30s poll + misleading error | ✅ attaches via file path |
| Stale `DevToolsActivePort` from prior `--user-data-dir` (#260's case) | ✅ /json/version returns live UUID | ✅ same path, unchanged |
| Chrome still starting (TCP connect-refused) | ✅ 30s retry on /json/version | ✅ same path, unchanged |
| `BU_CDP_WS` / `BU_CDP_URL` set | ✅ unchanged | ✅ unchanged |
| `DevToolsActivePort` missing entirely | ✅ falls through to 9222/9223 probe | ✅ unchanged |

## Verification

End-to-end on the affected setup:

```
$ rm /tmp/bu-default.* 2>/dev/null
$ unset BU_CDP_WS
$ browser-harness -c 'print(page_info())'
{'url': 'https://...', 'title': '...', 'w': 1900, 'h': 803, ...}

$ tail /tmp/bu-default.log
connecting to ws://127.0.0.1:9222/devtools/browser/14c7583e-755b-4b45-be74-793ea45e81be
attached BBADAE259F24F78824248BED6A3B29F5 ...
listening on /tmp/bu-default.sock (name=default, remote=local)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CDP attach on Chrome 147+ when remote debugging uses the default profile. When `/json/version` returns 404, we now fall back to the websocket path from `DevToolsActivePort` to avoid the 30s retry loop and attach immediately.

- **Bug Fixes**
  - Read both port and ws path from `DevToolsActivePort`; try `/json/version` first, and on HTTP 404 only, use `ws://127.0.0.1:{port}{ws_path}`.
  - Keep existing behavior for connection refused/timeouts (keep polling) and for env var overrides; no changes in non-404 scenarios.

<sup>Written for commit 5dfa89fa66c1d75ca3ac10896878aff6ad5aa99f. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/265?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

