### PR TITLE
fix: auto-bootstrap cloud daemon on headless servers when BROWSER_USE_API_KEY is set

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -1,4 +1,4 @@
-import os, sys
+import os, socket, sys
 
 # Windows default stdout encoding is cp1252, which can't encode the 🟢 marker
 # helpers prepend to tab titles (or anything else outside Latin-1). Force UTF-8
@@ -9,6 +9,8 @@ if hasattr(sys.stdout, "reconfigure"):
 
 from .admin import (
     _version,
+    NAME,
+    daemon_alive,
     ensure_daemon,
     list_cloud_profiles,
     list_local_profiles,
@@ -44,6 +46,21 @@ Commands:
 """
 
 
+def _local_chrome_listening():
+    """True if Chrome appears to be running with remote debugging on a known port.
+
+    9222 is Chrome's default CDP remote debugging port; 9223 is the common
+    fallback. Consistent with the same probe in daemon.py.
+    """
+    for port in (9222, 9223):
+        try:
+            socket.create_connection(("127.0.0.1", port), timeout=0.3).close()
+            return True
+        except OSError:
+            pass
+    return False
+
+
 def main():
     args = sys.argv[1:]
     if args and args[0] in {"-h", "--help"}:
@@ -71,6 +88,8 @@ def main():
     if len(args) < 2:
         sys.exit("Usage: browser-harness -c \"print(page_info())\"")
     print_update_banner()
+    if not daemon_alive() and not _local_chrome_listening() and os.environ.get("BROWSER_USE_API_KEY"):
+        start_remote_daemon(NAME)
     ensure_daemon()
     exec(args[1], globals())
 

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -1,4 +1,4 @@
-import os, socket, sys
+import os, sys, urllib.request
 
 # Windows default stdout encoding is cp1252, which can't encode the 🟢 marker
 # helpers prepend to tab titles (or anything else outside Latin-1). Force UTF-8
@@ -46,18 +46,15 @@ Commands:
 """
 
 
+# Probe /json/version (not a bare TCP connect) so a non-Chrome process bound to
+# 9222/9223 doesn't masquerade as Chrome and skip the cloud bootstrap. Mirrors
+# daemon.py's fallback probe.
 def _local_chrome_listening():
-    """True if Chrome appears to be running with remote debugging on a known port.
-
-    9222 is Chrome's default CDP remote debugging port; 9223 is the common
-    fallback. Consistent with the same probe in daemon.py.
-    """
     for port in (9222, 9223):
         try:
-            socket.create_connection(("127.0.0.1", port), timeout=0.3).close()
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=0.3).close()
             return True
-        except OSError:
-            pass
+        except OSError: pass
     return False
 
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,6 +1,6 @@
 import sys
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from browser_harness import run
 
@@ -13,6 +13,58 @@ def test_c_flag_executes_code():
          patch("sys.stdout", stdout):
         run.main()
     assert stdout.getvalue().strip() == "hello from -c"
+
+
+def test_cloud_bootstrap_on_headless_server(monkeypatch):
+    """Auto-provisions cloud daemon when no daemon, no local Chrome, and API key is set."""
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_called_once()
+
+
+def test_no_cloud_bootstrap_when_chrome_listening(monkeypatch):
+    """Does not provision cloud daemon when local Chrome is already running."""
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=True), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
+
+
+def test_no_cloud_bootstrap_when_daemon_alive(monkeypatch):
+    """Does not provision cloud daemon when a daemon is already running."""
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=True), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
+
+
+def test_no_cloud_bootstrap_without_api_key(monkeypatch):
+    """Does not provision cloud daemon when BROWSER_USE_API_KEY is not set."""
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
 
 
 def test_c_flag_does_not_read_stdin():

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,6 +1,6 @@
 import sys
 from io import StringIO
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from browser_harness import run
 
@@ -16,7 +16,7 @@ def test_c_flag_executes_code():
 
 
 def test_cloud_bootstrap_on_headless_server(monkeypatch):
-    """Auto-provisions cloud daemon when no daemon, no local Chrome, and API key is set."""
+    """No daemon, no local Chrome, API key set -> auto-provision cloud daemon."""
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
          patch("browser_harness.run.daemon_alive", return_value=False), \
@@ -28,43 +28,14 @@ def test_cloud_bootstrap_on_headless_server(monkeypatch):
     mock_start.assert_called_once()
 
 
-def test_no_cloud_bootstrap_when_chrome_listening(monkeypatch):
-    """Does not provision cloud daemon when local Chrome is already running."""
-    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
-         patch("browser_harness.run.daemon_alive", return_value=False), \
-         patch("browser_harness.run._local_chrome_listening", return_value=True), \
-         patch("browser_harness.run.start_remote_daemon") as mock_start, \
-         patch("browser_harness.run.ensure_daemon"), \
-         patch("browser_harness.run.print_update_banner"):
-        run.main()
-    mock_start.assert_not_called()
-
-
-def test_no_cloud_bootstrap_when_daemon_alive(monkeypatch):
-    """Does not provision cloud daemon when a daemon is already running."""
-    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
-         patch("browser_harness.run.daemon_alive", return_value=True), \
-         patch("browser_harness.run._local_chrome_listening", return_value=False), \
-         patch("browser_harness.run.start_remote_daemon") as mock_start, \
-         patch("browser_harness.run.ensure_daemon"), \
-         patch("browser_harness.run.print_update_banner"):
-        run.main()
-    mock_start.assert_not_called()
-
-
-def test_no_cloud_bootstrap_without_api_key(monkeypatch):
-    """Does not provision cloud daemon when BROWSER_USE_API_KEY is not set."""
-    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
-         patch("browser_harness.run.daemon_alive", return_value=False), \
-         patch("browser_harness.run._local_chrome_listening", return_value=False), \
-         patch("browser_harness.run.start_remote_daemon") as mock_start, \
-         patch("browser_harness.run.ensure_daemon"), \
-         patch("browser_harness.run.print_update_banner"):
-        run.main()
-    mock_start.assert_not_called()
+def test_local_chrome_listening_rejects_non_chrome():
+    """A bare TCP listener on 9222/9223 must not fool the probe — only a real
+    /json/version response counts as Chrome."""
+    with patch("browser_harness.run.urllib.request.urlopen", side_effect=OSError):
+        assert run._local_chrome_listening() is False
+    with patch("browser_harness.run.urllib.request.urlopen") as mock_open:
+        assert run._local_chrome_listening() is True
+        mock_open.assert_called_once()
 
 
 def test_c_flag_does_not_read_stdin():


### PR DESCRIPTION
## Summary

On headless servers (VPS, Docker) with no local Chrome, `browser-harness -c '...'` always fails even when `BROWSER_USE_API_KEY` is set and Browser Use Cloud is available.

## Repro

1. Run `browser-harness` on a headless Linux server with no Chrome installed
2. Set `BROWSER_USE_API_KEY` to a valid Browser Use Cloud key
3. Run any `-c` script — e.g. `browser-harness -c 'print(page_info())'`

```
RuntimeError: fatal: DevToolsActivePort not found in [...] — enable
chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser
```

## Why

`run.py` calls `ensure_daemon()` unconditionally before executing any user script. On a headless server `ensure_daemon()` finds no local Chrome and raises immediately — the user's script never runs, so `start_remote_daemon()` can never be called from within a `-c` script.

Issues #181 and #183 report this symptom. The root cause analysis in #181 suggests `start_remote_daemon()` fails to pass `BU_CDP_WS` to `ensure_daemon()` — this is not accurate. `start_remote_daemon()` passes it correctly; it simply never gets the chance to run.

## Fix

Add a pre-check before `ensure_daemon()`: if no daemon is alive, Chrome is not listening on known debugging ports, and `BROWSER_USE_API_KEY` is set, auto-provision a Browser Use cloud browser first.

```python
if not daemon_alive() and not _local_chrome_listening() and os.environ.get("BROWSER_USE_API_KEY"):
    start_remote_daemon(NAME)
ensure_daemon()
```

`_local_chrome_listening()` probes ports 9222 and 9223 with a 0.3s timeout — the same ports already probed in `daemon.py`. This is more precise than `_is_local_chrome_mode()`, which only checks for absence of `BU_CDP_WS` and would incorrectly trigger cloud bootstrap on a local machine where Chrome is running but `BROWSER_USE_API_KEY` is also set (e.g. for profile sync).

## Test

Tested on a headless Hostinger VPS running hermes-agent in Docker (no Chrome installed, `BROWSER_USE_API_KEY` set as a container environment variable).

**Before** (without the fix, same environment):

```bash
$ browser-harness -c "new_tab('https://www.google.com'); wait_for_load(); print(page_info())"
RuntimeError: fatal: DevToolsActivePort not found in /tmp/playwright/chrome-profile-...
— enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser
```

**After**:

```bash
$ browser-harness -c "new_tab('https://www.google.com'); wait_for_load(); print(page_info())"
https://live.browser-use.com?wss=https://...
(no local GUI — share the liveUrl with the user)
{'url': 'https://www.google.com/', 'title': 'Google', 'w': 1512, 'h': 770, ...}
```

Cloud daemon auto-provisioned transparently — no manual setup required. `_local_chrome_listening()` correctly returns `False` on this host (ports 9222/9223 are not open), so the bootstrap fires. On a local machine with Chrome running, those ports are open and the bootstrap is correctly skipped.

Unit tests:

```
uv run --with pytest pytest tests/unit/test_run.py -q
6 passed in 0.03s
```