### PR TITLE
domain-skills: add claude-ai/share-export

### DIFF
--- a/agent-workspace/domain-skills/claude-ai/extract-share-transcript.py
+++ b/agent-workspace/domain-skills/claude-ai/extract-share-transcript.py
@@ -54,13 +54,13 @@ out = pathlib.Path(out_dir)
 out.mkdir(parents=True, exist_ok=True)
 
 payload = {"title": title, "source_url": share_url, "turns": turns}
-(out / f"{slug}.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+(out / f"{slug}.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
 parts = [f"# {title}", "", f"Source: {share_url}", f"Turns: {len(turns)}", ""]
 for t in turns:
     label = "Human" if t["role"] == "user" else "Assistant"
     parts += [f"## {label}", "", t["text"], ""]
-(out / f"{slug}.md").write_text("\n".join(parts))
+(out / f"{slug}.md").write_text("\n".join(parts), encoding="utf-8")
 
 print(f"title: {title}")
 print(f"turns: {len(turns)}")

--- a/agent-workspace/domain-skills/claude-ai/extract-share-transcript.py
+++ b/agent-workspace/domain-skills/claude-ai/extract-share-transcript.py
@@ -1,0 +1,68 @@
+"""Extract a transcript from a claude.ai share URL.
+
+Usage (run inside browser-harness):
+    CLAUDE_SHARE_URL=https://claude.ai/share/<uuid> \
+    OUTPUT_DIR=/path/to/transcripts \
+    bh -c "$(cat agent-workspace/domain-skills/claude-ai/extract-share-transcript.py)"
+
+Requires: the user's running Chrome must be signed into claude.ai (share pages
+render the conversation only for authenticated viewers — see share-export.md).
+
+Writes two files into OUTPUT_DIR, named from the conversation title slug:
+    <slug>.json  — {title, source_url, turns: [{role, text}]}
+    <slug>.md    — Markdown with ## Human / ## Assistant headers
+"""
+import json, os, pathlib, re, sys, time
+
+share_url = os.environ.get("CLAUDE_SHARE_URL")
+out_dir = os.environ.get("OUTPUT_DIR")
+if not share_url or not out_dir:
+    sys.exit("set CLAUDE_SHARE_URL and OUTPUT_DIR env vars")
+
+new_tab(share_url)            # noqa: F821 — provided by browser-harness
+wait_for_load()               # noqa: F821
+time.sleep(2)                 # let the conversation tree render
+
+js_code = """
+(() => {
+  const userMsgs = [...document.querySelectorAll("[data-testid=user-message]")];
+  if (!userMsgs.length) return JSON.stringify({error: "no user messages found — is the user logged in to claude.ai?"});
+  let p = userMsgs[0];
+  while (p && !p.contains(userMsgs[userMsgs.length-1])) p = p.parentElement;
+  const container = p;
+  const turns = [];
+  for (const child of container.children) {
+    const u = child.querySelector("[data-testid=user-message]");
+    const a = child.querySelector(".font-claude-response");
+    if (u) turns.push({role: "user", text: u.innerText.trim()});
+    else if (a) turns.push({role: "assistant", text: a.innerText.trim()});
+  }
+  const ph = document.querySelector("[data-testid=page-header]");
+  const title = (ph?.innerText.split("\\n")[0] || document.title || "").trim();
+  return JSON.stringify({title, turns});
+})()
+"""
+data = json.loads(js(js_code))    # noqa: F821
+if data.get("error"):
+    sys.exit(data["error"])
+
+title = data["title"] or "claude-share"
+turns = data["turns"]
+slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-") or "claude-share"
+
+out = pathlib.Path(out_dir)
+out.mkdir(parents=True, exist_ok=True)
+
+payload = {"title": title, "source_url": share_url, "turns": turns}
+(out / f"{slug}.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+
+parts = [f"# {title}", "", f"Source: {share_url}", f"Turns: {len(turns)}", ""]
+for t in turns:
+    label = "Human" if t["role"] == "user" else "Assistant"
+    parts += [f"## {label}", "", t["text"], ""]
+(out / f"{slug}.md").write_text("\n".join(parts))
+
+print(f"title: {title}")
+print(f"turns: {len(turns)}")
+print(f"json:  {out / (slug + '.json')}")
+print(f"md:    {out / (slug + '.md')}")

--- a/agent-workspace/domain-skills/claude-ai/share-export.md
+++ b/agent-workspace/domain-skills/claude-ai/share-export.md
@@ -57,7 +57,7 @@ The script reads both via env vars (browser-harness's `-c` doesn't forward extra
 
 It produces two files in the output dir, named from the conversation title slug:
 
-- `<slug>.json` — `{title, turns: [{role, text}]}`
+- `<slug>.json` — `{title, source_url, turns: [{role, text}]}`
 - `<slug>.md` — LLM-friendly transcript with `## Human` / `## Assistant` headers
 
 ## What this skill does NOT cover

--- a/agent-workspace/domain-skills/claude-ai/share-export.md
+++ b/agent-workspace/domain-skills/claude-ai/share-export.md
@@ -1,0 +1,67 @@
+# claude.ai — Export a Shared Conversation
+
+URL pattern: `https://claude.ai/share/<uuid>`
+
+Extracts a full Human/Assistant transcript from a Claude share link as JSON or Markdown.
+
+## Auth requirement
+
+The share page **renders the chat content only when the user is logged into claude.ai**. Logged-out viewers see an app shell without the conversation DOM. Open the URL in a Chrome profile that's already signed in — bh attaches to the user's running Chrome, so this works automatically as long as their profile is logged in.
+
+If the conversation body is empty after navigation, that's the signal you're hitting an unauthenticated session.
+
+## DOM map
+
+Share pages render the conversation as a flat list of sibling `<div>` children inside a single container. There is **no per-turn wrapper element** that includes both messages — turns are alternating siblings.
+
+Stable selectors:
+
+- `[data-testid=user-message]` — user message body (clean text, no prefix)
+- `.font-claude-response` — assistant message body
+- `[data-testid=page-header]` — first line of `innerText` is the conversation title
+- `[data-testid=action-bar-copy]` — per-turn copy button (not needed for export)
+
+Traps to avoid:
+
+- `document.title` returns `"Claude"` — useless for the conversation title; use `[data-testid=page-header]`
+- `document.querySelector("h1, h2")` picks up sidebar `Starred` etc — not the chat title
+- Each assistant block contains an `H2.sr-only` reading "Claude responded:" — screen-reader only, but `innerText` includes it. Selecting `.font-claude-response` skips it.
+- User blocks render a "You said: <preview>" heading separate from the body — `[data-testid=user-message]` returns just the body, so use it directly. Don't use the wrapping turn div's `innerText` or you'll get the preview duplicated.
+- `js()` shares a global scope across calls in the same `bh -c` invocation. Wrap extraction in an IIFE — `const`/`let` at top level will collide on re-run. (General bh gotcha, but bites here because you'll iterate selectors.)
+
+## Container-walk pattern
+
+There's no semantic container ID, so find it by walking up from the first user message until you find an ancestor that also contains the last user message:
+
+```javascript
+const userMsgs = [...document.querySelectorAll("[data-testid=user-message]")];
+let p = userMsgs[0];
+while (p && !p.contains(userMsgs[userMsgs.length-1])) p = p.parentElement;
+const container = p;
+// container.children is now the alternating list of turn divs
+```
+
+Then iterate `container.children` and check each child for either `[data-testid=user-message]` (user turn) or `.font-claude-response` (assistant turn). Children that match neither are headers/notices — skip.
+
+## Extraction
+
+A working script lives next to this file: `extract-share-transcript.py`. Run it with:
+
+```bash
+CLAUDE_SHARE_URL=https://claude.ai/share/<uuid> \
+OUTPUT_DIR=/path/to/transcripts \
+bh -c "$(cat agent-workspace/domain-skills/claude-ai/extract-share-transcript.py)"
+```
+
+The script reads both via env vars (browser-harness's `-c` doesn't forward extra `argv`, so env vars are the cleanest passthrough).
+
+It produces two files in the output dir, named from the conversation title slug:
+
+- `<slug>.json` — `{title, turns: [{role, text}]}`
+- `<slug>.md` — LLM-friendly transcript with `## Human` / `## Assistant` headers
+
+## What this skill does NOT cover
+
+- Live conversations (`claude.ai/chat/<uuid>`) — different DOM, requires the user's own session and may include streaming/in-progress messages
+- Artifacts inside the conversation — captured as plain text only; the artifact panel is a separate iframe-like surface not covered here
+- Attachments — the page-header notice mentions "Shared snapshot may contain attachments and data not displayed here"; share exports are text-only by design


### PR DESCRIPTION
## Summary

Adds a new domain skill at `agent-workspace/domain-skills/claude-ai/` for exporting transcripts from `claude.ai/share/<uuid>` URLs.

- `share-export.md` — durable site map: stable selectors, the container-walk pattern (turns are alternating siblings, no semantic wrapper), traps to avoid (the `H2.sr-only` "Claude responded:" prefix, useless `document.title`), and the auth requirement (share pages render the conversation only for signed-in viewers).
- `extract-share-transcript.py` — working script invoked via `bh -c "$(cat ...)"` with `CLAUDE_SHARE_URL` and `OUTPUT_DIR` env vars. Emits both JSON (`{title, source_url, turns}`) and LLM-friendly Markdown (`## Human` / `## Assistant`).

Verified on a 90-pair / 180-turn conversation — all turns extracted in document order with clean text bodies.

## Test plan

- [x] Run script against a real `claude.ai/share/<uuid>` URL with a signed-in Chrome profile attached to bh
- [x] Confirm turn count matches the rendered conversation
- [x] Confirm title comes from `[data-testid=page-header]` (not `document.title` which is just `"Claude"`)
- [x] Confirm `.font-claude-response` selector skips the screen-reader-only `H2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)