### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+browser-harness is a thin layer that connects agents to browsers via an editable CDP harness.
+
+# Code priorities
+- Clarity
+- Precision
+- Low verbosity
+- Versatility
+
+# Overview
+Core code lives in `src/browser_harness/`:
+- `admin.py` — harness setup and daemon lifecycle (start, stop, attach, profile management)
+- `daemon.py` — the long-lived middleman process between the browser and the agent
+- `helpers.py` — CDP wrapper and core browser primitives auto-imported into `-c` scripts
+- `run.py` — the `browser-harness` CLI
+
+`SKILL.md` tells agents how to use the harness.
+`install.md` tells agents how to install it, attach a browser, and troubleshoot.
+
+An agent operating the harness only edits inside `agent-workspace/`, where it can add new helper functions and write or read skills.
+
+# Contributing
+Consider what is really needed. Prefer the smallest diff that fixes the bug.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,12 @@ Core code lives in `src/browser_harness/`:
 - `helpers.py` — CDP wrapper and core browser primitives auto-imported into `-c` scripts
 - `run.py` — the `browser-harness` CLI
 
-`SKILL.md` tells agents how to use the harness.
+`SKILL.md` tells agents how to use the harness and CLI.
 `install.md` tells agents how to install it, attach a browser, and troubleshoot.
 
-An agent operating the harness only edits inside `agent-workspace/`, where it can add new helper functions and write or read skills.
+An agent operating the harness only edits inside `agent-workspace/`:
+- `agent_helpers.py` — task-specific browser helpers the agent adds
+- `domain-skills/` — skills the agent writes and reads
 
 # Contributing
 Consider what is really needed. Prefer the smallest diff that fixes the bug.


### PR DESCRIPTION
Adds a concise AGENTS.md at the repo root to orient AI coding agents (and human contributors) in two screens or less.

## What

- One-line statement of what browser-harness is.
- Code priorities (clarity, precision, low verbosity, versatility).
- Map of the four core files in `src/browser_harness/` with one-line each.
- Pointers to `SKILL.md` (how to use the harness/CLI) and `install.md` (install/attach/troubleshoot).
- The `agent-workspace/` boundary: agents only edit there, with the two contents listed.
- A one-line contributing note: smallest diff that fixes the bug.

## Why

Agents landing in the repo currently have no entry point that tells them where things live and where they're allowed to edit. `SKILL.md` covers usage, `install.md` covers setup — neither covers code orientation. `AGENTS.md` is the conventional name picked up by Claude Code, OpenCode, Cursor, and similar tools.

## Non-goals

Kept it short on purpose — every token in this file gets read on every agent session. No CLI examples (covered in `SKILL.md`/`install.md`), no test/build instructions, no architecture deep-dive.