### PR TITLE
docs: add issue templates; route questions to Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Report a reproducible bug in browser-harness.
+labels: [bug]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: I ran `browser-harness --doctor` and read the output.
+          required: true
+        - label: I read the troubleshooting section of `install.md`.
+          required: true
+        - label: This is a reproducible bug in browser-harness — not a question, feature request, or `cloud.browser-use.com` issue.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What's broken, in one or two sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro
+      description: Numbered steps. Include the exact command and the output you saw.
+      placeholder: |
+        1. Chrome 147 on default profile, remote debugging on
+        2. browser-harness -c 'print(page_info())'
+        3. RuntimeError: DevTools is not live yet on 127.0.0.1:9222
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        OS:
+        Chrome version:
+        browser-harness --version:
+        browser-harness --doctor output:
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or how-to
+    url: https://github.com/browser-use/browser-harness/discussions/categories/q-a
+    about: Ask in Discussions Q&A, not Issues.
+  - name: Install or setup troubleshooting
+    url: https://github.com/browser-use/browser-harness/blob/main/install.md
+    about: Most install and "DevTools not live" errors are covered here.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose a new feature or change.
+labels: [feature-request]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions.
+          required: true
+        - label: This is a feature request, not a bug.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user pain or limitation motivates this?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else you tried, or why other approaches fall short.
+    validations:
+      required: true


### PR DESCRIPTION
Adds three files under `.github/ISSUE_TEMPLATE/` to enforce minimum-quality bug reports and route support questions out of the issue tracker.

## Files

- `bug-report.yml` — 3 required fields (Summary, Repro, Environment) plus a 4-box preflight (searched issues, ran `--doctor`, read `install.md` troubleshooting, this is a bug not a question/FR/cloud issue). Auto-labels `bug`.
- `feature-request.yml` — 3 required fields (Problem, Proposal, Alternatives considered) plus a 2-box preflight. Auto-labels `feature-request`.
- `config.yml` — sets `blank_issues_enabled: false` and adds two contact links: Discussions Q&A and `install.md`.

## Effect

The **New issue** button now shows three cards: Bug report, Feature request, and a link card to Discussions Q&A. The blank-issue option is gone. Free-text low-effort issues like #102 ("Site doesn't work") and pure how-to questions like #143 / #111 / #125 either route to Discussions or get blocked at the form level.

## Out of scope (handled separately)

- Discussions enabled in repo Settings (done).
- Bot opening hash-title issues — already removed.
