### PR TITLE
docs: add VOUCHED.td (vouch list)

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,12 @@
+# Vouched (or denounced) users for browser-harness.
+#
+# See https://github.com/mitchellh/vouch for details.
+#
+# Syntax:
+#   - One handle per line (without @), sorted alphabetically.
+#   - Optional platform prefix: platform:username (e.g., github:user).
+#   - Denounce by prefixing with minus: -username
+#   - Optional reason after a space following the handle.
+
+molesza
+shaunandrewjackson1977


### PR DESCRIPTION
Adds `.github/VOUCHED.td` for tracking vouched and denounced contributors.

## Format

Mitchell Hashimoto's [vouch](https://github.com/mitchellh/vouch) system, same file format as [Ghostty](https://github.com/ghostty-org/ghostty/blob/main/.github/VOUCHED.td) and [OpenCode](https://github.com/anomalyco/opencode/blob/dev/.github/VOUCHED.td). One handle per line, alphabetical, `-` prefix to denounce, optional reason after a space.

## Seeds

Two contributors from recent PRs:

- `molesza` — PR #265, Chrome 147 default-profile CDP fallback, accepted follow-up cleanly
- `shaunandrewjackson1977` — PR #266, headless cloud auto-bootstrap, accepted follow-up cleanly

## Out of scope

The vouch GitHub Actions (`check-pr`, `check-issue`, `manage-by-issue`, `sync-codeowners`) are deferred. This PR is data only — the file can be appended to as new PRs and issues land.
