### PR TITLE
Gate domain skills behind BH_DOMAIN_SKILLS env (default off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Paste into Claude Code or Codex:
 ```text
 Set up https://github.com/browser-use/browser-harness for me.
 
-Read `install.md` first to install and connect this repo to my real browser. Then read `SKILL.md` for normal usage. Use `agent-workspace/agent_helpers.py` and `agent-workspace/domain-skills/` for task-specific edits. When you open a setup or verification tab, activate it so I can see the active browser tab. After it is installed, open this repository in my browser and, if I am logged in to GitHub, ask me whether you should star it for me as a quick demo that the interaction works — only click the star if I say yes. If I am not logged in, just go to browser-use.com.
+Read `install.md` first to install and connect this repo to my real browser. Then read `SKILL.md` for normal usage. Use `agent-workspace/agent_helpers.py` for task-specific edits. When you open a setup or verification tab, activate it so I can see the active browser tab. After it is installed, open this repository in my browser and, if I am logged in to GitHub, ask me whether you should star it for me as a quick demo that the interaction works — only click the star if I say yes. If I am not logged in, just go to browser-use.com.
 ```
 
 When this page appears, tick the checkbox so the agent can connect to your browser:
@@ -54,6 +54,7 @@ Useful for stealth, sub-agents, or deployment.<br>
 
 PRs and improvements welcome. The best way to help: **contribute a new domain skill** under [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for a site or task you use often (LinkedIn outreach, ordering on Amazon, filing expenses, etc.). Each skill teaches the agent the selectors, flows, and edge cases it would otherwise have to rediscover.
 
+- **Skills are off by default.** Domain skills are opt-in via `BH_DOMAIN_SKILLS=1` (set it before invoking `browser-harness`). The directory is community-curated and quality varies — defaulting off keeps the average run unaffected while preserving the contribution loop.
 - **Skills are written by the harness, not by you.** Just run your task with the agent — when it figures something non-obvious out, it files the skill itself (see [SKILL.md](SKILL.md)). Please don't hand-author skill files; agent-generated ones reflect what actually works in the browser.
 - Open a PR with the generated `agent-workspace/domain-skills/<site>/` folder — small and focused is great.
 - Bug fixes, docs tweaks, and helper improvements are equally welcome.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Useful for stealth, sub-agents, or deployment.<br>
 
 PRs and improvements welcome. The best way to help: **contribute a new domain skill** under [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for a site or task you use often (LinkedIn outreach, ordering on Amazon, filing expenses, etc.). Each skill teaches the agent the selectors, flows, and edge cases it would otherwise have to rediscover.
 
-- **Skills are off by default.** Domain skills are opt-in via `BH_DOMAIN_SKILLS=1` (set it before invoking `browser-harness`). The directory is community-curated and quality varies — defaulting off keeps the average run unaffected while preserving the contribution loop.
+- **Skills are off by default.** Domain skills are opt-in via `BH_DOMAIN_SKILLS=1` (set it before invoking `browser-harness`). The directory remains the place to contribute and browse skills.
 - **Skills are written by the harness, not by you.** Just run your task with the agent — when it figures something non-obvious out, it files the skill itself (see [SKILL.md](SKILL.md)). Please don't hand-author skill files; agent-generated ones reflect what actually works in the browser.
 - Open a PR with the generated `agent-workspace/domain-skills/<site>/` folder — small and focused is great.
 - Bug fixes, docs tweaks, and helper improvements are equally welcome.

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,9 @@ description: Direct browser control via CDP. Use when the user wants to automate
 
 # browser-harness
 
-Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py` and `agent-workspace/domain-skills/`. For setup, install, or connection problems, read install.md.
+Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py`. For setup, install, or connection problems, read install.md.
+
+Domain skills (community-contributed per-site playbooks under `agent-workspace/domain-skills/`) are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.
 
 ## Usage
 
@@ -22,10 +24,6 @@ print(page_info())
 
 Available interaction skills:
 - interaction-skills/connection.md — startup sequence, tab visibility, omnibox popup fix
-
-Available domain skills:
-- tiktok/upload.md
-- polymarket/scraping.md
 
 ## Tool call shape
 
@@ -60,11 +58,9 @@ start_remote_daemon prints liveUrl and auto-opens it in the local browser (if a 
 
 Profiles (cookies-only login state) live in interaction-skills/profile-sync.md — covers list_cloud_profiles(), the chat-driven "which profile?" pattern, and sync_local_profile() for uploading a local Chrome profile.
 
-## Search first
+## Interaction skills
 
-Search `agent-workspace/domain-skills/` first for the domain you are working on before inventing a new approach.
-
-Only if you start struggling with a specific mechanic while navigating, look in interaction-skills/ for helpers. The available interaction skills are:
+If you start struggling with a specific mechanic while navigating, look in interaction-skills/ for helpers. They cover reusable UI mechanics like dialogs, tabs, dropdowns, iframes, and uploads. The available interaction skills are:
 - cookies.md
 - cross-origin-iframes.md
 - dialogs.md
@@ -81,44 +77,6 @@ Only if you start struggling with a specific mechanic while navigating, look in 
 - tabs.md
 - uploads.md
 - viewport.md
-
-Useful commands:
-
-```bash
-rg --files agent-workspace/domain-skills
-rg -n "tiktok|upload" agent-workspace/domain-skills
-```
-
-## Always contribute back
-
-If you learned anything non-obvious about how a site works, open a PR to `agent-workspace/domain-skills/<site>/` before you finish. Default to contributing. The harness gets better only because agents file what they learn. If figuring something out cost you a few steps, the next run should not pay the same tax.
-
-Examples of what's worth a PR:
-
-- A private API the page calls (XHR/fetch endpoint, request shape, auth) — often 10× faster than DOM scraping.
-- A stable selector that beats the obvious one, or an obfuscated CSS-module class to avoid.
-- A framework quirk — "the dropdown is a React combobox that only commits on Escape", "this Vue list only renders rows inside its own scroll container, so scrollIntoView on the row doesn't work — you have to scroll the container".
-- A URL pattern — direct route, required query params (?lang=en, ?th=1), a variant that skips a loader.
-- A wait that wait_for_load() misses, with the reason.
-- A trap — stale drafts, legacy IDs that now return null, unicode quirks, beforeunload dialogs, CAPTCHA surfaces.
-
-### What a domain skill should capture
-
-The *durable* shape of the site — the map, not the diary. Focus on what the next agent on this site needs to know before it starts:
-
-- URL patterns and query params.
-- Private APIs and their payload shape.
-- Stable selectors (data-*, aria-*, role, semantic classes).
-- Site structure — containers, items per page, framework, where state lives.
-- Framework/interaction quirks unique to this site.
-- Waits and the reasons they're needed.
-- Traps and the selectors that *don't* work.
-
-### Do not write
-
-- Raw pixel coordinates. They break on viewport, zoom, and layout changes. Describe how to *locate* the target (selector, scrollIntoView, aria-label, visible text) — never where it happened to be on your screen.
-- Run narration or step-by-step of the specific task you just did.
-- Secrets, cookies, session tokens, user-specific state. `agent-workspace/domain-skills/` is shared and public.
 
 ## What actually works
 
@@ -155,7 +113,44 @@ The *durable* shape of the site — the map, not the diary. Focus on what the ne
 - Prefer compositor-level actions over framework hacks. Try screenshots, coordinate clicks, and raw key input before adding DOM-specific workarounds.
 - If you need framework-specific DOM tricks, check interaction-skills/ first. That is where dropdown, dialog, iframe, shadow DOM, and form-specific guidance belongs.
 
-## Interaction notes
+## Domain skills (opt-in)
 
-- interaction-skills/ holds reusable UI mechanics such as dialogs, tabs, dropdowns, iframes, and uploads.
-- `agent-workspace/domain-skills/` holds site-specific workflows and should be updated when you discover reusable patterns for a website.
+This section only applies when `BH_DOMAIN_SKILLS=1` is set. Otherwise ignore it — `agent-workspace/domain-skills/` is dormant and `goto_url` will not surface skill files.
+
+When enabled, search `agent-workspace/domain-skills/` first for the domain you are working on before inventing a new approach. `goto_url` also returns up to 10 skill filenames for the navigated host.
+
+Useful commands:
+
+```bash
+rg --files agent-workspace/domain-skills
+rg -n "tiktok|upload" agent-workspace/domain-skills
+```
+
+If you learned anything non-obvious about how a site works, open a PR to `agent-workspace/domain-skills/<site>/` before you finish. Default to contributing. The harness gets better only because agents file what they learn. If figuring something out cost you a few steps, the next run should not pay the same tax.
+
+Examples of what's worth a PR:
+
+- A private API the page calls (XHR/fetch endpoint, request shape, auth) — often 10× faster than DOM scraping.
+- A stable selector that beats the obvious one, or an obfuscated CSS-module class to avoid.
+- A framework quirk — "the dropdown is a React combobox that only commits on Escape", "this Vue list only renders rows inside its own scroll container, so scrollIntoView on the row doesn't work — you have to scroll the container".
+- A URL pattern — direct route, required query params (?lang=en, ?th=1), a variant that skips a loader.
+- A wait that wait_for_load() misses, with the reason.
+- A trap — stale drafts, legacy IDs that now return null, unicode quirks, beforeunload dialogs, CAPTCHA surfaces.
+
+### What a domain skill should capture
+
+The *durable* shape of the site — the map, not the diary. Focus on what the next agent on this site needs to know before it starts:
+
+- URL patterns and query params.
+- Private APIs and their payload shape.
+- Stable selectors (data-*, aria-*, role, semantic classes).
+- Site structure — containers, items per page, framework, where state lives.
+- Framework/interaction quirks unique to this site.
+- Waits and the reasons they're needed.
+- Traps and the selectors that *don't* work.
+
+### Do not write
+
+- Raw pixel coordinates. They break on viewport, zoom, and layout changes. Describe how to *locate* the target (selector, scrollIntoView, aria-label, visible text) — never where it happened to be on your screen.
+- Run narration or step-by-step of the specific task you just did.
+- Secrets, cookies, session tokens, user-specific state. `agent-workspace/domain-skills/` is shared and public.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -162,6 +162,8 @@ def _has_return_statement(expression):
 # --- navigation / page ---
 def goto_url(url):
     r = cdp("Page.navigate", url=url)
+    if os.environ.get("BH_DOMAIN_SKILLS") != "1":
+        return r
     d = (AGENT_WORKSPACE / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0])
     return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]} if d.is_dir() else r
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -28,6 +28,39 @@ def test_max_dim_default_is_no_resize(fake_png):
     assert _run(fake_png, 4592, 2286) == (4592, 2286)
 
 
+def _seed_skill(tmp_path):
+    site = tmp_path / "domain-skills" / "example"
+    site.mkdir(parents=True)
+    (site / "scraping.md").write_text("hi")
+
+
+def test_goto_url_omits_domain_skills_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("BH_DOMAIN_SKILLS", raising=False)
+    monkeypatch.setattr(helpers, "AGENT_WORKSPACE", tmp_path)
+    _seed_skill(tmp_path)
+    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}):
+        result = helpers.goto_url("https://www.example.com/")
+    assert result == {"frameId": "f"}
+
+
+def test_goto_url_includes_domain_skills_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("BH_DOMAIN_SKILLS", "1")
+    monkeypatch.setattr(helpers, "AGENT_WORKSPACE", tmp_path)
+    _seed_skill(tmp_path)
+    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}):
+        result = helpers.goto_url("https://www.example.com/")
+    assert result == {"frameId": "f", "domain_skills": ["scraping.md"]}
+
+
+def test_goto_url_zero_value_keeps_domain_skills_off(tmp_path, monkeypatch):
+    monkeypatch.setenv("BH_DOMAIN_SKILLS", "0")
+    monkeypatch.setattr(helpers, "AGENT_WORKSPACE", tmp_path)
+    _seed_skill(tmp_path)
+    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}):
+        result = helpers.goto_url("https://www.example.com/")
+    assert "domain_skills" not in result
+
+
 def test_page_info_raises_clear_error_on_js_exception():
     def fake_send(req):
         return {}

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -52,15 +52,6 @@ def test_goto_url_includes_domain_skills_when_enabled(tmp_path, monkeypatch):
     assert result == {"frameId": "f", "domain_skills": ["scraping.md"]}
 
 
-def test_goto_url_zero_value_keeps_domain_skills_off(tmp_path, monkeypatch):
-    monkeypatch.setenv("BH_DOMAIN_SKILLS", "0")
-    monkeypatch.setattr(helpers, "AGENT_WORKSPACE", tmp_path)
-    _seed_skill(tmp_path)
-    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}):
-        result = helpers.goto_url("https://www.example.com/")
-    assert "domain_skills" not in result
-
-
 def test_page_info_raises_clear_error_on_js_exception():
     def fake_send(req):
         return {}


### PR DESCRIPTION
## Summary

- Domain skills auto-injected by `goto_url()` are now off by default; set `BH_DOMAIN_SKILLS=1` to opt in.
- `SKILL.md` and `README.md` updated so the core (off-by-default) doc has no skill mentions, and all skill-related instructions live in a single `## Domain skills (opt-in)` section gated by the env var.
- 3 new unit tests cover the gate (off by default, on with `=1`, off with `=0`).

## Why

Domain skills are community-contributed and quality varies 

## Scope

- Only `goto_url`'s skill enumeration is gated. `interaction-skills/` (17 internally-maintained UI mechanics) is unchanged — different threat profile, no auto-injection.
- No code-side migration: existing setups that rely on the previous behavior just need to set `BH_DOMAIN_SKILLS=1`.

## Tests

```
tests/unit/test_helpers.py ........... 7 passed
```
