### PR TITLE
harden Windows IPC: ping handshake, token auth, atomic port file

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -9,4 +9,5 @@
 #   - Optional reason after a space following the handle.
 
 molesza
+rohitdutt108
 shaunandrewjackson1977

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -1,5 +1,5 @@
 """Daemon IPC plumbing. AF_UNIX socket on POSIX, TCP loopback on Windows."""
-import asyncio, os, re, socket, subprocess, sys, tempfile
+import asyncio, json, os, re, secrets, socket, subprocess, sys, tempfile
 from pathlib import Path
 
 IS_WINDOWS = sys.platform == "win32"
@@ -11,6 +11,12 @@ BH_TMP_DIR = os.environ.get("BH_TMP_DIR")
 _TMP = Path(BH_TMP_DIR or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
 _TMP.mkdir(parents=True, exist_ok=True)
 _NAME_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
+
+# Set by serve() on Windows. Daemon's handle() requires every request to carry
+# this token (TCP loopback has no chmod-equivalent so any local process could
+# otherwise issue CDP commands). Stays None on POSIX where AF_UNIX + chmod 600
+# is the boundary.
+_server_token = None
 
 
 def _check(name):  # path-traversal guard for BU_NAME
@@ -26,14 +32,23 @@ def _stem(name):  # "bu" when BH_TMP_DIR isolates us, else "bu-<NAME>"
 
 def log_path(name):   return _TMP / f"{_stem(name)}.log"
 def pid_path(name):   return _TMP / f"{_stem(name)}.pid"
-def port_path(name):  return _TMP / f"{_stem(name)}.port"  # Windows-only: holds the daemon's TCP port
+def port_path(name):  return _TMP / f"{_stem(name)}.port"  # Windows-only: holds {"port","token"} JSON
 def _sock_path(name): return _TMP / f"{_stem(name)}.sock"
+
+
+def _read_port_file(name):
+    """(port, token) from the Windows port file, or (None, None) on any failure."""
+    try:
+        d = json.loads(port_path(name).read_text())
+        return int(d["port"]), d["token"]
+    except (FileNotFoundError, ValueError, KeyError, TypeError, OSError):
+        return None, None
 
 
 def sock_addr(name):  # display-only, used in log lines
     if not IS_WINDOWS: return str(_sock_path(name))
-    try: return f"127.0.0.1:{port_path(name).read_text().strip()}"
-    except FileNotFoundError: return f"tcp:{_stem(name)}"
+    port, _ = _read_port_file(name)
+    return f"127.0.0.1:{port}" if port else f"tcp:{_stem(name)}"
 
 
 def spawn_kwargs():  # subprocess.Popen flags so the daemon detaches from this terminal
@@ -48,34 +63,77 @@ def spawn_kwargs():  # subprocess.Popen flags so the daemon detaches from this t
 
 
 def connect(name, timeout=1.0):
-    """Blocking client. Raises FileNotFoundError if no daemon, TimeoutError on connect timeout."""
+    """Blocking client. Returns (sock, token); token is None on POSIX, hex string on Windows.
+    Callers sending JSON requests MUST include the token as req["token"] on Windows."""
     if not IS_WINDOWS:
         # uv-Python on Windows lacks socket.AF_UNIX, so this branch must be gated.
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(timeout); s.connect(str(_sock_path(name))); return s
-    try: port = int(port_path(name).read_text().strip())
-    except (FileNotFoundError, ValueError): raise FileNotFoundError(str(port_path(name)))
+        s.settimeout(timeout); s.connect(str(_sock_path(name))); return s, None
+    port, token = _read_port_file(name)
+    if port is None: raise FileNotFoundError(str(port_path(name)))
     s = socket.create_connection(("127.0.0.1", port), timeout=timeout)
-    s.settimeout(timeout); return s
+    s.settimeout(timeout); return s, token
+
+
+def request(c, token, req):
+    """One-shot send + recv + parse on an open socket. Injects token on Windows.
+    Returns the parsed JSON response. Caller closes the socket."""
+    if token: req = {**req, "token": token}
+    c.sendall((json.dumps(req) + "\n").encode())
+    data = b""
+    while not data.endswith(b"\n"):
+        chunk = c.recv(1 << 16)
+        if not chunk: break
+        data += chunk
+    return json.loads(data or b"{}")
+
+
+def ping(name, timeout=1.0):
+    """True iff a live daemon answers our ping. Defends against stale .port files
+    + port reuse: a bare TCP connect can succeed against an unrelated process that
+    grabbed the port after our daemon crashed; only our daemon answers {"pong":true}."""
+    try:
+        c, token = connect(name, timeout=timeout)
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
+        return False
+    try:
+        return request(c, token, {"meta": "ping"}).get("pong") is True
+    except (OSError, ValueError):
+        return False
+    finally:
+        try: c.close()
+        except OSError: pass
 
 
 async def serve(name, handler):
     """Run the server until cancelled. handler(reader, writer) sees the same interface either way."""
+    global _server_token
     if not IS_WINDOWS:
         path = str(_sock_path(name))
         if os.path.exists(path): os.unlink(path)
         server = await asyncio.start_unix_server(handler, path=path)
         os.chmod(path, 0o600)
+        _server_token = None
         async with server: await asyncio.Event().wait()
         return
     server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    _server_token = secrets.token_hex(32)
     pf = port_path(name)
-    pf.write_text(str(server.sockets[0].getsockname()[1]))  # so clients can find us
+    # Atomic write so a concurrent reader never sees a half-written file.
+    tmp = pf.with_name(pf.name + ".tmp")
+    tmp.write_text(json.dumps({"port": port, "token": _server_token}))
+    os.replace(tmp, pf)
     try:
         async with server: await asyncio.Event().wait()
     finally:
         try: pf.unlink()
         except FileNotFoundError: pass
+
+
+def expected_token():
+    """The token the running daemon will accept, or None on POSIX."""
+    return _server_token
 
 
 def cleanup_endpoint(name):  # best-effort; silent if already gone

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -69,10 +69,9 @@ def _is_local_chrome_mode(env=None):
 
 
 def daemon_alive(name=None):
-    try:
-        c = ipc.connect(name or NAME, timeout=1.0); c.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
-        return False
+    # Ping handshake (not a bare connect) so a stale .port file + port reuse
+    # after a daemon crash doesn't make us mistake an unrelated listener for ours.
+    return ipc.ping(name or NAME, timeout=1.0)
 
 
 def _daemon_endpoint_names():
@@ -97,15 +96,8 @@ def _daemon_endpoint_names():
 def _daemon_browser_connection(name):
     c = None
     try:
-        c = ipc.connect(name, timeout=1.0)
-        c.sendall(b'{"meta":"connection_status"}\n')
-        data = b""
-        while not data.endswith(b"\n"):
-            chunk = c.recv(1 << 16)
-            if not chunk:
-                break
-            data += chunk
-        response = json.loads(data)
+        c, token = ipc.connect(name, timeout=1.0)
+        response = ipc.request(c, token, {"meta": "connection_status"})
         if "error" in response:
             return None
         page = response.get("page")
@@ -148,14 +140,9 @@ def ensure_daemon(wait=60.0, name=None, env=None, _open_inspect=True):
         # Must go through ipc.connect so this works on Windows (TCP loopback) too;
         # raw AF_UNIX here would fail on every warm call and churn the daemon.
         try:
-            s = ipc.connect(name or NAME, timeout=3.0)
-            s.sendall(b'{"method":"Target.getTargets","params":{}}\n')
-            data = b""
-            while not data.endswith(b"\n"):
-                chunk = s.recv(1 << 16)
-                if not chunk: break
-                data += chunk
-            if b'"result"' in data: return
+            s, token = ipc.connect(name or NAME, timeout=3.0)
+            resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
+            if "result" in resp: return
         except Exception: pass
         restart_daemon(name)
 
@@ -206,9 +193,8 @@ def restart_daemon(name=None):
 
     pid_path = str(ipc.pid_path(name or NAME))
     try:
-        c = ipc.connect(name or NAME, timeout=5.0)
-        c.sendall(b'{"meta":"shutdown"}\n')
-        c.recv(1024)
+        c, token = ipc.connect(name or NAME, timeout=5.0)
+        ipc.request(c, token, {"meta": "shutdown"})
         c.close()
     except Exception:
         pass

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -210,7 +210,16 @@ class Daemon:
         self.cdp._event_registry.handle_event = tap
 
     async def handle(self, req):
+        # Token guard for Windows TCP loopback: any local process can otherwise
+        # connect and issue CDP commands. expected_token() is None on POSIX so
+        # this check is a no-op there (AF_UNIX + chmod 600 is the boundary).
+        expected = ipc.expected_token()
+        if expected is not None and req.get("token") != expected:
+            return {"error": "unauthorized"}
         meta = req.get("meta")
+        # Liveness probe — lets clients confirm the listener is actually this
+        # daemon and not an unrelated process that reused our port post-crash.
+        if meta == "ping":        return {"pong": True}
         if meta == "drain_events":
             out = list(self.events); self.events.clear()
             return {"events": out}
@@ -297,10 +306,9 @@ async def main():
 
 
 def already_running():
-    try:
-        c = ipc.connect(NAME, timeout=1.0); c.close(); return True
-    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
-        return False
+    # Ping handshake (not a bare connect) so a stale .port file + port reuse
+    # after a daemon crash doesn't make us mistake an unrelated listener for ours.
+    return ipc.ping(NAME, timeout=1.0)
 
 
 if __name__ == "__main__":

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -40,15 +40,11 @@ INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension
 
 
 def _send(req):
-    c = ipc.connect(NAME, timeout=5.0)
-    c.sendall((json.dumps(req) + "\n").encode())
-    data = b""
-    while not data.endswith(b"\n"):
-        chunk = c.recv(1 << 20)
-        if not chunk: break
-        data += chunk
-    c.close()
-    r = json.loads(data)
+    c, token = ipc.connect(NAME, timeout=5.0)
+    try:
+        r = ipc.request(c, token, req)
+    finally:
+        c.close()
     if "error" in r: raise RuntimeError(r["error"])
     return r
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -86,8 +86,8 @@ def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch):
         if name == "stale":
             raise ConnectionRefusedError()
         if name == "remote":
-            return FakeSocket(b'{"error":"no close frame received or sent"}\n')
-        return FakeSocket()
+            return FakeSocket(b'{"error":"no close frame received or sent"}\n'), None
+        return FakeSocket(), None
 
     monkeypatch.setattr(admin.ipc, "connect", fake_connect)
 
@@ -99,8 +99,8 @@ def test_active_browser_connections_skips_daemons_reporting_cdp_disconnected(mon
 
     def fake_connect(name, timeout=1.0):
         if name == "stale":
-            return FakeSocket(b'{"error":"cdp_disconnected"}\n')
-        return FakeSocket()
+            return FakeSocket(b'{"error":"cdp_disconnected"}\n'), None
+        return FakeSocket(), None
 
     monkeypatch.setattr(admin.ipc, "connect", fake_connect)
 
@@ -113,7 +113,7 @@ def test_browser_connections_returns_attached_page(monkeypatch):
         b'{"target_id":"target-1","session_id":"session-1",'
         b'"page":{"targetId":"target-1","title":"Cat - Wikipedia","url":"https://en.wikipedia.org/wiki/Cat"}}\n'
     )
-    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: FakeSocket(response))
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: (FakeSocket(response), None))
 
     assert admin.browser_connections() == [
         {


### PR DESCRIPTION
Three improvements to the cross-platform IPC layer, lifted from #104 (thanks @rohitdutt108).

## Changes

**1. `meta:"ping"` handshake replaces bare TCP connect.**
On Windows, `daemon_alive()` and `already_running()` previously did `connect; close; return True`. If the daemon crashes and the OS reuses its ephemeral port for an unrelated listener, that bare connect succeeds against the wrong process and we skip spawning a new daemon. Now both call `ipc.ping(name)`, which sends `{"meta":"ping"}` and requires `{"pong": true}` back — only our daemon answers that.

**2. Per-daemon random token gates every request on Windows.**
`secrets.token_hex(32)` generated at server start, written into the `.port` file as JSON `{"port", "token"}`. `daemon.handle()` rejects requests where `req.get("token") != expected`. AF_UNIX + `chmod 600` is the boundary on POSIX, but TCP loopback has no chmod-equivalent — without a token any local process on the same machine can connect to the daemon and issue CDP commands. The check is a no-op on POSIX (`expected_token()` returns `None` there).

**3. Atomic `.port` write.**
Write `bu-<NAME>.port.tmp`, then `os.replace`. A concurrent reader never sees a half-written file.

## API change

`ipc.connect(name)` now returns `(sock, token)` instead of `sock`. Token is `None` on POSIX, a hex string on Windows. New helper `ipc.request(c, token, req)` does the canonical send + recv + parse round-trip and injects the token on Windows; most call sites collapsed to one line.

## Migration note

Windows users with an old daemon running (bare-int `.port` file) will see the upgraded harness fail to parse it as JSON, treat it as "no daemon", and spawn a fresh one. The old daemon stays orphaned on its port until reboot or `taskkill`. Per the "no backwards compat" rule no fallback parser was added — Windows users may need to `taskkill` once after upgrading.

## Tested

- `pytest tests/unit -x -q` — 29 passed.
- Live token round-trip on Windows: token-gated request returns `{"pong": true}`, missing-token request returns `{"error": "unauthorized"}`, `ipc.ping` returns True against a live daemon and False against a missing one.
- `browser-harness --doctor` runs end-to-end on Windows.
- POSIX paths unchanged behaviorally (token always `None`, ping endpoint added).

## Credit

@rohitdutt108 is the original author of #104, which independently proposed the same improvements (and a few others). Adding him to `.github/VOUCHED.td` and crediting via `Co-authored-by:` in the commit.
