### PR TITLE
fix(run): make cloud auto-bootstrap opt-in via BU_AUTOSPAWN

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -85,7 +85,15 @@ def main():
     if len(args) < 2:
         sys.exit("Usage: browser-harness -c \"print(page_info())\"")
     print_update_banner()
-    if not daemon_alive() and not _local_chrome_listening() and os.environ.get("BROWSER_USE_API_KEY"):
+    # Auto-bootstrap a cloud browser is opt-in via BU_AUTOSPAWN — BROWSER_USE_API_KEY alone
+    # is not enough, since the key is commonly set for unrelated reasons (profile sync,
+    # cloud API calls, parent agents managing their own session).
+    if (
+        not daemon_alive()
+        and not _local_chrome_listening()
+        and os.environ.get("BROWSER_USE_API_KEY")
+        and os.environ.get("BU_AUTOSPAWN")
+    ):
         start_remote_daemon(NAME)
     ensure_daemon()
     exec(args[1], globals())


### PR DESCRIPTION
## Summary

[#266](https://github.com/browser-use/browser-harness/pull/266) made `browser-harness -c '...'` auto-provision a Browser Use cloud browser whenever `BROWSER_USE_API_KEY` was set and no local Chrome / daemon was alive. That gating signal is too broad — the API key is commonly set for unrelated reasons (profile sync, cloud API calls, parent agents managing their own session), so users with the key in env quietly got a *new* (billed) browser spawned every time they ran a script.

Make auto-bootstrap opt-in via **`BU_AUTOSPAWN`** (any non-empty value). Setting it alongside `BROWSER_USE_API_KEY` restores #266's "fresh headless box just works" behaviour. Anyone who only had the API key set for other reasons is no longer surprised by a billed spawn.

### Migration note for users on >= #266

If your workflow was a fresh box with just `BROWSER_USE_API_KEY` exported and you relied on the auto-spawn, add `export BU_AUTOSPAWN=1` to keep the same behaviour.

Refs #181, #183, #266.

## Test plan

- [x] `BU_AUTOSPAWN` set + `BROWSER_USE_API_KEY` set + no daemon + no local Chrome → spawns cloud browser (#266 path preserved)
- [x] `BU_AUTOSPAWN` unset + `BROWSER_USE_API_KEY` set + no daemon → no spawn, falls through to `ensure_daemon()`
- [ ] Local-Chrome path with `_local_chrome_listening()` true → unchanged (no code touched there)