### PR TITLE
feat: discover Dia browser profile on macOS

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -36,6 +36,7 @@ PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
     Path.home() / "Library/Application Support/Comet",
     Path.home() / "Library/Application Support/Arc/User Data",
+    Path.home() / "Library/Application Support/Dia/User Data",
     Path.home() / "Library/Application Support/Microsoft Edge",
     Path.home() / "Library/Application Support/Microsoft Edge Beta",
     Path.home() / "Library/Application Support/Microsoft Edge Dev",


### PR DESCRIPTION
## Summary

Adds `~/Library/Application Support/Dia/User Data` to the macOS profile discovery list so browser-harness can attach to [Dia](https://www.diabrowser.com/) without any extra setup.

## Why

Dia is a Chromium-based browser by The Browser Company (same makers as Arc). Unlike vanilla Chrome, it ships with CDP enabled by default — its `DevToolsActivePort` file is live on first launch — so no `chrome://inspect` opt-in is needed. Just adding the path makes attach work end-to-end.

Placed next to Arc since both are Browser Company products. Chrome remains first in the discovery order, so existing behavior is unchanged.

## Test plan

- [x] Installed editable, attached to a running Dia instance via `browser-harness -c 'print(page_info())'`
- [x] Verified UA reports Chromium 147 (Dia's underlying engine)
- [x] Opened a new tab and navigated with `new_tab(...)` — works through the same code path as Chrome
- [x] Confirmed Chrome still wins discovery when both browsers are running (Chrome remains first in `PROFILES`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `~/Library/Application Support/Dia/User Data` to macOS profile discovery so `browser-harness` can attach to Dia without any setup. Chrome stays first in the discovery order, so existing behavior is unchanged.

<sup>Written for commit edbb438930a90c8b12ae5c1db2639bff2635836d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

