### PR TITLE
fix(daemon): add Brave Browser's Windows path to PROFILES discovery

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -58,6 +58,7 @@ PROFILES = [
     Path.home() / "AppData/Local/Microsoft/Edge Beta/User Data",
     Path.home() / "AppData/Local/Microsoft/Edge Dev/User Data",
     Path.home() / "AppData/Local/Microsoft/Edge SxS/User Data",
+    Path.home() / "AppData/Local/BraveSoftware/Brave-Browser/User Data",
 ]
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"


### PR DESCRIPTION
## Summary

`PROFILES` in `src/browser_harness/daemon.py` already covers Brave on macOS (`Library/Application Support/BraveSoftware/Brave-Browser`) and Linux Flatpak (`.var/app/com.brave.Browser/...`), but is missing the standard Windows install path.

As a result, "Way 1" connection (the `chrome://inspect/#remote-debugging` checkbox flow described in `install.md`) fails on Windows + Brave with `DevToolsActivePort not found`, even when the user has correctly enabled remote debugging and `DevToolsActivePort` is being written by Brave.

This PR adds:

```py
Path.home() / "AppData/Local/BraveSoftware/Brave-Browser/User Data",
```

to the Windows section of `PROFILES`, mirroring the macOS/Linux Brave entries already present.

## Reproduction (before this patch)

1. On Windows + Brave, enable remote debugging via `brave://inspect/#remote-debugging`
2. Run any `browser-harness` command
3. Discovery fails with `DevToolsActivePort not found in [...]` — the search list omits Brave's Windows path

## After this patch

Verified locally: `browser-harness -c 'print(page_info())'` correctly attaches to Brave on Windows 11 via Way 1 once the user dismisses the M144 "Allow remote debugging?" popup.

## Possible follow-up (not in this PR)

- The `--doctor` `chrome running` probe also doesn't recognize `brave.exe` on Windows, leading to a misleading FAIL line even when an active connection is established. Happy to send a separate PR if of interest.

## Test plan

- [x] On Windows + Brave (the case this fixes): attach succeeds via Way 1
- [ ] Confirm no regression on macOS Brave / Linux Brave (path list is additive)
- [ ] Confirm no regression on Windows Chrome / Edge (those entries are untouched)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Brave Browser’s Windows profile path to `PROFILES` so discovery works on Windows Brave when using Way 1 (`chrome://inspect/#remote-debugging`). Fixes “DevToolsActivePort not found” errors.

<sup>Written for commit 3b02d8103ef1a7ac5007400ea6c2ca7489190860. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

