### PR TITLE
Animate README banner with ink-bleed SVG reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://r2.browser-use.com/github/ajsdlasnnalsgasld.png" alt="Browser Harness" width="100%" />
+<img src="https://raw.githubusercontent.com/browser-use/media/main/browser-harness/banner-ink.svg" alt="Browser Harness" width="100%" />
 
 # Browser Harness ♞
 


### PR DESCRIPTION
Swaps the static banner PNG for an animated SVG hosted in browser-use/media.

- 1 s transparent hold so the user has time to scroll to it
- 10 s ink-bleed reveal driven by feTurbulence + feDisplacementMap on a mask
- File size comparable to the original PNG; same width=100% layout
- Asset: https://raw.githubusercontent.com/browser-use/media/main/browser-harness/banner-ink.svg

One-line change in README.md.