### PR TITLE
fix(admin): recognize Brave in _chrome_running process check

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -498,16 +498,16 @@ def print_update_banner(out=None):
 
 
 def _chrome_running():
-    """Cross-platform best-effort check for a running Chrome/Edge process."""
+    """Cross-platform best-effort check for a running Chromium-based browser process."""
     import platform, subprocess
     system = platform.system()
     try:
         if system == "Windows":
             out = subprocess.check_output(["tasklist"], text=True, timeout=5)
-            names = ("chrome.exe", "msedge.exe")
+            names = ("chrome.exe", "msedge.exe", "brave.exe")
         else:
             out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, timeout=5)
-            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge")
+            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "Brave Browser", "brave-browser", "brave")
         return any(n.lower() in out.lower() for n in names)
     except Exception:
         return False

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -20,6 +20,22 @@ class FakeSocket:
         self.closed = True
 
 
+def test_chrome_running_detects_brave_on_windows(monkeypatch):
+    import platform, subprocess
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **kw: "Image Name\nbrave.exe                  1234 Console\n")
+
+    assert admin._chrome_running()
+
+
+def test_chrome_running_detects_brave_on_posix(monkeypatch):
+    import platform, subprocess
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **kw: "init\nbrave-browser\nbash\n")
+
+    assert admin._chrome_running()
+
+
 def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():
     assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
 


### PR DESCRIPTION
## What

`browser-harness --doctor` shows a misleading `[FAIL] chrome running — start chrome/edge` line on machines where Brave is the only Chromium-based browser running, even when the harness has connected to Brave successfully. The actual connection logic in `daemon.get_ws_url()` already discovers Brave's user-data-dir (added in #284), so users see a healthy active connection alongside a contradictory "no chrome" failure.

The cause is `_chrome_running()` in `admin.py`: its process-name allowlist is `("chrome.exe", "msedge.exe")` on Windows and `("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge")` on POSIX — neither set matches Brave's process names.

## Change

- `_chrome_running()`: add `brave.exe` (Windows) and `Brave Browser`, `brave-browser`, `brave` (macOS / Linux) to the recognized set
- Broaden docstring from "Chrome/Edge" to "Chromium-based browser"

## Tests

- New `test_chrome_running_detects_brave_on_windows` — monkeypatches `platform.system` + `subprocess.check_output`, asserts `_chrome_running()` returns `True`
- New `test_chrome_running_detects_brave_on_posix` — same shape, Linux output with `brave-browser`
- Both fail against the unmodified code (verified RED before the production change)
- 42/42 unit tests pass after the fix

## Context

Follow-up to #284, which made Brave's user-data-dir discoverable by the daemon's `get_ws_url()`. With #284 in place, Brave connects fine but `--doctor` still mis-reports `chrome running`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the misleading "[FAIL] chrome running" in `browser-harness --doctor` when Brave is the active browser. The doctor check now recognizes Brave, so its output matches the actual connection.

- **Bug Fixes**
  - Recognize Brave in `admin._chrome_running()`: `brave.exe` (Windows) and `Brave Browser`, `brave-browser`, `brave` (macOS/Linux).
  - Broaden docstring to “Chromium-based browser”.
  - Add unit tests for Brave detection on Windows and POSIX.

<sup>Written for commit e612f148c3f93b099b70c17f4982faed384fd75e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

