### PR TITLE
fix(daemon): fall back to DevToolsActivePort when BU_CDP_URL returns 404

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -85,6 +85,8 @@ def _ws_from_devtools_active_port(http_url: str) -> str | None:
     if not want_port:
         return None
     host = p.hostname or "127.0.0.1"
+    if ":" in host:  # urlparse strips IPv6 brackets; restore them for the ws:// URL
+        host = f"[{host}]"
     for base in PROFILES:
         try:
             active = (base / "DevToolsActivePort").read_text().splitlines()

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,5 +1,6 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
 import asyncio, json, os, socket, sys, time, urllib.error, urllib.request
+from urllib.parse import urlparse
 from collections import deque
 from pathlib import Path
 
@@ -77,6 +78,25 @@ async def _silent(coro):
         pass
 
 
+def _ws_from_devtools_active_port(http_url: str) -> str | None:
+    """When /json/version returns 404 (Chrome 147+ default profile), match DevToolsActivePort by port."""
+    p = urlparse(http_url)
+    want_port = str(p.port) if p.port else ""
+    if not want_port:
+        return None
+    host = p.hostname or "127.0.0.1"
+    for base in PROFILES:
+        try:
+            active = (base / "DevToolsActivePort").read_text().splitlines()
+        except (FileNotFoundError, NotADirectoryError):
+            continue
+        port = active[0].strip() if active else ""
+        ws_path = active[1].strip() if len(active) > 1 else ""
+        if port == want_port and ws_path:
+            return f"ws://{host}:{port}{ws_path}"
+    return None
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
@@ -86,9 +106,15 @@ def get_ws_url():
         # M144 "Allow remote debugging" dialog and the M136 default-profile lockdown.
         deadline = time.time() + 30
         last_err = None
+        base_url = url.rstrip("/")
         while time.time() < deadline:
             try:
-                return json.loads(urllib.request.urlopen(f"{url}/json/version", timeout=5).read())["webSocketDebuggerUrl"]
+                return json.loads(urllib.request.urlopen(f"{base_url}/json/version", timeout=5).read())["webSocketDebuggerUrl"]
+            except urllib.error.HTTPError as e:
+                last_err = e
+                if e.code == 404 and (ws := _ws_from_devtools_active_port(url)):
+                    return ws
+                time.sleep(1)
             except Exception as e:
                 last_err = e
                 time.sleep(1)


### PR DESCRIPTION
## Summary
- Handles HTTP 404 from `{BU_CDP_URL}/json/version` the same way profile discovery does: resolve the WebSocket URL from `DevToolsActivePort` under known profile roots.
- Parses host/port with `urlparse` and matches the `DevToolsActivePort` file whose first line equals that port (avoids attaching to the wrong browser when multiple profiles exist).

## Context
Chrome 147+ disables `/json/*` HTTP discovery for the default profile in some setups; `BU_CDP_URL` previously retried for 30s and failed with a generic unreachable error.

## Related
Closes #291

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fallback to `DevToolsActivePort` when `BU_CDP_URL` `/json/version` returns 404 to reliably discover the CDP WebSocket. This prevents 30s timeouts and fixes connection failures on Chrome 147+ default profiles.

- **Bug Fixes**
  - Parse host/port from `BU_CDP_URL` and select the `DevToolsActivePort` whose first line matches that port to avoid attaching to the wrong profile.
  - On 404 only, build `ws://{host}:{port}{path}` from `DevToolsActivePort`; keep existing retry logic for other errors and handle trailing slashes.
  - Restore brackets for IPv6 hosts when building the WebSocket URL (e.g., `ws://[::1]:9333/...`) to prevent malformed URLs.

<sup>Written for commit be9316630f9cdbd09d9e9486004e8a7f4eee7d55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

