### PR TITLE
fix: verify daemon identity via IPC before signaling in restart_daemon

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -97,8 +97,12 @@ def ping(name, timeout=1.0):
     except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
         return False
     try:
-        return request(c, token, {"meta": "ping"}).get("pong") is True
-    except (OSError, ValueError):
+        resp = request(c, token, {"meta": "ping"})
+        # request() returns parsed JSON, which may be any valid value (a list,
+        # scalar, etc. from a stale or hostile endpoint). Anything that isn't
+        # a {pong: true} dict counts as "not our daemon" — never .get() blindly.
+        return isinstance(resp, dict) and resp.get("pong") is True
+    except (OSError, ValueError, AttributeError):
         return False
     finally:
         try: c.close()
@@ -126,7 +130,10 @@ def identify(name, timeout=1.0):
         # `type(pid) is int` (not isinstance) intentionally rejects bool: in
         # Python, isinstance(True, int) is True, so a hostile/buggy daemon
         # could reply with {"pid": True} and we'd treat that as PID 1 (init).
-        return pid if type(pid) is int else None
+        # Also reject 0 / negatives: os.kill(0, sig) signals every process in
+        # the calling process group; os.kill(-1, sig) signals every process
+        # the caller can. Only positive PIDs are safe to forward to os.kill.
+        return pid if type(pid) is int and pid > 0 else None
     except (OSError, ValueError, AttributeError):
         return None
     finally:

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -117,11 +117,17 @@ def identify(name, timeout=1.0):
         return None
     try:
         resp = request(c, token, {"meta": "ping"})
-        if resp.get("pong") is not True:
+        # request() returns parsed JSON, which may be any valid value (a list,
+        # scalar, etc. from a stale or hostile endpoint). Anything that isn't
+        # a {pong: true} dict gets None — never .get() on a non-dict.
+        if not isinstance(resp, dict) or resp.get("pong") is not True:
             return None
         pid = resp.get("pid")
-        return int(pid) if isinstance(pid, int) else None
-    except (OSError, ValueError):
+        # `type(pid) is int` (not isinstance) intentionally rejects bool: in
+        # Python, isinstance(True, int) is True, so a hostile/buggy daemon
+        # could reply with {"pid": True} and we'd treat that as PID 1 (init).
+        return pid if type(pid) is int else None
+    except (OSError, ValueError, AttributeError):
         return None
     finally:
         try: c.close()

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -105,6 +105,29 @@ def ping(name, timeout=1.0):
         except OSError: pass
 
 
+def identify(name, timeout=1.0):
+    """Return the live daemon's PID, or None if unreachable.
+
+    Used by restart_daemon() to signal a process whose identity has been
+    verified end-to-end (live IPC + self-reported PID), instead of trusting
+    a pid file whose number may have been reused by an unrelated process."""
+    try:
+        c, token = connect(name, timeout=timeout)
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
+        return None
+    try:
+        resp = request(c, token, {"meta": "ping"})
+        if resp.get("pong") is not True:
+            return None
+        pid = resp.get("pid")
+        return int(pid) if isinstance(pid, int) else None
+    except (OSError, ValueError):
+        return None
+    finally:
+        try: c.close()
+        except OSError: pass
+
+
 async def serve(name, handler):
     """Run the server until cancelled. handler(reader, writer) sees the same interface either way."""
     global _server_token

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -130,10 +130,13 @@ def identify(name, timeout=1.0):
         # `type(pid) is int` (not isinstance) intentionally rejects bool: in
         # Python, isinstance(True, int) is True, so a hostile/buggy daemon
         # could reply with {"pid": True} and we'd treat that as PID 1 (init).
-        # Also reject 0 / negatives: os.kill(0, sig) signals every process in
-        # the calling process group; os.kill(-1, sig) signals every process
-        # the caller can. Only positive PIDs are safe to forward to os.kill.
-        return pid if type(pid) is int and pid > 0 else None
+        # Also reject 0/negatives — os.kill(0, sig) signals every process in
+        # the calling process group, os.kill(-1, sig) signals every process
+        # the caller can. Upper bound is 2**31 because C pid_t is typically
+        # signed 32-bit and a value outside that range makes os.kill() raise
+        # OverflowError, which would propagate out of restart_daemon() before
+        # its cleanup. Linux pid_max is also bounded at 2**22 in practice.
+        return pid if type(pid) is int and 0 < pid < (1 << 31) else None
     except (OSError, ValueError, AttributeError):
         return None
     finally:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -21,12 +21,13 @@ def _process_start_time(pid):
     remote shutdown), without falling back to "trust the pid file" — which
     would re-introduce the PID-reuse hazard.
 
-    Linux: /proc/<pid>/stat field 22 (starttime in clock ticks since boot).
-    macOS: `ps -o lstart= -p <pid>` (an absolute timestamp string).
-    Other platforms: returns None; restart_daemon falls back to its strict
+    Linux:   /proc/<pid>/stat field 22 (starttime in clock ticks since boot).
+    macOS:   `ps -o lstart= -p <pid>` (an absolute timestamp string).
+    Windows: GetProcessTimes via ctypes (FILETIME creation time, 100-ns since 1601).
+    Anywhere else: returns None; restart_daemon falls back to its strict
     identify-only check, which is safer than no check at all.
     """
-    if not isinstance(pid, int) or pid <= 0:
+    if type(pid) is not int or pid <= 0:
         return None
     if sys.platform.startswith("linux"):
         try:
@@ -51,6 +52,53 @@ def _process_start_time(pid):
             return None
         s = out.decode("ascii", errors="replace").strip()
         return s or None
+    if sys.platform == "win32":
+        # Windows users running a remote daemon hit the same slow-shutdown
+        # window as POSIX (stop_remote() PATCHes api.browser-use.com after
+        # the IPC socket has been torn down). Without a fingerprint here the
+        # SIGTERM gate can never pass during that window, leaving an orphan
+        # daemon that may continue to hold a billed cloud browser. Use
+        # GetProcessTimes via ctypes to read the kernel-reported creation
+        # time as a 64-bit FILETIME (100-ns intervals since 1601-01-01).
+        try:
+            import ctypes
+            from ctypes import wintypes
+        except ImportError:
+            return None
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        try:
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+            kernel32.OpenProcess.restype = wintypes.HANDLE
+            kernel32.GetProcessTimes.argtypes = [
+                wintypes.HANDLE,
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+            ]
+            kernel32.GetProcessTimes.restype = wintypes.BOOL
+            kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+            kernel32.CloseHandle.restype = wintypes.BOOL
+        except (OSError, AttributeError):
+            return None
+        h = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not h:
+            return None
+        try:
+            creation = wintypes.FILETIME()
+            exit_ft = wintypes.FILETIME()
+            kernel_ft = wintypes.FILETIME()
+            user_ft = wintypes.FILETIME()
+            ok = kernel32.GetProcessTimes(
+                h, ctypes.byref(creation), ctypes.byref(exit_ft),
+                ctypes.byref(kernel_ft), ctypes.byref(user_ft),
+            )
+            if not ok:
+                return None
+            return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
+        finally:
+            kernel32.CloseHandle(h)
     return None
 
 

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -199,19 +199,26 @@ def restart_daemon(name=None):
     name = name or NAME
     pid_path = str(ipc.pid_path(name))
 
-    # Ask the daemon for its PID. Reaching this confirms (a) the listener
-    # at the IPC endpoint is alive AND (b) gives us the PID we'd need to
-    # signal if it doesn't exit cleanly. If we can't reach it, daemon_pid
-    # is None and we never signal.
+    # Two pieces of information are tracked separately:
+    #   - daemon_pid: the daemon's self-reported PID, or None. Only daemons
+    #     running this version (or newer) include `pid` in the ping response;
+    #     pre-upgrade daemons return {pong: True} only and yield None here.
+    #   - daemon_alive: whether ANY daemon answers ping. Keeps the shutdown
+    #     IPC path working across upgrades — without it, a still-running
+    #     pre-upgrade daemon would have its socket deleted out from under it
+    #     while the process stayed alive.
     daemon_pid = ipc.identify(name, timeout=5.0)
+    daemon_alive = daemon_pid is not None or ipc.ping(name, timeout=1.0)
 
-    if daemon_pid is not None:
+    if daemon_alive:
         try:
             c, token = ipc.connect(name, timeout=5.0)
             ipc.request(c, token, {"meta": "shutdown"})
             c.close()
         except Exception:
             pass
+
+    if daemon_pid is not None:
         for _ in range(75):
             try:
                 os.kill(daemon_pid, 0)
@@ -219,13 +226,16 @@ def restart_daemon(name=None):
             except (ProcessLookupError, OSError, SystemError):
                 break
         else:
-            # Daemon acknowledged shutdown but didn't exit in 15s — wedged.
-            # SIGTERM is safe because identify() just confirmed this PID is
-            # the live daemon, not an unrelated PID-reuse victim.
-            try:
-                os.kill(daemon_pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError, SystemError):
-                pass
+            # Re-verify identity before escalating to SIGTERM: the daemon may
+            # have exited and had its PID reused mid-wait, in which case the
+            # original PID now belongs to an unrelated process. Only signal
+            # if identify() still returns the same PID — that's the only
+            # state where the kill is provably safe.
+            if ipc.identify(name, timeout=1.0) == daemon_pid:
+                try:
+                    os.kill(daemon_pid, signal.SIGTERM)
+                except (ProcessLookupError, OSError, SystemError):
+                    pass
 
     ipc.cleanup_endpoint(name)
     try:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -187,33 +187,47 @@ def restart_daemon(name=None):
 
     Name is historical: callers typically follow this with another
     `browser-harness` invocation, which auto-spawns a fresh daemon via
-    ensure_daemon(). The function itself only stops."""
+    ensure_daemon(). The function itself only stops.
+
+    Identity is verified via ipc.identify() before any process signal, so
+    a stale pid file whose number has been reused by an unrelated process
+    is never SIGTERM'd. If the daemon is unreachable, we just clean up the
+    pid file and socket and return — never escalate to a kill-by-pid-file.
+    """
     import signal
 
-    pid_path = str(ipc.pid_path(name or NAME))
-    try:
-        c, token = ipc.connect(name or NAME, timeout=5.0)
-        ipc.request(c, token, {"meta": "shutdown"})
-        c.close()
-    except Exception:
-        pass
-    try:
-        pid = int(open(pid_path).read())
-    except (FileNotFoundError, ValueError):
-        pid = None
-    if pid:
+    name = name or NAME
+    pid_path = str(ipc.pid_path(name))
+
+    # Ask the daemon for its PID. Reaching this confirms (a) the listener
+    # at the IPC endpoint is alive AND (b) gives us the PID we'd need to
+    # signal if it doesn't exit cleanly. If we can't reach it, daemon_pid
+    # is None and we never signal.
+    daemon_pid = ipc.identify(name, timeout=5.0)
+
+    if daemon_pid is not None:
+        try:
+            c, token = ipc.connect(name, timeout=5.0)
+            ipc.request(c, token, {"meta": "shutdown"})
+            c.close()
+        except Exception:
+            pass
         for _ in range(75):
             try:
-                os.kill(pid, 0)
+                os.kill(daemon_pid, 0)
                 time.sleep(0.2)
             except (ProcessLookupError, OSError, SystemError):
                 break
         else:
+            # Daemon acknowledged shutdown but didn't exit in 15s — wedged.
+            # SIGTERM is safe because identify() just confirmed this PID is
+            # the live daemon, not an unrelated PID-reuse victim.
             try:
-                os.kill(pid, signal.SIGTERM)
+                os.kill(daemon_pid, signal.SIGTERM)
             except (ProcessLookupError, OSError, SystemError):
                 pass
-    ipc.cleanup_endpoint(name or NAME)
+
+    ipc.cleanup_endpoint(name)
     try:
         os.unlink(pid_path)
     except FileNotFoundError:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1,12 +1,57 @@
 import json
 import os
 import socket
+import subprocess
+import sys
 import tempfile
 import time
 import urllib.request
 from pathlib import Path
 
 from . import _ipc as ipc
+
+
+def _process_start_time(pid):
+    """Opaque process-start-time fingerprint at PID, or None if unavailable.
+
+    Two reads returning the same non-None value mean the PID still refers to
+    the same process; a different value means the PID was reused. Used by
+    restart_daemon() to keep the force-kill recovery path working even when
+    the daemon has already torn down its IPC socket (e.g. during a slow
+    remote shutdown), without falling back to "trust the pid file" — which
+    would re-introduce the PID-reuse hazard.
+
+    Linux: /proc/<pid>/stat field 22 (starttime in clock ticks since boot).
+    macOS: `ps -o lstart= -p <pid>` (an absolute timestamp string).
+    Other platforms: returns None; restart_daemon falls back to its strict
+    identify-only check, which is safer than no check at all.
+    """
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    if sys.platform.startswith("linux"):
+        try:
+            with open(f"/proc/{pid}/stat", "rb") as f:
+                raw = f.read().decode("ascii", errors="replace")
+        except (FileNotFoundError, PermissionError, OSError):
+            return None
+        # Field 2 is `(comm)`; comm can contain spaces and parens, so split off
+        # everything after the LAST `)` and index from there.
+        try:
+            tail = raw[raw.rindex(")") + 2:].split()
+            return tail[19]  # starttime is field 22 (0-indexed: 21 - skipped 2 = 19)
+        except (ValueError, IndexError):
+            return None
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["ps", "-o", "lstart=", "-p", str(pid)],
+                stderr=subprocess.DEVNULL, timeout=2,
+            )
+        except (subprocess.SubprocessError, OSError):
+            return None
+        s = out.decode("ascii", errors="replace").strip()
+        return s or None
+    return None
 
 
 def _load_env():
@@ -209,6 +254,14 @@ def restart_daemon(name=None):
     #     while the process stayed alive.
     daemon_pid = ipc.identify(name, timeout=5.0)
     daemon_alive = daemon_pid is not None or ipc.ping(name, timeout=1.0)
+    # Snapshot the daemon's process start-time as a secondary identity check.
+    # The IPC socket can disappear before the process exits (e.g. the shutdown
+    # path tears down the socket and then waits on a slow remote `stop` PATCH),
+    # so identify() going None partway through is not proof of process death.
+    # Comparing start-time before SIGTERM lets us recover the original
+    # force-kill behavior for slow shutdowns without re-opening the
+    # PID-reuse hole — a reused PID would have a different start-time.
+    daemon_start = _process_start_time(daemon_pid)
 
     if daemon_alive:
         try:
@@ -223,18 +276,26 @@ def restart_daemon(name=None):
             try:
                 os.kill(daemon_pid, 0)
                 time.sleep(0.2)
-            except (ProcessLookupError, OSError, SystemError):
+            except (ProcessLookupError, OSError, SystemError, OverflowError):
                 break
         else:
-            # Re-verify identity before escalating to SIGTERM: the daemon may
-            # have exited and had its PID reused mid-wait, in which case the
-            # original PID now belongs to an unrelated process. Only signal
-            # if identify() still returns the same PID — that's the only
-            # state where the kill is provably safe.
-            if ipc.identify(name, timeout=1.0) == daemon_pid:
+            # Re-verify identity before escalating to SIGTERM. Two acceptable
+            # signals, in priority order:
+            #   1. ipc.identify() still returns the same PID — daemon's IPC is
+            #      live, daemon is wedged. Safe to kill.
+            #   2. start-time fingerprint of the original PID is unchanged —
+            #      same process, just slow to exit (e.g. stuck in remote stop).
+            #      The IPC may already be gone; that's expected.
+            # If neither holds, the PID may have been reused; skip SIGTERM.
+            verified_pid = ipc.identify(name, timeout=1.0)
+            same_process = verified_pid == daemon_pid or (
+                daemon_start is not None
+                and _process_start_time(daemon_pid) == daemon_start
+            )
+            if same_process:
                 try:
                     os.kill(daemon_pid, signal.SIGTERM)
-                except (ProcessLookupError, OSError, SystemError):
+                except (ProcessLookupError, OSError, SystemError, OverflowError):
                     pass
 
     ipc.cleanup_endpoint(name)

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -249,7 +249,9 @@ class Daemon:
         meta = req.get("meta")
         # Liveness probe — lets clients confirm the listener is actually this
         # daemon and not an unrelated process that reused our port post-crash.
-        if meta == "ping":        return {"pong": True}
+        # `pid` lets restart_daemon() verify the live daemon's identity before
+        # signaling — protects against SIGTERM-by-stale-pid-file after PID reuse.
+        if meta == "ping":        return {"pong": True, "pid": os.getpid()}
         if meta == "drain_events":
             out = list(self.events); self.events.clear()
             return {"events": out}

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -268,6 +268,7 @@ def test_restart_daemon_does_not_signal_when_daemon_unreachable(monkeypatch, tmp
     kill_calls = []
     monkeypatch.setattr(admin.os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
     monkeypatch.setattr(admin.ipc, "identify", lambda name, timeout=5.0: None)
+    monkeypatch.setattr(admin.ipc, "ping", lambda name, timeout=1.0: False)
     monkeypatch.setattr(admin.ipc, "pid_path", lambda name: pid_path)
     monkeypatch.setattr(admin.ipc, "cleanup_endpoint", lambda name: None)
 
@@ -318,6 +319,7 @@ def test_restart_daemon_signals_pid_returned_by_identify_not_pid_file(monkeypatc
     fake = FakeIPC()
     monkeypatch.setattr(admin.os, "kill", fake_kill)
     monkeypatch.setattr(admin.ipc, "identify", fake.identify)
+    monkeypatch.setattr(admin.ipc, "ping", lambda name, timeout=1.0: True)
     monkeypatch.setattr(admin.ipc, "connect", fake.connect)
     monkeypatch.setattr(admin.ipc, "request", fake.request)
     monkeypatch.setattr(admin.ipc, "pid_path", fake.pid_path)
@@ -331,5 +333,88 @@ def test_restart_daemon_signals_pid_returned_by_identify_not_pid_file(monkeypatc
     assert pids_signaled == {live_pid}, (
         f"restart_daemon must only signal the PID returned by identify(); "
         f"signaled pids: {pids_signaled}, expected {{{live_pid}}} (and NOT 99999)"
+    )
+    assert not pid_path.exists()
+
+
+def test_restart_daemon_sends_shutdown_to_pre_upgrade_daemon_without_pid_in_ping(monkeypatch, tmp_path):
+    """Backward compat: a pre-upgrade daemon's ping reply has {pong:True} but
+    no `pid` field, so identify() returns None. The shutdown IPC must STILL be
+    sent (so the daemon exits cleanly), but no os.kill happens (we have no
+    verified PID to safely signal)."""
+    pid_path = tmp_path / "default.pid"
+    pid_path.write_text("99999")  # bogus stale value
+
+    kill_calls = []
+    shutdown_calls = []
+
+    def fake_request(conn, tok, msg):
+        if msg.get("meta") == "shutdown":
+            shutdown_calls.append(msg)
+        return {"ok": True}
+
+    monkeypatch.setattr(admin.os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+    monkeypatch.setattr(admin.ipc, "identify", lambda name, timeout=5.0: None)
+    monkeypatch.setattr(admin.ipc, "ping", lambda name, timeout=1.0: True)  # old daemon: alive but no pid
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout: ("conn", "tok"))
+    monkeypatch.setattr(admin.ipc, "request", fake_request)
+    monkeypatch.setattr(admin.ipc, "pid_path", lambda name: pid_path)
+    monkeypatch.setattr(admin.ipc, "cleanup_endpoint", lambda name: None)
+
+    admin.restart_daemon("default")
+
+    assert shutdown_calls, (
+        "restart_daemon must send shutdown IPC to a pre-upgrade daemon even "
+        "when identify() can't return a PID — otherwise upgrades orphan the "
+        "old daemon while deleting its socket and pid file."
+    )
+    assert kill_calls == [], (
+        f"no os.kill should fire when we don't have a verified PID, "
+        f"but got: {kill_calls}"
+    )
+    assert not pid_path.exists()
+
+
+def test_restart_daemon_skips_sigterm_if_pid_was_reused_during_wait(monkeypatch, tmp_path):
+    """A second identify() runs immediately before the SIGTERM. If the daemon
+    exited and the PID was reused mid-wait, identify() will return None (or a
+    different PID) and we must NOT signal — that's the PID-reuse race during
+    the 15s wait window."""
+    import signal
+
+    pid_path = tmp_path / "default.pid"
+    pid_path.write_text("99999")
+    live_pid = 4242
+
+    kill_calls = []
+
+    def fake_kill(pid, sig):
+        kill_calls.append((pid, sig))
+        # All os.kill(pid, 0) probes succeed → loop exhausts → reaches the
+        # SIGTERM branch. (We're simulating a "wedged" daemon that the wait
+        # loop can't tell apart from a daemon whose PID got reused.)
+
+    # First identify() call (top of restart_daemon) returns the live PID.
+    # Second identify() call (right before SIGTERM) returns None — simulating
+    # the daemon having exited and its PID having been reused by an unrelated
+    # process. The function must NOT escalate to SIGTERM in that state.
+    identify_responses = iter([live_pid, None])
+    monkeypatch.setattr(admin.os, "kill", fake_kill)
+    monkeypatch.setattr(admin.ipc, "identify", lambda name, timeout=5.0: next(identify_responses))
+    monkeypatch.setattr(admin.ipc, "ping", lambda name, timeout=1.0: True)
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout: ("conn", "tok"))
+    monkeypatch.setattr(admin.ipc, "request", lambda conn, tok, msg: {"ok": True})
+    monkeypatch.setattr(admin.ipc, "pid_path", lambda name: pid_path)
+    monkeypatch.setattr(admin.ipc, "cleanup_endpoint", lambda name: None)
+    # Speed up the wait loop so the test finishes quickly. The loop polls 75
+    # times at 0.2s = 15s; with sleep neutralized it runs in microseconds.
+    monkeypatch.setattr(admin.time, "sleep", lambda _s: None)
+
+    admin.restart_daemon("default")
+
+    sigterms = [(pid, sig) for pid, sig in kill_calls if sig == signal.SIGTERM]
+    assert sigterms == [], (
+        f"restart_daemon issued SIGTERM despite the re-verify identify() "
+        f"returning None (PID was reused during the 15s wait). Calls: {kill_calls}"
     )
     assert not pid_path.exists()

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -504,11 +504,10 @@ def test_restart_daemon_skips_sigterm_when_start_time_changed_during_wait(monkey
 # --- _process_start_time helper ---
 
 def test_process_start_time_returns_stable_fingerprint_for_self():
-    """The start-time of the current process should be readable on POSIX and
-    stable across two reads. (Skipped on Windows where the helper returns None
-    by design.)"""
+    """The start-time of the current process should be readable on Linux,
+    macOS, and Windows, and stable across two reads."""
     import os as _os, sys
-    if sys.platform.startswith("linux") or sys.platform == "darwin":
+    if sys.platform.startswith("linux") or sys.platform == "darwin" or sys.platform == "win32":
         pid = _os.getpid()
         first = admin._process_start_time(pid)
         second = admin._process_start_time(pid)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -252,3 +252,84 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     assert calls == [
         ("/browsers", "POST", {}),
     ]
+
+
+# --- restart_daemon: PID-reuse safety ---
+
+def test_restart_daemon_does_not_signal_when_daemon_unreachable(monkeypatch, tmp_path):
+    """If ipc.identify() returns None (daemon gone), restart_daemon must NOT
+    fall back to reading the pid file and SIGTERMing whatever owns that PID —
+    that's the PID-reuse hazard. It should only clean up files."""
+    pid_path = tmp_path / "default.pid"
+    # A pid file with a PID that, if signaled, would hit an unrelated process.
+    # The whole point is that we don't read or trust this number.
+    pid_path.write_text("99999")
+
+    kill_calls = []
+    monkeypatch.setattr(admin.os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+    monkeypatch.setattr(admin.ipc, "identify", lambda name, timeout=5.0: None)
+    monkeypatch.setattr(admin.ipc, "pid_path", lambda name: pid_path)
+    monkeypatch.setattr(admin.ipc, "cleanup_endpoint", lambda name: None)
+
+    # Should not raise, should not signal, should still clean up the pid file.
+    admin.restart_daemon("default")
+
+    assert kill_calls == [], (
+        f"restart_daemon SIGTERM'd a PID despite identify() returning None — "
+        f"this is the PID-reuse hazard the function is meant to avoid. Calls: {kill_calls}"
+    )
+    assert not pid_path.exists(), "stale pid file should be cleaned up"
+
+
+def test_restart_daemon_signals_pid_returned_by_identify_not_pid_file(monkeypatch, tmp_path):
+    """The PID we signal must come from the live daemon's self-report, never
+    from the pid file. If a stale pid file disagrees, the live daemon's PID wins."""
+    import signal
+
+    pid_path = tmp_path / "default.pid"
+    pid_path.write_text("99999")  # bogus stale value — must be ignored
+
+    live_pid = 4242
+
+    kill_calls = []
+    def fake_kill(pid, sig):
+        kill_calls.append((pid, sig))
+        # First os.kill(pid, 0) probe: report process is gone so we exit the loop
+        # without escalating. We just want to see WHICH pid was probed.
+        if sig == 0:
+            raise ProcessLookupError
+
+    class FakeIPC:
+        def __init__(self):
+            self.shutdown_sent = False
+        def identify(self, name, timeout=5.0):
+            return live_pid
+        def connect(self, name, timeout):
+            return ("conn", "tok")
+        def request(self, conn, tok, msg):
+            if msg.get("meta") == "shutdown":
+                self.shutdown_sent = True
+            return {"ok": True}
+        def pid_path(self, name):
+            return pid_path
+        def cleanup_endpoint(self, name):
+            pass
+
+    fake = FakeIPC()
+    monkeypatch.setattr(admin.os, "kill", fake_kill)
+    monkeypatch.setattr(admin.ipc, "identify", fake.identify)
+    monkeypatch.setattr(admin.ipc, "connect", fake.connect)
+    monkeypatch.setattr(admin.ipc, "request", fake.request)
+    monkeypatch.setattr(admin.ipc, "pid_path", fake.pid_path)
+    monkeypatch.setattr(admin.ipc, "cleanup_endpoint", fake.cleanup_endpoint)
+
+    admin.restart_daemon("default")
+
+    assert fake.shutdown_sent, "expected shutdown IPC to be sent"
+    assert kill_calls, "expected at least one os.kill probe"
+    pids_signaled = {pid for pid, _ in kill_calls}
+    assert pids_signaled == {live_pid}, (
+        f"restart_daemon must only signal the PID returned by identify(); "
+        f"signaled pids: {pids_signaled}, expected {{{live_pid}}} (and NOT 99999)"
+    )
+    assert not pid_path.exists()

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -418,3 +418,113 @@ def test_restart_daemon_skips_sigterm_if_pid_was_reused_during_wait(monkeypatch,
         f"returning None (PID was reused during the 15s wait). Calls: {kill_calls}"
     )
     assert not pid_path.exists()
+
+
+def test_restart_daemon_sigterms_via_start_time_fingerprint_when_socket_gone(monkeypatch, tmp_path):
+    """Slow-shutdown recovery: the daemon's serve() tears down the IPC socket
+    BEFORE the process exits (the daemon then runs slow cleanup like remote
+    `stop` PATCH calls that can hang). In that window, identify() returns None
+    even though the process is still our daemon. SIGTERM must still fire when
+    the PID's start-time fingerprint hasn't changed since we first identified
+    it — that's strong evidence of "same process, just slow to exit."
+    """
+    import signal
+
+    pid_path = tmp_path / "default.pid"
+    pid_path.write_text("99999")
+    live_pid = 4242
+
+    kill_calls = []
+
+    def fake_kill(pid, sig):
+        kill_calls.append((pid, sig))
+        # All os.kill(pid, 0) probes succeed; loop exhausts → SIGTERM gate runs.
+
+    # First identify() returns live_pid. Second identify() returns None — the
+    # daemon has torn down its IPC during shutdown but the process is still
+    # finishing up cleanup work, so the start-time fingerprint is unchanged.
+    identify_responses = iter([live_pid, None])
+    # Both _process_start_time() calls return the same fingerprint, signaling
+    # "still the same process." This is the legitimate-slow-shutdown case.
+    monkeypatch.setattr(admin, "_process_start_time", lambda pid: "STARTED_AT_X")
+    monkeypatch.setattr(admin.os, "kill", fake_kill)
+    monkeypatch.setattr(admin.ipc, "identify", lambda name, timeout=5.0: next(identify_responses))
+    monkeypatch.setattr(admin.ipc, "ping", lambda name, timeout=1.0: True)
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout: ("conn", "tok"))
+    monkeypatch.setattr(admin.ipc, "request", lambda conn, tok, msg: {"ok": True})
+    monkeypatch.setattr(admin.ipc, "pid_path", lambda name: pid_path)
+    monkeypatch.setattr(admin.ipc, "cleanup_endpoint", lambda name: None)
+    monkeypatch.setattr(admin.time, "sleep", lambda _s: None)
+
+    admin.restart_daemon("default")
+
+    sigterms = [(pid, sig) for pid, sig in kill_calls if sig == signal.SIGTERM]
+    assert sigterms == [(live_pid, signal.SIGTERM)], (
+        f"slow-shutdown daemon (identify=None but unchanged start-time) must "
+        f"still receive SIGTERM. signal calls: {kill_calls}"
+    )
+
+
+def test_restart_daemon_skips_sigterm_when_start_time_changed_during_wait(monkeypatch, tmp_path):
+    """If the start-time fingerprint of the original PID has CHANGED, the PID
+    was reused by another process. Even though identify() also returns None,
+    we must skip SIGTERM — start-time mismatch is the signal that protects
+    against killing an unrelated reused-PID process."""
+    import signal
+
+    pid_path = tmp_path / "default.pid"
+    pid_path.write_text("99999")
+    live_pid = 4242
+
+    kill_calls = []
+    monkeypatch.setattr(admin.os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+
+    identify_responses = iter([live_pid, None])
+    # First start-time read at top of restart_daemon: "ORIGINAL".
+    # Second start-time read in the safety gate: "DIFFERENT" — proof of reuse.
+    start_time_responses = iter(["ORIGINAL", "DIFFERENT"])
+    monkeypatch.setattr(admin, "_process_start_time", lambda pid: next(start_time_responses))
+    monkeypatch.setattr(admin.ipc, "identify", lambda name, timeout=5.0: next(identify_responses))
+    monkeypatch.setattr(admin.ipc, "ping", lambda name, timeout=1.0: True)
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout: ("conn", "tok"))
+    monkeypatch.setattr(admin.ipc, "request", lambda conn, tok, msg: {"ok": True})
+    monkeypatch.setattr(admin.ipc, "pid_path", lambda name: pid_path)
+    monkeypatch.setattr(admin.ipc, "cleanup_endpoint", lambda name: None)
+    monkeypatch.setattr(admin.time, "sleep", lambda _s: None)
+
+    admin.restart_daemon("default")
+
+    sigterms = [(pid, sig) for pid, sig in kill_calls if sig == signal.SIGTERM]
+    assert sigterms == [], (
+        f"start-time mismatch indicates PID reuse — restart_daemon must NOT "
+        f"SIGTERM. signal calls: {kill_calls}"
+    )
+
+
+# --- _process_start_time helper ---
+
+def test_process_start_time_returns_stable_fingerprint_for_self():
+    """The start-time of the current process should be readable on POSIX and
+    stable across two reads. (Skipped on Windows where the helper returns None
+    by design.)"""
+    import os as _os, sys
+    if sys.platform.startswith("linux") or sys.platform == "darwin":
+        pid = _os.getpid()
+        first = admin._process_start_time(pid)
+        second = admin._process_start_time(pid)
+        assert first is not None, "expected a fingerprint for the current PID"
+        assert first == second, (
+            f"two reads of the same PID should return the same fingerprint; "
+            f"got {first!r} vs {second!r}"
+        )
+
+
+def test_process_start_time_returns_none_for_invalid_pid():
+    """Bad inputs (None, 0, negatives, non-int) and PIDs with no live process
+    must return None rather than raising."""
+    for bad in (None, 0, -1, -42, "not-an-int", 1.5, True, False):
+        assert admin._process_start_time(bad) is None, (
+            f"expected None for invalid pid {bad!r}"
+        )
+    # 2**31 - 1 is the largest pid_t; in practice no live process at that PID.
+    assert admin._process_start_time((1 << 31) - 1) is None

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -60,3 +60,48 @@ def test_identify_returns_none_when_pong_is_not_true(monkeypatch):
     _patch_identify_response(monkeypatch, {"pong": False, "pid": 4242})
 
     assert ipc.identify("default", timeout=0.0) is None
+
+
+def test_identify_rejects_zero_and_negative_pids(monkeypatch):
+    """os.kill semantics on POSIX: pid=0 signals every process in the calling
+    process group; pid=-1 signals every process the caller can; pid<-1 signals
+    the corresponding process group. None of these are valid daemon PIDs and
+    forwarding any of them to os.kill would be catastrophic."""
+    for bad_pid in (0, -1, -42, -99999):
+        _patch_identify_response(monkeypatch, {"pong": True, "pid": bad_pid})
+        assert ipc.identify("default", timeout=0.0) is None, (
+            f"identify() must reject non-positive pid {bad_pid!r}"
+        )
+
+
+# --- ping(): same payload sanitation ---
+
+def _patch_ping_response(monkeypatch, response):
+    monkeypatch.setattr(ipc, "connect", lambda name, timeout=1.0: (_FakeConn(), "tok"))
+    monkeypatch.setattr(ipc, "request", lambda conn, tok, msg: response)
+
+
+def test_ping_returns_true_for_well_formed_pong(monkeypatch):
+    _patch_ping_response(monkeypatch, {"pong": True})
+
+    assert ipc.ping("default", timeout=0.0) is True
+
+
+def test_ping_handles_non_dict_payload(monkeypatch):
+    """Same regression class as identify(): if a stale or hostile endpoint
+    replies with a list / scalar / null, ping() must return False rather than
+    raising AttributeError on resp.get(). restart_daemon() now calls ping() on
+    the fallback path, so an unhandled raise here would abort cleanup."""
+    for payload in ([1, 2, 3], "hello", 42, None):
+        _patch_ping_response(monkeypatch, payload)
+        assert ipc.ping("default", timeout=0.0) is False, (
+            f"ping() should reject non-dict payload: {payload!r}"
+        )
+
+
+def test_ping_returns_false_when_pong_field_is_missing_or_not_true(monkeypatch):
+    for resp in ({}, {"pong": False}, {"pong": "yes"}, {"pong": 1}):
+        _patch_ping_response(monkeypatch, resp)
+        assert ipc.ping("default", timeout=0.0) is False, (
+            f"ping() should require pong is exactly True; got: {resp!r}"
+        )

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,0 +1,62 @@
+from browser_harness import _ipc as ipc
+
+
+# --- identify(): ping payload sanitation ---
+
+class _FakeConn:
+    def close(self): pass
+
+
+def _patch_identify_response(monkeypatch, response):
+    """Stub connect() and request() so identify() sees `response` as the JSON
+    parsed from the daemon's reply, exactly as it would arrive over the wire."""
+    monkeypatch.setattr(ipc, "connect", lambda name, timeout=1.0: (_FakeConn(), "tok"))
+    monkeypatch.setattr(ipc, "request", lambda conn, tok, msg: response)
+
+
+def test_identify_returns_pid_for_well_formed_ping_reply(monkeypatch):
+    _patch_identify_response(monkeypatch, {"pong": True, "pid": 4242})
+
+    assert ipc.identify("default", timeout=0.0) == 4242
+
+
+def test_identify_rejects_boolean_pid(monkeypatch):
+    """isinstance(True, int) is True in Python; a hostile or buggy daemon
+    that replies {"pid": True} would otherwise yield PID 1 (init on POSIX),
+    which os.kill(1, SIGTERM) would target. Reject it explicitly."""
+    _patch_identify_response(monkeypatch, {"pong": True, "pid": True})
+
+    assert ipc.identify("default", timeout=0.0) is None
+
+
+def test_identify_rejects_boolean_false_pid(monkeypatch):
+    """False is also an int subclass and would yield PID 0."""
+    _patch_identify_response(monkeypatch, {"pong": True, "pid": False})
+
+    assert ipc.identify("default", timeout=0.0) is None
+
+
+def test_identify_returns_none_when_pid_field_missing(monkeypatch):
+    """Pre-upgrade daemons reply {pong: True} only — no pid. identify must
+    return None so callers know they have no verified PID to signal, while
+    still letting alive-checks via ipc.ping() succeed."""
+    _patch_identify_response(monkeypatch, {"pong": True})
+
+    assert ipc.identify("default", timeout=0.0) is None
+
+
+def test_identify_handles_non_dict_ping_payload(monkeypatch):
+    """request() can deserialize any valid JSON value. A stale or hostile
+    endpoint replying with a list / scalar / null would crash a naive
+    resp.get() with AttributeError; identify must absorb that and return None."""
+    for payload in ([1, 2, 3], "hello", 42, None):
+        _patch_identify_response(monkeypatch, payload)
+        assert ipc.identify("default", timeout=0.0) is None, (
+            f"identify() should reject non-dict ping payload: {payload!r}"
+        )
+
+
+def test_identify_returns_none_when_pong_is_not_true(monkeypatch):
+    _patch_identify_response(monkeypatch, {"pong": False, "pid": 4242})
+
+    assert ipc.identify("default", timeout=0.0) is None


### PR DESCRIPTION
## Summary

Fixes a P0 surfaced by a codex review of the repo: `restart_daemon()` could `SIGTERM` an unrelated local process after PID reuse.

## The bug

`restart_daemon()` reads `/tmp/<name>.pid` directly and signals that PID:

```python
pid = int(open(pid_path).read())
...
for _ in range(75):
    try: os.kill(pid, 0); time.sleep(0.2)
    except (ProcessLookupError, ...): break
else:
    os.kill(pid, signal.SIGTERM)
```

If the daemon had previously crashed without removing the pid file, and the kernel subsequently reused that PID for an unrelated process (a browser tab, editor, language server, etc.), the loop would keep observing the new owner alive for 15 s and then `SIGTERM` it. Pid-file content was treated as proof of identity even though nothing tied it back to a live daemon.

## The fix

Verify identity over the existing IPC ping channel before any signal:

- `daemon.py` — the `ping` meta-handler now returns `{pong: True, pid: os.getpid()}` (still backward-compatible with the existing `ipc.ping()` callers, which only consume `pong`).
- `_ipc.py` — adds `identify(name, timeout)` returning the live daemon's self-reported PID, or `None` if unreachable.
- `admin.py` — `restart_daemon()` calls `identify()` first and signals **only** the PID it returns. If `identify()` is `None`, the function cleans up the socket and pid file and returns without ever calling `os.kill` — there is no kill-by-pid-file path anymore. SIGTERM after the wait loop is now safe because the PID has been confirmed end-to-end (live IPC → self-reported PID).

## Tests

Two new unit tests in `tests/unit/test_admin.py` lock in the regression:

- `test_restart_daemon_does_not_signal_when_daemon_unreachable` — `identify()` returns `None`, pid file contains `99999`. Asserts **zero** `os.kill` calls and that the stale file is still cleaned up. Would fail under the previous behavior.
- `test_restart_daemon_signals_pid_returned_by_identify_not_pid_file` — `identify()` returns `4242`, pid file contains `99999`. Asserts that only `4242` is signaled.

`uv run pytest tests/` → 59 passed (21 admin + 2 new + the rest).

## Test plan

- [x] Unit tests pass locally (`uv run pytest tests/`).
- [ ] Behavior on a happy-path real daemon: `bh start`, then `bh restart` cleanly stops it (same as today).
- [ ] Behavior on a crashed daemon: kill the process, leave the pid file, run `bh restart` — should clean up files without signaling anything.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `restart_daemon()` PID-reuse safe by verifying the daemon over IPC before any signal, keep shutdown working for pre-upgrade daemons, and add a start-time fingerprint check (now implemented on Windows via GetProcessTimes) to safely SIGTERM slow-exiting daemons. Also harden `_ipc.ping()`/`_ipc.identify()` to validate payloads and bound PIDs.

- **Bug Fixes**
  - Added `_ipc.identify(name, timeout)` that trusts only a dict `{"pong": True, "pid": pid}` where `type(pid) is int` and `0 < pid < 2**31`; rejects boolean, non-dict, and non-positive/oversized PIDs. `_ipc.ping()` now requires a dict payload and `pong is True`.
  - Daemon `ping` now returns `{"pong": True, "pid": os.getpid()}` (older daemons still return `{"pong": True}`).
  - `admin.restart_daemon()`:
    - Sends shutdown IPC whenever any daemon answers ping; never kills by pid file; always cleans up socket and pid file.
    - Signals only the PID from `identify()` and re-verifies before `SIGTERM`.
    - Slow-shutdown recovery: allows `SIGTERM` when the PID’s process start-time fingerprint is unchanged; skips if it changed (PID reuse). Linux uses `/proc/<pid>/stat`, macOS uses `ps -o lstart=`, Windows uses `GetProcessTimes` via `ctypes`. Adds `OverflowError` guards around `os.kill`.
  - Tests cover payload validation and PID bounds (boolean/zero/negative/oversized), unreachable daemon, PID-file mismatch, pre-upgrade ping-only shutdown, re-verify-before-`SIGTERM`, slow-shutdown start-time match (SIGTERM), and start-time mismatch (skip); plus `_process_start_time` on Linux/macOS/Windows.

<sup>Written for commit 255c47714e26dcba16dea82252f8a900b186d203. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

