### PR TITLE
fix(daemon): set_session must enable all four default domains, not just Page

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -211,15 +211,21 @@ class Daemon:
         notably wait_for_network_idle() — silently stop receiving events
         after a tab switch, because each fresh CDP session starts with all
         domains disabled.
+
+        Runs the four enables in parallel via gather so the worst-case time is
+        bounded by a single CDP round trip rather than four sequential ones —
+        important on the set_session path, where the helper's IPC socket has
+        a 5s read timeout.
         """
-        for d in ("Page", "DOM", "Runtime", "Network"):
+        async def enable_one(d):
             try:
                 await asyncio.wait_for(
                     self.cdp.send_raw(f"{d}.enable", session_id=session_id),
-                    timeout=5
+                    timeout=4,
                 )
             except Exception as e:
                 log(f"enable {d} on {session_id}: {e}")
+        await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
 
     async def start(self):
         self.stop = asyncio.Event()
@@ -284,25 +290,36 @@ class Daemon:
             old_session = self.session
             self.session = req.get("session_id")
             self.target_id = req.get("target_id") or self.target_id
-            # Best-effort: stop the previously-attached session from emitting
-            # Network events into the global buffer. wait_for_network_idle
-            # also filters by session_id on the consumer side, but disabling
-            # at the source keeps the buffer from filling with background-tab
-            # noise (e.g. a polling/SSE page the agent switched away from).
+            # Run the old-session Network.disable (defense in depth — keeps
+            # background-tab traffic out of the global event buffer; the
+            # consumer-side filter in wait_for_network_idle is the actual
+            # correctness gate) in parallel with the four enables on the new
+            # session. Different sessions, independent CDP requests. Keeps
+            # the synchronous reply under the helper's 5s IPC read timeout
+            # even on a remote daemon — sequentially these would have stacked
+            # to ~22s worst case.
+            tasks = []
             if old_session and old_session != self.session:
-                try:
-                    await asyncio.wait_for(
-                        self.cdp.send_raw("Network.disable", session_id=old_session),
-                        timeout=2,
-                    )
-                except Exception: pass
-            # Mirror the initial-attach domain set so helpers that depend on
-            # Network/DOM events (e.g. wait_for_network_idle) keep working
-            # after switch_tab/new_tab. Initial attach does the same four.
-            await self._enable_default_domains(self.session)
-            try:
-                await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"}, session_id=self.session), timeout=2)
-            except Exception: pass
+                async def disable_old():
+                    try:
+                        await asyncio.wait_for(
+                            self.cdp.send_raw("Network.disable", session_id=old_session),
+                            timeout=2,
+                        )
+                    except Exception: pass
+                tasks.append(disable_old())
+            tasks.append(self._enable_default_domains(self.session))
+            await asyncio.gather(*tasks)
+            # 🟢 tab-marker title prefix is purely cosmetic — fire-and-forget so
+            # it doesn't add to the synchronous IPC budget.
+            asyncio.create_task(_silent(asyncio.wait_for(
+                self.cdp.send_raw(
+                    "Runtime.evaluate",
+                    {"expression": "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"},
+                    session_id=self.session,
+                ),
+                timeout=2,
+            )))
             return {"session_id": self.session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -200,15 +200,26 @@ class Daemon:
         ))["sessionId"]
         self.target_id = pages[0]["targetId"]
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
+        await self._enable_default_domains(self.session)
+        return pages[0]
+
+    async def _enable_default_domains(self, session_id):
+        """Enable Page/DOM/Runtime/Network on a CDP session.
+
+        Used by both initial attach and set_session (called after switch_tab/
+        new_tab). Without this, helpers that depend on Network.* events —
+        notably wait_for_network_idle() — silently stop receiving events
+        after a tab switch, because each fresh CDP session starts with all
+        domains disabled.
+        """
         for d in ("Page", "DOM", "Runtime", "Network"):
             try:
                 await asyncio.wait_for(
-                    self.cdp.send_raw(f"{d}.enable", session_id=self.session),
+                    self.cdp.send_raw(f"{d}.enable", session_id=session_id),
                     timeout=5
                 )
             except Exception as e:
-                log(f"enable {d}: {e}")
-        return pages[0]
+                log(f"enable {d} on {session_id}: {e}")
 
     async def start(self):
         self.stop = asyncio.Event()
@@ -272,8 +283,11 @@ class Daemon:
         if meta == "set_session":
             self.session = req.get("session_id")
             self.target_id = req.get("target_id") or self.target_id
+            # Mirror the initial-attach domain set so helpers that depend on
+            # Network/DOM events (e.g. wait_for_network_idle) keep working
+            # after switch_tab/new_tab. Initial attach does the same four.
+            await self._enable_default_domains(self.session)
             try:
-                await asyncio.wait_for(self.cdp.send_raw("Page.enable", session_id=self.session), timeout=3)
                 await asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"}, session_id=self.session), timeout=2)
             except Exception: pass
             return {"session_id": self.session}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -281,8 +281,21 @@ class Daemon:
                 }
             return {"target_id": self.target_id, "session_id": self.session, "page": page}
         if meta == "set_session":
+            old_session = self.session
             self.session = req.get("session_id")
             self.target_id = req.get("target_id") or self.target_id
+            # Best-effort: stop the previously-attached session from emitting
+            # Network events into the global buffer. wait_for_network_idle
+            # also filters by session_id on the consumer side, but disabling
+            # at the source keeps the buffer from filling with background-tab
+            # noise (e.g. a polling/SSE page the agent switched away from).
+            if old_session and old_session != self.session:
+                try:
+                    await asyncio.wait_for(
+                        self.cdp.send_raw("Network.disable", session_id=old_session),
+                        timeout=2,
+                    )
+                except Exception: pass
             # Mirror the initial-attach domain set so helpers that depend on
             # Network/DOM events (e.g. wait_for_network_idle) keep working
             # after switch_tab/new_tab. Initial attach does the same four.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -393,12 +393,20 @@ def wait_for_network_idle(timeout=10.0, idle_ms=500):
     Useful after form submits, SPA route transitions, and any action that triggers
     XHR/fetch without a visible DOM change. Builds on drain_events() — no daemon changes.
     Returns True if idle window reached, False on timeout.
+
+    Events are filtered to the active session — a previously-attached background
+    tab (e.g. a polling/SSE page the agent switched away from) keeps emitting
+    Network events into the daemon's global event buffer; without this filter
+    they would poison the idle check on the current tab.
     """
     deadline = time.time() + timeout
     last_activity = time.time()
     inflight = set()
+    active_session = _send({"meta": "session"}).get("session_id")
     while time.time() < deadline:
         for e in drain_events():
+            if e.get("session_id") != active_session:
+                continue
             method = e.get("method", "")
             params = e.get("params", {})
             if method == "Network.requestWillBeSent":

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -137,3 +137,109 @@ def test_set_session_does_not_disable_network_when_no_previous_session():
         f"Network.disable must not fire when there's no previous session "
         f"to disable. Got: {disables}"
     )
+
+
+def test_set_session_runs_disable_and_enables_in_parallel():
+    """The four Domain.enable calls (plus Network.disable on the old session)
+    must run concurrently via asyncio.gather, not sequentially. With the old
+    sequential code, helpers.switch_tab() would block in _send() for up to
+    ~22s on a slow/remote daemon while the helper's IPC socket has a 5s
+    read timeout, causing client-side socket timeouts. Verifying that all
+    five CDP calls reach send_raw before any returns proves parallelization."""
+    class _ConcurrencyProbeCDP:
+        def __init__(self):
+            self.calls = []
+            self.in_flight = 0
+            self.max_concurrent = 0
+            self.release = None  # asyncio.Event, set inside the test loop
+
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            self.in_flight += 1
+            self.max_concurrent = max(self.max_concurrent, self.in_flight)
+            try:
+                await self.release.wait()
+            finally:
+                self.in_flight -= 1
+            return {}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _ConcurrencyProbeCDP()
+        d.session = "session-OLD"  # ensures Network.disable on old fires
+        d.cdp.release = asyncio.Event()
+
+        handle_task = asyncio.create_task(d.handle({
+            "meta": "set_session",
+            "session_id": "session-NEW",
+            "target_id": "target-NEW",
+        }))
+        # Yield repeatedly until everything that's going to be in-flight is
+        # in-flight. Cap iterations to avoid hanging if parallelization breaks.
+        for _ in range(50):
+            await asyncio.sleep(0)
+            # 5 = Network.disable on OLD + 4 enables on NEW.
+            if d.cdp.in_flight >= 5:
+                break
+        peak = d.cdp.max_concurrent
+        d.cdp.release.set()
+        await handle_task
+        return peak, d.cdp.calls
+
+    peak, calls = asyncio.run(run())
+    assert peak == 5, (
+        f"set_session must run disable + 4 enables concurrently via gather "
+        f"(observed peak in-flight = {peak}; expected 5 = 1 disable on OLD + "
+        f"4 enables on NEW). Sequential await would peak at 1."
+    )
+    # Sanity: the right calls were made.
+    methods = sorted({m for (m, _p, _s) in calls})
+    assert "Network.disable" in methods
+    assert {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}.issubset(methods)
+
+
+def test_set_session_first_attach_runs_four_enables_in_parallel():
+    """When there's no previous session, the disable path is skipped — only
+    the four enables run, still in parallel."""
+    class _ConcurrencyProbeCDP:
+        def __init__(self):
+            self.calls = []
+            self.in_flight = 0
+            self.max_concurrent = 0
+            self.release = None
+
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            self.in_flight += 1
+            self.max_concurrent = max(self.max_concurrent, self.in_flight)
+            try:
+                await self.release.wait()
+            finally:
+                self.in_flight -= 1
+            return {}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _ConcurrencyProbeCDP()
+        d.session = None  # no previous session
+        d.cdp.release = asyncio.Event()
+
+        handle_task = asyncio.create_task(d.handle({
+            "meta": "set_session",
+            "session_id": "session-FIRST",
+            "target_id": "target-FIRST",
+        }))
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if d.cdp.in_flight >= 4:
+                break
+        peak = d.cdp.max_concurrent
+        d.cdp.release.set()
+        await handle_task
+        return peak
+
+    peak = asyncio.run(run())
+    assert peak == 4, (
+        f"first set_session must run 4 enables concurrently "
+        f"(observed peak = {peak}). No Network.disable should fire."
+    )

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,0 +1,88 @@
+import asyncio
+
+from browser_harness import daemon
+
+
+class _FakeCDP:
+    """Records send_raw calls so tests can assert which CDP methods fired."""
+
+    def __init__(self):
+        self.calls = []  # list of (method, params, session_id)
+
+    async def send_raw(self, method, params=None, session_id=None):
+        self.calls.append((method, params, session_id))
+        # Set-session/initial-attach paths only need a benign response.
+        return {}
+
+
+def _fresh_daemon():
+    d = daemon.Daemon()
+    d.cdp = _FakeCDP()
+    return d
+
+
+def test_set_session_enables_all_four_default_domains_on_new_session():
+    """Regression: switch_tab() / new_tab() in helpers.py route through the
+    `set_session` IPC, which previously only enabled Page on the new
+    session. With Network disabled, wait_for_network_idle() silently stops
+    receiving events after a tab switch. Initial attach enables all four
+    (Page, DOM, Runtime, Network); set_session must enable the same set."""
+    d = _fresh_daemon()
+    new_session = "session-AFTER-switch"
+
+    asyncio.run(d.handle({
+        "meta": "set_session",
+        "session_id": new_session,
+        "target_id": "target-2",
+    }))
+
+    enabled_on_new = [
+        method for (method, _params, sid) in d.cdp.calls
+        if sid == new_session and method.endswith(".enable")
+    ]
+    assert set(enabled_on_new) == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}, (
+        f"set_session must enable Page/DOM/Runtime/Network on the new session "
+        f"(parity with initial attach). Got: {enabled_on_new}"
+    )
+    assert d.session == new_session
+    assert d.target_id == "target-2"
+
+
+def test_set_session_falls_back_to_existing_target_id_when_not_provided():
+    """If a caller forgets target_id (passes None), the daemon should keep its
+    existing target_id rather than overwriting it with None — otherwise
+    subsequent calls that depend on self.target_id would break."""
+    d = _fresh_daemon()
+    d.target_id = "original-target"
+
+    asyncio.run(d.handle({
+        "meta": "set_session",
+        "session_id": "session-AFTER",
+        "target_id": None,
+    }))
+
+    assert d.target_id == "original-target"
+    assert d.session == "session-AFTER"
+
+
+def test_enable_default_domains_swallows_errors_per_domain():
+    """A single domain failing to enable must not prevent the others from
+    being attempted — that would leave the daemon in a partially-configured
+    state. Each Domain.enable call has its own try/except inside the helper."""
+    class _PartialFailureCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "DOM.enable":
+                raise RuntimeError("simulated DOM failure")
+            return {}
+
+    d = daemon.Daemon()
+    d.cdp = _PartialFailureCDP()
+
+    asyncio.run(d._enable_default_domains("session-X"))
+
+    attempted = [m for (m, _p, _s) in d.cdp.calls]
+    assert "Page.enable" in attempted
+    assert "DOM.enable" in attempted  # attempted, but raised
+    assert "Runtime.enable" in attempted
+    assert "Network.enable" in attempted

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -86,3 +86,54 @@ def test_enable_default_domains_swallows_errors_per_domain():
     assert "DOM.enable" in attempted  # attempted, but raised
     assert "Runtime.enable" in attempted
     assert "Network.enable" in attempted
+
+
+def test_set_session_disables_network_on_old_session_before_enabling_new():
+    """When switching tabs, the previous session's Network domain must be
+    disabled so background tabs (polling, SSE, etc.) stop emitting events
+    into the global buffer that wait_for_network_idle reads. Initial attach
+    has no `old_session` so this disable doesn't fire then."""
+    d = _fresh_daemon()
+    d.session = "session-OLD"
+    d.target_id = "target-OLD"
+
+    asyncio.run(d.handle({
+        "meta": "set_session",
+        "session_id": "session-NEW",
+        "target_id": "target-NEW",
+    }))
+
+    disabled = [
+        (method, sid) for (method, _params, sid) in d.cdp.calls
+        if method == "Network.disable"
+    ]
+    assert disabled == [("Network.disable", "session-OLD")], (
+        f"Network.disable must fire on the old session before re-enabling on "
+        f"the new one. Got: {disabled}"
+    )
+
+    # Sanity: the new session still gets Network.enable.
+    enabled_on_new = {
+        method for (method, _p, sid) in d.cdp.calls
+        if sid == "session-NEW" and method.endswith(".enable")
+    }
+    assert "Network.enable" in enabled_on_new
+
+
+def test_set_session_does_not_disable_network_when_no_previous_session():
+    """First set_session call (e.g. very early in startup before any attach)
+    has no old_session — the Network.disable path must be skipped."""
+    d = _fresh_daemon()
+    d.session = None  # no prior attach
+
+    asyncio.run(d.handle({
+        "meta": "set_session",
+        "session_id": "session-FIRST",
+        "target_id": "target-FIRST",
+    }))
+
+    disables = [m for (m, _p, _s) in d.cdp.calls if m == "Network.disable"]
+    assert disables == [], (
+        f"Network.disable must not fire when there's no previous session "
+        f"to disable. Got: {disables}"
+    )

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -303,3 +303,50 @@ def test_wait_for_network_idle_returns_false_on_timeout():
 
     assert result is False
 
+
+
+def test_wait_for_network_idle_filters_events_to_active_session():
+    """Background tabs (e.g. a polling page the agent switched away from) keep
+    emitting Network events into the daemon's global buffer. The wait must
+    filter by session_id of the currently-attached tab — otherwise it would
+    see the background tab's traffic and either fail to return idle or wait
+    on the wrong tab's requests."""
+    active = "session-ACTIVE"
+    background = "session-BACKGROUND"
+
+    # First /drain_events/ payload: rWS + lF on the BACKGROUND session that we
+    # must ignore, plus zero events on the active session. With filtering, the
+    # active session sees no traffic and the idle window can elapse.
+    events_seq = [
+        [
+            {"session_id": background, "method": "Network.requestWillBeSent", "params": {"requestId": "bg1"}},
+            {"session_id": background, "method": "Network.loadingFinished",   "params": {"requestId": "bg1"}},
+        ],
+        [],  # second drain — quiet on both sessions; idle window should fire here
+    ]
+    drain_idx = 0
+
+    def fake_send(req):
+        nonlocal drain_idx
+        if req.get("meta") == "session":
+            return {"session_id": active}
+        if req.get("meta") == "drain_events":
+            evs = events_seq[min(drain_idx, len(events_seq) - 1)]
+            drain_idx += 1
+            return {"events": evs}
+        return {}
+
+    with patch("browser_harness.helpers._send", side_effect=fake_send), \
+         patch("browser_harness.helpers.time") as mock_time:
+        start = 1000.0
+        # No inflight on active session → idle check uses time.time().
+        mock_time.time.side_effect = [start, start, start, start + 0.6, start + 0.6]
+        mock_time.sleep = lambda _: None
+        result = helpers.wait_for_network_idle(timeout=5.0, idle_ms=500)
+
+    assert result is True, (
+        "wait_for_network_idle must return True even when the BACKGROUND "
+        "session is busy, as long as the ACTIVE session is idle. Without the "
+        "session filter, the background rWS/lF pair would have updated "
+        "last_activity and prevented the idle window from elapsing."
+    )


### PR DESCRIPTION
## Summary

Fixes a P1 surfaced by a codex review of the repo: `wait_for_network_idle()` (just landed in #258) silently stops working after `new_tab()` / `switch_tab()`, because the daemon's `set_session` only re-enables `Page` while initial attach enables `Page` / `DOM` / `Runtime` / `Network`.

## The bug

`Daemon.attach_first_page()` enables four CDP domains on the freshly-attached session:

```python
for d in ("Page", "DOM", "Runtime", "Network"):
    await asyncio.wait_for(self.cdp.send_raw(f"{d}.enable", session_id=self.session), timeout=5)
```

But the `set_session` meta-handler — which is what `helpers.switch_tab()` and `helpers.new_tab()` route through — only called `Page.enable`:

```python
if meta == "set_session":
    self.session = req.get("session_id")
    self.target_id = req.get("target_id") or self.target_id
    try:
        await asyncio.wait_for(self.cdp.send_raw("Page.enable", session_id=self.session), timeout=3)
        ...
```

Each fresh CDP session starts with all domains disabled, so after a tab switch an agent's session has no `Network.*` events flowing. `wait_for_network_idle()` reads from `drain_events()`, observes silence, and returns idle while requests are actually still in flight. The same applies to anything that consumes `DOM.*` events.

## The fix

- Extracted the four-domain enable loop into a private helper `_enable_default_domains(session_id)` on `Daemon`. Each domain is enabled with its own timeout, and a single failure doesn't abort the others.
- `attach_first_page` now calls the helper instead of inlining the loop.
- `set_session` calls the same helper, so a tab switch leaves the session in the same state as initial attach.
- The `Runtime.evaluate` for the 🟢 title prefix stays where it was (it's a fire-and-forget, separate from the domain enable).
- Existing `target_id = req.get("target_id") or self.target_id` fallback semantics preserved (now exercised by a test).

## Tests

Three new tests in `tests/unit/test_daemon.py` (new file). They drive `Daemon.handle()` directly with a fake CDP client that records `send_raw` calls:

- `test_set_session_enables_all_four_default_domains_on_new_session` — would fail under the old single-`Page.enable` code.
- `test_set_session_falls_back_to_existing_target_id_when_not_provided` — pins the `or self.target_id` fallback so a future change doesn't accidentally clobber `target_id` with `None`.
- `test_enable_default_domains_swallows_errors_per_domain` — pinned per-domain isolation so one failing `enable` doesn't stop the others.

`uv run pytest tests/` → 60 passed (57 prior + 3 new).

## Test plan

- [x] Unit tests pass locally (`uv run pytest tests/`).
- [ ] On a real daemon: attach, call `new_tab(url)`, then call `wait_for_network_idle()` — should now actually wait for the network instead of returning immediately.
- [ ] Same for `switch_tab(other_tab)` followed by `wait_for_network_idle()`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes early returns in `wait_for_network_idle()` after `new_tab()` / `switch_tab()` by enabling all default CDP domains and filtering events to the active session. Also runs domain changes in parallel and disables `Network` on the old session to avoid background noise and stay within the IPC timeout.

- **Bug Fixes**
  - Enable `Page`, `DOM`, `Runtime`, and `Network` on attach and on `set_session` via `_enable_default_domains(session_id)` (parallel enables, 4s per-call timeouts).
  - Filter `wait_for_network_idle()` to the active `session_id` so background tabs are ignored.
  - Run `Network.disable` on the previous session in parallel with the four enables on the new session to keep `set_session` under the 5s IPC deadline.
  - Preserve existing `target_id` when `set_session` is called without one.
  - Keep enabling other domains if a single `*.enable` call fails (log and continue).

<sup>Written for commit 2a9c64548eff8b16774a3437f6b3eeae10b2c6ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

