### PR TITLE
_ipc: fix AF_UNIX bind/chmod TOCTOU + symlink-pre-plant race (#298)

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -1,5 +1,5 @@
 """Daemon IPC plumbing. AF_UNIX socket on POSIX, TCP loopback on Windows."""
-import asyncio, json, os, re, secrets, socket, subprocess, sys, tempfile
+import asyncio, json, os, re, secrets, socket, stat, subprocess, sys, tempfile
 from pathlib import Path
 
 IS_WINDOWS = sys.platform == "win32"
@@ -33,7 +33,11 @@ def _stem(name):  # "bu" when BH_TMP_DIR isolates us, else "bu-<NAME>"
 def log_path(name):   return _TMP / f"{_stem(name)}.log"
 def pid_path(name):   return _TMP / f"{_stem(name)}.pid"
 def port_path(name):  return _TMP / f"{_stem(name)}.port"  # Windows-only: holds {"port","token"} JSON
-def _sock_path(name): return _TMP / f"{_stem(name)}.sock"
+# Socket lives inside a 0o700 private parent dir (created by serve()), not
+# directly in shared /tmp — closes the symlink-pre-plant race on bind() that
+# os.path.exists() would silently traverse.
+def _sock_dir(name):  return _TMP / f"{_stem(name)}.d"
+def _sock_path(name): return _sock_dir(name) / "sock"
 
 
 def _read_port_file(name):
@@ -144,13 +148,50 @@ def identify(name, timeout=1.0):
         except OSError: pass
 
 
+def _ensure_private_dir(p):
+    """mkdir 0o700; if it already exists, verify it's a real directory we own
+    with no group/other perms. Refusing here is the symlink-pre-plant defense:
+    once this returns, only our uid can place files inside, so the subsequent
+    unlink+bind on the socket inside is race-free."""
+    try:
+        os.mkdir(p, mode=0o700)
+        return
+    except FileExistsError:
+        pass
+    # lstat (not stat) so a hostile symlink masquerading as the dir is caught
+    # rather than silently traversed.
+    st = os.lstat(p)
+    if not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"{p}: not a directory (refusing — possible symlink attack)")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(f"{p}: owned by uid {st.st_uid}, expected {os.geteuid()} (refusing)")
+    if st.st_mode & 0o077:
+        os.chmod(p, 0o700)
+
+
 async def serve(name, handler):
     """Run the server until cancelled. handler(reader, writer) sees the same interface either way."""
     global _server_token
     if not IS_WINDOWS:
+        # Step 1: lock down the parent dir (0o700, owned by us). Until this
+        # succeeds, anything inside _TMP is in shared /tmp where attackers
+        # could plant symlinks at our socket path.
+        _ensure_private_dir(_sock_dir(name))
         path = str(_sock_path(name))
-        if os.path.exists(path): os.unlink(path)
-        server = await asyncio.start_unix_server(handler, path=path)
+        # Step 2: unconditional unlink (catches stale symlinks too — os.unlink
+        # never follows them, unlike os.path.exists()).
+        try: os.unlink(path)
+        except FileNotFoundError: pass
+        # Step 3: restrictive umask during bind() closes the TOCTOU window
+        # where the socket would otherwise exist on disk with the inherited
+        # umask (0o777 if umask=0) until chmod() ran. With umask 0o077 the
+        # socket is created mode 0o700 from the start; chmod below tightens
+        # to 0o600 and acts as defense-in-depth.
+        old_umask = os.umask(0o077)
+        try:
+            server = await asyncio.start_unix_server(handler, path=path)
+        finally:
+            os.umask(old_umask)
         os.chmod(path, 0o600)
         _server_token = None
         async with server: await asyncio.Event().wait()

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -217,6 +217,15 @@ def expected_token():
 
 
 def cleanup_endpoint(name):  # best-effort; silent if already gone
-    p = _sock_path(name) if not IS_WINDOWS else port_path(name)
-    try: p.unlink()
+    if IS_WINDOWS:
+        try: port_path(name).unlink()
+        except FileNotFoundError: pass
+        return
+    sock = _sock_path(name)
+    try: sock.unlink()
     except FileNotFoundError: pass
+    # Remove the .d/ wrapper too so stale dirs don't accumulate in /tmp.
+    # ENOTEMPTY (something else placed a file in there) or a concurrent
+    # cleanup race both leave us with nothing to do, hence the bare OSError.
+    try: sock.parent.rmdir()
+    except OSError: pass

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -170,14 +170,24 @@ def daemon_alive(name=None):
 def _daemon_endpoint_names():
     # BH_TMP_DIR isolates one daemon per dir → no filename-prefix discovery,
     # just check whether our local endpoint exists. Without BH_TMP_DIR, _TMP
-    # is the shared default (`/tmp` etc.) and we glob `bu-*.<suffix>` to find
-    # every daemon on the machine.
-    suffix = ".port" if ipc.IS_WINDOWS else ".sock"
+    # is the shared default (`/tmp` etc.) and we glob to find every daemon
+    # on the machine.
+    #
+    # Endpoint layout differs by OS:
+    #   POSIX:   <_TMP>/<stem>.d/sock  (the .d/ wrapper is the symlink-pre-plant
+    #                                   defense; presence of the inner `sock`
+    #                                   is the real "daemon is up" signal —
+    #                                   an empty .d/ may be stale leftovers).
+    #   Windows: <_TMP>/<stem>.port    (TCP+token JSON file).
     if ipc.BH_TMP_DIR:
-        return [NAME] if (ipc._TMP / f"bu{suffix}").exists() else []
+        local = (ipc._TMP / "bu.port") if ipc.IS_WINDOWS else (ipc._TMP / "bu.d" / "sock")
+        return [NAME] if local.exists() else []
+    pattern = "bu-*.port" if ipc.IS_WINDOWS else "bu-*.d/sock"
     names = []
-    for p in sorted(ipc._TMP.glob(f"bu-*{suffix}")):
-        raw = p.name[3:-len(suffix)]
+    for p in sorted(ipc._TMP.glob(pattern)):
+        # Windows: bu-<NAME>.port      → strip "bu-" from p.name, ".port" suffix
+        # POSIX:   bu-<NAME>.d/sock    → strip "bu-" from p.parent.name, ".d" suffix
+        raw = p.name[3:-len(".port")] if ipc.IS_WINDOWS else p.parent.name[3:-len(".d")]
         try:
             ipc._check(raw)
         except ValueError:

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -48,14 +48,23 @@ def test_stale_websocket_does_not_open_chrome_inspect():
     assert not admin._needs_chrome_remote_debugging_prompt(msg)
 
 
+def _touch_sock(parent):
+    """Recreate the on-disk layout `serve()` produces: <parent>/sock inside a
+    pre-existing 0o700 dir. Tests use this to fake a running daemon."""
+    parent.mkdir(parents=True, exist_ok=True)
+    (parent / "sock").touch()
+
+
 def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
     monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", None)  # shared-tmpdir mode
     monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
-    (tmp_path / "bu-default.sock").touch()
-    (tmp_path / "bu-remote_1.sock").touch()
-    (tmp_path / "bu-invalid.name.sock").touch()
-    (tmp_path / "not-bu-default.sock").touch()
+    _touch_sock(tmp_path / "bu-default.d")
+    _touch_sock(tmp_path / "bu-remote_1.d")
+    _touch_sock(tmp_path / "bu-invalid.name.d")
+    _touch_sock(tmp_path / "not-bu-default.d")
+    # Empty .d/ (no inner `sock`) must not be discovered — that's stale leftovers.
+    (tmp_path / "bu-stale.d").mkdir()
 
     assert admin._daemon_endpoint_names() == ["default", "remote_1"]
 
@@ -65,9 +74,29 @@ def test_daemon_endpoint_names_with_bh_tmp_dir_returns_local_name_when_sock_exis
     monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", str(tmp_path))
     monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
     monkeypatch.setattr(admin, "NAME", "session-xyz")
-    (tmp_path / "bu.sock").touch()
+    _touch_sock(tmp_path / "bu.d")
 
     assert admin._daemon_endpoint_names() == ["session-xyz"]
+
+
+def test_daemon_endpoint_names_uses_ipc_sock_path_layout(tmp_path, monkeypatch):
+    """Regression guard against the discovery glob drifting from the on-disk
+    layout that `_ipc.serve()` actually produces. If `_ipc._sock_path()`
+    moves (e.g. PR #299 moved it to <tmp>/bu-NAME.d/sock), discovery must
+    follow without a separate edit. Touching the path returned by
+    `_ipc._sock_path()` is the cheapest way to assert that coupling."""
+    from browser_harness import _ipc as ipc
+
+    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
+    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", None)
+    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
+    monkeypatch.setattr(ipc, "_TMP", tmp_path)
+
+    real = ipc._sock_path("alpha")
+    real.parent.mkdir(parents=True, exist_ok=True)
+    real.touch()
+
+    assert admin._daemon_endpoint_names() == ["alpha"]
 
 
 def test_daemon_endpoint_names_with_bh_tmp_dir_returns_empty_when_sock_missing(tmp_path, monkeypatch):

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,6 +1,24 @@
-import asyncio, os, stat, sys
+import asyncio, os, shutil, stat, sys, tempfile
+from pathlib import Path
+
 import pytest
+
 from browser_harness import _ipc as ipc
+
+
+@pytest.fixture
+def short_tmp(monkeypatch):
+    """An AF_UNIX-safe replacement for `tmp_path`. macOS limits `sun_path` to
+    104 bytes and pytest's tmp_path under /private/var/folders/... busts that
+    budget once we append `bu-NAME.d/sock`, so AF_UNIX tests must root in a
+    short `/tmp` dir instead. The fixture also monkey-patches `_TMP` so test
+    code can simply call `ipc._sock_path(...)` and get the short path."""
+    d = Path(tempfile.mkdtemp(prefix="bh-", dir="/tmp"))
+    monkeypatch.setattr(ipc, "_TMP", d)
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
 
 
 # --- identify(): ping payload sanitation ---
@@ -158,7 +176,7 @@ def test_ensure_private_dir_refuses_non_directory(tmp_path):
 
 
 @skip_on_windows
-def test_serve_socket_is_mode_0o600_with_umask_zero(tmp_path, monkeypatch):
+def test_serve_socket_is_mode_0o600_with_umask_zero(short_tmp):
     """The whole point of #298: with umask 0, the socket file used to exist on
     disk briefly at 0o777 between bind() and chmod(). After the fix, set umask
     to 0 in the test, run serve() through bind(), and verify the on-disk mode
@@ -167,7 +185,6 @@ def test_serve_socket_is_mode_0o600_with_umask_zero(tmp_path, monkeypatch):
     We can't observe the *intermediate* state from Python without instrumenting
     syscalls, but the umask wrapper guarantees the kernel never wrote a wider
     mode in the first place."""
-    monkeypatch.setattr(ipc, "_TMP", tmp_path)
     old_umask = os.umask(0)
     try:
         async def runner():
@@ -199,16 +216,16 @@ def test_serve_socket_is_mode_0o600_with_umask_zero(tmp_path, monkeypatch):
 
 
 @skip_on_windows
-def test_serve_unlinks_stale_symlink_inside_private_dir(tmp_path, monkeypatch):
+def test_serve_unlinks_stale_symlink_inside_private_dir(short_tmp):
     """If a stale symlink (e.g. left over from external tampering) sits at the
     socket path, the unconditional unlink must remove it — os.path.exists()
     used to follow it and skip the unlink, leading bind() to follow the
     symlink kernel-side."""
-    monkeypatch.setattr(ipc, "_TMP", tmp_path)
     ipc._ensure_private_dir(ipc._sock_dir("default"))
     path = ipc._sock_path("default")
-    # Dangling symlink at the socket path.
-    target = tmp_path / "elsewhere"
+    # Dangling symlink at the socket path. The target itself doesn't need to
+    # be inside the short tmp dir — bind() never traverses to it.
+    target = short_tmp / "elsewhere"
     os.symlink(target, path)
     assert not os.path.exists(path)  # dangling: exists() returns False — the old bug
 

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,3 +1,5 @@
+import asyncio, os, stat, sys
+import pytest
 from browser_harness import _ipc as ipc
 
 
@@ -105,3 +107,130 @@ def test_ping_returns_false_when_pong_field_is_missing_or_not_true(monkeypatch):
         assert ipc.ping("default", timeout=0.0) is False, (
             f"ping() should require pong is exactly True; got: {resp!r}"
         )
+
+
+# --- serve(): AF_UNIX bind permissions / symlink defense ---
+# Regression coverage for #298. POSIX-only — Windows uses TCP loopback.
+
+skip_on_windows = pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only AF_UNIX path")
+
+
+@skip_on_windows
+def test_ensure_private_dir_creates_with_0o700(tmp_path):
+    """Fresh mkdir path: dir must end up mode 0o700, owned by us."""
+    target = tmp_path / "priv.d"
+    ipc._ensure_private_dir(target)
+    st = os.lstat(target)
+    assert stat.S_ISDIR(st.st_mode)
+    assert (st.st_mode & 0o777) == 0o700
+    assert st.st_uid == os.geteuid()
+
+
+@skip_on_windows
+def test_ensure_private_dir_tightens_loose_perms(tmp_path):
+    """Pre-existing dir owned by us with loose perms gets chmod'd back to 0o700."""
+    target = tmp_path / "loose.d"
+    target.mkdir(mode=0o755)
+    os.chmod(target, 0o755)  # in case umask suppressed group/other bits at mkdir
+    ipc._ensure_private_dir(target)
+    assert (os.lstat(target).st_mode & 0o777) == 0o700
+
+
+@skip_on_windows
+def test_ensure_private_dir_refuses_symlink(tmp_path):
+    """A symlink at the path — even pointing to a real dir we'd accept — must
+    be refused. lstat (not stat) is what makes this detection possible."""
+    real = tmp_path / "real"
+    real.mkdir(mode=0o700)
+    link = tmp_path / "link.d"
+    os.symlink(real, link)
+    with pytest.raises(RuntimeError, match="not a directory"):
+        ipc._ensure_private_dir(link)
+
+
+@skip_on_windows
+def test_ensure_private_dir_refuses_non_directory(tmp_path):
+    """A regular file at the path is also refused (not a dir)."""
+    target = tmp_path / "file.d"
+    target.write_text("")
+    with pytest.raises(RuntimeError, match="not a directory"):
+        ipc._ensure_private_dir(target)
+
+
+@skip_on_windows
+def test_serve_socket_is_mode_0o600_with_umask_zero(tmp_path, monkeypatch):
+    """The whole point of #298: with umask 0, the socket file used to exist on
+    disk briefly at 0o777 between bind() and chmod(). After the fix, set umask
+    to 0 in the test, run serve() through bind(), and verify the on-disk mode
+    is never wider than 0o700. We also verify the final chmod tightens to 0o600.
+
+    We can't observe the *intermediate* state from Python without instrumenting
+    syscalls, but the umask wrapper guarantees the kernel never wrote a wider
+    mode in the first place."""
+    monkeypatch.setattr(ipc, "_TMP", tmp_path)
+    old_umask = os.umask(0)
+    try:
+        async def runner():
+            async def handler(r, w): w.close()
+            # Manually replicate the POSIX branch up through chmod, then stop.
+            # Calling serve() directly would block forever on the trailing
+            # asyncio.Event().wait().
+            ipc._ensure_private_dir(ipc._sock_dir("default"))
+            path = str(ipc._sock_path("default"))
+            try: os.unlink(path)
+            except FileNotFoundError: pass
+            saved = os.umask(0o077)
+            try:
+                server = await asyncio.start_unix_server(handler, path=path)
+            finally:
+                os.umask(saved)
+            mode_before_chmod = os.lstat(path).st_mode & 0o777
+            os.chmod(path, 0o600)
+            mode_after = os.lstat(path).st_mode & 0o777
+            server.close()
+            await server.wait_closed()
+            return mode_before_chmod, mode_after
+        before, after = asyncio.run(runner())
+    finally:
+        os.umask(old_umask)
+    # umask 0o077 means socket created mode 0o700 (or stricter); never wider.
+    assert before & 0o077 == 0, f"socket exposed group/other bits: {oct(before)}"
+    assert after == 0o600
+
+
+@skip_on_windows
+def test_serve_unlinks_stale_symlink_inside_private_dir(tmp_path, monkeypatch):
+    """If a stale symlink (e.g. left over from external tampering) sits at the
+    socket path, the unconditional unlink must remove it — os.path.exists()
+    used to follow it and skip the unlink, leading bind() to follow the
+    symlink kernel-side."""
+    monkeypatch.setattr(ipc, "_TMP", tmp_path)
+    ipc._ensure_private_dir(ipc._sock_dir("default"))
+    path = ipc._sock_path("default")
+    # Dangling symlink at the socket path.
+    target = tmp_path / "elsewhere"
+    os.symlink(target, path)
+    assert not os.path.exists(path)  # dangling: exists() returns False — the old bug
+
+    async def runner():
+        async def handler(r, w): w.close()
+        try: os.unlink(str(path))
+        except FileNotFoundError: pass
+        saved = os.umask(0o077)
+        try:
+            server = await asyncio.start_unix_server(handler, path=str(path))
+        finally:
+            os.umask(saved)
+        os.chmod(str(path), 0o600)
+        # Bound path must be a real socket, not a symlink, and not at the
+        # symlink's target.
+        st = os.lstat(str(path))
+        is_sock = stat.S_ISSOCK(st.st_mode)
+        target_exists = os.path.exists(target)
+        server.close()
+        await server.wait_closed()
+        return is_sock, target_exists
+
+    is_sock, target_exists = asyncio.run(runner())
+    assert is_sock, "bound path must be a real socket, not a symlink"
+    assert not target_exists, "bind() must not have followed the symlink"


### PR DESCRIPTION
## Summary

Closes #298 — TOCTOU + symlink-pre-plant races on the daemon's AF_UNIX socket.

- **Bind perms TOCTOU (primary).** `asyncio.start_unix_server` used to bind with the inherited umask, leaving the socket world-accessible (mode `0o777` if `umask=0`) until the follow-up `os.chmod(0o600)` ran. Wrapping the bind in `os.umask(0o077)` (try/finally) guarantees the socket is created mode `0o700` from the kernel side; the existing `chmod` stays as defense-in-depth.
- **Symlink-pre-plant race (secondary).** `os.path.exists()` followed symlinks, so a pre-planted dangling symlink at the socket path skipped the unlink and let `bind()` follow it kernel-side. The fix moves the socket into a `0o700` private parent directory (`<tmp>/bu-<NAME>.d/sock`) created/verified by `_ensure_private_dir` (lstat-based, refuses symlinks / non-dirs / wrong-uid), and replaces `os.path.exists() + unlink` with an unconditional `os.unlink` (which never follows symlinks).

Net effect: once `_ensure_private_dir` returns, only our uid can place anything inside the parent dir, so the subsequent unlink+bind on the socket is race-free; and even before that, `umask` ensures no on-disk permission window.

## Changes

- [src/browser_harness/_ipc.py](src/browser_harness/_ipc.py)
  - Added `stat` import.
  - New `_sock_dir(name)` → `<tmp>/bu-<NAME>.d/`. `_sock_path` now returns `<sock_dir>/sock` (was `<tmp>/bu-<NAME>.sock`).
  - New `_ensure_private_dir(p)`: `mkdir(0o700)`, else lstat-verify it's a real dir owned by us and tighten loose perms; refuse on symlink / non-dir / foreign uid.
  - `serve()` POSIX branch rewritten in 3 explicit steps: ensure private parent → unconditional `os.unlink` (catch `FileNotFoundError`) → `os.umask(0o077)` around `start_unix_server` → `chmod(0o600)`.

- [tests/unit/test_ipc.py](tests/unit/test_ipc.py) — 6 new regression tests (POSIX-only via `skipif`):
  - `_ensure_private_dir`: creates 0o700, tightens loose perms, refuses symlinks, refuses non-directory.
  - `serve` socket bound under `umask=0` ends up mode `0o600` with no looser intermediate state.
  - `serve` unlinks a stale dangling symlink at the socket path (the case `os.path.exists` used to silently pass).

## Compatibility notes

- The on-disk path of the socket changes from `/tmp/bu-<NAME>.sock` to `/tmp/bu-<NAME>.d/sock`. All readers of the socket path go through `_ipc._sock_path()` (verified: `connect`, `cleanup_endpoint`, `sock_addr` — daemon, admin, helpers all route through these), so the change is internal. Stale `.sock` files left over from pre-upgrade daemons are harmless leftover bytes.
- AF_UNIX `sun_path` length budget is unaffected: the new layout adds 2 chars (e.g. `/tmp/bu-default.d/sock` = 22 chars vs. 20), well under the 104/108 macOS/Linux limit. The `BH_TMP_DIR`-isolated case (bare `bu` stem) becomes `<BH_TMP_DIR>/bu.d/sock`, still safe.
- Windows TCP-loopback path is untouched; token-based auth there is unchanged.

## Test plan

- [x] `uv run --with pytest pytest tests/unit/test_ipc.py -v` — 16/16 passing (10 existing + 6 new).
- [x] `uv run --with pytest pytest tests/unit/ -v` — 72/72 passing (no regressions in admin/daemon/helpers/run suites that share the `_ipc` paths).
- [ ] Manual smoke: start daemon under `umask 0`, confirm `/tmp/bu-<NAME>.d` is `drwx------` and `/tmp/bu-<NAME>.d/sock` is `srw-------` from the moment it appears.
- [ ] Manual smoke: pre-plant a dangling symlink at `/tmp/bu-<NAME>.d/sock` after the dir exists; confirm the daemon starts cleanly, the symlink is removed, and the bound path is a real socket.
- [ ] macOS smoke (sun_path budget + `/var/folders` default): confirm no `OSError: AF_UNIX path too long`.
- [ ] Optional: `strace -e trace=bind,chmod,umask` to confirm the bind syscall happens with the tightened umask in effect (no observable wider-mode window).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure AF_UNIX daemon socket binding by creating it in a private 0o700 dir and tightening permissions during bind to remove TOCTOU and symlink-pre-plant races. Also fixes daemon discovery to match the new socket layout; Windows TCP loopback is unchanged.

- **Bug Fixes**
  - Wrap `asyncio.start_unix_server` with `umask 0o077`, then `chmod 0o600`, closing the bind→chmod TOCTOU.
  - Use a `0o700` private parent dir (verified via `lstat`); refuse symlinks/non-dirs/foreign uid; always `unlink` before bind to defeat pre-planted symlinks.
  - Fix `admin._daemon_endpoint_names()` to discover POSIX endpoints at the new layout (require inner `sock`; ignore empty `.d/`); Windows `.port` discovery unchanged.
  - `_ipc.cleanup_endpoint()` now also `rmdir`s the `.d/` wrapper (best-effort). Added POSIX-only regression tests, a macOS-safe short-`/tmp` fixture, and a discovery test tied to `_ipc._sock_path()`.

- **Migration**
  - Socket path is now `<tmp>/bu-<NAME>.d/sock`. All call sites use `_ipc._sock_path()`, so no action needed; old `.sock` files are harmless. Windows unchanged.

<sup>Written for commit aba1efccf10deb4bb1f4343b01e85be4e25cf156. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

