### PR TITLE
fix(run): respect explicit CDP endpoint before cloud auto-bootstrap

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -56,6 +56,15 @@ def _local_chrome_listening():
     return False
 
 
+# BU_CDP_URL / BU_CDP_WS are documented to override local Chrome discovery
+# (install.md:58-59), so they must also block cloud auto-bootstrap. Without this
+# guard, start_remote_daemon() in admin.py overwrites BU_CDP_WS in the daemon
+# env with a cloud WebSocket URL, silently replacing the user's explicit endpoint
+# *and* billing them for a cloud browser they never asked for.
+def _explicit_cdp_configured():
+    return bool(os.environ.get("BU_CDP_URL") or os.environ.get("BU_CDP_WS"))
+
+
 def main():
     args = sys.argv[1:]
     if args and args[0] in {"-h", "--help"}:
@@ -83,10 +92,12 @@ def main():
     print_update_banner()
     # Auto-bootstrap a cloud browser is opt-in via BU_AUTOSPAWN — BROWSER_USE_API_KEY alone
     # is not enough, since the key is commonly set for unrelated reasons (profile sync,
-    # cloud API calls, parent agents managing their own session).
+    # cloud API calls, parent agents managing their own session). An explicit BU_CDP_URL
+    # or BU_CDP_WS also blocks the spawn so we honour the precedence install.md promises.
     if (
         not daemon_alive()
         and not _local_chrome_listening()
+        and not _explicit_cdp_configured()
         and os.environ.get("BROWSER_USE_API_KEY")
         and os.environ.get("BU_AUTOSPAWN")
     ):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -29,6 +29,139 @@ def test_cloud_bootstrap_on_headless_server(monkeypatch):
     mock_start.assert_called_once()
 
 
+def test_explicit_bu_cdp_url_blocks_cloud_bootstrap(monkeypatch):
+    """BU_CDP_URL is documented to override local Chrome discovery (install.md:58-59),
+    so it must also block cloud auto-bootstrap. Otherwise start_remote_daemon would
+    overwrite BU_CDP_WS in the daemon env and silently bill the user for a cloud
+    browser instead of attaching to their explicit endpoint."""
+    monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
+
+
+def test_explicit_bu_cdp_ws_blocks_cloud_bootstrap(monkeypatch):
+    """Same precedence guarantee for BU_CDP_WS — install.md:58 promises it overrides
+    local Chrome discovery for remote browsers, so cloud auto-bootstrap must defer
+    to the explicit WebSocket endpoint the caller already chose."""
+    monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/abc")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
+
+
+def test_empty_bu_cdp_url_does_not_block_bootstrap(monkeypatch):
+    """An env var set to empty string is conventionally treated as unset; the helper
+    must not let `BU_CDP_URL=""` accidentally suppress cloud bootstrap on the headless
+    fresh-box path #277 explicitly preserved."""
+    monkeypatch.setenv("BU_CDP_URL", "")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_called_once()
+
+
+def test_both_bu_cdp_url_and_bu_cdp_ws_set_blocks_bootstrap(monkeypatch):
+    """When the caller has BOTH endpoints configured (e.g. a parent agent that probes
+    BU_CDP_URL first and falls back to a known BU_CDP_WS), bootstrap must still defer
+    — the user has been doubly explicit about their intent."""
+    monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
+    monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/abc")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
+
+
+def test_explicit_endpoint_does_not_break_daemon_alive_short_circuit(monkeypatch):
+    """daemon_alive=True must continue to short-circuit auto-bootstrap regardless of
+    whether an explicit endpoint is configured — re-using a live daemon was the
+    pre-existing fast path and the precedence guard must not regress it."""
+    monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=True), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
+
+
+def test_explicit_endpoint_does_not_break_local_chrome_short_circuit(monkeypatch):
+    """If a local Chrome is already listening on 9222/9223 the bootstrap must skip
+    even when the user *also* set an explicit endpoint pointing somewhere else.
+    The auto-bootstrap path is for cloud only; routing between local-default and
+    explicit-non-default endpoints is handled later in daemon.py:get_ws_url()."""
+    monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=True), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+    mock_start.assert_not_called()
+
+
+def test_explicit_cdp_configured_helper_truthy(monkeypatch):
+    """Direct unit test of the helper: any non-empty BU_CDP_URL or BU_CDP_WS must
+    return True so the bootstrap guard reads as 'caller has been explicit'."""
+    for name, value in [
+        ("BU_CDP_URL", "http://127.0.0.1:9333"),
+        ("BU_CDP_WS", "ws://example.test/devtools/browser/abc"),
+        ("BU_CDP_URL", "http://[::1]:9333"),  # IPv6 host
+        ("BU_CDP_WS", "wss://cloud.example.com/devtools/browser/x"),  # secure WS
+    ]:
+        monkeypatch.delenv("BU_CDP_URL", raising=False)
+        monkeypatch.delenv("BU_CDP_WS", raising=False)
+        monkeypatch.setenv(name, value)
+        assert run._explicit_cdp_configured() is True, f"{name}={value!r} should be truthy"
+
+
+def test_explicit_cdp_configured_helper_falsy(monkeypatch):
+    """Helper must return False for unset, empty-string, or both-unset cases —
+    those are all 'caller has not chosen an endpoint' from the bootstrap's POV."""
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    assert run._explicit_cdp_configured() is False, "both unset"
+    monkeypatch.setenv("BU_CDP_URL", "")
+    assert run._explicit_cdp_configured() is False, "BU_CDP_URL empty string"
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setenv("BU_CDP_WS", "")
+    assert run._explicit_cdp_configured() is False, "BU_CDP_WS empty string"
+
+
 def test_local_chrome_listening_rejects_non_chrome():
     """A bare TCP listener on 9222/9223 must not fool the probe — only a real
     /json/version response counts as Chrome."""


### PR DESCRIPTION
## Summary

`BU_AUTOSPAWN` cloud auto-bootstrap currently fires even when the caller
explicitly sets `BU_CDP_URL` or `BU_CDP_WS`, contradicting `install.md:58-59`:

> BU_CDP_WS overrides local Chrome discovery for remote browsers.
> BU_CDP_URL overrides local Chrome discovery with a specific DevTools HTTP endpoint (used for Way 2).

## Why this matters

A caller with `BU_CDP_URL` set for a corporate automation Chrome AND
`BROWSER_USE_API_KEY` set for `profile-use` sync (a common combination —
both env vars get exported once and stay set across unrelated sessions)
currently gets:

1. A billed Browser Use cloud browser provisioned the first time they run
   `browser-harness -c '...'` on a fresh shell.
2. Their explicit endpoint **silently swapped** for the cloud WebSocket
   (see `admin.py:471` smoking gun below).

#181 is an existing report of users already hitting this kind of
`BU_CDP_WS` swap and working around it manually; this PR makes that
workaround unnecessary by honouring the precedence `install.md` promises.

## Reproduction

With `BU_CDP_URL=http://127.0.0.1:9333` plus `BROWSER_USE_API_KEY` and
`BU_AUTOSPAWN=1`, no daemon, and no local Chrome on 9222/9223:

1. `run.py:87-92` does not check explicit endpoints → guard fires.
2. `start_remote_daemon(NAME)` is called → **a billed cloud browser is provisioned**.
3. `admin.py:471` then calls
   `ensure_daemon(env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), ...})` —
   **overwriting the user's explicit `BU_CDP_URL`** with the cloud WebSocket in the daemon env.

Net: surprise cloud bill plus the explicit endpoint silently replaced.

### Verified against the editable-installed package

| Run | `run.py` state | helper exists | `start_remote_daemon` called |
|---|---|---|---|
| A | upstream main (`origin/main`) | False | **True (bug reproduces)** |
| B | this PR's fix applied | True | **False (correct)** |

Identical env, identical invocation, identical mocks for `daemon_alive` /
`_local_chrome_listening` / `start_remote_daemon`. Only `run.py` differs.

## Fix

Add `_explicit_cdp_configured()` next to `_local_chrome_listening()` and
gate the auto-bootstrap with `not _explicit_cdp_configured()`. Mirrors the
existing `_is_local_chrome_mode` helper at `admin.py:159-161` that already
treats `BU_CDP_WS` as the "not local discovery" signal. #277's
fresh-headless-box behaviour (no explicit endpoint set) is preserved verbatim.

12 LOC change in `run.py` (helper + one guard line + comment refresh).

## Tests

8 new unit tests in `tests/unit/test_run.py`:

- `test_explicit_bu_cdp_url_blocks_cloud_bootstrap` — fix verification (URL)
- `test_explicit_bu_cdp_ws_blocks_cloud_bootstrap` — fix verification (WS)
- `test_both_bu_cdp_url_and_bu_cdp_ws_set_blocks_bootstrap` — caller doubly explicit
- `test_empty_bu_cdp_url_does_not_block_bootstrap` — empty string treated as unset
- `test_explicit_endpoint_does_not_break_daemon_alive_short_circuit` — daemon-alive path preserved
- `test_explicit_endpoint_does_not_break_local_chrome_short_circuit` — local-Chrome path preserved
- `test_explicit_cdp_configured_helper_truthy` — helper input table (URL/WS, IPv6, wss://)
- `test_explicit_cdp_configured_helper_falsy` — helper unset / empty-string

```
$ uv run --with pytest pytest tests/unit/ -q
74 passed in 0.40s
```

Without this patch, exactly 5 of the 8 new tests fail (the ones targeting
the guard + helper); the 3 short-circuit/empty edge cases pass even
unpatched because existing guards already cover those paths — confirms the
new tests isolate the regression cleanly.

## Edge case

If `BU_CDP_URL` is set but unreachable, this PR makes that case fail loudly
via `daemon.py:get_ws_url()`'s 30s probe rather than silently falling back
to a billed cloud browser. If silent fallback was intended, happy to
discuss — but `install.md:58-59` currently reads as an unconditional override.

## Refs

- #266 (original headless auto-bootstrap)
- #277 (`BU_AUTOSPAWN` opt-in by @Alezander9 — same area, didn't address explicit-endpoint precedence)
- #292 (`BU_CDP_URL` `/json/version` 404 fallback by @claytonlin1110)
- #181 (existing user report of manual `BU_CDP_WS` workaround)
- Doc contract: `install.md:58-59`
- Helper precedent: `admin.py:159-161` `_is_local_chrome_mode`
- Smoking gun: `admin.py:471` `start_remote_daemon` overwrites `BU_CDP_WS` in daemon env
