### PR TITLE
current_tab: resolve attached target_id server-side via daemon meta

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -273,6 +273,18 @@ class Daemon:
             out = list(self.events); self.events.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
+        if meta == "current_tab":
+            # Resolve the attached page's target info server-side. Helpers can't
+            # send Target.getTargetInfo themselves: daemon strips session_id for
+            # any Target.* method (browser-level call), and without a targetId
+            # Chrome silently returns the *browser* target.
+            if not self.target_id:
+                return {"error": "not_attached"}
+            try:
+                info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
+            except Exception:
+                return {"error": "cdp_disconnected"}
+            return {"targetId": info.get("targetId"), "url": info.get("url", ""), "title": info.get("title", "")}
         if meta == "connection_status":
             if not self.target_id:
                 return {"error": "not_attached"}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -292,8 +292,8 @@ def list_tabs(include_chrome=True):
     return out
 
 def current_tab():
-    t = cdp("Target.getTargetInfo").get("targetInfo", {})
-    return {"targetId": t.get("targetId"), "url": t.get("url", ""), "title": t.get("title", "")}
+    r = _send({"meta": "current_tab"})
+    return {"targetId": r["targetId"], "url": r["url"], "title": r["title"]}
 
 def _mark_tab():
     """Prepend 🟢 to tab title so the user can see which tab the agent controls."""

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -243,3 +243,53 @@ def test_set_session_first_attach_runs_four_enables_in_parallel():
         f"first set_session must run 4 enables concurrently "
         f"(observed peak = {peak}). No Network.disable should fire."
     )
+
+
+def test_current_tab_meta_passes_attached_target_id():
+    """Regression for issue #304: helpers.current_tab() previously sent
+    Target.getTargetInfo with no targetId. The daemon strips session_id for
+    Target.* methods, so the call hit the browser-level connection with empty
+    params, and Chrome returned info about the *browser* target (empty
+    url/title) instead of the attached page. The daemon now resolves this
+    server-side using its tracked target_id."""
+    class _TargetInfoCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Target.getTargetInfo":
+                return {"targetInfo": {
+                    "targetId": params["targetId"],
+                    "url": "https://example.com/",
+                    "title": "Example Domain",
+                    "type": "page",
+                }}
+            return {}
+
+    d = daemon.Daemon()
+    d.cdp = _TargetInfoCDP()
+    d.target_id = "page-target-abc"
+
+    result = asyncio.run(d.handle({"meta": "current_tab"}))
+
+    assert result == {
+        "targetId": "page-target-abc",
+        "url": "https://example.com/",
+        "title": "Example Domain",
+    }
+    # The targetId must be passed through — that's the whole point of the fix.
+    get_info_calls = [(p, s) for (m, p, s) in d.cdp.calls if m == "Target.getTargetInfo"]
+    assert get_info_calls == [({"targetId": "page-target-abc"}, None)]
+
+
+def test_current_tab_meta_returns_not_attached_when_no_target_id():
+    """Without an attached page, current_tab() has no meaningful answer.
+    Returning {error: not_attached} causes _send() to raise in helpers, which
+    is the right signal for callers like ensure_real_tab() that wrap the call
+    in try/except."""
+    d = _fresh_daemon()
+    d.target_id = None
+
+    result = asyncio.run(d.handle({"meta": "current_tab"}))
+
+    assert result == {"error": "not_attached"}
+    # No CDP call should have been issued.
+    assert d.cdp.calls == []


### PR DESCRIPTION
## Summary

- Fixes #304: `current_tab()` was returning the **browser target** (empty `url`/`title`) instead of the attached page, silently. The daemon strips `session_id` for any `Target.*` method, so `cdp("Target.getTargetInfo")` from helpers landed at the browser-level CDP connection with no `targetId` — and modern Chromium responds with the browser target's info rather than erroring.
- Resolves the target server-side: new `current_tab` daemon meta calls `Target.getTargetInfo` with `self.target_id` (mirroring the existing `connection_status` path). [`helpers.current_tab()`](src/browser_harness/helpers.py#L294-L296) now goes through the meta — single round-trip, no client-side target-id juggling.
- Restores `switch_tab(current_tab())` round-trip and the `ensure_real_tab()` short-circuit (which was dead code because `cur["url"]` was always empty).

## Root cause

Regression introduced in `da8257c` ("simplify: drop 14 unused helpers"). The pre-refactor `current_tab()` had 4 round-trips that resolved the target id; the 1-line replacement assumed `Target.getTargetInfo` with no params would return the attached page — it doesn't.

```python
# Before (helpers.py)
def current_tab():
    t = cdp("Target.getTargetInfo").get("targetInfo", {})  # browser target!
    return {"targetId": t.get("targetId"), "url": t.get("url", ""), "title": t.get("title", "")}
```

```python
# After (helpers.py)
def current_tab():
    r = _send({"meta": "current_tab"})
    return {"targetId": r["targetId"], "url": r["url"], "title": r["title"]}
```

The new daemon meta uses the same `self.target_id` resolution that [`connection_status`](src/browser_harness/daemon.py#L288-L300) already relies on:

```python
if meta == "current_tab":
    if not self.target_id:
        return {"error": "not_attached"}
    try:
        info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
    except Exception:
        return {"error": "cdp_disconnected"}
    return {"targetId": info.get("targetId"), "url": info.get("url", ""), "title": info.get("title", "")}
```

## Why server-side

Helpers can't fix this on the client: the daemon deliberately strips `session_id` for `Target.*` methods (browser-level only), and helpers don't track the page's `targetId` independently. The daemon already does — reusing it keeps the fix to one round-trip and avoids racing with `set_session`.

## Test plan

- [x] Unit: `test_current_tab_meta_passes_attached_target_id` — asserts the meta forwards `self.target_id` to `Target.getTargetInfo` and returns the `{targetId, url, title}` shape.
- [x] Unit: `test_current_tab_meta_returns_not_attached_when_no_target_id` — asserts the boundary case returns `{error: not_attached}` without issuing a CDP call (causes `_send()` to raise in helpers; `ensure_real_tab()`'s try/except handles it).
- [ ] Manual: attach to `https://example.com`, run `print(current_tab())` — should print the page's url/title, not empty strings.
- [ ] Manual: `original = current_tab(); new_tab("https://google.com"); switch_tab(original)` — round-trip should land back on `example.com`, not error attaching to the browser target.
- [ ] Manual: open a `chrome://newtab` tab, call `ensure_real_tab()` — short-circuit should now correctly detect the internal URL and switch to a real tab (previously fell through unconditionally).

## Files changed

- [src/browser_harness/daemon.py](src/browser_harness/daemon.py) — new `current_tab` meta (+12 lines).
- [src/browser_harness/helpers.py](src/browser_harness/helpers.py) — `current_tab()` routes through the meta (-2/+2 lines).
- [tests/unit/test_daemon.py](tests/unit/test_daemon.py) — two regression tests (+50 lines).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #304: `current_tab()` now returns the attached page (correct url/title) by resolving the target on the daemon. Helpers call a new `current_tab` meta that uses the tracked `target_id`, avoiding the browser-target fallback.

- **Bug Fixes**
  - Added daemon meta `current_tab` that calls `Target.getTargetInfo` with `self.target_id`; helpers route through it (single round-trip).
  - Restores `switch_tab(current_tab())` and `ensure_real_tab()` behavior; added unit tests for target-id forwarding and not-attached cases.

<sup>Written for commit b766246defa21e5b44fb5cefeb3ed3b4f9120664. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

