### PR TITLE
fix(ipc): set umask 0077 around AF_UNIX bind to avoid chmod TOCTOU

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -150,8 +150,10 @@ async def serve(name, handler):
     if not IS_WINDOWS:
         path = str(_sock_path(name))
         if os.path.exists(path): os.unlink(path)
-        server = await asyncio.start_unix_server(handler, path=path)
-        os.chmod(path, 0o600)
+        # umask 0o077 makes bind() create the socket as 0600 — no TOCTOU window before chmod.
+        old_umask = os.umask(0o077)
+        try: server = await asyncio.start_unix_server(handler, path=path)
+        finally: os.umask(old_umask)
         _server_token = None
         async with server: await asyncio.Event().wait()
         return


### PR DESCRIPTION
## Summary

Closes the chmod TOCTOU window flagged in #298. Previously `asyncio.start_unix_server` would `bind()` + `listen()` with a umask-derived mode before `os.chmod(0o600)` ran, leaving a brief window where the socket reflected the caller's umask (e.g. `0o755` on default `umask 0o022`, `0o777` if a user explicitly set `umask 0`). Setting `umask 0o077` around the bind makes the socket land at `0600` directly, removing the window. The umask is restored in `finally`.

## Scope notes (re #298)

The reporter also flagged a `unlink()` -> `bind()` symlink race. That one isn't acted on here:

- `/tmp` carries the sticky bit (`1777`) on every supported platform, so a different UID cannot replace files at our path.
- A same-UID local attacker doesn't need to win a race to begin with — they can already attach to the Chrome process, read the user data dir, or connect to the socket post-`chmod`.

So in browser-harness's threat model (single-user sandbox/VM) this PR addresses the only race with a non-empty practical attack surface. If we ever support multi-tenant hosts, the right move is a per-UID parent directory (`/tmp/bu-<uid>/` mode `0700`), not chmod-after-bind hardening.
