### PR TITLE
Detect Helium as a local browser

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -631,16 +631,16 @@ def print_update_banner(out=None):
 
 
 def _chrome_running():
-    """Cross-platform best-effort check for a running Chrome/Edge process."""
+    """Cross-platform best-effort check for a running Chromium-based browser."""
     import platform, subprocess
     system = platform.system()
     try:
         if system == "Windows":
             out = subprocess.check_output(["tasklist"], text=True, timeout=5)
-            names = ("chrome.exe", "msedge.exe")
+            names = ("chrome.exe", "msedge.exe", "helium.exe")
         else:
             out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, timeout=5)
-            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge")
+            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium")
         return any(n.lower() in out.lower() for n in names)
     except Exception:
         return False

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -123,6 +123,16 @@ def test_browser_connections_returns_attached_page(monkeypatch):
     ]
 
 
+def test_chrome_running_detects_helium_on_linux(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *args, **kwargs: "systemd\nhelium\nxdg-desktop-portal\n",
+    )
+
+    assert admin._chrome_running()
+
+
 def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypatch, capsys):
     monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
     monkeypatch.setattr(admin, "_install_mode", lambda: "git")


### PR DESCRIPTION
## Summary
- detect Helium browser processes in local browser diagnostics
- broaden the local browser wording from Chrome/Edge to Chromium-based browsers
- add a unit test covering Helium process detection on Linux

## Tests
- uv run --with pytest pytest -q
- browser-harness --doctor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects Helium as a local browser in diagnostics and updates wording to “Chromium-based browsers.” Adds a Linux unit test to verify Helium process detection.

<sup>Written for commit 16925613bf2458123247f660290565c7d4d516b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

