### PR TITLE
fix: address reviewer comments from PR #315 (snap detection + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,31 @@ One websocket to Chrome, nothing between. The agent writes what's missing during
 
 Before running browser-harness, Chrome must be running with remote debugging enabled. The harness connects to Chrome via CDP — it will not launch Chrome itself.
 
-**macOS**
+There are two supported connection methods. Use **Way 1** if you want your real browser profile (logins, extensions, history). Use **Way 2** for an isolated profile with no interruptions.
+
+**Way 1 — your real profile, no command-line**
+
+1. Launch Chrome normally (or `open -a 'Google Chrome'` on macOS / `google-chrome` on Linux)
+2. Open `chrome://inspect/#remote-debugging`
+3. Tick **"Allow remote debugging for this browser instance"** — this setting is per-profile and sticky
+
+On Chrome 144+, the first attach by the harness triggers a per-attach "Allow remote debugging?" popup. Click Allow. See `install.md` for full details.
+
+**Way 2 — isolated profile, no popups, command-line only**
+
 ```bash
-open -a 'Google Chrome' --args --remote-debugging-port=9222
+# macOS
+open -a 'Google Chrome' --args --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-harness
+
+# Linux
+google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-harness
 ```
 
-**Linux**
-```bash
-google-chrome --remote-debugging-port=9222
-```
+On Chrome 136+, the port flag is silently ignored when `--user-data-dir` points to Chrome's platform default. Use an explicit non-default directory (empty or new — a fresh profile will be created there). Set `BU_CDP_URL=http://127.0.0.1:9222` before running `browser-harness`.
 
-Then open `chrome://inspect/#remote-debugging` and enable **Discover network targets** in the Devices tab.
+> **Linux snap users:** If the harness doctor reports snap confinement, install Chrome from [google.com/chrome](https://www.google.com/chrome/) or use the `.tar.gz` binary. Snap Chromium cannot bind the CDP port.
 
-> **Note:** On Linux, the default `chromium` package is often a Snap with restricted network access. If browser-harness cannot connect, install the official Chrome deb from google.com/chrome or use the `.tar.gz` binary instead.
+See `install.md` for the canonical setup reference.
 
 ## Setup prompt
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ One websocket to Chrome, nothing between. The agent writes what's missing during
 
 **You will never use the browser again.**
 
+## Prerequisites
+
+Before running browser-harness, Chrome must be running with remote debugging enabled. The harness connects to Chrome via CDP — it will not launch Chrome itself.
+
+**macOS**
+```bash
+open -a 'Google Chrome' --args --remote-debugging-port=9222
+```
+
+**Linux**
+```bash
+google-chrome --remote-debugging-port=9222
+```
+
+Then open `chrome://inspect/#remote-debugging` and enable **Discover network targets** in the Devices tab.
+
+> **Note:** On Linux, the default `chromium` package is often a Snap with restricted network access. If browser-harness cannot connect, install the official Chrome deb from google.com/chrome or use the `.tar.gz` binary instead.
+
 ## Setup prompt
 
 Paste into Claude Code or Codex:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -668,19 +668,20 @@ def _open_chrome_inspect():
 
 def _snap_browser_detected():
     """Check if Chrome/Chromium is running as a snap (restricted CDP port access)."""
-    import platform, subprocess
+    import platform
     if platform.system() != "Linux":
         return False
-    if os.environ.get("SNAP"):
-        return True
     try:
-        # Walk /proc looking for chromium/chrome processes with a snap mount
+        # Walk /proc looking for chromium/chrome processes with a snap mount.
+        # Unlike the SNAP env var (which only tells us if *this* process is snap-wrapped),
+        # scanning cmdline correctly identifies whether the actual browser is snap-confined.
         for pid_dir in Path("/proc").iterdir():
             if not pid_dir.name.isdigit():
                 continue
             try:
                 cmdline = Path(pid_dir / "cmdline").read_text()
-            except (FileNotFoundError, PermissionError, OSError):
+            except (FileNotFoundError, PermissionError, OSError, ValueError):
+                # ValueError covers UnicodeDecodeError from non-UTF-8 cmdline bytes
                 continue
             if "/snap/chromium/" in cmdline or "/snap/google-chrome/" in cmdline:
                 return True
@@ -695,7 +696,7 @@ def run_doctor():
     cur = _version()
     mode = _install_mode()
     chrome = _chrome_running()
-    snap = _snap_browser_detected()
+    snap = _snap_browser_detected() if chrome else False  # only scan /proc when chrome is running
     daemon = daemon_alive()
     connections = browser_connections()
     profile_use = shutil.which("profile-use") is not None
@@ -732,8 +733,8 @@ def run_doctor():
             print(f"        {conn['name']} — active page: (no real page)")
     row("profile-use installed", profile_use, "" if profile_use else "optional: curl -fsSL https://browser-use.com/profile.sh | sh")
     row("BROWSER_USE_API_KEY set", api_key, "" if api_key else "optional: needed only for cloud browsers / profile sync")
-    # Core health = chrome + daemon. Profile-use/api-key are optional.
-    return 0 if (chrome and daemon) else 1
+    # Core health = chrome + daemon + no snap confinement. Profile-use/api-key are optional.
+    return 0 if (chrome and daemon and not snap) else 1
 
 
 def _prompt_yes(question, default_yes=True, yes=False):

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -666,12 +666,36 @@ def _open_chrome_inspect():
         pass
 
 
+def _snap_browser_detected():
+    """Check if Chrome/Chromium is running as a snap (restricted CDP port access)."""
+    import platform, subprocess
+    if platform.system() != "Linux":
+        return False
+    if os.environ.get("SNAP"):
+        return True
+    try:
+        # Walk /proc looking for chromium/chrome processes with a snap mount
+        for pid_dir in Path("/proc").iterdir():
+            if not pid_dir.name.isdigit():
+                continue
+            try:
+                cmdline = Path(pid_dir / "cmdline").read_text()
+            except (FileNotFoundError, PermissionError, OSError):
+                continue
+            if "/snap/chromium/" in cmdline or "/snap/google-chrome/" in cmdline:
+                return True
+    except Exception:
+        pass
+    return False
+
+
 def run_doctor():
     """Read-only diagnostics. Exit 0 iff everything looks healthy."""
     import platform, shutil, sys
     cur = _version()
     mode = _install_mode()
     chrome = _chrome_running()
+    snap = _snap_browser_detected()
     daemon = daemon_alive()
     connections = browser_connections()
     profile_use = shutil.which("profile-use") is not None
@@ -695,6 +719,7 @@ def run_doctor():
     else:
         print("  latest release    (could not reach github)")
     row("chrome running", chrome, "" if chrome else "start chrome/edge")
+    row("snap confinement", not snap, "" if not snap else "snap Chromium cannot bind CDP port — install Chrome from google.com/chrome instead")
     row("daemon alive", daemon, "" if daemon else "see install.md")
     row("active browser connections", bool(connections), str(len(connections)))
     for conn in connections:


### PR DESCRIPTION
## Summary

Two fixes bundled into one PR:

### 1. README: Add Chrome Remote Debugging Prerequisite (fixes #123)

New Prerequisites section before the Setup prompt with:
- macOS: open -a 'Google Chrome' --args --remote-debugging-port=9222
- Linux: google-chrome --remote-debugging-port=9222
- Note about Snap Chromium CDP limitations

### 2. admin.py: Add Snap Confinement Detection (fixes #191)

New _snap_browser_detected() helper that checks:
- SNAP env var is set (running inside a snap)
- /snap/chromium/ or /snap/google-chrome/ in process cmdlines via /proc/

Surfaced as a FAIL row in run_doctor() with:
> snap Chromium cannot bind CDP port — install Chrome from google.com/chrome instead

## Files Changed

- README.md — added Prerequisites section
- src/browser_harness/admin.py — _snap_browser_detected() + doctor row

## Tests

63/64 unit tests pass. The single failure (test_cloud_bootstrap_on_headless_server) is pre-existing and unrelated to these changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clear Chrome remote‑debugging Prerequisites section (two ways to connect) and updates the doctor to detect and fail on Snap‑confined Chromium, reducing Linux setup issues.

- **New Features**
  - README: Adds Prerequisites with two options: (Way 1) enable “Allow remote debugging for this browser instance” in `chrome://inspect/#remote-debugging` (handles Chrome 144+ allow prompt), or (Way 2) launch with `--remote-debugging-port=9222` and a non‑default `--user-data-dir` (e.g. `/tmp/chrome-harness`); recommend setting `BU_CDP_URL=http://127.0.0.1:9222`.
  - Doctor: Adds `_snap_browser_detected()` (Linux) that scans `/proc/*/cmdline` for `/snap/chromium/` or `/snap/google-chrome/` (no `SNAP` env var reliance), scans only when Chrome is running, and tolerates non‑UTF‑8 cmdlines; adds a “snap confinement” row and includes it in the exit status with guidance: “snap Chromium cannot bind CDP port — install Chrome from google.com/chrome instead”.

<sup>Written for commit a7a7b520f3acae8293dcc3914a7139d97d19a22c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

