### PR TITLE
feat: auto-dismiss native dialogs in action helpers

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -47,8 +47,28 @@ def drain_events():  return _send({"meta": "drain_events"})["events"]
 
 
 # --- navigation / page ---
+def _check_and_dismiss_dialog(accept=True, prompt_text=""):
+    """Auto-dismiss any pending native dialog. Returns the dialog dict if one was
+    dismissed, else None.
+
+    Dialogs (alert/confirm/prompt/beforeunload) freeze the JS thread, so any
+    subsequent action helper hangs silently. Action helpers call this after their
+    CDP work so a stray dialog doesn't deadlock the run. Opt out per-process with
+    BH_NO_AUTO_DISMISS=1; manual API in interaction-skills/dialogs.md."""
+    if os.environ.get("BH_NO_AUTO_DISMISS"):
+        return None
+    dialog = _send({"meta": "pending_dialog"}).get("dialog")
+    if not dialog:
+        return None
+    cdp("Page.handleJavaScriptDialog", accept=accept, promptText=prompt_text)
+    msg = (dialog.get("message") or "")[:200]
+    print(f"[auto-dismissed {dialog.get('type', 'dialog')}] {msg}")
+    return dialog
+
+
 def goto_url(url):
     r = cdp("Page.navigate", url=url)
+    _check_and_dismiss_dialog()
     d = (Path(__file__).parent / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0])
     return {**r, "domain_skills": sorted(p.name for p in d.rglob("*.md"))[:10]} if d.is_dir() else r
 
@@ -90,6 +110,7 @@ def click_at_xy(x, y, button="left", clicks=1):
         _debug_click_counter += 1
     cdp("Input.dispatchMouseEvent", type="mousePressed", x=x, y=y, button=button, clickCount=clicks)
     cdp("Input.dispatchMouseEvent", type="mouseReleased", x=x, y=y, button=button, clickCount=clicks)
+    _check_and_dismiss_dialog()
 
 def type_text(text):
     cdp("Input.insertText", text=text)
@@ -112,6 +133,7 @@ def press_key(key, modifiers=0):
     if text and len(text) == 1:
         cdp("Input.dispatchKeyEvent", type="char", text=text, **{k: v for k, v in base.items() if k != "text"})
     cdp("Input.dispatchKeyEvent", type="keyUp", **base)
+    _check_and_dismiss_dialog()
 
 def scroll(x, y, dy=-300, dx=0):
     cdp("Input.dispatchMouseEvent", type="mouseWheel", x=x, y=y, deltaX=dx, deltaY=dy)
@@ -226,6 +248,7 @@ def dispatch_key(selector, key="Enter", event="keypress"):
     js(
         f"(()=>{{const e=document.querySelector({json.dumps(selector)});if(e){{e.focus();e.dispatchEvent(new KeyboardEvent({json.dumps(event)},{{key:{json.dumps(key)},code:{json.dumps(key)},keyCode:{kc},which:{kc},bubbles:true}}));}}}})()"
     )
+    _check_and_dismiss_dialog()
 
 def upload_file(selector, path):
     """Set files on a file input via CDP DOM.setFileInputFiles. `path` is an absolute filepath (use tempfile.mkstemp if needed)."""

--- a/test_dialog_auto_dismiss.py
+++ b/test_dialog_auto_dismiss.py
@@ -1,0 +1,116 @@
+from unittest.mock import patch, call
+import helpers
+
+
+def _mk_send(dialog):
+    def _send(req):
+        if req.get("meta") == "pending_dialog":
+            return {"dialog": dialog}
+        return {}
+    return _send
+
+
+def test_no_dialog_returns_none_and_does_not_call_cdp():
+    with patch("helpers._send", side_effect=_mk_send(None)), \
+         patch("helpers.cdp") as mock_cdp:
+        result = helpers._check_and_dismiss_dialog()
+    assert result is None
+    mock_cdp.assert_not_called()
+
+
+def test_dialog_pending_dismisses_with_accept_true():
+    dialog = {"type": "alert", "message": "boom"}
+    with patch("helpers._send", side_effect=_mk_send(dialog)), \
+         patch("helpers.cdp") as mock_cdp:
+        result = helpers._check_and_dismiss_dialog()
+    assert result == dialog
+    mock_cdp.assert_called_once_with(
+        "Page.handleJavaScriptDialog", accept=True, promptText=""
+    )
+
+
+def test_dialog_dismiss_respects_accept_false():
+    dialog = {"type": "confirm", "message": "delete?"}
+    with patch("helpers._send", side_effect=_mk_send(dialog)), \
+         patch("helpers.cdp") as mock_cdp:
+        helpers._check_and_dismiss_dialog(accept=False)
+    mock_cdp.assert_called_once_with(
+        "Page.handleJavaScriptDialog", accept=False, promptText=""
+    )
+
+
+def test_dialog_dismiss_passes_prompt_text():
+    dialog = {"type": "prompt", "message": "name?"}
+    with patch("helpers._send", side_effect=_mk_send(dialog)), \
+         patch("helpers.cdp") as mock_cdp:
+        helpers._check_and_dismiss_dialog(prompt_text="alice")
+    mock_cdp.assert_called_once_with(
+        "Page.handleJavaScriptDialog", accept=True, promptText="alice"
+    )
+
+
+def test_env_var_disables_auto_dismiss(monkeypatch):
+    monkeypatch.setenv("BH_NO_AUTO_DISMISS", "1")
+    dialog = {"type": "alert", "message": "x"}
+    with patch("helpers._send", side_effect=_mk_send(dialog)) as mock_send, \
+         patch("helpers.cdp") as mock_cdp:
+        result = helpers._check_and_dismiss_dialog()
+    assert result is None
+    mock_cdp.assert_not_called()
+    mock_send.assert_not_called()
+
+
+def test_click_at_xy_auto_dismisses_dialog():
+    dialog = {"type": "alert", "message": "clicked"}
+    cdp_calls = []
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        return {}
+    with patch("helpers._send", side_effect=_mk_send(dialog)), \
+         patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.click_at_xy(100, 200)
+    methods = [c[0] for c in cdp_calls]
+    assert "Input.dispatchMouseEvent" in methods
+    assert "Page.handleJavaScriptDialog" in methods
+    assert methods.index("Page.handleJavaScriptDialog") > methods.index("Input.dispatchMouseEvent")
+
+
+def test_press_key_auto_dismisses_dialog():
+    dialog = {"type": "confirm", "message": "submit?"}
+    cdp_calls = []
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        return {}
+    with patch("helpers._send", side_effect=_mk_send(dialog)), \
+         patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.press_key("Enter")
+    methods = [c[0] for c in cdp_calls]
+    assert "Input.dispatchKeyEvent" in methods
+    assert "Page.handleJavaScriptDialog" in methods
+
+
+def test_goto_url_auto_dismisses_beforeunload():
+    dialog = {"type": "beforeunload", "message": "leave?"}
+    cdp_calls = []
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        return {}
+    with patch("helpers._send", side_effect=_mk_send(dialog)), \
+         patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.goto_url("https://example.com")
+    methods = [c[0] for c in cdp_calls]
+    assert "Page.navigate" in methods
+    assert "Page.handleJavaScriptDialog" in methods
+
+
+def test_click_no_dialog_only_calls_input_dispatch():
+    cdp_calls = []
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        return {}
+    with patch("helpers._send", side_effect=_mk_send(None)), \
+         patch("helpers.cdp", side_effect=fake_cdp):
+        helpers.click_at_xy(50, 60)
+    methods = [c[0] for c in cdp_calls]
+    assert "Page.handleJavaScriptDialog" not in methods
+    assert methods.count("Input.dispatchMouseEvent") == 2


### PR DESCRIPTION
## Summary

Native dialogs (`alert` / `confirm` / `prompt` / `beforeunload`) freeze the JS thread, causing action helpers to silently hang behind a modal the agent never expected. The daemon already tracks pending dialogs via `Page.javascriptDialogOpening`, but helpers don't consult it. This PR makes action helpers auto-detect and dismiss after each action so a stray dialog doesn't deadlock the run.

## Changes

- New private helper `_check_and_dismiss_dialog(accept=True, prompt_text="")` in `helpers.py`. Reuses the existing `_send({"meta": "pending_dialog"})` daemon channel that `page_info()` already uses.
- Wraps four action helpers to auto-check after their CDP work:
  - `goto_url` (catches `beforeunload`)
  - `click_at_xy`
  - `press_key`
  - `dispatch_key`
- Logs `[auto-dismissed <type>] <message>` per dismissal so runs are debuggable.
- Opt out per process with `BH_NO_AUTO_DISMISS=1` for callers that need to inspect dialogs manually (the existing API in `interaction-skills/dialogs.md` still works).
- `accept=True` matches the JS-stub pattern in `interaction-skills/dialogs.md` (confirm returns true, beforeunload leaves).

## Why

Currently agents get stuck on sites that throw an unexpected `confirm()` mid-flow (e.g. "Are you sure you want to leave?", form-validation alerts, beforeunload on navigation). The screenshot looks normal, the click coordinates are right, but every subsequent action silently no-ops because the JS thread is frozen. The fix is one CDP call (`Page.handleJavaScriptDialog`) — making it implicit in the action helpers eliminates an entire class of silent-hang failure mode.

## Test plan

- [x] 9 new unit tests in `test_dialog_auto_dismiss.py` covering:
  - No-dialog path (no extra CDP call, no daemon round-trip when env-disabled)
  - Dialog present → `Page.handleJavaScriptDialog` called with correct args
  - `accept=False` and `prompt_text=` overrides
  - `BH_NO_AUTO_DISMISS=1` opt-out
  - Integration through `click_at_xy`, `press_key`, `goto_url`
- [x] Full existing suite still passes (10 → 19 tests, all green)

## Notes

- The daemon already clears `self.dialog` on `Page.javascriptDialogClosed` (`daemon.py:168`), so there's no infinite-loop risk after dismissal.
- Doesn't wrap `type_text` / `scroll` / `upload_file` — these don't typically trigger dialogs synchronously and the next action will catch any that slip through.
- Manual API in `interaction-skills/dialogs.md` is unchanged; this only affects the default behavior of the wrapped helpers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-dismiss native `alert`/`confirm`/`prompt`/`beforeunload` dialogs after each action helper to prevent runs hanging behind unexpected modals. This makes interactions more reliable by unfreezing the JS thread automatically.

- **New Features**
  - Added private `_check_and_dismiss_dialog(accept=True, prompt_text="")` that checks daemon `pending_dialog` and calls `Page.handleJavaScriptDialog`.
  - Auto-check added to `goto_url`, `click_at_xy`, `press_key`, and `dispatch_key`.
  - Logs `[auto-dismissed <type>] <message>` for debugging.
  - Opt out with `BH_NO_AUTO_DISMISS=1` for manual dialog handling.

<sup>Written for commit af66c7ce1c343b13c58ece493e610444809cd4d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

