### PR TITLE
feat(ipc): split BH_RUNTIME_DIR (sock) from BH_TMP_DIR (logs/screenshots)

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -3,13 +3,22 @@ import asyncio, json, os, re, secrets, socket, subprocess, sys, tempfile
 from pathlib import Path
 
 IS_WINDOWS = sys.platform == "win32"
-# BH_TMP_DIR set → caller-isolated dir, bare filenames (avoids AF_UNIX sun_path
-# overrun: 104 macOS / 108 Linux). Unset → shared tmpdir, "bu-<NAME>" prefix
-# disambiguates daemons. POSIX default is /tmp (gettempdir() returns long
-# /var/folders/... on macOS); Windows uses TCP so any tempdir is fine.
+# Two caller-supplied dirs:
+#   BH_RUNTIME_DIR — sock/port/pid. AF_UNIX sun_path is 104 bytes on macOS, so
+#       the runtime dir must be short. Caller is responsible for keeping it
+#       within budget. Falls back to BH_TMP_DIR (legacy single-dir callers),
+#       then to /tmp on POSIX (gettempdir() returns long /var/folders/... on
+#       macOS — unsafe for AF_UNIX) or tempfile.gettempdir() on Windows (TCP).
+#   BH_TMP_DIR — screenshots, debug overlays, daemon log. No path-length
+#       sensitivity; caller can use a deep persistent path.
+# When the caller supplies a per-instance dir for either purpose, files use
+# bare "bu" stems; otherwise "bu-<NAME>" disambiguates co-tenants.
 BH_TMP_DIR = os.environ.get("BH_TMP_DIR")
+BH_RUNTIME_DIR = os.environ.get("BH_RUNTIME_DIR") or BH_TMP_DIR
 _TMP = Path(BH_TMP_DIR or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
+_RUNTIME = Path(BH_RUNTIME_DIR or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
 _TMP.mkdir(parents=True, exist_ok=True)
+_RUNTIME.mkdir(parents=True, exist_ok=True)
 _NAME_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
 
 # Set by serve() on Windows. Daemon's handle() requires every request to carry
@@ -25,15 +34,20 @@ def _check(name):  # path-traversal guard for BU_NAME
     return name
 
 
-def _stem(name):  # "bu" when BH_TMP_DIR isolates us, else "bu-<NAME>"
+def _runtime_stem(name):  # "bu" when BH_RUNTIME_DIR isolates us, else "bu-<NAME>"
+    _check(name)
+    return "bu" if BH_RUNTIME_DIR else f"bu-{name}"
+
+
+def _tmp_stem(name):  # "bu" when BH_TMP_DIR isolates us, else "bu-<NAME>"
     _check(name)
     return "bu" if BH_TMP_DIR else f"bu-{name}"
 
 
-def log_path(name):   return _TMP / f"{_stem(name)}.log"
-def pid_path(name):   return _TMP / f"{_stem(name)}.pid"
-def port_path(name):  return _TMP / f"{_stem(name)}.port"  # Windows-only: holds {"port","token"} JSON
-def _sock_path(name): return _TMP / f"{_stem(name)}.sock"
+def log_path(name):   return _TMP / f"{_tmp_stem(name)}.log"
+def pid_path(name):   return _RUNTIME / f"{_runtime_stem(name)}.pid"
+def port_path(name):  return _RUNTIME / f"{_runtime_stem(name)}.port"  # Windows-only: holds {"port","token"} JSON
+def _sock_path(name): return _RUNTIME / f"{_runtime_stem(name)}.sock"
 
 
 def _read_port_file(name):
@@ -48,7 +62,7 @@ def _read_port_file(name):
 def sock_addr(name):  # display-only, used in log lines
     if not IS_WINDOWS: return str(_sock_path(name))
     port, _ = _read_port_file(name)
-    return f"127.0.0.1:{port}" if port else f"tcp:{_stem(name)}"
+    return f"127.0.0.1:{port}" if port else f"tcp:{_runtime_stem(name)}"
 
 
 def spawn_kwargs():  # subprocess.Popen flags so the daemon detaches from this terminal

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -168,15 +168,15 @@ def daemon_alive(name=None):
 
 
 def _daemon_endpoint_names():
-    # BH_TMP_DIR isolates one daemon per dir → no filename-prefix discovery,
-    # just check whether our local endpoint exists. Without BH_TMP_DIR, _TMP
-    # is the shared default (`/tmp` etc.) and we glob `bu-*.<suffix>` to find
-    # every daemon on the machine.
+    # BH_RUNTIME_DIR isolates one daemon per dir → no filename-prefix discovery,
+    # just check whether our local endpoint exists. Without BH_RUNTIME_DIR,
+    # _RUNTIME is the shared default (`/tmp` etc.) and we glob `bu-*.<suffix>`
+    # to find every daemon on the machine.
     suffix = ".port" if ipc.IS_WINDOWS else ".sock"
-    if ipc.BH_TMP_DIR:
-        return [NAME] if (ipc._TMP / f"bu{suffix}").exists() else []
+    if ipc.BH_RUNTIME_DIR:
+        return [NAME] if (ipc._RUNTIME / f"bu{suffix}").exists() else []
     names = []
-    for p in sorted(ipc._TMP.glob(f"bu-*{suffix}")):
+    for p in sorted(ipc._RUNTIME.glob(f"bu-*{suffix}")):
         raw = p.name[3:-len(suffix)]
         try:
             ipc._check(raw)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -50,8 +50,8 @@ def test_stale_websocket_does_not_open_chrome_inspect():
 
 def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", None)  # shared-tmpdir mode
-    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
+    monkeypatch.setattr(admin.ipc, "BH_RUNTIME_DIR", None)  # shared-tmpdir mode
+    monkeypatch.setattr(admin.ipc, "_RUNTIME", tmp_path)
     (tmp_path / "bu-default.sock").touch()
     (tmp_path / "bu-remote_1.sock").touch()
     (tmp_path / "bu-invalid.name.sock").touch()
@@ -60,20 +60,20 @@ def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatc
     assert admin._daemon_endpoint_names() == ["default", "remote_1"]
 
 
-def test_daemon_endpoint_names_with_bh_tmp_dir_returns_local_name_when_sock_exists(tmp_path, monkeypatch):
+def test_daemon_endpoint_names_with_bh_runtime_dir_returns_local_name_when_sock_exists(tmp_path, monkeypatch):
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", str(tmp_path))
-    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
+    monkeypatch.setattr(admin.ipc, "BH_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "_RUNTIME", tmp_path)
     monkeypatch.setattr(admin, "NAME", "session-xyz")
     (tmp_path / "bu.sock").touch()
 
     assert admin._daemon_endpoint_names() == ["session-xyz"]
 
 
-def test_daemon_endpoint_names_with_bh_tmp_dir_returns_empty_when_sock_missing(tmp_path, monkeypatch):
+def test_daemon_endpoint_names_with_bh_runtime_dir_returns_empty_when_sock_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", str(tmp_path))
-    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
+    monkeypatch.setattr(admin.ipc, "BH_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "_RUNTIME", tmp_path)
     monkeypatch.setattr(admin, "NAME", "session-xyz")
 
     assert admin._daemon_endpoint_names() == []


### PR DESCRIPTION
## Summary

Splits the single `BH_TMP_DIR` env var into two: `BH_RUNTIME_DIR` for sock/port/pid, `BH_TMP_DIR` for log/screenshots. `BH_RUNTIME_DIR` falls back to `BH_TMP_DIR` so existing callers keep working without changes.

## Why

A single dir conflated two storage concerns with opposite constraints:

- **sock/port/pid** — AF_UNIX `sun_path` is **104 bytes on macOS**, 108 on Linux. The runtime dir must be short.
- **log/screenshots** — no length limit; benefit from a deep, indexable, persistent path.

Forcing both into one dir means a caller either:

1. picks a short path (e.g. `/tmp/bu-<sid>/`) and buries screenshots under tmp where they get GC''d on reboot and are awkward to find, or
2. picks a deep path (e.g. `~/.local/share/myapp/sessions/<sid>/`) and silently overruns `sun_path` on macOS for any non-trivial username/session-id.

Two dirs lets a caller put each file class where it belongs.

## Behavior

```
BH_RUNTIME_DIR   sock/port/pid     short path required
BH_TMP_DIR       log, screenshots  persistent path OK
```

Resolution: `BH_RUNTIME_DIR` → `BH_TMP_DIR` → `/tmp` (POSIX) / `tempfile.gettempdir()` (Windows).

The `bu` vs `bu-<NAME>` stem rule is now per-dir: a caller can isolate runtime files (one daemon per `BH_RUNTIME_DIR`) while still sharing a log/screenshot dir, or vice versa.

## Changes

- `_ipc.py` — add `BH_RUNTIME_DIR`, `_RUNTIME`; split `_stem` into `_runtime_stem` / `_tmp_stem`; route `pid_path`/`port_path`/`_sock_path` through `_RUNTIME` and `log_path` through `_TMP`.
- `admin.py` — `_daemon_endpoint_names()` discovers daemons via `_RUNTIME` instead of `_TMP`.
- `tests/unit/test_admin.py` — patch `BH_RUNTIME_DIR` / `_RUNTIME`.

`helpers.py` screenshot paths continue to use `_TMP` (correct: they are persistent, not runtime).

## Tests

`pytest tests/` — 93 passed.