### PR TITLE
docs: nudge agents to read matching domain skills

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -9,6 +9,8 @@ Direct browser control via CDP. For task-specific edits, use `agent-workspace/ag
 
 Domain skills (community-contributed per-site playbooks under `agent-workspace/domain-skills/`) are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.
 
+**If `BH_DOMAIN_SKILLS=1` and the task is site-specific, read every file in the matching `agent-workspace/domain-skills/<site>/` directory before inventing an approach.**
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- Add the requested one-sentence prompt to `SKILL.md` so agents that load the main skill consult the matching site-specific domain skill directory before inventing an approach.
- Keep the instruction gated on `BH_DOMAIN_SKILLS=1`, matching the existing opt-in behavior.

Closes #155

## Verification
- Confirmed `agent-workspace/domain-skills/` currently has 94 site directories; largest single site directory has 4 files, so this reads only the relevant site's bounded files.
- `python3` markdown/frontmatter sanity check for `SKILL.md`
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests` → 93 passed
- `python -m build --outdir /tmp/browser-harness-pr-dist .` → wheel and sdist built successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-line instruction to `SKILL.md` directing agents that when `BH_DOMAIN_SKILLS=1` and a task is site-specific, they should read every file in the matching `agent-workspace/domain-skills/<site>/` directory before choosing an approach. Keeps domain skills opt-in and nudges use of per-site playbooks.

<sup>Written for commit 226876d56e46ff755b7f5049b088f76be65bce65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

