### PR TITLE
install.md: drop star-the-repo prompt from first-run demo

### DIFF
--- a/install.md
+++ b/install.md
@@ -129,5 +129,4 @@ If the user hasn't said which connection method to use, default to Way 1 if Chro
 
 If Way 1 fails repeatedly or the user's task is unattended, move to Way 2 or a cloud browser per the Browser connection reference (these have no popups).
 
-If you are testing browser connection for the first time, run this demo: open `https://github.com/browser-use/browser-harness` in a new tab and activate it (`switch_tab`) so the user sees the harness has attached. If they are logged into GitHub, ask whether to star the repo for them — only click if they say yes. If they are not logged in, navigate to `https://browser-use.com` instead. Then ask what they want to do next.
-
+If you are testing browser connection for the first time, run this demo: open `https://github.com/browser-use/browser-harness` in a new tab and activate it (`switch_tab`) so the user sees the harness has attached. Then ask what they want to do next.


### PR DESCRIPTION
## Summary

Several users (Slack + GitHub) flagged that `install.md`'s first-time-setup demo currently tells the agent to ask the user whether to star the browser-harness repo on their behalf:

> If they are logged into GitHub, ask whether to star the repo for them — only click if they say yes.

That reads as star-farming and is the first thing a brand-new user experiences after installing the harness — bad first impression.

This drops the star ask entirely. The demo still opens `github.com/browser-use/browser-harness` in a new tab so the user can see the harness has attached, but it no longer solicits a star or branches on login state.

## Diff

Last paragraph of `install.md`, before:

> If you are testing browser connection for the first time, run this demo: open `https://github.com/browser-use/browser-harness` in a new tab and activate it (`switch_tab`) so the user sees the harness has attached. **If they are logged into GitHub, ask whether to star the repo for them — only click if they say yes. If they are not logged in, navigate to `https://browser-use.com` instead.** Then ask what they want to do next.

After:

> If you are testing browser connection for the first time, run this demo: open `https://github.com/browser-use/browser-harness` in a new tab and activate it (`switch_tab`) so the user sees the harness has attached. Then ask what they want to do next.

## Test plan

- [x] Diff is documentation-only — `install.md` is the only file touched
- [ ] Skim the full file to confirm no other references to starring remain

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the star-the-repo prompt from the first-run demo in `install.md` to avoid star-farming and improve the first-time experience. The demo still opens `https://github.com/browser-use/browser-harness` and activates the tab, then asks what to do next, with no login-based branching.

<sup>Written for commit 32be32fa66b297540882eb619b4689196a8934bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

