### PR TITLE
feat: use 🐴 (horse) instead of 🟢 as the controlled-tab marker

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -246,7 +246,7 @@ class Daemon:
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
-        mark_js = "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"
+        mark_js = "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"
         async def tap(method, params, session_id=None):
             self.events.append({"method": method, "params": params, "session_id": session_id})
             if method == "Page.javascriptDialogOpening":
@@ -326,12 +326,12 @@ class Daemon:
                 tasks.append(disable_old())
             tasks.append(self._enable_default_domains(self.session))
             await asyncio.gather(*tasks)
-            # 🟢 tab-marker title prefix is purely cosmetic — fire-and-forget so
+            # 🐴 tab-marker title prefix is purely cosmetic — fire-and-forget so
             # it doesn't add to the synchronous IPC budget.
             asyncio.create_task(_silent(asyncio.wait_for(
                 self.cdp.send_raw(
                     "Runtime.evaluate",
-                    {"expression": "if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title"},
+                    {"expression": "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"},
                     session_id=self.session,
                 ),
                 timeout=2,

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -296,16 +296,17 @@ def current_tab():
     return {"targetId": r["targetId"], "url": r["url"], "title": r["title"]}
 
 def _mark_tab():
-    """Prepend 🟢 to tab title so the user can see which tab the agent controls."""
-    try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F7E2'))document.title='\U0001F7E2 '+document.title")
+    """Prepend 🐴 to tab title so the user can see which tab the agent controls."""
+    try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
 def switch_tab(target):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
     target_id = target.get("targetId") if isinstance(target, dict) else target
-    # Unmark old tab
-    try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F7E2 '))document.title=document.title.slice(2)")
+    # Unmark old tab. 🐴 is a surrogate pair in JS UTF-16 strings (2 code units),
+    # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
+    try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
     cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -1,6 +1,6 @@
 import os, sys, urllib.request
 
-# Windows default stdout encoding is cp1252, which can't encode the 🟢 marker
+# Windows default stdout encoding is cp1252, which can't encode the 🐴 marker
 # helpers prepend to tab titles (or anything else outside Latin-1). Force UTF-8
 # so `print(page_info())` doesn't UnicodeEncodeError on Windows. Issue #124(4).
 if hasattr(sys.stdout, "reconfigure"):


### PR DESCRIPTION
## Summary
- Replaces the `🟢` controlled-tab title prefix with `🐴`. The green dot didn't fit the harness theme; the horse is a small in-joke (a horse wears a harness) and visually distinct from real-site favicons/titles.
- Fixes a latent slice bug along the way: the prefix is 3 UTF-16 code units (surrogate pair + space), so `switch_tab`'s unmark now uses `.slice(3)` and removes the trailing space cleanly. The old `🟢 + .slice(2)` left the space behind, which would slowly accumulate leading spaces across repeated switch cycles.

## Files
- `src/browser_harness/helpers.py` — `_mark_tab` / `switch_tab` use `\U0001F434` and `slice(3)`.
- `src/browser_harness/daemon.py` — both daemon-side mark sites updated.
- `src/browser_harness/run.py` — comment refers to the new marker (UTF-8 stdout reconfigure still required, `🐴` is also outside Latin-1).

## Tested
Way 2 (`--remote-debugging-port=9222 --user-data-dir=<temp>`) on Windows:
- `new_tab("https://example.com")` → title `🐴 Example Domain` (codepoint `0x1f434`).
- Opening a second tab moves the marker to the new active tab; the first tab's title is restored to `Example Domain` (no leading space).
- Switching back via `switch_tab` moves the marker again; only ever one tab is marked.

## Notes
- `agent-workspace/domain-skills/` files still reference the old `🟢` marker. Per `AGENTS.md` those are agent-authored notes and weren't touched here; they'll be refreshed when agents revisit those skills.
- `🐴` will render as a colorful emoji wherever `🟢` did, so platform support is unchanged.