### PR TITLE
fix(daemon): fall back to /json/version when no DevToolsActivePort exists

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -82,6 +82,23 @@ def get_ws_url():
             finally:
                 probe.close()
         return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+    # Fallback: no DevToolsActivePort file was found in any known profile
+    # (e.g. Chrome launched with a --user-data-dir outside the list, or a Chrome
+    # build that doesn't write the file at all). Probe the common CDP ports and
+    # read the authoritative ws URL from /json/version.
+    for probe_port in (9222, 9223, 9224):
+        try:
+            data = urllib.request.urlopen(
+                f"http://127.0.0.1:{probe_port}/json/version", timeout=2
+            ).read()
+        except Exception:
+            continue
+        try:
+            ws = json.loads(data).get("webSocketDebuggerUrl")
+            if ws:
+                return ws
+        except Exception:
+            continue
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 


### PR DESCRIPTION
## Problem

When Chrome is launched with a custom `--user-data-dir` (i.e. not its default
`~/Library/Application Support/Google/Chrome` or Linux/Windows equivalents),
**Chrome does not write `DevToolsActivePort` into that directory.** It only
writes the file into its standard user data dir, regardless of `--user-data-dir`.

This means `daemon.py`'s `get_ws_url()` walks the entire `PROFILES` list, finds
no `DevToolsActivePort` anywhere, and raises:

```
DevToolsActivePort not found in [...] — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser
```

…even though a CDP endpoint is live on `http://127.0.0.1:9222/json/version`
and ready to serve.

### Motivating case

On macOS, Chrome's main Default profile shows an **"Allow remote debugging"**
consent dialog on every launch when remote-debugging is enabled via
`chrome://inspect/#remote-debugging`. The common workaround is to use a
dedicated debug profile via a LaunchAgent or shell alias:

```
Chrome --user-data-dir=~/Library/Application\ Support/Chrome-Debug \
       --remote-debugging-port=9222
```

Chrome honors the flag silently in this custom dir (no prompt, ever) — but
because it writes `DevToolsActivePort` only into the standard dir, the harness
currently can't attach.

## Fix

Add a fallback at the end of `get_ws_url()` in `daemon.py`: if no
`DevToolsActivePort` file is found in any known `PROFILES` path, probe the
common CDP ports (`9222`, `9223`, `9224`) via `/json/version` and return the
authoritative `webSocketDebuggerUrl` from the response.

This mirrors the pattern already used in `admin.py`'s `_cdp_ws_from_url` for
remote browsers, and is a no-op for users whose profile already has
`DevToolsActivePort` — the existing loop runs first and returns before the
fallback is reached.

## Diff

Isolated to 17 added lines in `daemon.py`:

```python
# Fallback: no DevToolsActivePort file was found in any known profile
# (e.g. Chrome launched with a --user-data-dir outside the list, or a Chrome
# build that doesn't write the file at all). Probe the common CDP ports and
# read the authoritative ws URL from /json/version.
for probe_port in (9222, 9223, 9224):
    try:
        data = urllib.request.urlopen(
            f"http://127.0.0.1:{probe_port}/json/version", timeout=2
        ).read()
    except Exception:
        continue
    try:
        ws = json.loads(data).get("webSocketDebuggerUrl")
        if ws:
            return ws
    except Exception:
        continue
```

## Verification

Reproduced locally on macOS 14, Chrome 147:

1. Launched Chrome with `--user-data-dir=~/Library/Application Support/Chrome-Debug --remote-debugging-port=9222`.
2. Confirmed `find ~/Library/Application\ Support -name DevToolsActivePort`
   returns nothing (Chrome wrote no file).
3. Confirmed `curl http://127.0.0.1:9222/json/version` returns a valid
   `webSocketDebuggerUrl`.
4. Before the fix: `browser-harness <<< 'print(page_info())'` raises
   `DevToolsActivePort not found in [...]`.
5. After the fix: attaches via the `/json/version` fallback, `page_info()`
   returns the live tab info.

Users with a standard Chrome profile layout see no behavior change — the
fallback only runs when the original loop finds nothing.

## Notes

- `BU_CDP_WS` remains the preferred escape hatch for fully custom CDP endpoints
  (non-default ports, remote hosts). The fallback just extends attach coverage
  to the common "custom data-dir, default port" case.
- Ports probed (`9222`, `9223`, `9224`) match the conventional range for local
  CDP; happy to widen if useful.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed Chrome attach when using a custom --user-data-dir by falling back to /json/version to resolve the CDP WebSocket URL. Stops the “DevToolsActivePort not found” error without changing behavior for standard profiles.

- **Bug Fixes**
  - Added a fallback in get_ws_url() to probe ports 9222–9224 via http://127.0.0.1:<port>/json/version and read webSocketDebuggerUrl.
  - Runs only when no DevToolsActivePort file is found; mirrors existing remote-browser logic.
  - Supports common custom profile setups; `BU_CDP_WS` still works for custom endpoints.

<sup>Written for commit bcc1c6c52daa7db7b384a5d1b354cddbe0194bdf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

