### PR TITLE
feat(daemon): opt-in BU_CDP_HTTP env var for ws URL discovery via /json/version

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -162,6 +162,7 @@ Chrome / Browser Use cloud -> CDP WS -> daemon.py -> /tmp/bu-<NAME>.sock -> run.
 - Responses are `{result}` / `{error}` / `{events}` / `{session_id}`.
 - `BU_NAME` namespaces socket, pid, and log files.
 - `BU_CDP_WS` overrides local Chrome discovery for remote browsers.
+- `BU_CDP_HTTP` (e.g. `http://127.0.0.1:9222`) opts into HTTP-based ws discovery via `/json/version`. Use this when Chrome is launched with a custom `--user-data-dir` that doesn't produce a `DevToolsActivePort` file the PROFILES loop can find. Takes precedence over the PROFILES loop; `BU_CDP_WS` still wins over both.
 - `BU_BROWSER_ID` + `BROWSER_USE_API_KEY` lets the daemon stop a Browser Use cloud browser on shutdown.
 
 ## Gotchas (field-tested)

--- a/daemon.py
+++ b/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + Unix socket relay. One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.request
+import asyncio, json, os, socket, sys, time, urllib.error, urllib.request
 from collections import deque
 from pathlib import Path
 
@@ -61,6 +61,29 @@ def log(msg):
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
+    if base_url := os.environ.get("BU_CDP_HTTP"):
+        # Opt-in: resolve the authoritative browser ws URL by fetching
+        # /json/version from a known local CDP HTTP endpoint. Useful when
+        # Chrome is launched with a custom --user-data-dir, which on some
+        # platforms/builds does not write a DevToolsActivePort file that
+        # the PROFILES loop below can discover.
+        version_url = f"{base_url.rstrip('/')}/json/version"
+        deadline = time.time() + 30
+        last_err = None
+        while True:
+            try:
+                data = urllib.request.urlopen(version_url, timeout=2).read()
+                ws = json.loads(data).get("webSocketDebuggerUrl")
+                if ws:
+                    return ws
+                last_err = f"{version_url} returned no webSocketDebuggerUrl"
+            except (urllib.error.URLError, OSError, ValueError) as e:
+                last_err = f"{type(e).__name__}: {e}"
+            if time.time() >= deadline:
+                raise RuntimeError(
+                    f"BU_CDP_HTTP={base_url} did not yield a ws URL within 30s ({last_err}) — is Chrome running with --remote-debugging-port on that port?"
+                )
+            time.sleep(1)
     for base in PROFILES:
         try:
             port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)


### PR DESCRIPTION
## Summary

Adds an opt-in `BU_CDP_HTTP` env var (e.g. `http://127.0.0.1:9222`) that
lets the daemon resolve the authoritative browser `webSocketDebuggerUrl`
by fetching `/json/version` from a known local CDP HTTP endpoint,
instead of walking `PROFILES` for a `DevToolsActivePort` file.

This is fully opt-in. Users who don't set the variable see zero behavior
change — the existing `PROFILES` walk still runs exactly as before.

Precedence:
```
BU_CDP_WS → BU_CDP_HTTP → PROFILES file walk → raise
```

## Motivation

I wanted to run Chrome out of a dedicated `--user-data-dir` (migrated
from my real profile) so that `--remote-debugging-port=9222` wouldn't
trigger Chrome's per-launch "Allow remote debugging" consent dialog on
my main Default profile. A LaunchAgent + shell alias handle launching,
and the CDP port comes up silently with no prompts.

However, in that configuration (Chrome 147.0.7727.138 on macOS), Chrome
**did not write a `DevToolsActivePort` file at all** — I confirmed with
`find ~/Library/Application\ Support -name DevToolsActivePort` while
Chrome was running with the custom data-dir and the flag. Meanwhile
`curl http://127.0.0.1:9222/json/version` returned a valid
`webSocketDebuggerUrl` just fine.

Without this file, the `PROFILES` loop in `get_ws_url()` raises
`DevToolsActivePort not found in [...]`, and there is no built-in
escape hatch short of computing the full ws URL (UUID included) and
stuffing it into `BU_CDP_WS` — but that UUID changes on every Chrome
launch, so it can't be a static env var.

I looked at just falling back to `/json/version` implicitly when
`PROFILES` yields nothing, but:

- That would be an undocumented behavior change for existing users.
- It couldn't distinguish "user intends HTTP discovery" from "user
  happens to have some other local CDP endpoint listening on 9222".
- It conflicts with the existing gotcha in `SKILL.md`:
  > Chrome 144+ `chrome://inspect/#remote-debugging` does NOT serve
  > `/json/version`. Read `DevToolsActivePort` instead.

  That note applies to Chrome's inspect-checkbox flow. The
  `--remote-debugging-port` CLI flag flow — the one this PR targets —
  does serve `/json/version`. Keeping the new path explicit and opt-in
  avoids crossing wires between the two flows.

So this is strictly additive: a second escape hatch sitting between
`BU_CDP_WS` (which needs the UUID) and the `PROFILES` walk (which
needs the file), for the "I know the port but not the UUID" case.

## Changes

`daemon.py` — new branch in `get_ws_url()` reached only when
`BU_CDP_HTTP` is set:

```python
if base_url := os.environ.get("BU_CDP_HTTP"):
    version_url = f"{base_url.rstrip('/')}/json/version"
    deadline = time.time() + 30
    last_err = None
    while True:
        try:
            data = urllib.request.urlopen(version_url, timeout=2).read()
            ws = json.loads(data).get("webSocketDebuggerUrl")
            if ws:
                return ws
            last_err = f"{version_url} returned no webSocketDebuggerUrl"
        except (urllib.error.URLError, OSError, ValueError) as e:
            last_err = f"{type(e).__name__}: {e}"
        if time.time() >= deadline:
            raise RuntimeError(
                f"BU_CDP_HTTP={base_url} did not yield a ws URL within "
                f"30s ({last_err}) — is Chrome running with "
                f"--remote-debugging-port on that port?"
            )
        time.sleep(1)
```

- 30-second retry window mirrors the existing `PROFILES` loop, so it's
  safe to set `BU_CDP_HTTP` in a `.zshrc` or LaunchAgent env while
  Chrome is still starting up after login.
- Narrow exception catches (`URLError`, `OSError`, `ValueError`).
- Diagnostic error names the endpoint, the last failure, and points at
  the likely root cause (Chrome not running or on a different port).

Also adds `urllib.error` to the existing `import` line (it was implicit
before via `urllib.request`, but this makes the reference explicit).

`SKILL.md` — one bullet added next to the existing `BU_CDP_WS` line:

```md
- `BU_CDP_HTTP` (e.g. `http://127.0.0.1:9222`) opts into HTTP-based ws
  discovery via `/json/version`. Use this when Chrome is launched with
  a custom `--user-data-dir` that doesn't produce a `DevToolsActivePort`
  file the PROFILES loop can find. Takes precedence over the PROFILES
  loop; `BU_CDP_WS` still wins over both.
```

## Verification

Scope of testing: Chrome 147.0.7727.138 on macOS (Darwin 25.4). I did
not retest across Chrome versions or other OSes, so the observation
about Chrome not writing `DevToolsActivePort` is scoped to my setup —
but the PR doesn't rely on that behavior being universal. It just
provides a way out for anyone who hits it, whatever the underlying
cause.

1. Launch Chrome:
   ```
   Google\ Chrome \
     --user-data-dir=~/Library/Application\ Support/Chrome-Debug \
     --remote-debugging-port=9222
   ```
2. `find ~/Library/Application\ Support -name DevToolsActivePort`
   returns nothing.
3. `curl http://127.0.0.1:9222/json/version` returns a valid
   `webSocketDebuggerUrl`.
4. Without `BU_CDP_HTTP`: `browser-harness <<< 'print(page_info())'`
   raises `DevToolsActivePort not found in [...]`.
5. With `BU_CDP_HTTP=http://127.0.0.1:9222`: attaches via the new
   branch, `page_info()` returns the live tab info.
6. Sanity-checked the fall-through: attached successfully on a clean
   Chrome launch with no `BU_CDP_HTTP` set and `DevToolsActivePort`
   present — existing `PROFILES` loop wins, unchanged behavior.

## Trust boundary

No change from the existing `BU_CDP_WS` escape hatch: both trust
whatever is listening at the URL the user passes in. The fallback is
opt-in, so users who don't set the variable never attach to a
localhost port they didn't ask for.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `BU_CDP_HTTP` env var to resolve the Chrome DevTools `webSocketDebuggerUrl` via `/json/version` when a `DevToolsActivePort` file isn’t available. No behavior change unless set; precedence is `BU_CDP_WS` → `BU_CDP_HTTP` → PROFILES walk → raise.

- **New Features**
  - `BU_CDP_HTTP` (e.g., `http://127.0.0.1:9222`) fetches `/json/version` and returns `webSocketDebuggerUrl`.
  - 30s retry with 1s interval and a 2s per-request timeout; clear error message with last failure.
  - Narrow exception handling (`URLError`, `OSError`, `ValueError`) and explicit import of `urllib.error`.
  - `SKILL.md` updated; existing PROFILES-based discovery unchanged.

<sup>Written for commit 43bab0b841cdd7984f601925ae47359a83104ba2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

