### PR TITLE
docs: add model suitability guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ Click Allow when the per-attach popup appears (Chrome 144+):
 
 See [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for example tasks.
 
+## Choosing a model
+
+Browser-harness does not keep a definitive supported-model list yet. The harness is changing quickly, and real performance depends more on the agent's behavior than the provider name.
+
+A good browser-harness model should be able to:
+
+- read and follow a repo-local skill file before acting
+- write small Python helpers in `agent-workspace/agent_helpers.py`
+- inspect errors and retry with a narrower browser action
+- use screenshots and page state instead of guessing selectors
+- keep enough context to remember the current tab, goal, and recent failures
+
+For self-hosted or smaller models, start with simple observe-and-click tasks before relying on long multi-step workflows. If a model cannot reliably edit helper code, recover from CDP errors, or explain why a click failed, it is not yet a good fit for autonomous browser-harness use.
+
+Benchmarks and a more concrete model guide are being tracked in [#235](https://github.com/browser-use/browser-harness/issues/235).
+
 ## Free Browser Use Cloud browsers
 
 Stealth, sub-agents, or headless deployment.<br>


### PR DESCRIPTION
## Summary
- Add a short "Choosing a model" section to the README
- Clarify that browser-harness does not yet maintain a definitive supported-model list
- Document model capabilities that matter for browser-harness: skill following, helper editing, retrying from errors, screenshot/page-state use, and context retention

## Test Plan
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests` → 94 passed
- `python -m build` → sdist and wheel built successfully

Refs #235


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Choosing a model" section to the README with clear suitability guidance for `browser-harness`. It notes there’s no definitive supported-model list and summarizes required capabilities (follow skills, edit helpers, retry on errors, use screenshots/page state, retain context), with tips for smaller/self-hosted models and a link to benchmarks in #235.

<sup>Written for commit f2f1f9cfdac72c997475e10354fb3393d5e4c919. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

