### PR TITLE
Add inline screenshot extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,44 @@ One websocket to Chrome, nothing between. The agent writes what's missing during
 
 **You will never use the browser again.**
 
-## Setup prompt
+## Quickstart
 
-Paste into Claude Code or Codex:
+Install once from a durable checkout:
 
-```text
-Set up https://github.com/browser-use/browser-harness for me.
-
-Read `install.md` and follow the steps to install browser-harness and connect it to my browser.
+```bash
+git clone https://github.com/browser-use/browser-harness
+cd browser-harness
+uv tool install -e .
+command -v browser-harness
 ```
 
-The agent will open `chrome://inspect/#remote-debugging`. Tick the checkbox so the agent can connect to your browser:
+Connect Chrome using one of these paths:
+
+- Real profile: open `chrome://inspect/#remote-debugging` in Chrome, tick "Allow remote debugging for this browser instance", then click Allow when Chrome asks.
+- Isolated profile: launch Chrome with `--remote-debugging-port=9222 --user-data-dir=/tmp/browser-harness-profile`, then run commands with `BU_CDP_URL=http://127.0.0.1:9222`.
 
 <img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />
 
-Click Allow when the per-attach popup appears (Chrome 144+):
-
 <img src="docs/allow-remote-debugging.png" alt="Allow remote debugging popup" width="520" style="border-radius: 12px;" />
 
-See [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for example tasks.
+Run a smoke test:
+
+```bash
+browser-harness -c 'print(page_info())'
+```
+
+Use it from an agent or shell:
+
+```bash
+browser-harness -c '
+new_tab("https://example.com")
+wait_for_load()
+capture_screenshot()
+print(page_info())
+'
+```
+
+Helpers are pre-imported. `capture_screenshot()` saves a PNG and returns it inline to image-aware agent loops, so the agent can inspect the page without a second file-read call. Put custom helpers in `agent-workspace/agent_helpers.py`; see `SKILL.md` for day-to-day agent instructions and `install.md` for detailed troubleshooting.
 
 ## Free Browser Use Cloud browsers
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -80,7 +80,7 @@ If you start struggling with a specific mechanic while navigating, look in inter
 
 ## What actually works
 
-- Screenshots first: use capture_screenshot() to understand the current page quickly, find visible targets, and decide whether you need a click, a selector, or more navigation.
+- Screenshots first: use capture_screenshot() to understand the current page quickly, find visible targets, and decide whether you need a click, a selector, or more navigation. After navigation, clicks, form submissions, or other actions that may visibly change the page, prefer capture_screenshot() to inspect the result before deciding the next step. Screenshots are returned inline in the tool result.
 - Clicking: capture_screenshot() → read the pixel off the image → click_at_xy(x, y) → capture_screenshot() to verify. Suppress the Playwright-habit reflex of "locate first, then click" — no getBoundingClientRect, no selector hunt. Drop to DOM only when the target has no visible geometry (hidden input, 0×0 node). Hit-testing happens in Chrome's browser process, so clicks go through iframes / shadow DOM / cross-origin without extra work.
 - Bulk HTTP: http_get(url) + ThreadPoolExecutor. No browser for static pages (249 Netflix pages in 2.8s).
 - After goto: wait_for_load().

--- a/agent-workspace/agent_helpers.py
+++ b/agent-workspace/agent_helpers.py
@@ -1,7 +1,8 @@
+from browser_harness.inline_screenshot import capture_screenshot
+
 """Agent-editable browser helpers.
 
 Add task-specific browser primitives here. Core helpers from browser_harness.helpers
 load this file when BH_AGENT_WORKSPACE points at this directory, or when this
 repo's default agent-workspace exists.
 """
-

--- a/src/browser_harness/inline_screenshot.py
+++ b/src/browser_harness/inline_screenshot.py
@@ -1,0 +1,108 @@
+"""Inline screenshot extension for browser-harness.
+
+capture_screenshot() saves a PNG like the core helper, and can also emit a
+base64 input_image marker on stdout for agent loops that support typed content.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import _ipc as ipc
+
+
+CORE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = CORE_DIR.parent.parent
+NAME = os.environ.get("BU_NAME", "default")
+
+_MARKER_START = "\x00INLINE_IMAGE:"
+_MARKER_END = ":INLINE_IMAGE\x00"
+_MARKER_RE = re.compile(r"\x00INLINE_IMAGE:(.*?):INLINE_IMAGE\x00", re.DOTALL)
+
+
+def _send(req):
+    c, token = ipc.connect(NAME, timeout=5.0)
+    try:
+        r = ipc.request(c, token, req)
+    finally:
+        c.close()
+    if "error" in r:
+        raise RuntimeError(r["error"])
+    return r
+
+
+def cdp(method, session_id=None, **params):
+    """Raw CDP for the inline screenshot extension."""
+    helpers = sys.modules.get("browser_harness.helpers")
+    helpers_cdp = getattr(helpers, "cdp", None)
+    if helpers_cdp is not None:
+        return helpers_cdp(method, session_id=session_id, **params)
+    return _send({"method": method, "params": params, "session_id": session_id}).get(
+        "result", {}
+    )
+
+
+def _emit_inline(path: str, detail: str = "auto") -> None:
+    data = base64.b64encode(Path(path).read_bytes()).decode("ascii")
+    block = {
+        "type": "input_image",
+        "detail": detail,
+        "image_url": f"data:image/png;base64,{data}",
+    }
+    sys.stdout.write(
+        _MARKER_START + json.dumps(block, separators=(",", ":")) + _MARKER_END
+    )
+    sys.stdout.flush()
+
+
+def capture_screenshot(
+    path: str | None = None,
+    full: bool = False,
+    max_dim: int | None = None,
+    attach: bool = True,
+    detail: str = "auto",
+) -> str:
+    """Save a PNG and optionally emit it as an inline image marker."""
+    path = path or str(ipc._TMP / "shot.png")
+    r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
+    Path(path).write_bytes(base64.b64decode(r["data"]))
+    if max_dim:
+        from PIL import Image
+
+        img = Image.open(path)
+        if max(img.size) > max_dim:
+            img.thumbnail((max_dim, max_dim))
+            img.save(path)
+    if attach:
+        _emit_inline(path, detail=detail)
+    return path
+
+
+def parse_tool_stdout(raw: str) -> tuple[str, list[dict[str, Any]]]:
+    """Split raw stdout into clean text and input_image blocks."""
+    image_blocks: list[dict[str, Any]] = []
+    for match in _MARKER_RE.finditer(raw):
+        try:
+            image_blocks.append(json.loads(match.group(1)))
+        except json.JSONDecodeError:
+            pass
+    return _MARKER_RE.sub("", raw), image_blocks
+
+
+def build_tool_content(
+    text: str,
+    image_blocks: list[dict[str, Any]],
+) -> str | list[dict[str, Any]]:
+    """Build a provider-ready tool-result content value."""
+    if not image_blocks:
+        return text
+    content: list[dict[str, Any]] = []
+    if text.strip():
+        content.append({"type": "input_text", "text": text})
+    content.extend(image_blocks)
+    return content

--- a/tests/unit/test_inline_screenshot.py
+++ b/tests/unit/test_inline_screenshot.py
@@ -1,0 +1,177 @@
+import base64
+import json
+
+from PIL import Image
+
+from browser_harness import inline_screenshot
+
+
+def _image_block(data="abc", detail="auto"):
+    return {
+        "type": "input_image",
+        "detail": detail,
+        "image_url": f"data:image/png;base64,{data}",
+    }
+
+
+def _marker(block):
+    return (
+        "\x00INLINE_IMAGE:"
+        + json.dumps(block, separators=(",", ":"))
+        + ":INLINE_IMAGE\x00"
+    )
+
+
+def test_parse_tool_stdout_without_markers_returns_text_unchanged():
+    clean, blocks = inline_screenshot.parse_tool_stdout("done\n")
+
+    assert clean == "done\n"
+    assert blocks == []
+
+
+def test_parse_tool_stdout_strips_marker_and_returns_image_block():
+    block = _image_block()
+    clean, blocks = inline_screenshot.parse_tool_stdout(f"before{_marker(block)}after")
+
+    assert clean == "beforeafter"
+    assert blocks == [block]
+
+
+def test_parse_tool_stdout_collects_multiple_images_in_order():
+    first = _image_block("one")
+    second = _image_block("two", detail="high")
+
+    clean, blocks = inline_screenshot.parse_tool_stdout(
+        f"a{_marker(first)}b{_marker(second)}c"
+    )
+
+    assert clean == "abc"
+    assert blocks == [first, second]
+
+
+def test_parse_tool_stdout_ignores_malformed_marker_json():
+    clean, blocks = inline_screenshot.parse_tool_stdout(
+        "a\x00INLINE_IMAGE:not-json:INLINE_IMAGE\x00b"
+    )
+
+    assert clean == "ab"
+    assert blocks == []
+
+
+def test_build_tool_content_returns_plain_text_without_images():
+    assert inline_screenshot.build_tool_content("done\n", []) == "done\n"
+
+
+def test_build_tool_content_returns_typed_blocks_with_text_and_images():
+    image = _image_block()
+
+    content = inline_screenshot.build_tool_content("done\n", [image])
+
+    assert content == [{"type": "input_text", "text": "done\n"}, image]
+
+
+def test_build_tool_content_returns_image_only_blocks_when_text_empty():
+    image = _image_block()
+
+    assert inline_screenshot.build_tool_content("\n", [image]) == [image]
+
+
+def test_capture_screenshot_saves_file_returns_path_and_emits_marker(
+    tmp_path, fake_png, capsys, monkeypatch
+):
+    png_data = fake_png(20, 10)
+    shot_path = tmp_path / "shot.png"
+
+    def fake_cdp(method, **kwargs):
+        assert method == "Page.captureScreenshot"
+        assert kwargs == {"format": "png", "captureBeyondViewport": False}
+        return {"data": png_data}
+
+    monkeypatch.setattr(inline_screenshot, "cdp", fake_cdp)
+
+    returned = inline_screenshot.capture_screenshot(str(shot_path))
+
+    assert returned == str(shot_path)
+    assert Image.open(shot_path).size == (20, 10)
+
+    clean, blocks = inline_screenshot.parse_tool_stdout(capsys.readouterr().out)
+    assert clean == ""
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "input_image"
+    assert blocks[0]["detail"] == "auto"
+    assert blocks[0]["image_url"].startswith("data:image/png;base64,")
+    assert base64.b64decode(blocks[0]["image_url"].split(",", 1)[1])
+
+
+def test_capture_screenshot_attach_false_saves_without_marker(
+    tmp_path, fake_png, capsys, monkeypatch
+):
+    png_data = fake_png(12, 8)
+    shot_path = tmp_path / "shot.png"
+    monkeypatch.setattr(
+        inline_screenshot,
+        "cdp",
+        lambda method, **kwargs: {"data": png_data},
+    )
+
+    returned = inline_screenshot.capture_screenshot(str(shot_path), attach=False)
+
+    assert returned == str(shot_path)
+    assert Image.open(shot_path).size == (12, 8)
+    assert capsys.readouterr().out == ""
+
+
+def test_capture_screenshot_resizes_before_emitting_marker(
+    tmp_path, fake_png, capsys, monkeypatch
+):
+    png_data = fake_png(120, 60)
+    shot_path = tmp_path / "shot.png"
+    monkeypatch.setattr(
+        inline_screenshot,
+        "cdp",
+        lambda method, **kwargs: {"data": png_data},
+    )
+
+    inline_screenshot.capture_screenshot(str(shot_path), max_dim=30)
+
+    assert max(Image.open(shot_path).size) == 30
+    _, blocks = inline_screenshot.parse_tool_stdout(capsys.readouterr().out)
+    emitted_png = base64.b64decode(blocks[0]["image_url"].split(",", 1)[1])
+    emitted_path = tmp_path / "emitted.png"
+    emitted_path.write_bytes(emitted_png)
+    assert max(Image.open(emitted_path).size) == 30
+
+
+def test_capture_screenshot_does_not_call_overwritten_helpers_function(
+    tmp_path, fake_png, monkeypatch
+):
+    from browser_harness import helpers
+
+    png_data = fake_png(10, 10)
+    monkeypatch.setattr(
+        inline_screenshot,
+        "cdp",
+        lambda method, **kwargs: {"data": png_data},
+    )
+
+    def overwritten_capture_screenshot(*args, **kwargs):
+        raise AssertionError("inline capture must not call helpers.capture_screenshot")
+
+    monkeypatch.setattr(helpers, "capture_screenshot", overwritten_capture_screenshot)
+
+    returned = inline_screenshot.capture_screenshot(
+        str(tmp_path / "shot.png"), attach=False
+    )
+
+    assert returned.endswith("shot.png")
+
+
+def test_agent_workspace_activates_inline_capture_screenshot():
+    agent_helpers = (
+        inline_screenshot.REPO_ROOT / "agent-workspace" / "agent_helpers.py"
+    ).read_text()
+
+    assert (
+        "from browser_harness.inline_screenshot import capture_screenshot"
+        in agent_helpers
+    )


### PR DESCRIPTION
## Summary
- add inline screenshot support that emits input_image markers on stdout
- activate the override through agent-workspace/agent_helpers.py
- document screenshot guidance and make the README quickstart self-contained
- cover parsing, content building, attach=False, resize, and recursion safety with tests

## Test
- uv run --with pytest python -m pytest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an inline screenshot extension that emits typed image blocks on stdout so agents can consume screenshots inline, and makes the Quickstart self‑contained for easier setup.

- **New Features**
  - Added `browser_harness.inline_screenshot` with `capture_screenshot(path=None, full=False, max_dim=None, attach=True, detail="auto")`. Saves a PNG and, when `attach=True`, writes an `input_image` marker to stdout (base64 data URL). Includes `parse_tool_stdout` and `build_tool_content` helpers.
  - Activated the inline helper by importing it in `agent-workspace/agent_helpers.py`, so `capture_screenshot()` returns images inline in tool results by default.
  - Updated `README.md` with a self-contained Quickstart (install, connect Chrome, smoke test, example usage) and clarified screenshot-first guidance in `SKILL.md`.
  - Added unit tests covering marker parsing, content building, `attach=False`, resizing via `max_dim`, and ensuring no recursion with core helpers.

<sup>Written for commit 5b83fc0bac004321a64a2c852ef34577b07c48fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

