### PR TITLE
[codex] Add self-modifying harness edge-case docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Click Allow when the per-attach popup appears (Chrome 144+):
 <img src="docs/allow-remote-debugging.png" alt="Allow remote debugging popup" width="520" style="border-radius: 12px;" />
 
 See [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for example tasks.
+For the core pattern behind hard browser tasks, read
+[Self-modifying browser harness](docs/self-modifying-harness.md). It includes
+concrete examples for signature canvases, file uploads, drag/drop, and
+coordinate-only controls, plus a local edge-case benchmark page.
 
 ## Free Browser Use Cloud browsers
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -81,6 +81,7 @@ If you start struggling with a specific mechanic while navigating, look in inter
 ## What actually works
 
 - Screenshots first: use capture_screenshot() to understand the current page quickly, find visible targets, and decide whether you need a click, a selector, or more navigation.
+- If an interaction helper is missing, treat that as editable harness work, not a task failure. Reproduce, inspect, add the smallest helper in `agent-workspace/agent_helpers.py`, retry, and keep the reusable pattern. See `docs/self-modifying-harness.md` and `docs/edge-case-benchmark.html` for upload, drag/drop, signature canvas, and coordinate-only examples.
 - Clicking: capture_screenshot() → read the pixel off the image → click_at_xy(x, y) → capture_screenshot() to verify. Suppress the Playwright-habit reflex of "locate first, then click" — no getBoundingClientRect, no selector hunt. Drop to DOM only when the target has no visible geometry (hidden input, 0×0 node). Hit-testing happens in Chrome's browser process, so clicks go through iframes / shadow DOM / cross-origin without extra work.
 - Bulk HTTP: http_get(url) + ThreadPoolExecutor. No browser for static pages (249 Netflix pages in 2.8s).
 - After goto: wait_for_load().

--- a/docs/edge-case-benchmark.html
+++ b/docs/edge-case-benchmark.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Browser Harness edge-case benchmark</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f7faf9;
+      color: #17211f;
+    }
+    body {
+      margin: 0;
+      padding: 32px;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 32px;
+      margin: 0 0 8px;
+    }
+    .intro {
+      margin: 0 0 28px;
+      color: #4b5d58;
+      max-width: 760px;
+      line-height: 1.45;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 18px;
+    }
+    .task {
+      background: #ffffff;
+      border: 1px solid #d8e3df;
+      border-radius: 8px;
+      padding: 20px;
+      min-height: 250px;
+      box-shadow: 0 1px 2px rgba(11, 36, 31, 0.06);
+    }
+    .task h2 {
+      font-size: 18px;
+      margin: 0 0 12px;
+    }
+    .status {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      margin-top: 14px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: #edf2f0;
+      color: #4b5d58;
+      font-size: 13px;
+      font-weight: 700;
+    }
+    .status.pass {
+      background: #d9f8e7;
+      color: #126236;
+    }
+    .upload-label, .drag-card {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 150px;
+      height: 46px;
+      border-radius: 6px;
+      background: #17211f;
+      color: white;
+      font-weight: 800;
+      cursor: pointer;
+      user-select: none;
+    }
+    input[type="file"] {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      opacity: 0.01;
+    }
+    .drop-zone {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 92px;
+      margin-top: 14px;
+      border: 2px dashed #87a49d;
+      border-radius: 8px;
+      color: #587069;
+      background: #f1f6f4;
+      font-weight: 700;
+    }
+    .drop-zone.hot {
+      border-color: #168a54;
+      background: #e4f9ed;
+      color: #126236;
+    }
+    canvas {
+      display: block;
+      width: 100%;
+      max-width: 420px;
+      height: 140px;
+      border: 1px solid #b9c8c3;
+      border-radius: 6px;
+      background: white;
+      touch-action: none;
+    }
+    #coordinate-canvas {
+      cursor: crosshair;
+    }
+    .summary {
+      margin-top: 22px;
+      padding: 16px 18px;
+      background: #eaf2ef;
+      border-radius: 8px;
+      color: #31423e;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 14px;
+    }
+    @media (max-width: 760px) {
+      body {
+        padding: 18px;
+      }
+      .grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Browser Harness edge-case benchmark</h1>
+    <p class="intro">
+      Four small browser tasks that usually force agents to switch tactics:
+      hidden file input, drag/drop event payloads, canvas signature input, and a
+      coordinate-only canvas target.
+    </p>
+
+    <section class="grid">
+      <article class="task" data-task="file">
+        <h2>1. File upload</h2>
+        <label class="upload-label" for="file-input">Choose file</label>
+        <input id="file-input" type="file">
+        <div id="file-status" class="status">waiting for file</div>
+      </article>
+
+      <article class="task" data-task="drag">
+        <h2>2. Drag and drop</h2>
+        <div id="drag-source" class="drag-card" draggable="true">drag token</div>
+        <div id="drop-target" class="drop-zone">drop token here</div>
+        <div id="drag-status" class="status">waiting for drop</div>
+      </article>
+
+      <article class="task" data-task="signature">
+        <h2>3. Canvas signature</h2>
+        <canvas id="signature-canvas" width="420" height="140"></canvas>
+        <div id="signature-status" class="status">waiting for stroke</div>
+      </article>
+
+      <article class="task" data-task="coordinate">
+        <h2>4. Coordinate target</h2>
+        <canvas id="coordinate-canvas" width="420" height="140"></canvas>
+        <div id="coordinate-status" class="status">waiting for target click</div>
+      </article>
+    </section>
+
+    <pre id="summary" class="summary">window.bhBenchmarkResults() -> pending</pre>
+  </main>
+
+  <script>
+    (() => {
+    const state = {
+      file: false,
+      drag: false,
+      signature: false,
+      coordinate: false,
+    };
+
+    function mark(name, detail) {
+      state[name] = true;
+      const node = document.getElementById(`${name}-status`);
+      node.textContent = detail || "passed";
+      node.classList.add("pass");
+      renderSummary();
+    }
+
+    function renderSummary() {
+      document.getElementById("summary").textContent =
+        JSON.stringify(window.bhBenchmarkResults(), null, 2);
+    }
+
+    window.bhBenchmarkResults = () => ({
+      ...state,
+      passed: Object.values(state).every(Boolean),
+    });
+
+    document.getElementById("file-input").addEventListener("change", (event) => {
+      const file = event.target.files && event.target.files[0];
+      if (file && file.name) mark("file", `uploaded: ${file.name}`);
+    });
+
+    const source = document.getElementById("drag-source");
+    const target = document.getElementById("drop-target");
+    source.addEventListener("dragstart", (event) => {
+      event.dataTransfer.setData("text/plain", "browser-harness-token");
+    });
+    target.addEventListener("dragenter", () => target.classList.add("hot"));
+    target.addEventListener("dragover", (event) => event.preventDefault());
+    target.addEventListener("dragleave", () => target.classList.remove("hot"));
+    target.addEventListener("drop", (event) => {
+      event.preventDefault();
+      target.classList.remove("hot");
+      if (event.dataTransfer.getData("text/plain") === "browser-harness-token") {
+        target.textContent = "token dropped";
+        mark("drag", "dropped token");
+      }
+    });
+
+    const signature = document.getElementById("signature-canvas");
+    const sigCtx = signature.getContext("2d");
+    sigCtx.lineWidth = 4;
+    sigCtx.lineCap = "round";
+    sigCtx.strokeStyle = "#17211f";
+    let drawing = false;
+    let last = null;
+    let pathLength = 0;
+    let pointCount = 0;
+
+    function sigPoint(event) {
+      const rect = signature.getBoundingClientRect();
+      return {
+        x: (event.clientX - rect.left) * (signature.width / rect.width),
+        y: (event.clientY - rect.top) * (signature.height / rect.height),
+      };
+    }
+
+    function startSignature(event) {
+      drawing = true;
+      last = sigPoint(event);
+      pointCount = 1;
+      pathLength = 0;
+      sigCtx.beginPath();
+      sigCtx.moveTo(last.x, last.y);
+    }
+    function moveSignature(event) {
+      if (!drawing) return;
+      const next = sigPoint(event);
+      sigCtx.lineTo(next.x, next.y);
+      sigCtx.stroke();
+      pathLength += Math.hypot(next.x - last.x, next.y - last.y);
+      pointCount += 1;
+      last = next;
+    }
+    function endSignature() {
+      drawing = false;
+      if (pathLength > 120 && pointCount >= 5) mark("signature", "signature captured");
+    }
+    signature.addEventListener("pointerdown", startSignature);
+    signature.addEventListener("pointermove", moveSignature);
+    signature.addEventListener("pointerup", endSignature);
+    signature.addEventListener("mousedown", startSignature);
+    signature.addEventListener("mousemove", moveSignature);
+    window.addEventListener("mouseup", endSignature);
+
+    const coordinate = document.getElementById("coordinate-canvas");
+    const coordCtx = coordinate.getContext("2d");
+    const targetPoint = { x: 312, y: 82, radius: 18 };
+    coordCtx.fillStyle = "#f1f6f4";
+    coordCtx.fillRect(0, 0, coordinate.width, coordinate.height);
+    coordCtx.fillStyle = "#168a54";
+    coordCtx.beginPath();
+    coordCtx.arc(targetPoint.x, targetPoint.y, targetPoint.radius, 0, Math.PI * 2);
+    coordCtx.fill();
+    coordCtx.fillStyle = "#17211f";
+    coordCtx.font = "700 16px system-ui";
+    coordCtx.fillText("click the green target", 24, 42);
+
+    coordinate.addEventListener("click", (event) => {
+      const rect = coordinate.getBoundingClientRect();
+      const x = (event.clientX - rect.left) * (coordinate.width / rect.width);
+      const y = (event.clientY - rect.top) * (coordinate.height / rect.height);
+      if (Math.hypot(x - targetPoint.x, y - targetPoint.y) <= targetPoint.radius) {
+        mark("coordinate", "target clicked");
+      }
+    });
+
+    renderSummary();
+    })();
+  </script>
+</body>
+</html>

--- a/docs/self-modifying-harness.md
+++ b/docs/self-modifying-harness.md
@@ -1,0 +1,156 @@
+# Self-modifying harness
+
+Browser Harness works because the agent is not trapped behind a fixed browser API.
+When a page has a new edge case, the agent can inspect the page, add the missing
+helper in `agent-workspace/agent_helpers.py` or a domain skill, retry the task,
+and keep the working code for the next run.
+
+The loop is:
+
+1. Use `capture_screenshot()` and `page_info()` to understand the current state.
+2. Try the smallest existing primitive: `click_at_xy`, `type_text`, `press_key`,
+   `upload_file`, `js`, or raw `cdp`.
+3. If the primitive is missing, add a helper in `agent-workspace/agent_helpers.py`
+   or a site-specific note in `agent-workspace/domain-skills/<site>/`.
+4. Run the helper, then verify with a screenshot or page state.
+5. Commit only durable knowledge: selectors, DOM events, CDP calls, endpoint
+   shape, or framework quirks. Do not commit secrets or one-off pixel positions.
+
+That is why browser edge cases are not permanent. They are usually just missing
+local code.
+
+## Example 1: file upload
+
+Start with the built-in helper when there is a real file input:
+
+```python
+upload_file("input[type=file]", "/tmp/invoice.pdf")
+js("""
+const input = document.querySelector('input[type=file]');
+input.dispatchEvent(new Event('input', {bubbles: true}));
+input.dispatchEvent(new Event('change', {bubbles: true}));
+""")
+```
+
+If the app hides the input behind a custom button, add a helper that finds the
+real input once and then reuses the same path:
+
+```python
+# agent-workspace/agent_helpers.py
+def upload_to_hidden_input(label_text, path):
+    selector = js(f"""
+    const labels = [...document.querySelectorAll('label,button,[role=button]')];
+    const trigger = labels.find(e => e.innerText.trim().includes({label_text!r}));
+    const root = trigger?.closest('form,section,div') || document;
+    const input = root.querySelector('input[type=file]');
+    if (!input) throw new Error('no file input near upload trigger');
+    input.setAttribute('data-bh-upload-target', '1');
+    return '[data-bh-upload-target="1"]';
+    """)
+    upload_file(selector, path)
+```
+
+Keep this in a domain skill if the selector is specific to one product.
+
+## Example 2: drag and drop
+
+Try compositor-level input first when the page responds to real pointer motion:
+
+```python
+cdp("Input.dispatchMouseEvent", type="mouseMoved", x=120, y=220)
+cdp("Input.dispatchMouseEvent", type="mousePressed", x=120, y=220, button="left")
+cdp("Input.dispatchMouseEvent", type="mouseMoved", x=500, y=260, button="left")
+cdp("Input.dispatchMouseEvent", type="mouseReleased", x=500, y=260, button="left")
+```
+
+Some React or editor surfaces require DOM drag events with a `DataTransfer`
+payload. Put that site-specific sequence in a helper:
+
+```python
+# agent-workspace/agent_helpers.py
+def dom_drag_text(source_selector, target_selector, payload):
+    js(f"""
+    const source = document.querySelector({source_selector!r});
+    const target = document.querySelector({target_selector!r});
+    const dt = new DataTransfer();
+    dt.setData('text/plain', {payload!r});
+    for (const type of ['dragstart', 'dragenter', 'dragover', 'drop', 'dragend']) {{
+      const node = type === 'dragstart' || type === 'dragend' ? source : target;
+      node.dispatchEvent(new DragEvent(type, {{bubbles: true, cancelable: true, dataTransfer: dt}}));
+    }}
+    """)
+```
+
+The durable knowledge is not the one drag coordinate. It is whether that app
+wants real pointer events, DOM drag events, or a hidden file input.
+
+## Example 3: canvas signature
+
+Canvas fields often have no useful DOM target inside the drawing area. Use the
+canvas bounds plus raw mouse events:
+
+```python
+box = js("""
+const r = document.querySelector('canvas.signature').getBoundingClientRect();
+return {x: r.left, y: r.top, w: r.width, h: r.height};
+""")
+
+points = [
+    (box["x"] + 20, box["y"] + box["h"] * 0.55),
+    (box["x"] + 80, box["y"] + box["h"] * 0.35),
+    (box["x"] + 150, box["y"] + box["h"] * 0.60),
+    (box["x"] + 220, box["y"] + box["h"] * 0.40),
+]
+cdp("Input.dispatchMouseEvent", type="mousePressed", x=points[0][0], y=points[0][1], button="left")
+for x, y in points[1:]:
+    cdp("Input.dispatchMouseEvent", type="mouseMoved", x=x, y=y, button="left")
+cdp("Input.dispatchMouseEvent", type="mouseReleased", x=points[-1][0], y=points[-1][1], button="left")
+```
+
+Verify by reading app state or screenshotting the canvas. If the page stores a
+hidden signature value, add a site helper that checks that field too.
+
+## Example 4: coordinate-only target
+
+Some UI is only visible pixels: maps, whiteboards, games, image editors, or
+custom canvas widgets. Do not hunt for selectors that do not exist. Let the
+screenshot drive the next action:
+
+```python
+shot = capture_screenshot("/tmp/target.png", max_dim=1800)
+info = page_info()
+print(info)
+# read the target position from the screenshot, convert image pixels to CSS
+# pixels if devicePixelRatio > 1, then click:
+click_at_xy(412, 318)
+capture_screenshot("/tmp/after.png", max_dim=1800)
+```
+
+If the target is stable enough to compute, write the helper:
+
+```python
+# agent-workspace/agent_helpers.py
+def click_canvas_target(canvas_selector, rel_x, rel_y):
+    box = js(f"""
+    const r = document.querySelector({canvas_selector!r}).getBoundingClientRect();
+    return {{x: r.left, y: r.top, w: r.width, h: r.height}};
+    """)
+    click_at_xy(box["x"] + box["w"] * rel_x, box["y"] + box["h"] * rel_y)
+```
+
+The point is not that coordinates are magic. The point is that the agent can
+choose coordinates, DOM, CDP, or a new helper after it sees the actual page.
+
+## Benchmark page
+
+`docs/edge-case-benchmark.html` contains a small local page with four tasks:
+
+- file upload
+- drag and drop
+- canvas signature
+- coordinate-only canvas click
+
+Use it when changing helper behavior or when demonstrating the self-modifying
+loop. A run is successful when `window.bhBenchmarkResults()` returns all four
+checks as `true`.
+


### PR DESCRIPTION
## Summary
- Add a docs page explaining the self-modifying harness loop: try existing primitives, patch helpers/domain skills, retry, and preserve reusable knowledge
- Cover four concrete edge cases: file upload, drag/drop, signature canvas, and coordinate-only controls
- Add a self-contained edge-case benchmark HTML page and link the docs from README/SKILL

## Validation
- Ran Browser Harness against the benchmark page by loading the HTML into `about:blank` and exercising all four mechanics
- Benchmark results: file=true, drag=true, signature=true, coordinate=true, passed=true
- Ran `env -u BU_CDP_URL -u BU_CDP_WS uv run --with pytest pytest tests`: 94 passed

## Notes
- First benchmark run found the signature canvas only handled pointer events; patched the page to accept mouse events too, which matches the CDP mouse path used by Browser Harness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self‑modifying harness guide and a local edge‑case benchmark to help solve uploads, drag/drop, canvas signatures, and coordinate‑only controls. Linked from README and SKILL to make the loop easy to find and reuse.

- **New Features**
  - Added docs at docs/self-modifying-harness.md covering the loop and four edge cases.
  - Added local benchmark at docs/edge-case-benchmark.html with file, drag/drop, signature, and coordinate tasks (exposes window.bhBenchmarkResults()).
  - Linked from README.md and SKILL.md; benchmark updated to handle both pointer and mouse events for signatures.

<sup>Written for commit 7deecc9248c23ddc3fe979d2626a6e30efc0a8cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

