### PR TITLE
feat: add close_tab() helper to close browser tabs via CDP Target.closeTarget

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -296,7 +296,7 @@ def current_tab():
     return {"targetId": r["targetId"], "url": r["url"], "title": r["title"]}
 
 def _mark_tab():
-    """Prepend 🐴 to tab title so the user can see which tab the agent controls."""
+    """Prepend horse emoji to tab title so the user can see which tab the agent controls."""
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
@@ -304,7 +304,7 @@ def switch_tab(target):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
     target_id = target.get("targetId") if isinstance(target, dict) else target
-    # Unmark old tab. 🐴 is a surrogate pair in JS UTF-16 strings (2 code units),
+    # Unmark old tab. Horse emoji is a surrogate pair in JS UTF-16 strings (2 code units),
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
@@ -323,6 +323,15 @@ def new_tab(url="about:blank"):
     if url != "about:blank":
         goto_url(url)
     return tid
+
+def close_tab(target=None):
+    """Close a tab. If `target` is omitted, closes the currently attached tab.
+    Accepts a raw targetId string or a dict from list_tabs()/current_tab()."""
+    target_id = target.get("targetId") if isinstance(target, dict) else target
+    if target_id is None:
+        target_id = current_tab()["targetId"]
+    cdp("Target.closeTarget", targetId=target_id)
+
 
 def ensure_real_tab():
     """Switch to a real user tab if current is chrome:// / internal / stale."""


### PR DESCRIPTION
Adds `close_tab(target=None)` — the symmetric counterpart to `new_tab()` that was missing from the tab operations section.

## Why

Each Chrome tab is a separate renderer process (~50-200MB). After an automation task opens several tabs, there was no convenient way to clean them up — you had to drop to raw `cdp("Target.closeTarget", targetId=id)`. This adds a first-class helper alongside `list_tabs` / `new_tab` / `switch_tab`.

## What

```python
def close_tab(target=None):
    """Close a tab. If `target` is omitted, closes the currently attached tab.
    Accepts a raw targetId string or a dict from list_tabs()/current_tab()."""
    target_id = target.get("targetId") if isinstance(target, dict) else target
    if target_id is None:
        target_id = current_tab()["targetId"]
    cdp("Target.closeTarget", targetId=target_id)
```

## Usage

```python
# Close a specific tab
tid = new_tab("https://example.com")
# ... do work ...
close_tab(tid)

# Close current tab
close_tab()

# Bulk cleanup — keep current, close rest
tabs = list_tabs(include_chrome=False)
cur = current_tab()["targetId"]
for t in tabs:
    if t["targetId"] != cur:
        close_tab(t)
```

## Placement

Placed right after `new_tab()` and before `ensure_real_tab()` in the `# --- tabs ---` section, following the same conventions for argument handling (accepts both dict and raw string).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `close_tab()` to close Chrome tabs via CDP, making it easy to clean up tabs and free memory. Complements `new_tab()`/`switch_tab()` for full tab lifecycle control.

- **New Features**
  - `close_tab(target=None)` closes a specific tab or the current tab when omitted.
  - Accepts a `targetId` string or a tab dict from `list_tabs()`/`current_tab()`.
  - Uses CDP `Target.closeTarget` under the hood.

<sup>Written for commit e0e7f0b1095359fe1d77bc4b8e2e4b95ad9670c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

