### PR TITLE
fix: lazy-load CLI execution helpers

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -23,7 +23,25 @@ from .admin import (
     stop_remote_daemon,
     sync_local_profile,
 )
-from .helpers import *
+
+
+def _execution_globals():
+    """Globals for stdin scripts, with helpers loaded only for execution.
+
+    Maintenance commands like --version and --help must not import
+    BH_AGENT_WORKSPACE/agent_helpers.py. That file is user-editable and can have
+    arbitrary side effects, so keep it out of the CLI control path and expose it
+    only to scripts that explicitly execute through stdin.
+    """
+    from . import helpers
+
+    namespace = dict(globals())
+    namespace.update(
+        (name, value)
+        for name, value in vars(helpers).items()
+        if not name.startswith("_")
+    )
+    return namespace
 
 HELP = """Browser Harness
 
@@ -122,7 +140,7 @@ def main():
     ):
         start_remote_daemon(NAME)
     ensure_daemon()
-    exec(code, globals())
+    exec(code, _execution_globals())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,11 +1,57 @@
+import os
+import subprocess
 import sys
 from io import StringIO
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from browser_harness import run
 
+
+def test_maintenance_commands_do_not_load_agent_helpers(tmp_path):
+    (tmp_path / "agent_helpers.py").write_text(
+        "raise RuntimeError('agent_helpers should not load for maintenance commands')\n"
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["BH_AGENT_WORKSPACE"] = str(tmp_path)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root / "src"), env.get("PYTHONPATH", "")]
+    )
+
+    for arg in ("--version", "--help"):
+        result = subprocess.run(
+            [sys.executable, "-m", "browser_harness.run", arg],
+            cwd=repo_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "agent_helpers should not load" not in result.stderr
+
+
+def test_execution_globals_load_agent_workspace_helpers(tmp_path, monkeypatch):
+    import browser_harness
+
+    (tmp_path / "agent_helpers.py").write_text("CUSTOM_AGENT_HELPER = 'loaded'\n")
+    monkeypatch.setenv("BH_AGENT_WORKSPACE", str(tmp_path))
+    original_helpers = sys.modules.pop("browser_harness.helpers", None)
+    original_package_helper = getattr(browser_harness, "helpers", None)
+    if hasattr(browser_harness, "helpers"):
+        delattr(browser_harness, "helpers")
+    try:
+        namespace = run._execution_globals()
+        assert namespace["CUSTOM_AGENT_HELPER"] == "loaded"
+    finally:
+        sys.modules.pop("browser_harness.helpers", None)
+        if original_helpers is not None:
+            sys.modules["browser_harness.helpers"] = original_helpers
+        if original_package_helper is not None:
+            browser_harness.helpers = original_package_helper
 
 def test_stdin_executes_code():
     stdout = StringIO()
@@ -237,4 +283,3 @@ def test_cli_doctor_rejects_unknown_flags():
             run.main()
     assert ei.value.code == 2
     assert "usage" in err.getvalue().lower()
-


### PR DESCRIPTION
## Summary
- Lazy-load `browser_harness.helpers` only when executing `browser-harness -c ...`
- Keep maintenance commands such as `--version` and `--help` from importing user-editable `BH_AGENT_WORKSPACE/agent_helpers.py`
- Preserve `-c` helper availability, including agent workspace helpers, via a dedicated execution namespace

## Root cause
`run.py` imported `from .helpers import *` at module import time. Since `helpers.py` immediately loads `BH_AGENT_WORKSPACE/agent_helpers.py`, even safe maintenance commands could fail or trigger user helper side effects before `main()` handled `--version`/`--help`.

## Test Plan
- RED: `uv run --with pytest --with-editable . python -m pytest tests/unit/test_run.py::test_maintenance_commands_do_not_load_agent_helpers tests/unit/test_run.py::test_execution_globals_load_agent_workspace_helpers -q` failed before the fix because `--version` loaded the raising `agent_helpers.py` and `_execution_globals` did not exist.
- GREEN: `uv run --with pytest --with-editable . python -m pytest tests/unit/test_run.py::test_maintenance_commands_do_not_load_agent_helpers tests/unit/test_run.py::test_execution_globals_load_agent_workspace_helpers -q` → `2 passed`
- `uv run --with pytest --with-editable . python -m pytest tests/unit/test_run.py -q` → `14 passed`
- `uv run --with pytest --with-editable . python -m pytest tests -q` → `96 passed`
- `uv run --with-editable . python -m compileall -q src tests`
- `uv run --with pip --with-editable . python -m pip check` → `No broken requirements found.`
- `uv run --with pip-audit --with-editable . pip-audit` → `No known vulnerabilities found` (local package skipped because it is not on PyPI)
- `uv run --with ruff --with-editable . ruff check --select B src/browser_harness/run.py tests/unit/test_run.py` → `All checks passed!`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load CLI helpers so `--help` and `--version` run without importing user workspace code. Scripts run via stdin or `-c` still get access to `browser_harness.helpers` and workspace helpers.

- **Bug Fixes**
  - Load helpers inside `_execution_globals()` only during code execution.
  - Keep maintenance commands from importing `BH_AGENT_WORKSPACE/agent_helpers.py`.
  - Execute code with a namespace exposing public names from `browser_harness.helpers`.

<sup>Written for commit 3f7116db5125f9e893f7ee09a1ef9fb0e8a54790. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

