### PR TITLE
fix: handle empty IPC responses

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -91,15 +91,19 @@ def connect(name, timeout=1.0):
 
 def request(c, token, req):
     """One-shot send + recv + parse on an open socket. Injects token on Windows.
-    Returns the parsed JSON response. Caller closes the socket."""
+    Returns the parsed JSON response. Caller closes the socket.
+    Raises ConnectionError if the peer closes before sending any response."""
     if token: req = {**req, "token": token}
     c.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):
         chunk = c.recv(1 << 16)
-        if not chunk: break
+        if not chunk:
+            if not data:
+                raise ConnectionError("IPC peer closed without a response")
+            break
         data += chunk
-    return json.loads(data or b"{}")
+    return json.loads(data)
 
 
 def ping(name, timeout=1.0):

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -191,6 +191,8 @@ def _daemon_browser_connection(name):
     try:
         c, token = ipc.connect(name, timeout=1.0)
         response = ipc.request(c, token, {"meta": "connection_status"})
+        if not isinstance(response, dict):
+            return None
         if "error" in response:
             return None
         page = response.get("page")

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -123,6 +123,26 @@ def test_browser_connections_returns_attached_page(monkeypatch):
     ]
 
 
+def test_browser_connections_skips_daemon_that_closes_without_response(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "stale"])
+
+    def fake_connect(name, timeout=1.0):
+        if name == "stale":
+            return FakeSocket(b""), None
+        return FakeSocket(), None
+
+    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+
+    assert admin.browser_connections() == [{"name": "default", "page": None}]
+
+
+def test_browser_connections_skips_non_dict_connection_status_response(monkeypatch):
+    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["stale"])
+    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: (FakeSocket(b"[]\n"), None))
+
+    assert admin.browser_connections() == []
+
+
 def test_chrome_running_detects_helium_on_linux(monkeypatch):
     monkeypatch.setattr("platform.system", lambda: "Linux")
     monkeypatch.setattr(

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,4 +1,28 @@
+import pytest
+
 from browser_harness import _ipc as ipc
+
+
+# --- request(): EOF handling ---
+
+class _EOFConn:
+    def __init__(self):
+        self.sent = b""
+
+    def sendall(self, data):
+        self.sent += data
+
+    def recv(self, _size):
+        return b""
+
+
+def test_request_raises_connection_error_when_peer_closes_without_response():
+    conn = _EOFConn()
+
+    with pytest.raises(ConnectionError, match="closed without a response"):
+        ipc.request(conn, None, {"meta": "ping"})
+
+    assert conn.sent
 
 
 # --- identify(): ping payload sanitation ---


### PR DESCRIPTION
## Summary
- Raise `ConnectionError` when an IPC peer closes before sending any response, instead of treating EOF as `{}`.
- Skip malformed/non-dict `connection_status` replies in `browser_connections()` so stale endpoints do not crash diagnostics or count as active browsers.
- Add regression coverage for empty EOF and malformed status replies.

## Test Plan
- RED: `uv run --with pytest python -m pytest tests/unit/test_ipc.py::test_request_raises_connection_error_when_peer_closes_without_response tests/unit/test_admin.py::test_browser_connections_skips_daemon_that_closes_without_response tests/unit/test_admin.py::test_browser_connections_skips_non_dict_connection_status_response -q` failed before the fix.
- GREEN: same focused command passed (`3 passed`).
- GREEN: `uv run --with pytest python -m pytest tests -q` (`97 passed`).
- GREEN: `uv run python -m compileall src tests`.
- GREEN: `uv pip check --python .venv/bin/python`.
- GREEN: `uv run --with pip-audit python -m pip_audit` (no known vulnerabilities; local package skipped because it is not on PyPI).
- GREEN: `uv run --with ruff python -m ruff check --select B src/browser_harness/_ipc.py src/browser_harness/admin.py tests/unit/test_admin.py tests/unit/test_ipc.py`.

Note: repo-wide `ruff --select B .` currently reports pre-existing B904 findings in `src/browser_harness/daemon.py`, outside this PR's diff; the changed-file B check passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IPC EOF handling and hardens browser diagnostics to ignore malformed responses. Prevents crashes and stops stale daemons from being counted as active browsers.

- **Bug Fixes**
  - `ipc.request`: raise `ConnectionError` when the peer closes without sending a response (no more `{}` on EOF).
  - `browser_connections()`: skip non-dict or `"error"` `connection_status` replies so stale endpoints don’t appear active.
  - Added regression tests for empty EOF and malformed status replies.

<sup>Written for commit 08815e6c7434cf57edf6eaf36e5a3014063f0cc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

