### PR TITLE
Remove -c script execution

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -14,22 +14,23 @@ Domain skills (community-contributed per-site playbooks under `agent-workspace/d
 ## Usage
 
 ```bash
-browser-harness -c '
+browser-harness <<'PY'
 new_tab("https://docs.browser-use.com")
 wait_for_load()
 print(page_info())
-'
+PY
 ```
 
 - Invoke as browser-harness — it's on $PATH. No cd, no uv run.
+- Use the heredoc form for every multi-line command. It prevents shell quote mangling inside Python strings and JavaScript snippets.
 - First navigation is new_tab(url), not goto_url(url) — goto runs in the user's active tab and clobbers their work.
 
 ## Tool call shape
 
 ```bash
-browser-harness -c '
+browser-harness <<'PY'
 # any python. helpers pre-imported. daemon auto-starts.
-'
+PY
 ```
 
 run.py calls ensure_daemon() before exec — you never start/stop manually unless you want to.
@@ -39,18 +40,18 @@ run.py calls ensure_daemon() before exec — you never start/stop manually unles
 Use remote for parallel sub-agents (each gets its own isolated browser via a distinct BU_NAME) or on a headless server. BROWSER_USE_API_KEY must be set. start_remote_daemon, list_cloud_profiles, list_local_profiles, sync_local_profile are pre-imported.
 
 ```bash
-browser-harness -c '
+browser-harness <<'PY'
 start_remote_daemon("work")                               # default — clean browser, no profile
 # start_remote_daemon("work", profileName="my-work")      # reuse a cloud profile (already logged in)
 # start_remote_daemon("work", profileId="<uuid>")         # same, but by UUID
 # start_remote_daemon("work", proxyCountryCode="de", timeout=120)   # DE proxy, 2-hour timeout
 # start_remote_daemon("work", proxyCountryCode=None)      # disable the Browser Use proxy
-'
+PY
 
-BU_NAME=work browser-harness -c '
+BU_NAME=work browser-harness <<'PY'
 new_tab("https://example.com")
 print(page_info())
-'
+PY
 ```
 
 start_remote_daemon prints liveUrl and auto-opens it in the local browser (if a GUI is detected) so the user can watch along. Headless servers print only — share the URL with the user. The daemon PATCHes the cloud browser to stop on shutdown, which persists profile state. Running remote daemons bill until timeout.

--- a/install.md
+++ b/install.md
@@ -93,7 +93,9 @@ If the user hasn't said which connection method to use, default to Way 1 if Chro
 1. Try the harness:
 
    ```bash
-   browser-harness -c 'print(page_info())'
+   browser-harness <<'PY'
+   print(page_info())
+   PY
    ```
 
    If it prints page info, you're done.
@@ -120,7 +122,9 @@ If the user hasn't said which connection method to use, default to Way 1 if Chro
    - **chrome ok, daemon ok, but step 1 still failed** → stale daemon. Restart it:
 
      ```bash
-     browser-harness -c 'restart_daemon()'
+     browser-harness <<'PY'
+     restart_daemon()
+     PY
      ```
 
      If that hangs, escalate: kill all Chrome and daemon processes, then reopen Chrome and retry. On macOS/Linux, also remove `/tmp/bu-default.sock` and `/tmp/bu-default.pid` if they linger.

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -10,7 +10,7 @@ curl -fsSL https://browser-use.com/profile.sh | sh
 
 Downloads `profile-use` (macOS / Linux, x64 / arm64). The Python helpers shell out to it; you don't run `profile-use` directly.
 
-## Python API (pre-imported in `browser-harness -c`)
+## Python API (pre-imported in `browser-harness`)
 
 ```python
 list_cloud_profiles()

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -29,10 +29,10 @@ HELP = """Browser Harness
 Read SKILL.md for the default workflow and examples.
 
 Typical usage:
-  browser-harness -c '
+  browser-harness <<'PY'
   ensure_real_tab()
   print(page_info())
-  '
+  PY
 
 Helpers are pre-imported. The daemon auto-starts and connects to the running browser.
 
@@ -41,6 +41,12 @@ Commands:
   browser-harness --doctor         diagnose install, daemon, and browser state
   browser-harness --update [-y]    pull the latest version (agents: pass -y)
   browser-harness --reload         stop the daemon so next call picks up code changes
+"""
+
+USAGE = """Usage:
+  browser-harness <<'PY'
+  print(page_info())
+  PY
 """
 
 
@@ -85,10 +91,12 @@ def main():
     if args and args[0] == "--debug-clicks":
         os.environ["BH_DEBUG_CLICKS"] = "1"
         args = args[1:]
-    if not args or args[0] != "-c":
-        sys.exit("Usage: browser-harness -c \"print(page_info())\"")
-    if len(args) < 2:
-        sys.exit("Usage: browser-harness -c \"print(page_info())\"")
+    if not args and not sys.stdin.isatty():
+        code = sys.stdin.read()
+        if not code.strip():
+            sys.exit(USAGE)
+    else:
+        sys.exit(USAGE)
     print_update_banner()
     # Auto-bootstrap a cloud browser is opt-in via BU_AUTOSPAWN — BROWSER_USE_API_KEY alone
     # is not enough, since the key is commonly set for unrelated reasons (profile sync,
@@ -103,7 +111,7 @@ def main():
     ):
         start_remote_daemon(NAME)
     ensure_daemon()
-    exec(args[1], globals())
+    exec(code, globals())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -5,21 +5,62 @@ from unittest.mock import patch
 from browser_harness import run
 
 
-def test_c_flag_executes_code():
+def test_stdin_executes_code():
     stdout = StringIO()
-    with patch.object(sys, "argv", ["browser-harness", "-c", "print('hello from -c')"]), \
+    fake_stdin = StringIO("print('hello from stdin')")
+
+    with patch.object(sys, "argv", ["browser-harness"]), \
          patch("browser_harness.run.ensure_daemon"), \
          patch("browser_harness.run.print_update_banner"), \
+         patch("sys.stdin", fake_stdin), \
          patch("sys.stdout", stdout):
         run.main()
-    assert stdout.getvalue().strip() == "hello from -c"
+
+    assert stdout.getvalue().strip() == "hello from stdin"
+
+
+def test_c_flag_is_rejected():
+    with patch.object(sys, "argv", ["browser-harness", "-c", "print('old path')"]), \
+         patch("sys.stdin", StringIO("print('ignored')")):
+        try:
+            run.main()
+        except SystemExit as e:
+            assert "browser-harness <<'PY'" in str(e)
+        else:
+            raise AssertionError("-c should be rejected")
+
+
+def test_no_args_interactive_stdin_prints_usage():
+    fake_stdin = StringIO("")
+    fake_stdin.isatty = lambda: True
+
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", fake_stdin):
+        try:
+            run.main()
+        except SystemExit as e:
+            assert "browser-harness <<'PY'" in str(e)
+        else:
+            raise AssertionError("interactive no-args invocation should exit with usage")
+
+
+def test_no_args_empty_stdin_prints_usage():
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("")):
+        try:
+            run.main()
+        except SystemExit as e:
+            assert "browser-harness <<'PY'" in str(e)
+        else:
+            raise AssertionError("empty stdin should exit with usage")
 
 
 def test_cloud_bootstrap_on_headless_server(monkeypatch):
     """No daemon, no local Chrome, API key + BU_AUTOSPAWN set -> auto-provision cloud daemon."""
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     monkeypatch.setenv("BU_AUTOSPAWN", "1")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
          patch("browser_harness.run.daemon_alive", return_value=False), \
          patch("browser_harness.run._local_chrome_listening", return_value=False), \
          patch("browser_harness.run.start_remote_daemon") as mock_start, \
@@ -37,7 +78,8 @@ def test_explicit_bu_cdp_url_blocks_cloud_bootstrap(monkeypatch):
     monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     monkeypatch.setenv("BU_AUTOSPAWN", "1")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
          patch("browser_harness.run.daemon_alive", return_value=False), \
          patch("browser_harness.run._local_chrome_listening", return_value=False), \
          patch("browser_harness.run.start_remote_daemon") as mock_start, \
@@ -54,7 +96,8 @@ def test_explicit_bu_cdp_ws_blocks_cloud_bootstrap(monkeypatch):
     monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/abc")
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     monkeypatch.setenv("BU_AUTOSPAWN", "1")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
          patch("browser_harness.run.daemon_alive", return_value=False), \
          patch("browser_harness.run._local_chrome_listening", return_value=False), \
          patch("browser_harness.run.start_remote_daemon") as mock_start, \
@@ -71,7 +114,8 @@ def test_empty_bu_cdp_url_does_not_block_bootstrap(monkeypatch):
     monkeypatch.setenv("BU_CDP_URL", "")
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     monkeypatch.setenv("BU_AUTOSPAWN", "1")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
          patch("browser_harness.run.daemon_alive", return_value=False), \
          patch("browser_harness.run._local_chrome_listening", return_value=False), \
          patch("browser_harness.run.start_remote_daemon") as mock_start, \
@@ -89,7 +133,8 @@ def test_both_bu_cdp_url_and_bu_cdp_ws_set_blocks_bootstrap(monkeypatch):
     monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/abc")
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     monkeypatch.setenv("BU_AUTOSPAWN", "1")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
          patch("browser_harness.run.daemon_alive", return_value=False), \
          patch("browser_harness.run._local_chrome_listening", return_value=False), \
          patch("browser_harness.run.start_remote_daemon") as mock_start, \
@@ -106,7 +151,8 @@ def test_explicit_endpoint_does_not_break_daemon_alive_short_circuit(monkeypatch
     monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     monkeypatch.setenv("BU_AUTOSPAWN", "1")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
          patch("browser_harness.run.daemon_alive", return_value=True), \
          patch("browser_harness.run._local_chrome_listening", return_value=False), \
          patch("browser_harness.run.start_remote_daemon") as mock_start, \
@@ -124,7 +170,8 @@ def test_explicit_endpoint_does_not_break_local_chrome_short_circuit(monkeypatch
     monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
     monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
     monkeypatch.setenv("BU_AUTOSPAWN", "1")
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
          patch("browser_harness.run.daemon_alive", return_value=False), \
          patch("browser_harness.run._local_chrome_listening", return_value=True), \
          patch("browser_harness.run.start_remote_daemon") as mock_start, \
@@ -171,16 +218,3 @@ def test_local_chrome_listening_rejects_non_chrome():
         assert run._local_chrome_listening() is True
         mock_open.assert_called_once()
 
-
-def test_c_flag_does_not_read_stdin():
-    stdin_read = []
-    fake_stdin = StringIO("should not be read")
-    fake_stdin.read = lambda: stdin_read.append(True) or ""
-
-    with patch.object(sys, "argv", ["browser-harness", "-c", "x = 1"]), \
-         patch("browser_harness.run.ensure_daemon"), \
-         patch("browser_harness.run.print_update_banner"), \
-         patch("sys.stdin", fake_stdin):
-        run.main()
-
-    assert not stdin_read, "stdin should not be read when -c is passed"


### PR DESCRIPTION
## Summary
- make stdin/heredoc the only script input mode for browser-harness
- remove documented -c usage from agent-facing docs
- update run CLI tests to cover stdin execution and -c rejection

## Tests
- pytest tests/unit/test_run.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `-c` script execution from `browser-harness`; scripts now run only from stdin via a heredoc. Docs and tests updated, and the CLI now shows a short heredoc-based usage; daemon/cloud bootstrap remains unchanged.

- **Migration**
  - Use stdin/heredoc instead of `-c`:
    ```
    browser-harness <<'PY'
    print(page_info())
    PY
    ```
  - `-c` now exits with usage; pass scripts via stdin. Interactive or empty stdin also prints usage.
  - No changes to `BU_AUTOSPAWN`, `BROWSER_USE_API_KEY`, `BU_CDP_URL`, or `BU_CDP_WS`; cloud bootstrap logic stays the same.

<sup>Written for commit a9f7b1d5473e0bb54b6813993bfc4d4bfaecf8cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

