### PR TITLE
feat: warn on Snap Chromium and add doctor --fix-snap guide

### DIFF
--- a/docs/snap-linux-headless.md
+++ b/docs/snap-linux-headless.md
@@ -1,0 +1,45 @@
+# Snap Chromium and browser-harness (Linux)
+
+## Why Snap browsers break CDP
+
+Ubuntu and several other distributions ship Chromium as a [Snap](https://snapcraft.io/) package. Snap runs apps in a confined environment. Chrome’s remote debugging endpoint must bind on the host network where the `browser-harness` daemon can reach it. Snap’s sandbox and filesystem layout commonly prevent that from working the way a normal `.deb` Chrome install does, so the harness may see no usable DevTools port even when Chromium appears to run.
+
+Symptoms: `browser-harness --doctor` shows Chrome running, but the daemon never attaches, or CDP handshake fails without an obvious cause. [Issue #191](https://github.com/browser-use/browser-harness/issues/191) discusses this class of setup problem.
+
+## Install Google Chrome natively (Ubuntu example)
+
+Use Google’s official package (AMD64), not the Snap:
+
+```bash
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo apt install ./google-chrome-stable_current_amd64.deb
+```
+
+ARM or other architectures: download the matching package from [Google Chrome for Linux](https://www.google.com/chrome/linux/).
+
+## Point the harness at the native binary
+
+Put the non-Snap binary **first** in how you resolve “which Chrome,” so a Snap wrapper on `PATH` is not chosen by mistake.
+
+- **`BH_CHROME_PATH`** — preferred name in this project’s docs and `browser-harness --doctor` snap probe.
+- **`CHROME_PATH`** — honored the same way for compatibility with other tooling.
+
+Example for `~/.bashrc` or your environment:
+
+```bash
+export BH_CHROME_PATH=/usr/bin/google-chrome-stable
+```
+
+Then start Chrome from that path for Way 2 (`--remote-debugging-port=…`), or use Way 1 with a profile opened from the native install. Connection details are in [`install.md`](../install.md).
+
+## Verify
+
+```bash
+browser-harness --doctor
+```
+
+If a Snap binary is still the one detected on Linux, doctor prints a `[snap-detect]` warning. For a concise fix checklist:
+
+```bash
+browser-harness doctor --fix-snap
+```

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -225,6 +225,67 @@ def _doctor_short_text(value, limit=None):
     return value if len(value) <= limit else value[:limit - 3] + "..."
 
 
+def _is_snap_browser(path: str) -> bool:
+    """True when a Chrome binary path lives under /snap/ (Snap confinement on Linux)."""
+    return bool(path) and "/snap/" in path.lower()
+
+
+def _doctor_probe_chrome_binary_for_snap():
+    """Return (label, resolved_path) for the first Chrome/Chromium binary found, else (None, None).
+
+    Honors BH_CHROME_PATH and CHROME_PATH before searching PATH for common names.
+    """
+    import shutil
+
+    for key in ("BH_CHROME_PATH", "CHROME_PATH"):
+        raw = (os.environ.get(key) or "").strip()
+        if not raw:
+            continue
+        p = Path(raw).expanduser()
+        try:
+            if p.is_file():
+                return (p.name, os.path.realpath(str(p)))
+        except OSError:
+            continue
+    for cmd in ("google-chrome-stable", "google-chrome", "chromium-browser", "chromium"):
+        w = shutil.which(cmd)
+        if not w:
+            continue
+        try:
+            return (cmd, os.path.realpath(w))
+        except OSError:
+            continue
+    return (None, None)
+
+
+def _snap_linux_headless_doc_url():
+    return "https://github.com/browser-use/browser-harness/blob/main/docs/snap-linux-headless.md"
+
+
+def run_doctor_fix_snap():
+    """Print steps to replace Snap Chromium with a native Chrome for CDP. Always exit 0."""
+    doc = _snap_linux_headless_doc_url()
+    print("browser-harness doctor --fix-snap")
+    print()
+    print("Snap-packaged Chromium cannot expose DevTools the way browser-harness needs.")
+    print(f"Full background: {doc}")
+    print()
+    print("1. Install Google Chrome from Google's .deb (not the Snap store):")
+    print("   wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb")
+    print("   sudo apt install ./google-chrome-stable_current_amd64.deb")
+    print()
+    print("2. Point the harness (and your shell) at the native binary so PATH does not")
+    print("   pick the Snap wrapper first. Example for bash (~/.bashrc or session env):")
+    print("   export BH_CHROME_PATH=/usr/bin/google-chrome-stable")
+    print("   # CHROME_PATH is also honored by doctor's snap probe if you prefer that name.")
+    print()
+    print("3. Launch Chrome from that path (Way 2) or open your profile Chrome (Way 1),")
+    print("   enable remote debugging per install.md, then verify:")
+    print("   browser-harness --doctor")
+    print()
+    return 0
+
+
 def ensure_daemon(wait=60.0, name=None, env=None):
     """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
@@ -681,6 +742,7 @@ def run_doctor():
     # for display would otherwise be parsed as (0,) and flag every latest as newer.
     newer = bool(cur and latest and _version_tuple(latest) > _version_tuple(cur))
     cur_display = cur or "(unknown)"
+    doc_url = _snap_linux_headless_doc_url()
 
     def row(label, ok, detail=""):
         mark = "ok  " if ok else "FAIL"
@@ -694,6 +756,13 @@ def run_doctor():
         print(f"  latest release    {latest}" + (" (update available)" if newer else ""))
     else:
         print("  latest release    (could not reach github)")
+    if platform.system() == "Linux":
+        bname, bpath = _doctor_probe_chrome_binary_for_snap()
+        if bname and bpath and _is_snap_browser(bpath):
+            print("[snap-detect]")
+            print(f"Browser: {bname} (snap) — WARNING: Snap confinement prevents CDP binding.")
+            print(f"  Fix: Install Chrome natively (see docs/snap-linux-headless.md)")
+            print(f"  Docs: {doc_url}")
     row("chrome running", chrome, "" if chrome else "start chrome/edge")
     row("daemon alive", daemon, "" if daemon else "see install.md")
     row("active browser connections", bool(connections), str(len(connections)))

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -230,8 +230,17 @@ def _is_snap_browser(path: str) -> bool:
     return bool(path) and "/snap/" in path.lower()
 
 
+def _doctor_snap_probe_path(path: str) -> str:
+    raw = str(path)
+    try:
+        resolved = os.path.realpath(raw)
+    except OSError:
+        resolved = raw
+    return raw if _is_snap_browser(raw) else resolved
+
+
 def _doctor_probe_chrome_binary_for_snap():
-    """Return (label, resolved_path) for the first Chrome/Chromium binary found, else (None, None).
+    """Return (label, probe_path) for the first Chrome/Chromium binary found, else (None, None).
 
     Honors BH_CHROME_PATH and CHROME_PATH before searching PATH for common names.
     """
@@ -244,7 +253,7 @@ def _doctor_probe_chrome_binary_for_snap():
         p = Path(raw).expanduser()
         try:
             if p.is_file():
-                return (p.name, os.path.realpath(str(p)))
+                return (p.name, _doctor_snap_probe_path(str(p)))
         except OSError:
             continue
     for cmd in ("google-chrome-stable", "google-chrome", "chromium-browser", "chromium"):
@@ -252,7 +261,7 @@ def _doctor_probe_chrome_binary_for_snap():
         if not w:
             continue
         try:
-            return (cmd, os.path.realpath(w))
+            return (cmd, _doctor_snap_probe_path(w))
         except OSError:
             continue
     return (None, None)

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -17,6 +17,7 @@ from .admin import (
     print_update_banner,
     restart_daemon,
     run_doctor,
+    run_doctor_fix_snap,
     run_update,
     start_remote_daemon,
     stop_remote_daemon,
@@ -39,6 +40,8 @@ Helpers are pre-imported. The daemon auto-starts and connects to the running bro
 Commands:
   browser-harness --version        print the installed version
   browser-harness --doctor         diagnose install, daemon, and browser state
+  browser-harness doctor           same as --doctor
+  browser-harness doctor --fix-snap   print how to fix Snap Chromium blocking CDP (Linux)
   browser-harness --update [-y]    pull the latest version (agents: pass -y)
   browser-harness --reload         stop the daemon so next call picks up code changes
 """
@@ -80,6 +83,14 @@ def main():
         print(_version() or "unknown")
         return
     if args and args[0] == "--doctor":
+        sys.exit(run_doctor())
+    if args and args[0] == "doctor":
+        rest = args[1:]
+        if rest == ["--fix-snap"]:
+            sys.exit(run_doctor_fix_snap())
+        if rest:
+            print("usage: browser-harness doctor [--fix-snap]", file=sys.stderr)
+            sys.exit(2)
         sys.exit(run_doctor())
     if args and args[0] == "--update":
         yes = any(a in {"-y", "--yes"} for a in args[1:])

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -133,6 +133,67 @@ def test_chrome_running_detects_helium_on_linux(monkeypatch):
     assert admin._chrome_running()
 
 
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("/snap/chromium/1234/usr/lib/chromium-browser/chromium-browser", True),
+        ("/SNAP/foo", True),
+        ("/usr/bin/google-chrome-stable", False),
+        ("", False),
+    ],
+)
+def test_is_snap_browser(path, expected):
+    assert admin._is_snap_browser(path) == expected
+
+
+def test_run_doctor_prints_snap_detect_on_linux_when_probe_is_snap(monkeypatch, capsys):
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: False)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: False)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_doctor_probe_chrome_binary_for_snap", lambda: ("chromium", "/snap/chromium/1/usr/bin/chromium"))
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+    assert admin.run_doctor() == 1
+
+    out = capsys.readouterr().out
+    assert "[snap-detect]" in out
+    assert "Browser: chromium (snap)" in out
+    assert "Snap confinement prevents CDP binding" in out
+    assert "docs/snap-linux-headless.md" in out
+
+
+def test_run_doctor_skips_snap_detect_on_non_linux(monkeypatch, capsys):
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_doctor_probe_chrome_binary_for_snap", lambda: ("chromium", "/snap/chromium/1/usr/bin/chromium"))
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+    assert admin.run_doctor() == 0
+
+    out = capsys.readouterr().out
+    assert "[snap-detect]" not in out
+
+
+def test_run_doctor_fix_snap_prints_steps(capsys):
+    assert admin.run_doctor_fix_snap() == 0
+    out = capsys.readouterr().out
+    assert "browser-harness doctor --fix-snap" in out
+    assert "BH_CHROME_PATH" in out
+    assert "google-chrome-stable_current_amd64.deb" in out
+    assert "browser-harness --doctor" in out
+
+
 def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypatch, capsys):
     monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
     monkeypatch.setattr(admin, "_install_mode", lambda: "git")

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -146,6 +146,49 @@ def test_is_snap_browser(path, expected):
     assert admin._is_snap_browser(path) == expected
 
 
+def test_doctor_probe_preserves_snap_bin_env_symlink(monkeypatch, tmp_path):
+    target = tmp_path / "usr" / "bin" / "snap"
+    target.parent.mkdir(parents=True)
+    target.write_text("#!/bin/sh\n")
+    snap_bin = tmp_path / "snap" / "bin"
+    snap_bin.mkdir(parents=True)
+    chromium = snap_bin / "chromium"
+    chromium.symlink_to(target)
+
+    monkeypatch.setenv("BH_CHROME_PATH", str(chromium))
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+
+    name, path = admin._doctor_probe_chrome_binary_for_snap()
+
+    assert name == "chromium"
+    assert path == str(chromium)
+    assert admin._is_snap_browser(path)
+
+
+def test_doctor_probe_preserves_snap_bin_path_symlink(monkeypatch, tmp_path):
+    target = tmp_path / "usr" / "bin" / "snap"
+    target.parent.mkdir(parents=True)
+    target.write_text("#!/bin/sh\n")
+    snap_bin = tmp_path / "snap" / "bin"
+    snap_bin.mkdir(parents=True)
+    chromium = snap_bin / "chromium"
+    chromium.symlink_to(target)
+
+    monkeypatch.delenv("BH_CHROME_PATH", raising=False)
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+
+    def fake_which(cmd):
+        return str(chromium) if cmd == "chromium" else None
+
+    monkeypatch.setattr("shutil.which", fake_which)
+
+    name, path = admin._doctor_probe_chrome_binary_for_snap()
+
+    assert name == "chromium"
+    assert path == str(chromium)
+    assert admin._is_snap_browser(path)
+
+
 def test_run_doctor_prints_snap_detect_on_linux_when_probe_is_snap(monkeypatch, capsys):
     monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
     monkeypatch.setattr(admin, "_install_mode", lambda: "git")

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -2,6 +2,8 @@ import sys
 from io import StringIO
 from unittest.mock import patch
 
+import pytest
+
 from browser_harness import run
 
 
@@ -217,4 +219,22 @@ def test_local_chrome_listening_rejects_non_chrome():
     with patch("browser_harness.run.urllib.request.urlopen") as mock_open:
         assert run._local_chrome_listening() is True
         mock_open.assert_called_once()
+
+
+def test_cli_doctor_fix_snap_invokes_guide():
+    with patch.object(sys, "argv", ["browser-harness", "doctor", "--fix-snap"]), \
+         patch("browser_harness.run.run_doctor_fix_snap", return_value=0) as m:
+        with pytest.raises(SystemExit) as ei:
+            run.main()
+    assert ei.value.code == 0
+    m.assert_called_once()
+
+
+def test_cli_doctor_rejects_unknown_flags():
+    err = StringIO()
+    with patch.object(sys, "argv", ["browser-harness", "doctor", "--bogus"]), patch("sys.stderr", err):
+        with pytest.raises(SystemExit) as ei:
+            run.main()
+    assert ei.value.code == 2
+    assert "usage" in err.getvalue().lower()
 


### PR DESCRIPTION
## Summary
- Extends `browser-harness --doctor` on Linux to detect when the resolved Chrome/Chromium binary lives under Snap (`/snap/`) and prints a clear `[snap-detect]` warning with fix/docs links.
- Adds `browser-harness doctor` as an alias for `--doctor` and `browser-harness doctor --fix-snap` for a short remediation checklist.
- Adds `docs/snap-linux-headless.md` explaining why Snap breaks CDP, how to install native Chrome, and how to use `BH_CHROME_PATH` / `CHROME_PATH`.

## Context
Closes #328 

## How to test
- `browser-harness --doctor` on Linux with only Snap Chromium: expect `[snap-detect]` when the probed binary resolves under `/snap/`.
- `browser-harness doctor --fix-snap`: expect printed steps and exit 0.
- `browser-harness doctor --bogus`: expect usage on stderr and exit 2.
- `python -m pytest tests/unit/test_admin.py tests/unit/test_run.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when Snap-installed Chromium is detected on Linux in `browser-harness --doctor` and adds a `doctor --fix-snap` guide with clear steps to resolve CDP issues.

- **New Features**
  - Doctor checks the resolved Chrome/Chromium path on Linux and shows a `[snap-detect]` warning if it’s under `/snap/`, with a link to `docs/snap-linux-headless.md`. Honors `BH_CHROME_PATH` and `CHROME_PATH` before searching `PATH`.
  - New CLI: `browser-harness doctor` (alias for `--doctor`) and `browser-harness doctor --fix-snap` to print a short fix guide.

- **Bug Fixes**
  - Correctly detects Snap Chromium when launched via symlinks (e.g., `/snap/bin/chromium`) and when paths are provided via `BH_CHROME_PATH`/`CHROME_PATH`.

<sup>Written for commit 21c94e342c76e5c238cb2135012986f535e75e6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

