### PR TITLE
fix: prevent duplicate character insertion in press_key() for contenteditable

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -256,7 +256,7 @@ def press_key(key, modifiers=0):
     so listeners checking e.keyCode / e.key all fire."""
     vk, code, text = _KEYS.get(key, (ord(key[0]) if len(key) == 1 else 0, key, key if len(key) == 1 else ""))
     base = {"key": key, "code": code, "modifiers": modifiers, "windowsVirtualKeyCode": vk, "nativeVirtualKeyCode": vk}
-    cdp("Input.dispatchKeyEvent", type="keyDown", **base, **({"text": text} if text else {}))
+    cdp("Input.dispatchKeyEvent", type="keyDown", **base)
     if text and len(text) == 1:
         cdp("Input.dispatchKeyEvent", type="char", text=text, **{k: v for k, v in base.items() if k != "text"})
     cdp("Input.dispatchKeyEvent", type="keyUp", **base)


### PR DESCRIPTION
## Summary

- `press_key()` currently sends text on both `keyDown` and `char` CDP events.
- Chrome's editing handler may insert text during both phases in `contenteditable` elements.
- Result: every typed character can appear twice, for example `你好` → `你你好好`.

## Fix

Remove `text` from the `keyDown` event. The `char` event, which immediately follows, remains the insertion-bearing event.

This preserves the `keyDown` / `keyUp` pair for listeners that watch raw keyboard events while ensuring printable text is inserted only once.

## Test

Example case:

```html
<div id="ce" contenteditable="true"></div>

fill_input("#ce", "你好测试")
assert js("return document.getElementById('ce').textContent") == "你好测试"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicate character insertion when typing into contenteditable elements.

- **Bug Fixes**
  - Only `char` events carry text in `press_key()`; `keyDown` no longer sends `text` via `Input.dispatchKeyEvent`.
  - Prevents double characters in Chromium contenteditable and keeps `keyDown`/`keyUp` for listeners.

<sup>Written for commit c6f16f2548e2dd3ef442d38ce1aa410180cf01cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

