### PR TITLE
fix(daemon): re-attach on 'no close frame' WebSocket error

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -349,7 +349,7 @@ class Daemon:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
             msg = str(e)
-            if "Session with given id not found" in msg and sid == self.session and sid:
+            if ("Session with given id not found" in msg or "no close frame" in msg) and sid == self.session and sid:
                 log(f"stale session {sid}, re-attaching")
                 if await self.attach_first_page():
                     return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}


### PR DESCRIPTION
## Problem

When a Chrome tab's DevTools session closes without a proper WebSocket close handshake (e.g., tab navigated away, closed, or Chrome killed the session), the `websockets` library raises:

```
RuntimeError: no close frame received or sent
```

The daemon's stale-session recovery in `handle()` only matched `"Session with given id not found"` — so this error bypassed re-attach and propagated back to the caller as a hard failure.

## Fix

Add `"no close frame"` to the stale-session condition so both error strings trigger `attach_first_page()` and retry:

```python
if ("Session with given id not found" in msg or "no close frame" in msg) and sid == self.session and sid:
```

## Impact

- Stale sessions from closed/navigated tabs now recover automatically instead of crashing callers
- No behaviour change for any other error type
- One-line change, no new dependencies

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle stale DevTools sessions by re-attaching when `websockets` raises "no close frame received or sent" after a tab closes or navigates. This prevents hard failures and matches the existing behavior for "Session with given id not found".

<sup>Written for commit e8d11b5f86c01e0e555e71c14e02532fbddabc12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

