### PR TITLE
test: cover remote daemon env forwarding

### DIFF
--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -264,6 +264,28 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     ]
 
 
+def test_start_remote_daemon_forwards_remote_cdp_env_to_daemon(monkeypatch):
+    ensure_calls = []
+    browser = {"id": "browser-123", "cdpUrl": "https://cdp.example", "liveUrl": "https://live.example"}
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin, "_browser_use", lambda path, method, body=None: browser)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
+    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: ensure_calls.append(kwargs))
+    monkeypatch.setattr(admin, "_show_live_url", lambda url: None)
+
+    assert admin.start_remote_daemon("work", proxyCountryCode="us") == browser
+    assert ensure_calls == [
+        {
+            "name": "work",
+            "env": {
+                "BU_CDP_WS": "ws://example.test/devtools/browser/1",
+                "BU_BROWSER_ID": "browser-123",
+            },
+        }
+    ]
+
+
 # --- restart_daemon: PID-reuse safety ---
 
 def test_restart_daemon_does_not_signal_when_daemon_unreachable(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Add regression coverage that `start_remote_daemon()` forwards the resolved remote websocket and Browser Use browser id into `ensure_daemon()`.
- This guards against the #181 failure mode where the daemon falls back to local Chrome discovery instead of using `BU_CDP_WS`.

Refs #181.

## Test Plan
- `uv run --with pytest --with pillow python -m pytest tests/unit/test_admin.py -q`
- `uv run --with pytest --with pillow python -m pytest tests -q`
- `uv run python -m compileall src tests`
- `uv pip check --python .venv/bin/python`
- `uv run --with ruff python -m ruff check --select B tests/unit/test_admin.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test to ensure start_remote_daemon forwards the resolved remote CDP websocket and browser ID to ensure_daemon via env vars. Confirms `BU_CDP_WS` and `BU_BROWSER_ID` are set so the daemon doesn’t fall back to local Chrome discovery (guards against #181).

<sup>Written for commit 559bc1bdadf239d9aa64fb55a3db9adb521f082e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

