### PR TITLE
Stage file uploads for remote browsers

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, sys, time, urllib.request
+import base64, hashlib, importlib.util, json, math, mimetypes, os, sys, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -449,12 +449,103 @@ def dispatch_key(selector, key="Enter", event="keypress"):
         f"(()=>{{const e=document.querySelector({json.dumps(selector)});if(e){{e.focus();e.dispatchEvent(new KeyboardEvent({json.dumps(event)},{{key:{json.dumps(key)},code:{json.dumps(key)},keyCode:{kc},which:{kc},bubbles:true}}));}}}})()"
     )
 
+def _remote_cdp_needs_file_staging():
+    if os.environ.get("BU_BROWSER_ID"):
+        return True
+    cdp_url = os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")
+    if not cdp_url:
+        return False
+    host = (urlparse(cdp_url).hostname or "").lower()
+    return host not in ("", "localhost", "127.0.0.1", "::1")
+
+
+def stage_file_for_upload(path, remote_dir="/tmp/browser-harness-uploads", timeout=30.0):
+    """Copy a local file into the browser host and return the browser-side path.
+
+    CDP DOM.setFileInputFiles only accepts paths readable by Chrome. For remote
+    browsers, stage the file by making Chrome download a Blob into a known
+    browser-side directory, then use that path for the file input.
+    """
+    local = Path(path).expanduser().resolve()
+    if not local.is_file():
+        raise FileNotFoundError(str(local))
+
+    safe_name = local.name.replace("/", "_").replace("\x00", "_")
+    data = local.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()[:12]
+    remote_name = f"bh-{digest}-{safe_name}"
+    target_dir = remote_dir.rstrip("/")
+    remote_path = f"{target_dir}/{remote_name}"
+    mime = mimetypes.guess_type(str(local))[0] or "application/octet-stream"
+    encoded = base64.b64encode(data).decode("ascii")
+
+    cdp("Browser.setDownloadBehavior", behavior="allow", downloadPath=target_dir, eventsEnabled=True)
+    drain_events()
+    js("window.__bh_upload_chunks = []")
+
+    # The daemon reads newline-delimited JSON over an asyncio stream with the
+    # default 64 KiB line limit, so keep each CDP request comfortably below it.
+    chunk_size = 40_000
+    for i in range(0, len(encoded), chunk_size):
+        js("window.__bh_upload_chunks.push(" + json.dumps(encoded[i:i + chunk_size]) + ")")
+
+    js(
+        """
+(async () => {
+  const b64 = window.__bh_upload_chunks.join('');
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  const blob = new Blob([bytes], {type: MIME});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = FILENAME;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 30000);
+  return true;
+})()
+        """.replace("MIME", json.dumps(mime)).replace("FILENAME", json.dumps(remote_name))
+    )
+
+    expected_size = local.stat().st_size
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for event in drain_events():
+            if event.get("method") != "Page.downloadProgress":
+                continue
+            params = event.get("params", {})
+            if params.get("state") == "completed" and params.get("totalBytes") == expected_size:
+                return remote_path
+        time.sleep(0.2)
+    raise TimeoutError(f"timed out staging {local.name!r} into remote browser")
+
+
 def upload_file(selector, path):
-    """Set files on a file input via CDP DOM.setFileInputFiles. `path` is an absolute filepath (use tempfile.mkstemp if needed)."""
+    """Set files on a file input via CDP DOM.setFileInputFiles.
+
+    Local Chrome can read local paths directly. Remote browsers cannot, so local
+    files are first staged into the browser host and then selected from there.
+    """
+    files = [path] if isinstance(path, (str, os.PathLike)) else list(path)
+    if _remote_cdp_needs_file_staging():
+        staged = []
+        for f in files:
+            local = Path(os.fspath(f)).expanduser()
+            staged.append(stage_file_for_upload(local) if local.is_file() else os.fspath(f))
+        files = staged
+    else:
+        files = [os.fspath(f) for f in files]
+
+    # Staging remote files uses a browser download, which can trigger page
+    # re-rendering on SPAs. Resolve the file input after staging so the node id
+    # is fresh.
     doc = cdp("DOM.getDocument", depth=-1)
     nid = cdp("DOM.querySelector", nodeId=doc["root"]["nodeId"], selector=selector)["nodeId"]
     if not nid: raise RuntimeError(f"no element for {selector}")
-    cdp("DOM.setFileInputFiles", files=[path] if isinstance(path, str) else list(path), nodeId=nid)
+    cdp("DOM.setFileInputFiles", files=files, nodeId=nid)
 
 def http_get(url, headers=None, timeout=20.0):
     """Pure HTTP — no browser. Use for static pages / APIs. Wrap in ThreadPoolExecutor for bulk.

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -350,3 +350,91 @@ def test_wait_for_network_idle_filters_events_to_active_session():
         "session filter, the background rWS/lF pair would have updated "
         "last_activity and prevented the idle window from elapsing."
     )
+
+
+# --- upload_file / remote staging ---
+
+def test_stage_file_for_upload_downloads_blob_into_browser(tmp_path, monkeypatch):
+    local = tmp_path / "demo.txt"
+    local.write_text("hello")
+    cdp_calls = []
+    js_calls = []
+    drain_calls = 0
+
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        return {}
+
+    def fake_js(expr, **kwargs):
+        js_calls.append(expr)
+        return True
+
+    def fake_drain_events():
+        nonlocal drain_calls
+        drain_calls += 1
+        if drain_calls == 1:
+            return []
+        return [{
+            "method": "Page.downloadProgress",
+            "params": {"state": "completed", "totalBytes": local.stat().st_size},
+        }]
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "js", fake_js)
+    monkeypatch.setattr(helpers, "drain_events", fake_drain_events)
+    monkeypatch.setattr(helpers.time, "time", lambda: 1000.0)
+    monkeypatch.setattr(helpers.time, "sleep", lambda _: None)
+
+    remote = helpers.stage_file_for_upload(local)
+
+    assert remote.endswith("-demo.txt")
+    assert any(method == "Browser.setDownloadBehavior" for method, _ in cdp_calls)
+    assert any("window.__bh_upload_chunks.push" in expr for expr in js_calls)
+    assert any("URL.createObjectURL" in expr for expr in js_calls)
+
+
+def test_upload_file_stages_local_file_for_remote_browser(tmp_path, monkeypatch):
+    local = tmp_path / "demo.txt"
+    local.write_text("hello")
+    cdp_calls = []
+
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        if method == "DOM.getDocument":
+            return {"root": {"nodeId": 1}}
+        if method == "DOM.querySelector":
+            return {"nodeId": 2}
+        return {}
+
+    monkeypatch.setenv("BU_BROWSER_ID", "browser-123")
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "stage_file_for_upload", lambda path: "/tmp/browser/demo.txt")
+
+    helpers.upload_file("input[type=file]", local)
+
+    set_calls = [kwargs for method, kwargs in cdp_calls if method == "DOM.setFileInputFiles"]
+    assert set_calls == [{"files": ["/tmp/browser/demo.txt"], "nodeId": 2}]
+
+
+def test_upload_file_uses_local_path_for_local_browser(tmp_path, monkeypatch):
+    local = tmp_path / "demo.txt"
+    local.write_text("hello")
+    cdp_calls = []
+
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        if method == "DOM.getDocument":
+            return {"root": {"nodeId": 1}}
+        if method == "DOM.querySelector":
+            return {"nodeId": 2}
+        return {}
+
+    monkeypatch.delenv("BU_BROWSER_ID", raising=False)
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+
+    helpers.upload_file("input[type=file]", local)
+
+    set_calls = [kwargs for method, kwargs in cdp_calls if method == "DOM.setFileInputFiles"]
+    assert set_calls == [{"files": [str(local)], "nodeId": 2}]


### PR DESCRIPTION
## Summary
- stage local files into remote Browser Use Cloud browsers before calling DOM.setFileInputFiles
- keep local Chrome uploads on the direct local path path
- add unit coverage for remote staging and local upload behavior

## Diagnosis
Remote Chrome could not read the local VPS path passed to DOM.setFileInputFiles. The fix makes Chrome download a Blob copy into a known browser-side temp directory, then selects that remote path.

## Test
- uv run --with pytest pytest -q tests/unit/test_helpers.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file uploads in remote Chrome by staging local files into the browser host and using that path for `DOM.setFileInputFiles`. Local browsers keep using the original local path.

- **Bug Fixes**
  - Detect remote CDP (`BU_BROWSER_ID` or non-local `BU_CDP_WS`/`BU_CDP_URL`) and stage files by chunking base64 data, creating a Blob, and downloading to `/tmp/browser-harness-uploads` via `Browser.setDownloadBehavior`, waiting for `Page.downloadProgress`.
  - Added `stage_file_for_upload()` and integrated it into `upload_file`; resolve the input after staging to avoid stale node IDs on SPA re-renders.
  - Unit tests cover remote staging and local-path behavior.

<sup>Written for commit f2269723022c3cdf620b9d13ac6978112a1d178e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

