### PR TITLE
Link Browser Use Box deployment demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Stealth, sub-agents, or headless deployment.<br>
 - Grab a key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key)
 - Or let the agent sign up itself via [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt) (setup flow + challenge context included).
 
+Want the deployed version: a 24/7 Linux box agent with Telegram control and a persistent cloud browser? See [Browser Use Box](https://github.com/browser-use/bux) and [watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## Architecture (~1k lines across 4 core files)
 
 - `install.md` — first-time install and browser bootstrap


### PR DESCRIPTION
Adds a small README pointer from the remote-browser deployment section to Browser Use Box and its TikTok demo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a README link in the remote-browser deployment section to the `browser-use/bux` repo and its TikTok demo. This helps users find a ready-to-deploy 24/7 Linux box agent with Telegram control and a persistent cloud browser.

<sup>Written for commit bdd550b9be0f3efd3c58aea9cf729eafe8c16ed5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

