### PR TITLE
fix: sanitize lone surrogates from js results

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -90,6 +90,22 @@ def _decode_unserializable_js_value(value):
     return value
 
 
+def _replace_lone_surrogates(value):
+    if isinstance(value, str):
+        return "".join(
+            "\ufffd" if 0xD800 <= ord(ch) <= 0xDFFF else ch
+            for ch in value
+        )
+    if isinstance(value, list):
+        return [_replace_lone_surrogates(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            _replace_lone_surrogates(k): _replace_lone_surrogates(v)
+            for k, v in value.items()
+        }
+    return value
+
+
 def _runtime_value(response, expression):
     result = response.get("result", {})
     details = response.get("exceptionDetails")
@@ -103,7 +119,7 @@ def _runtime_value(response, expression):
             loc = ""
         raise RuntimeError(f"JavaScript evaluation failed{loc}: {desc}; expression: {_js_snippet(expression)}")
     if "value" in result:
-        return result["value"]
+        return _replace_lone_surrogates(result["value"])
     if "unserializableValue" in result:
         return _decode_unserializable_js_value(result["unserializableValue"])
     return None

--- a/tests/integration/test_js.py
+++ b/tests/integration/test_js.py
@@ -169,3 +169,24 @@ def test_js_timeout_error_includes_expression_context():
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
         with pytest.raises(RuntimeError, match="Runtime.evaluate.*document.title"):
             helpers.js("document.title")
+
+
+def test_js_replaces_lone_surrogates_in_returned_values():
+    def fake_cdp(method, **kwargs):
+        return {
+            "result": {
+                "type": "object",
+                "value": {
+                    "title": "中文\udc80content",
+                    "items": ["ok", "\udc81"],
+                },
+            }
+        }
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        value = helpers.js("return document.body.innerText")
+
+    assert value == {
+        "title": "中文\ufffdcontent",
+        "items": ["ok", "\ufffd"],
+    }


### PR DESCRIPTION
## What changed

- Sanitize lone UTF-16 surrogate code points from `js()` return values before handing them to user code.
- Preserve normal Unicode text, including Chinese characters and emoji.
- Apply the sanitization recursively for lists and dictionaries returned by CDP.
- Add regression coverage for issue #359.

## Why

On Windows, pages can return strings containing lone surrogate code points through CDP. Those values are invalid for UTF-8 output, so a script like `print(js(...))` can raise `UnicodeEncodeError` even though navigation and `page_info()` work. Replacing only lone surrogates at the helper boundary keeps `js()` results printable without corrupting valid Unicode content.

Fixes #359.

## Validation

Passed locally on Windows:

- `.\.venv\Scripts\python.exe -m pytest tests/integration/test_js.py tests/unit/test_helpers.py tests/unit/test_run.py`

Also ran:

- `.\.venv\Scripts\python.exe -m pytest tests/unit`

That collected 90 tests: 88 passed, 2 failed because this Windows session lacks symlink privileges for the existing snap-path tests in `tests/unit/test_admin.py`. Those failures are unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes lone UTF-16 surrogate code points in `js()` results so output is printable on Windows without altering valid Unicode.

- **Bug Fixes**
  - Replace lone surrogates with U+FFFD in strings returned by `js()`.
  - Sanitize recursively for lists and dicts from CDP.
  - Add regression test; fixes #359.

<sup>Written for commit 5f91a9cb8329cc76f33ad9cd104652deab3d1c05. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/368?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

