### PR TITLE
fix(daemon): bound CDP request waits

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -33,6 +33,7 @@ SOCK = ipc.sock_addr(NAME)
 LOG = str(ipc.log_path(NAME))
 PID = str(ipc.pid_path(NAME))
 BUF = 500
+CDP_CALL_TIMEOUT = 4.5
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
     Path.home() / "Library/Application Support/Google/Chrome Canary",
@@ -229,6 +230,17 @@ class Daemon:
                 log(f"enable {d} on {session_id}: {e}")
         await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
 
+    async def send_cdp(self, method, params=None, session_id=None):
+        if self.cdp is None:
+            raise RuntimeError("CDP client not started")
+        try:
+            return await asyncio.wait_for(
+                self.cdp.send_raw(method, params, session_id=session_id),
+                timeout=CDP_CALL_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            raise TimeoutError(f"{method} timed out after {CDP_CALL_TIMEOUT:g}s") from None
+
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
@@ -346,13 +358,13 @@ class Daemon:
         # For everything else, explicit session in req wins; else default.
         sid = None if method.startswith("Target.") else (req.get("session_id") or self.session)
         try:
-            return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
+            return {"result": await self.send_cdp(method, params, session_id=sid)}
         except Exception as e:
             msg = str(e)
             if "Session with given id not found" in msg and sid == self.session and sid:
                 log(f"stale session {sid}, re-attaching")
                 if await self.attach_first_page():
-                    return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
+                    return {"result": await self.send_cdp(method, params, session_id=self.session)}
             return {"error": msg}
 
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -293,3 +293,36 @@ def test_current_tab_meta_returns_not_attached_when_no_target_id():
     assert result == {"error": "not_attached"}
     # No CDP call should have been issued.
     assert d.cdp.calls == []
+
+
+def test_regular_cdp_calls_timeout_before_client_socket_deadline(monkeypatch):
+    """If Chrome/CDP stops answering, daemon.handle() must return a useful
+    error before the helpers.py IPC client hits its 5s socket timeout.
+
+    Otherwise the helper sees only a client-side timeout at _ipc.request(),
+    and the daemon can later log ``conn: Connection lost`` when it finally
+    tries to write to a socket the helper already closed.
+    """
+    class _HangingCDP:
+        def __init__(self):
+            self.calls = []
+
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            await asyncio.Event().wait()
+
+    d = daemon.Daemon()
+    d.cdp = _HangingCDP()
+    d.session = "session-current"
+    monkeypatch.setattr(daemon, "CDP_CALL_TIMEOUT", 0.01, raising=False)
+
+    async def run():
+        return await asyncio.wait_for(
+            d.handle({"method": "Page.navigate", "params": {"url": "https://example.com"}}),
+            timeout=0.5,
+        )
+
+    result = asyncio.run(run())
+
+    assert result == {"error": "Page.navigate timed out after 0.01s"}
+    assert d.cdp.calls == [("Page.navigate", {"url": "https://example.com"}, "session-current")]


### PR DESCRIPTION
## Summary
- Bound regular daemon CDP request waits so a stuck Chrome/CDP call returns an error before the helper IPC socket times out.
- Add a regression test for a hanging `Page.navigate` path that previously left the helper with only a client-side `_ipc.request()` timeout.

Refs #370

## Why
In #370, the visible symptom is a second navigation timing out in `_ipc.py` while the daemon later logs `conn: Connection lost`. I could not reproduce the underlying WebSocket drop on current `main`, but this hardens the daemon boundary so a stuck CDP send produces a useful `Page.navigate timed out after 4.5s` response instead of letting the helper hit its 5s socket deadline first.

## Test Plan
- RED: `uv run --with pytest --with pillow python -m pytest tests/unit/test_daemon.py::test_regular_cdp_calls_timeout_before_client_socket_deadline -q` failed before the fix with an outer `TimeoutError`.
- GREEN: `uv run --with pytest --with pillow python -m pytest tests/unit/test_daemon.py::test_regular_cdp_calls_timeout_before_client_socket_deadline -q` → `1 passed`.
- GREEN: `uv run --with pytest --with pillow python -m pytest tests/unit -q` → `91 passed`.
- GREEN: `uv run python -m compileall -q src tests` → passed.
- GREEN: `git diff --check` → passed.
- Dynamic probe: `BU_NAME=oss370pr2 uv run browser-harness` with `new_tab('https://example.com')` followed by `new_tab('https://httpbin.org/ip')` → both navigations returned `page_info()` successfully on my local Chrome.

## Notes
This is a scoped mitigation/diagnostic hardening PR, not a claim that the root WebSocket drop reported in #370 is fully fixed. If maintainers prefer a different timeout budget or want this limited to navigation/session-bound calls, I can adjust.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound CDP request waits in the daemon to 4.5s so stalled Chrome/CDP calls return a clear error before the helper’s 5s IPC socket deadline. Mitigates the timeout symptom in #370 by failing fast with messages like "Page.navigate timed out after 4.5s".

- **Bug Fixes**
  - Added `CDP_CALL_TIMEOUT = 4.5` and a `send_cdp()` wrapper that uses `asyncio.wait_for` and returns a concise timeout error.
  - Used the wrapper for normal sends and after session re-attach.
  - Added a regression test ensuring the daemon surfaces the timeout before the client IPC socket deadline.

<sup>Written for commit 1689057df3c859863784f2094c1d3501bb044dc0. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/372?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

