### PR TITLE
docs: note manual browser connection setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Set up https://github.com/browser-use/browser-harness for me.
 Read `install.md` and follow the steps to install browser-harness and connect it to my browser.
 ```
 
+Manual first run: `browser-harness` needs a connected browser before commands can run.
+Use one of the browser connection paths from [`install.md`](install.md):
+
+- Normal Chrome profile: open `chrome://inspect/#remote-debugging` and allow remote debugging.
+- Isolated automation profile: launch Chrome with `--remote-debugging-port=9222 --user-data-dir=<non-default path>`, then set `BU_CDP_URL=http://127.0.0.1:9222`.
+
 The agent will open `chrome://inspect/#remote-debugging`. Tick the checkbox so the agent can connect to your browser:
 
 <img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />


### PR DESCRIPTION
## Summary
- add a short README note that browser-harness needs a connected browser before commands run
- point manual users to the two safer connection paths already covered in `install.md`
- avoid the unsafe bare `--remote-debugging-port=9222` default-profile snippet

## Test Plan
- `git diff --check origin/main...HEAD`
- `uv run python -m compileall -q src tests`

Closes #107


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies manual first-run setup in README so `browser-harness` connects to a browser before any commands run. Points to the two safe connection options from `install.md` (normal profile via `chrome://inspect/#remote-debugging`, or isolated profile with `--remote-debugging-port=9222 --user-data-dir=<path>` and `BU_CDP_URL`) and avoids the unsafe bare default-profile flag.

<sup>Written for commit 5203dba8a0e837bd09c69e99ecbbdfc5f543acc2. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/373?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

