### PR TITLE
fix(admin): open Chrome inspect page on Windows

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -720,7 +720,8 @@ def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
     import platform, subprocess, webbrowser
     url = "chrome://inspect/#remote-debugging"
-    if platform.system() == "Darwin":
+    system = platform.system()
+    if system == "Darwin":
         try:
             subprocess.run([
                 "osascript",
@@ -730,6 +731,22 @@ def _open_chrome_inspect():
             return
         except Exception:
             pass
+    if system == "Windows":
+        for root in (
+            os.environ.get("PROGRAMFILES"),
+            os.environ.get("PROGRAMFILES(X86)"),
+            os.environ.get("LOCALAPPDATA"),
+        ):
+            if not root:
+                continue
+            chrome = Path(root) / "Google" / "Chrome" / "Application" / "chrome.exe"
+            if not chrome.exists():
+                continue
+            try:
+                subprocess.Popen([str(chrome), url])
+                return
+            except Exception:
+                pass
     try:
         webbrowser.open(url, new=2)
     except Exception:

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -133,6 +133,44 @@ def test_chrome_running_detects_helium_on_linux(monkeypatch):
     assert admin._chrome_running()
 
 
+def test_open_chrome_inspect_uses_chrome_executable_on_windows(monkeypatch, tmp_path):
+    program_files = tmp_path / "Program Files"
+    chrome = program_files / "Google" / "Chrome" / "Application" / "chrome.exe"
+    chrome.parent.mkdir(parents=True)
+    chrome.write_text("chrome")
+    popen_calls = []
+    webbrowser_calls = []
+
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setenv("PROGRAMFILES", str(program_files))
+    monkeypatch.delenv("PROGRAMFILES(X86)", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setattr("subprocess.Popen", lambda args: popen_calls.append(args))
+    monkeypatch.setattr("webbrowser.open", lambda *args, **kwargs: webbrowser_calls.append((args, kwargs)))
+
+    admin._open_chrome_inspect()
+
+    assert popen_calls == [[str(chrome), "chrome://inspect/#remote-debugging"]]
+    assert webbrowser_calls == []
+
+
+def test_open_chrome_inspect_falls_back_to_webbrowser_when_windows_chrome_missing(monkeypatch):
+    popen_calls = []
+    webbrowser_calls = []
+
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.delenv("PROGRAMFILES", raising=False)
+    monkeypatch.delenv("PROGRAMFILES(X86)", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setattr("subprocess.Popen", lambda args: popen_calls.append(args))
+    monkeypatch.setattr("webbrowser.open", lambda *args, **kwargs: webbrowser_calls.append((args, kwargs)))
+
+    admin._open_chrome_inspect()
+
+    assert popen_calls == []
+    assert webbrowser_calls == [(("chrome://inspect/#remote-debugging",), {"new": 2})]
+
+
 @pytest.mark.parametrize(
     "path, expected",
     [


### PR DESCRIPTION
## Summary
- open `chrome://inspect/#remote-debugging` through the Chrome executable on Windows
- keep the existing macOS AppleScript path and `webbrowser.open()` fallback for other cases
- add Windows unit coverage for executable launch and missing-Chrome fallback

## Test Plan
- RED: `uv run --with pytest --with pillow python -m pytest tests/unit/test_admin.py::test_open_chrome_inspect_uses_chrome_executable_on_windows -q` failed before the fix because Windows still called `webbrowser.open()`
- GREEN: `uv run --with pytest --with pillow python -m pytest tests/unit/test_admin.py::test_open_chrome_inspect_uses_chrome_executable_on_windows tests/unit/test_admin.py::test_open_chrome_inspect_falls_back_to_webbrowser_when_windows_chrome_missing -q`
- GREEN: `uv run --with pytest --with pillow python -m pytest tests/unit/test_admin.py -q`
- GREEN: `uv run --with pytest --with pillow python -m pytest tests/unit -q`
- GREEN: `uv run python -m compileall -q src tests`
- GREEN: `git diff --check`

Closes #290


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes opening the Chrome inspect page on Windows by launching `chrome://inspect/#remote-debugging` via the Chrome executable. Falls back to `webbrowser.open()` when Chrome isn’t found; macOS AppleScript path remains unchanged.

- **Bug Fixes**
  - Windows: find `chrome.exe` in `PROGRAMFILES`, `PROGRAMFILES(X86)`, or `LOCALAPPDATA` and launch the URL directly.
  - Fallback to `webbrowser.open(url, new=2)` if Chrome is missing or launch fails.
  - Added unit tests for Windows launch and fallback behavior.

<sup>Written for commit eaf6704986d000de5f89fe2dbdf5c237fc43abbe. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/374?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

