### PR TITLE
fix: IPC payload limits and harden socket/file creation security

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -59,6 +59,19 @@ def _read_port_file(name):
         return None, None
 
 
+def safe_open_write(path, append=False):
+    """Securely open a file for writing, refusing to follow symlinks where supported."""
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_APPEND if append else os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(str(path), flags, 0o600)
+        return open(fd, "a" if append else "w")
+    except OSError:
+        raise RuntimeError(f"Refusing to write to {path} as it may be a symlink attack.")
+
+
 def sock_addr(name):  # display-only, used in log lines
     if not IS_WINDOWS: return str(_sock_path(name))
     port, _ = _read_port_file(name)
@@ -163,15 +176,16 @@ async def serve(name, handler):
     global _server_token
     if not IS_WINDOWS:
         path = str(_sock_path(name))
-        if os.path.exists(path): os.unlink(path)
+        try: os.unlink(path)
+        except OSError: pass
         # umask 0o077 makes bind() create the socket as 0600 — no TOCTOU window before chmod.
         old_umask = os.umask(0o077)
-        try: server = await asyncio.start_unix_server(handler, path=path)
+        try: server = await asyncio.start_unix_server(handler, path=path, limit=1024 * 1024 * 16)
         finally: os.umask(old_umask)
         _server_token = None
         async with server: await asyncio.Event().wait()
         return
-    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    server = await asyncio.start_server(handler, "127.0.0.1", 0, limit=1024 * 1024 * 16)
     port = server.sockets[0].getsockname()[1]
     _server_token = secrets.token_hex(32)
     pf = port_path(name)
@@ -194,4 +208,4 @@ def expected_token():
 def cleanup_endpoint(name):  # best-effort; silent if already gone
     p = _sock_path(name) if not IS_WINDOWS else port_path(name)
     try: p.unlink()
-    except FileNotFoundError: pass
+    except OSError: pass

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -185,7 +185,9 @@ async def serve(name, handler):
         _server_token = None
         async with server: await asyncio.Event().wait()
         return
-    server = await asyncio.start_server(handler, "127.0.0.1", 0, limit=1024 * 1024 * 16)
+    # Windows TCP loopback: keep the default 64KB limit to prevent unauthenticated
+    # local clients from forcing large pre-auth memory allocations (DoS).
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
     _server_token = secrets.token_hex(32)
     pf = port_path(name)

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -70,7 +70,11 @@ API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
 def log(msg):
-    open(LOG, "a").write(f"{msg}\n")
+    try:
+        with ipc.safe_open_write(LOG, append=True) as f:
+            f.write(f"{msg}\n")
+    except RuntimeError:
+        pass
 
 
 async def _silent(coro):
@@ -405,8 +409,13 @@ if __name__ == "__main__":
     if already_running():
         print(f"daemon already running on {SOCK}", file=sys.stderr)
         sys.exit(0)
-    open(LOG, "w").close()
-    open(PID, "w").write(str(os.getpid()))
+    try:
+        ipc.safe_open_write(LOG).close()
+        with ipc.safe_open_write(PID) as f:
+            f.write(str(os.getpid()))
+    except RuntimeError as e:
+        print(f"fatal: {e}", file=sys.stderr)
+        sys.exit(1)
     try:
         asyncio.run(main())
     except KeyboardInterrupt:


### PR DESCRIPTION
This PR introduces three targeted, non-destructive hardening improvements to the daemon's IPC and file handling architecture. 

During load testing and security review of the local daemon setup, I identified a functional limitation with large CDP payloads, a potential ToCToU socket creation race, and a CWE-61 symlink vulnerability in the default `/tmp` logging mechanism. 

This PR resolves all three without changing any of the public `helpers.py` API or requiring any new dependencies.

### 1. Fix IPC Payload Limit (Architecture & Functional)
**The Root Cause:** 
The `asyncio.start_unix_server` and `asyncio.start_server` initializations in `_ipc.py` were using the Python standard library's default `limit` parameter, which strictly bounds the `reader.readline()` buffer to 64KB (65536 bytes). If an LLM agent attempts to inject a large JavaScript library via `helpers.js()` or sends a large DOM CDP payload, the daemon silently terminates the connection with a `LimitOverrunError`.

**The Fix:**
I explicitly passed `limit=1024 * 1024 * 16` (16MB) to the server socket initializations. This securely scales the maximum allowable buffer size in memory without allocating it up-front, allowing the harness to robustly process arbitrarily large AI-generated scripts and HTML payloads.

### 2. Prevent Unix Socket Denial of Service (Robustness)
**The Root Cause:**
When binding the UNIX socket on POSIX systems, the daemon cleans up stale sockets using the `if os.path.exists(path): os.unlink(path)` pattern. Because `os.path.exists()` resolves symlinks, it returns `False` if the path is a *broken symlink*. If a broken symlink exists at the socket path (due to a previous crash or malicious pre-creation), the `unlink` is bypassed, and the subsequent `bind()` call fatally crashes with `Address already in use`.

**The Fix:**
I refactored the socket cleanup to use the standard, race-free EAFP pattern: `try: os.unlink(path) except OSError: pass`. This guarantees the socket path is securely cleared regardless of its symlink state, eliminating the Denial of Service vector and removing a Time-Of-Check to Time-Of-Use (ToCToU) race condition.

### 3. Patch Log/PID Symlink Vulnerability (Security - CWE-61)
**The Root Cause:**
By default, `daemon.py` created the `LOG` and `PID` files directly in `/tmp` using the high-level `open(path, "w")` function. Because `/tmp` is a world-writable shared directory on POSIX systems, a malicious local user could execute a symlink attack (CWE-61) by pre-creating `/tmp/bu-default.log` as a symlink pointing to another user's sensitive file (e.g., `~/.bashrc`). The daemon would blindly follow the symlink and overwrite the target file.

**The Fix:**
I introduced a `safe_open_write()` helper in `_ipc.py` that utilizes the low-level `os.open` syscall. Where supported by the OS (Linux/macOS), it passes the `os.O_NOFOLLOW` flag to strictly reject symlink traversal at the kernel level. On Windows (where `O_NOFOLLOW` is not present), it degrades gracefully to standard behavior, ensuring perfect cross-platform compatibility while securing POSIX environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the IPC read buffer to 16MB on UNIX sockets and hardens socket and PID/LOG file handling to prevent crashes and symlink attacks. Keeps Windows TCP at 64KB to avoid pre-auth DoS while allowing large CDP/JS payloads on POSIX.

- **Bug Fixes**
  - Increase asyncio server read limit to 16MB for UNIX sockets to avoid LimitOverrunError on large messages; keep Windows TCP at the default 64KB.
  - Replace exists()+unlink with try: unlink except OSError for socket cleanup to handle broken symlinks and remove the ToCToU window; broaden best-effort endpoint cleanup to ignore OSError.

- **Security**
  - Add safe_open_write using os.open with O_NOFOLLOW (0600 perms) for LOG/PID files to block symlink overwrites in /tmp; daemon exits if PID/LOG cannot be opened (Windows degrades gracefully).

<sup>Written for commit 20ea1333c96ae0e789f93f3e657b6bab955f9e48. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/376?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

