### PR TITLE
fix: harden IPC limits and secure file handling

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -59,6 +59,19 @@ def _read_port_file(name):
         return None, None
 
 
+def safe_open_write(path, append=False):
+    """Securely open a file for writing, refusing to follow symlinks where supported."""
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_APPEND if append else os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(str(path), flags, 0o600)
+        return open(fd, "a" if append else "w")
+    except OSError:
+        raise RuntimeError(f"Refusing to write to {path} as it may be a symlink attack.")
+
+
 def sock_addr(name):  # display-only, used in log lines
     if not IS_WINDOWS: return str(_sock_path(name))
     port, _ = _read_port_file(name)
@@ -163,14 +176,17 @@ async def serve(name, handler):
     global _server_token
     if not IS_WINDOWS:
         path = str(_sock_path(name))
-        if os.path.exists(path): os.unlink(path)
+        try: os.unlink(path)
+        except OSError: pass
         # umask 0o077 makes bind() create the socket as 0600 — no TOCTOU window before chmod.
         old_umask = os.umask(0o077)
-        try: server = await asyncio.start_unix_server(handler, path=path)
+        try: server = await asyncio.start_unix_server(handler, path=path, limit=1024 * 1024 * 16)
         finally: os.umask(old_umask)
         _server_token = None
         async with server: await asyncio.Event().wait()
         return
+    # Windows TCP loopback: keep the default 64KB limit to prevent unauthenticated
+    # local clients from forcing large pre-auth memory allocations (DoS).
     server = await asyncio.start_server(handler, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
     _server_token = secrets.token_hex(32)
@@ -194,4 +210,4 @@ def expected_token():
 def cleanup_endpoint(name):  # best-effort; silent if already gone
     p = _sock_path(name) if not IS_WINDOWS else port_path(name)
     try: p.unlink()
-    except FileNotFoundError: pass
+    except OSError: pass

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -70,7 +70,11 @@ API_KEY = os.environ.get("BROWSER_USE_API_KEY")
 
 
 def log(msg):
-    open(LOG, "a").write(f"{msg}\n")
+    try:
+        with ipc.safe_open_write(LOG, append=True) as f:
+            f.write(f"{msg}\n")
+    except RuntimeError:
+        pass
 
 
 async def _silent(coro):
@@ -405,8 +409,13 @@ if __name__ == "__main__":
     if already_running():
         print(f"daemon already running on {SOCK}", file=sys.stderr)
         sys.exit(0)
-    open(LOG, "w").close()
-    open(PID, "w").write(str(os.getpid()))
+    try:
+        ipc.safe_open_write(LOG).close()
+        with ipc.safe_open_write(PID) as f:
+            f.write(str(os.getpid()))
+    except RuntimeError as e:
+        print(f"fatal: {e}", file=sys.stderr)
+        sys.exit(1)
     try:
         asyncio.run(main())
     except KeyboardInterrupt:


### PR DESCRIPTION
This PR introduces targeted, non-destructive hardening improvements to the daemon's IPC and file handling architecture. 

During load testing and security review of the local daemon setup, I identified a functional limitation with large CDP payloads, a potential ToCToU socket creation race, and a CWE-61 symlink vulnerability in the default `/tmp` logging mechanism. 

### 1. Fix IPC Payload Limit (Architecture & Functional)
**The Root Cause:** 
`asyncio.start_unix_server` limits the `reader.readline()` buffer to 64KB by default. If an agent injects a large JavaScript library via `helpers.js()` or sends a large DOM CDP payload, the daemon silently terminates the connection with a `LimitOverrunError`.
**The Fix:**
I explicitly passed `limit=1024 * 1024 * 16` (16MB) to the Unix socket initialization to natively support arbitrarily large AI-generated scripts. *(Note: Windows TCP loopback is intentionally left at 64KB to prevent unauthenticated local clients from forcing large pre-auth memory allocations).*

### 2. Prevent Unix Socket Denial of Service (Robustness)
**The Root Cause:**
The daemon cleans up stale sockets using `if os.path.exists(path): os.unlink(path)`. Because `os.path.exists()` resolves symlinks, it returns `False` if the path is a *broken symlink*. If a broken symlink exists at the socket path, the `unlink` is bypassed, and the `bind()` call fatally crashes with `Address already in use`.
**The Fix:**
Refactored socket cleanup to use the standard, race-free EAFP pattern: `try: os.unlink(path) except OSError: pass`. 

### 3. Patch Log/PID Symlink Vulnerability (Security - CWE-61)
**The Root Cause:**
`daemon.py` created the `LOG` and `PID` files directly in `/tmp`. Because `/tmp` is a world-writable shared directory on POSIX systems, a malicious local user could execute a symlink attack (CWE-61) by pre-creating `/tmp/bu-default.log` as a symlink pointing to another user's sensitive file (e.g., `~/.bashrc`). The daemon would blindly follow the symlink and overwrite the target file.
**The Fix:**
Introduced a `safe_open_write()` helper utilizing the low-level `os.open` syscall with the `os.O_NOFOLLOW` flag to strictly reject symlink traversal at the kernel level (falling back gracefully to standard behavior on Windows).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the daemon’s IPC and file handling for stability and security. Supports large Unix socket payloads and blocks symlink-based file overwrites.

- **Bug Fixes**
  - Raised Unix socket read limit to 16MB to handle large CDP/JS payloads; kept Windows TCP loopback at 64KB to reduce pre-auth DoS risk.
  - Switched socket cleanup to EAFP unlink (try/except OSError), fixing crashes when a broken symlink exists.

- **Security**
  - Added `safe_open_write()` using `os.O_NOFOLLOW` and 0600 perms; applied to `LOG` and `PID` in `/tmp` to prevent CWE-61 symlink overwrites.
  - Startup now fails closed if a symlink is detected; logging uses the safe appender.

<sup>Written for commit 1e59cc85da10caebf7736e16b3c5e45d1ef94fd6. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

