### PR TITLE
Remove Firecrawl mentions from Facebook skills

### DIFF
--- a/agent-workspace/domain-skills/facebook/groups.md
+++ b/agent-workspace/domain-skills/facebook/groups.md
@@ -9,7 +9,7 @@ views serve a stripped landing page with no post content.
 
 1. Pull the N most recent posts from a named FB group
 2. Harvest every external URL that members have shared
-3. Hand that URL list to Firecrawl (or `http_get`) for structured scraping at scale
+3. Hand that URL list to `http_get` or another downstream extractor for structured scraping at scale
 4. Cache post text + author + timestamp for downstream keyword matching
 
 It is NOT for: replying in groups, DMing members, or any write action.
@@ -101,11 +101,11 @@ def decode_fb_link(href):
     return unquote(q["u"][0]) if "u" in q else href
 ```
 
-## Handoff to Firecrawl (for the public outbound URLs)
+## Handoff for the public outbound URLs
 
 Once you have the harvested external list, those URLs are outside FB's walled
-garden — public, scrapable by anything. Firecrawl's schema-native extraction
-shines here because you want typed results across heterogeneous sources.
+garden — public, scrapable by ordinary HTTP clients or downstream extractors.
+Typed extraction is useful here because the sources are heterogeneous.
 
 ```python
 # After the scroll loop:
@@ -116,17 +116,13 @@ for p in seen.values():
 external_urls = sorted(set(external_urls))
 print(f"harvested {len(external_urls)} unique external URLs")
 
-# Hand off to Firecrawl MCP in the calling conversation:
-#   firecrawl_extract(
-#       urls=external_urls,
-#       prompt="Extract product/listing name, price, location, year, and key features.",
-#       schema={...}
-#   )
+# Hand off to a downstream extractor in the calling conversation with whatever
+# schema matches the task, such as product/listing name, price, location, year,
+# and key features.
 ```
 
-When Firecrawl isn't available or the pages are simple, `http_get(url)` from
-Harness itself is fine — it does a plain HTTP fetch without a browser, works
-for static pages, and is the fastest option for bulk.
+For simple or static pages, `http_get(url)` from Harness itself is fine — it
+does a plain HTTP fetch without a browser and is the fastest option for bulk.
 
 
 ## Rate-limit discipline
@@ -226,8 +222,8 @@ PY
 ```
 
 The JSON on stdout is the handoff payload — parse it in the calling agent and
-route `external_urls` into `firecrawl_extract` with whatever schema matches the
-downstream task (competitor inventory, pricing intel, boat listings, etc).
+route `external_urls` into the downstream extractor that matches the task
+(competitor inventory, pricing intel, boat listings, etc).
 
 ## Gotchas log (append when you hit something new)
 

--- a/agent-workspace/domain-skills/facebook/pages.md
+++ b/agent-workspace/domain-skills/facebook/pages.md
@@ -15,7 +15,7 @@ scroll loop after ~5 posts. Stay signed in.
 1. Pull the N most recent posts from a named FB Page (brand, publisher, local business)
 2. Harvest every external URL the Page has linked out to
 3. Grab Page metadata — follower count, category, website, verified status
-4. Hand the outbound URL list to Firecrawl (or `http_get`) for downstream extraction
+4. Hand the outbound URL list to `http_get` or another downstream extractor
 
 It is NOT for: leaving comments, reacting, messaging the Page, or any write action.
 
@@ -145,17 +145,17 @@ def decode_fb_link(href):
     return unquote(q["u"][0]) if "u" in q else href
 ```
 
-## Handoff to Firecrawl
+## Handoff for outbound URLs
 
 Same pattern as groups — Pages are the walled-garden surface that Harness is
 good at; the external URLs the Page has shared are public and better suited to
-Firecrawl's schema-native extraction.
+ordinary HTTP clients or downstream extractors.
 
 ```python
 external_urls = sorted({decode_fb_link(x) for p in seen.values() for x in p["externals"]})
 print(f"harvested {len(external_urls)} unique external URLs from Page")
 # In the calling conversation:
-#   firecrawl_extract(urls=external_urls, prompt="...", schema={...})
+#   send external_urls to the downstream extractor that matches the task schema
 ```
 
 ## Rate-limit discipline
@@ -270,7 +270,7 @@ PY
 ```
 
 The stdout JSON is the handoff payload — parse it in the calling agent and
-route `external_urls` into `firecrawl_extract`, route `meta` into a
+route `external_urls` into a downstream extractor, route `meta` into a
 competitor-intel table, or feed `posts` into keyword matching.
 
 ## When to reach for pages.md vs groups.md


### PR DESCRIPTION
Removes vendor-specific Firecrawl references from the Facebook Groups and Pages domain skills while keeping the skills and their generic downstream extraction guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed vendor-specific Firecrawl references from the Facebook Groups and Pages domain skills. Guidance is now vendor-neutral, using `http_get` and generic downstream extractors with no behavior changes.

- **Refactors**
  - Renamed “Handoff to Firecrawl” sections to “Handoff for outbound URLs.”
  - Updated examples to route `external_urls` to a downstream extractor; kept `http_get` for simple/static pages.
  - Simplified wording around typed extraction to stay tool-agnostic.

<sup>Written for commit ad7f4f233cbde8bb21ecf93c2e8b3297abcba093. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/381?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

