### PR TITLE
[codex] Add Supplier Coupang domain skill

### DIFF
--- a/agent-workspace/domain-skills/supplier-coupang/auth-session.md
+++ b/agent-workspace/domain-skills/supplier-coupang/auth-session.md
@@ -1,0 +1,61 @@
+# Coupang Supplier Hub Auth And CDP Session
+
+## Canonical Shape
+
+- Host: `https://supplier.coupang.com/`
+- Browser path: `CdpChromeSession` through browser-harness CLI/daemon IPC.
+- Use a dedicated non-default Chrome profile. Do not rely on the user's default Chrome profile.
+- Fresh workflow session is the default for Coupang 1P. Reuse is allowed only inside one workflow when the code owns cleanup and state checks.
+- Public CDP workflows must close the session in `finally`, including failures after artifact capture.
+
+Relevant code:
+- `coupang-1p-auto/infrastructure/bots/bot_coupang_1p.py`: `_get_cdp_session`, `cdp_login_if_needed`, `_run_cdp_registration_workflow`, `_run_cdp_download_workflow`, `_close_cdp_session`
+- `coupang-1p-auto/infrastructure/external_services/cdp_chrome.py`: `CdpChromeSession`
+
+## Login State Classification
+
+Treat these as hard blocks:
+- HTML contains `Access Denied` plus permission/reference wording.
+- URL or HTML contains `errors.edgesuite.net`.
+- Account lock or human decision pages.
+
+Treat these as normal flow states:
+- `xauth.../auth/...` redirect with visible username/password fields.
+- Known Supplier Hub paths that render a warning modal but still have the expected business page underneath.
+
+Do not mark a normal auth redirect as an anti-bot wall just because the URL is not the target URL yet.
+
+## Automated Login
+
+The CDP path should:
+
+1. Navigate to a Supplier Hub page.
+2. Detect login fields.
+3. Fill username/password from the configured credentials source.
+4. Click the login button.
+5. Wait until either a known Supplier Hub page appears or a hard block is detected.
+
+Do not store real credentials in this skill. Local credentials belong in the existing local variables mechanism such as `.variables.local` and environment variables handled by the app.
+
+## Manual Handoff
+
+Manual login handoff is a separate CDP path, not a reason to fall back to Selenium for side-effecting work.
+
+Manual handoff messages should include:
+- Sanitized current URL with query removed.
+- Reason code.
+- Screenshot/DOM artifact paths when available.
+- Clear instruction not to press business action buttons.
+
+After manual login, copy only the session state needed by retained legacy compatibility. The browser profile remains the primary state store for CDP workflows.
+
+## Session Reuse Rule
+
+For Coupang 1P, the safer default is:
+
+- Start or attach a workflow-scoped CDP session.
+- Execute one business workflow.
+- Capture artifacts on failure.
+- Close CDP session and automation-launched Chrome when done.
+
+This avoids stale modal state, old downloads, partially registered forms, and hidden tabs leaking into the next workflow.

--- a/agent-workspace/domain-skills/supplier-coupang/failure-artifacts.md
+++ b/agent-workspace/domain-skills/supplier-coupang/failure-artifacts.md
@@ -1,0 +1,66 @@
+# Failure Artifacts
+
+## Path Contract
+
+For Coupang 1P bot workflows, artifacts should land under:
+
+```text
+coupang-1p-auto/logs/<arrival_or_workflow_label>/browser-harness/
+```
+
+The generic CDP default may be:
+
+```text
+coupang-1p-auto/logs/browser-harness/
+```
+
+Prefer the workflow/date-specific path from the bot wrapper when available.
+
+## Required Evidence
+
+Capture before closing the failed CDP session:
+
+- Screenshot PNG.
+- DOM HTML.
+- Summary JSON.
+- Selector probe JSON.
+- Current URL with query stripped.
+- Exception type and message.
+- CDP URL, profile dir, download folder, and browser-harness name when available.
+
+The selector probe list should include login, search, download, modal, upload, save, and known blocker selectors relevant to the workflow.
+
+## Reporting
+
+When reporting a portal failure:
+
+- Include the sanitized URL, never a full URL with business query params.
+- Include the artifact directory and the failure label.
+- Include whether the session was closed.
+- State whether the workflow performed any external mutation before the failure.
+
+## Common Probe Selectors
+
+Useful Supplier Hub probes include:
+
+```text
+[name='username']
+[name='password']
+text=로그인
+#search
+#milkrunListTable
+#batchRegisterMilkrun
+#supplierMilkrunLocationBtn
+#saveButton
+#saveMilkrun
+#checkbox
+.modal.show
+.bootstrap-dialog
+.modal-backdrop
+.blockUI
+#edd
+#shipment-search-btn
+input[type='file']
+```
+
+Keep the global probe list broad, but add workflow-specific selectors when debugging a new failure.

--- a/agent-workspace/domain-skills/supplier-coupang/milkrun-bulk-register.md
+++ b/agent-workspace/domain-skills/supplier-coupang/milkrun-bulk-register.md
@@ -1,0 +1,84 @@
+# Milkrun Bulk Registration
+
+## URL
+
+```text
+https://supplier.coupang.com/milkrun/batchRegister?warehousingPlannedAt={arrival_date}
+```
+
+Expected ready selector:
+
+```text
+#batchRegisterMilkrun
+```
+
+## Blocking Notice Modal
+
+The page may show a visible `접수 주의사항` Bootstrap dialog. This modal is async and can keep the close button disabled until `#checkbox` is checked.
+
+Reliable close pattern:
+- Find visible `.modal` / `.bootstrap-dialog`.
+- Click/check `input#checkbox` or visible checkbox inputs.
+- Dispatch `input` and `change`.
+- If the close/confirm button is still disabled while `input#checkbox:checked` is true, remove the disabled state.
+- Click close/confirm.
+- Remove stale `.modal-backdrop`.
+- Wait for a quiet period with no visible `접수 주의사항`.
+
+Do not click through the business form while this modal is still visible.
+
+## Per-row Entry
+
+For each Supplier Hub row:
+
+1. Match the center name to Google Sheet data.
+2. Compare Supplier Hub PO numbers with sheet PO numbers before entering data.
+3. If `#completeRegistration_{row_index}` exists, treat the row as already registered and skip it.
+4. Click `#releaseAddressImport_{row_index}` and wait for the visible `출고지 선택` dialog.
+5. Find the warehouse cell in `#purchaseOrderTable` and extract the location seq from `locationName_<seq>`.
+6. Click `button[name='selectLocation'][data-supplier-milkrun-location-seq='<seq>']`.
+7. Wait until `#supplierLocationSeq_{row_index}` equals the seq and the dialog is closed.
+8. Fill boxes, pallet rows, weight, contents, allocation reply, and pallet rental company.
+
+## Pallet Add Button Pitfall
+
+`#addPallet_{row_index}` can log as clicked while no row is added. The stable sequence is:
+
+1. Wait for the element.
+2. Prefer waiting for a jQuery click handler via `$._data(element, "events").click`.
+3. Click the button and then trigger the jQuery click if the row count did not increase.
+4. Verify `#palletBody_{row_index} tr` increased.
+5. If the site handler is absent or does not add a row, use the local DOM fallback that inserts the same input shape (`length`, `width`, `height`, `count`) expected by the save endpoint.
+
+Do not proceed to save unless the row count and pallet inputs are verified.
+
+## Guidelines Checkboxes
+
+The guidance checkbox count is dynamic. Do not assume fixed IDs `milkrunGuidCheck1..4`.
+
+Find:
+
+```text
+input[name='milkrunGuideCheckBox'], input[id^='milkrunGuidCheck']
+```
+
+Click unchecked boxes and dispatch `change`. Raise if no checkbox is found or a checkbox remains unchecked.
+
+## Save
+
+Save selector:
+
+```text
+#batchRegisterMilkrun
+```
+
+Reliable save pattern:
+- Install dialog capture before save.
+- Wait for jQuery click handler on `#batchRegisterMilkrun`.
+- Use JS click.
+- Accept the completion alert if it appears.
+- If no alert appears, verify `completeRegistration_*` markers instead of retrying blindly.
+
+If zero rows changed because all matching rows already have completion markers, skip save. This avoids duplicate registration.
+
+Field-tested lesson: 입고예정일 `2026-05-26` completed 12/12 rows through this path.

--- a/agent-workspace/domain-skills/supplier-coupang/milkrun-list.md
+++ b/agent-workspace/domain-skills/supplier-coupang/milkrun-list.md
@@ -1,0 +1,49 @@
+# Milkrun List And Table Extraction
+
+## URLs
+
+Milkrun list by receiving date:
+
+```text
+https://supplier.coupang.com/milkrun/milkrunList?page={page}&milkrunSearchType=RECEIVING_AT&startDate={arrival_date}&endDate={arrival_date}
+```
+
+Milkrun list by purchase order:
+
+```text
+https://supplier.coupang.com/milkrun/milkrunList?purchaseOrderSeq={purchase_order_seq}
+```
+
+## Table Contract
+
+Selector:
+
+```text
+#milkrunListTable
+```
+
+Empty result marker:
+
+```text
+xpath=//td[normalize-space()='검색 결과가 없습니다.']
+```
+
+Extraction rules:
+- Read `<th>` text for headers.
+- For body rows, ignore `td` with `style="display:none"`.
+- If a cell contains links, join link text with commas. This preserves purchase-order numbers the same way the previous parser expected them.
+- Return a pandas `DataFrame` with the rendered headers.
+
+## Pagination
+
+For date-based list scans, start at page 1 and stop on an empty page. Do not reuse a previous page's table after navigation; wait for `#milkrunListTable` on every page.
+
+## Flow Users
+
+This table is shared by:
+- Transaction statement downloads.
+- Pallet attachment list downloads.
+- Split milkrun precheck and saved-state verification.
+- Pallet company saved-state verification.
+
+Changing the parser can break filenames, split detection, and S3 upload grouping at the same time. Add focused tests before changing table extraction.

--- a/agent-workspace/domain-skills/supplier-coupang/milkrun-pallet-attachment.md
+++ b/agent-workspace/domain-skills/supplier-coupang/milkrun-pallet-attachment.md
@@ -1,0 +1,43 @@
+# Milkrun Pallet Attachment Labels
+
+## List Button
+
+Selector:
+
+```text
+xpath=//span[@name='printMilkrunLabalForPda' and @milkrun-seq='{milkrun_seq}']
+```
+
+The original browser behavior is:
+
+```text
+Coupang JS builds HTML -> window.open -> new window document.write -> print() -> Chrome auto-save
+```
+
+The CDP/browser-harness path captures this more directly:
+
+```text
+stub window.open -> capture document.write HTML -> render captured HTML in temporary CDP tab -> Page.printToPDF
+```
+
+Do not assume byte-identical output versus Chrome's print dialog. Treat it as acceptable only when:
+
+- The captured HTML contains the expected marker, currently `Milkrun(밀크런) 팔레트 부착 리스트`.
+- A focused PDF/content regression or manual inspection confirms the rendered document is functionally equivalent.
+- Filename, merge, and S3 upload contracts remain unchanged.
+
+## Handler Pitfall
+
+The label click handler may be bound through jQuery or inline script. The current harness helper tries:
+
+1. Native click on the element.
+2. Invoke jQuery click handlers from `$._data(element, "events").click`.
+3. Locate the inline `span[name='printMilkrunLabalForPda']` handler and call it with the target element.
+
+If the helper fails, capture failure artifacts with the label selector before changing the print path again.
+
+## Merge And Upload
+
+After individual pallet attachment PDFs are renamed, merge by active origin using the existing PDF merge helper. If a given origin has no files, log and skip upload.
+
+Do not change merge filenames or S3 key shape unless the downstream contract is updated with tests.

--- a/agent-workspace/domain-skills/supplier-coupang/milkrun-split.md
+++ b/agent-workspace/domain-skills/supplier-coupang/milkrun-split.md
@@ -1,0 +1,74 @@
+# Milkrun Split And Pallet Company Save
+
+## Entry Points
+
+Start from a purchase order number:
+
+```text
+https://supplier.coupang.com/milkrun/milkrunList?purchaseOrderSeq={purchase_order_seq}
+```
+
+Split form:
+
+```text
+https://supplier.coupang.com/milkrun/splitform?milkrunSeq={milkrun_seq}
+```
+
+Pallet company edit form:
+
+```text
+https://supplier.coupang.com/milkrun/saveform?milkrunSeq={milkrun_seq}
+```
+
+## Precheck
+
+- If the milkrun list already has a row with 출고지 `양주시_1`, treat the order as already split and skip split save.
+- If no source row exists for 출고지 `이천시_4`, fail fast.
+- Use the list table parser from `milkrun-list.md`.
+
+## Location Modal Pitfall
+
+The button:
+
+```text
+#supplierMilkrunLocationBtn
+```
+
+often logs a click but fails to load the modal content. Reliable sequence:
+
+1. Wait for optional jQuery click handler.
+2. JS click `#supplierMilkrunLocationBtn`.
+3. Wait for actual location rows, not only for the text `정보 조회`.
+4. If rows do not load, fetch the split location list endpoint and inject it into `#detailLayer`, then show `#location-modal`.
+5. Retry the open/load path several times before failing.
+
+Important: hidden modal DOM can still contain `h4 정보 조회`. Do not use text existence alone as proof that the modal is open or closed. Verify `#supplierMilkrunLocationSeq` value and visible modal state.
+
+## Split Save Sequence
+
+1. Select `양주시_1` from `#purchaseOrderTable` by extracting `locationName_<seq>`.
+2. Click `button[name='selectLocation'][data-supplier-milkrun-location-seq='<seq>']`.
+3. Wait until `#supplierMilkrunLocationSeq` equals the selected seq and `#location-modal` is no longer visible.
+4. Read `tr[name='milkrunPalletDto']` and its `data-milkrunpalletseq`.
+5. Use the bulk-fill buttons:
+   - `button[name='milkrunPalletBtn']` then `#cntCopy_<pallet_seq>`
+   - `button[name='milkrunBoxCountBtn']` then `#boxCntCopy`
+   - `button[name='milkrunWeightBtn']` then `#weightCopy`
+6. For each `tr[name='milkrunPoTr']`, remove the correct side:
+   - PO being split: `#milkrunPoDelBtn{po}` and wait for `span[name='milkrunPoLabel{po}']` hidden.
+   - PO staying behind: `#copyPoDelBtn{po}` and wait for `label[name='milkrunPoLabel{po}']` hidden.
+7. Save with `#saveButton` using optional jQuery handler wait and JS click.
+
+If no alert appears after save, verify the milkrun list shows the expected `양주시_1` row before treating the save as success.
+
+## Pallet Company Change
+
+For the split row:
+
+1. Open `saveform?milkrunSeq=<split_row_seq>`.
+2. Select `#pltRentalCompany`.
+3. Check dynamic milkrun guideline checkboxes.
+4. Save with `#saveMilkrun` using optional jQuery handler wait and JS click.
+5. If no alert appears, verify the list/saveform shows the saved pallet company.
+
+Field-tested lesson: `2026-05-26` split `마장1` to `양주시_1`, row `10235934`, pallet company `아주팔레트`.

--- a/agent-workspace/domain-skills/supplier-coupang/milkrun-transaction-statement.md
+++ b/agent-workspace/domain-skills/supplier-coupang/milkrun-transaction-statement.md
@@ -1,0 +1,35 @@
+# Milkrun Transaction Statement Downloads
+
+## URL
+
+```text
+https://supplier.coupang.com/milkrun/previewPOFiles?milkrunSeq={comma_separated_milkrun_seq}
+```
+
+## Flow
+
+1. Read milkrun rows from the date-filtered list.
+2. Group by active origin from constants.
+3. Sort by logistics center.
+4. Split seqs by `Constants.MILKRUN_PREVIEW_BATCH_SIZE`.
+5. Navigate to `previewPOFiles`.
+6. Use `download_current_pdf()`.
+7. Rename with the existing deterministic filename contract:
+   - order type: milkrun
+   - document name: transaction statement
+   - origin
+   - arrival date
+   - `partNN` suffix only when chunked
+8. Upload using the existing Coupang S3 key generator.
+
+Do not Selenium fallback on failure. A fallback can create duplicate PDFs and duplicate S3 writes.
+
+## Known Failure Shape
+
+If `previewPOFiles` does not produce a PDF, capture artifacts with:
+
+```text
+download-milkrun-attached-files
+```
+
+Include `#milkrunListTable`, login selectors, and any PDF viewer/print selectors in selector probes.

--- a/agent-workspace/domain-skills/supplier-coupang/overview.md
+++ b/agent-workspace/domain-skills/supplier-coupang/overview.md
@@ -18,7 +18,8 @@ This directory mirrors the same page and workflow knowledge in browser-harness `
 - `milkrun-pallet-attachment.md` — pallet attachment `window.open`/print/PDF path.
 - `milkrun-bulk-register.md` — bulk registration, modal handling, save verification.
 - `milkrun-split.md` — split order, location modal, pallet company save.
-- `shipment-attachments.md` — shipment attachment downloads and remaining upload boundary.
+- `shipment-bulk-register.md` — shipment bulk register upload and jobs status verification.
+- `shipment-attachments.md` — shipment attachment downloads.
 - `failure-artifacts.md` — screenshot/DOM/JSON/selector probe evidence contract.
 - `side-effect-boundaries.md` — no Selenium fallback and remaining legacy map.
 

--- a/agent-workspace/domain-skills/supplier-coupang/overview.md
+++ b/agent-workspace/domain-skills/supplier-coupang/overview.md
@@ -1,0 +1,27 @@
+# Supplier Coupang — Coupang 1P Supplier Hub
+
+Use this domain skill for `supplier.coupang.com` Coupang 1P browser-harness/CDP automation.
+
+The canonical nc-tools agent skill lives at:
+
+```text
+/Users/lichard/nc-tools/.agents/skills/supplier-coupang/
+```
+
+This directory mirrors the same page and workflow knowledge in browser-harness `domain-skills` form so browser-harness agents can load Supplier Hub lessons directly.
+
+## References
+
+- `auth-session.md` — login, profile, manual handoff, and session-close rules.
+- `milkrun-list.md` — list URL patterns and table extraction contract.
+- `milkrun-transaction-statement.md` — transaction statement PDF download.
+- `milkrun-pallet-attachment.md` — pallet attachment `window.open`/print/PDF path.
+- `milkrun-bulk-register.md` — bulk registration, modal handling, save verification.
+- `milkrun-split.md` — split order, location modal, pallet company save.
+- `shipment-attachments.md` — shipment attachment downloads and remaining upload boundary.
+- `failure-artifacts.md` — screenshot/DOM/JSON/selector probe evidence contract.
+- `side-effect-boundaries.md` — no Selenium fallback and remaining legacy map.
+
+## Prime Directive
+
+Do not let hard-earned Supplier Hub behavior live only in Python retry code. If a selector, popup, jQuery handler, print path, or saved-state marker matters for reliability, record it in this domain skill.

--- a/agent-workspace/domain-skills/supplier-coupang/shipment-attachments.md
+++ b/agent-workspace/domain-skills/supplier-coupang/shipment-attachments.md
@@ -28,13 +28,8 @@ The public shipment attachment document path is CDP-only and must not fall back 
 4. Preserve existing filenames, merge behavior if any, and S3 key generation.
 5. Clear or reset download state after completion.
 
-## Remaining Legacy Area
+## Registration Boundary
 
-Shipment registration/upload/status helpers still have retained Selenium variants in the bot. Treat them as legacy boundaries until each workflow has:
+Do not use the shipment attachment download conversion as proof for other shipment workflows. Shipment bulk registration is its own side-effecting route; use `shipment-bulk-register.md`.
 
-- A fake CDP/session contract test.
-- A side-effect-safe saved-state verification marker.
-- Failure artifacts on all CDP errors.
-- No Selenium fallback for the public side-effecting route.
-
-Do not use the shipment attachment download conversion as proof that shipment registration/upload is already browser-harness complete.
+Retained `_selenium` helper variants may still exist in the bot for legacy comparison, but the public shipment attachment download and public shipment bulk registration routes are CDP-only and should fail fast with artifacts rather than falling back.

--- a/agent-workspace/domain-skills/supplier-coupang/shipment-attachments.md
+++ b/agent-workspace/domain-skills/supplier-coupang/shipment-attachments.md
@@ -1,0 +1,40 @@
+# Shipment Attachment Downloads
+
+## URL
+
+```text
+https://supplier.coupang.com/ibs/asn/active?type=parcel
+```
+
+Ready selector:
+
+```text
+#edd
+```
+
+Search:
+
+1. Fill `#edd` with arrival date.
+2. Click `#shipment-search-btn`.
+3. Wait for load or table refresh.
+
+## Download Contract
+
+The public shipment attachment document path is CDP-only and must not fall back to Selenium on failure. It should:
+
+1. Start with a clean download folder snapshot.
+2. Search by arrival date.
+3. Download generated shipment attachment files.
+4. Preserve existing filenames, merge behavior if any, and S3 key generation.
+5. Clear or reset download state after completion.
+
+## Remaining Legacy Area
+
+Shipment registration/upload/status helpers still have retained Selenium variants in the bot. Treat them as legacy boundaries until each workflow has:
+
+- A fake CDP/session contract test.
+- A side-effect-safe saved-state verification marker.
+- Failure artifacts on all CDP errors.
+- No Selenium fallback for the public side-effecting route.
+
+Do not use the shipment attachment download conversion as proof that shipment registration/upload is already browser-harness complete.

--- a/agent-workspace/domain-skills/supplier-coupang/shipment-bulk-register.md
+++ b/agent-workspace/domain-skills/supplier-coupang/shipment-bulk-register.md
@@ -1,0 +1,101 @@
+# Shipment Bulk Registration Upload
+
+## Public Route
+
+The public workflow is CDP-only:
+
+```text
+register_shipment(arrival_date)
+  -> _register_shipment_cdp(arrival_date)
+  -> upload page
+  -> set upload options
+  -> upload shipment register file
+  -> jobs page status verification
+```
+
+Do not add Selenium fallback to this route. It uploads a file to Supplier Hub and can create duplicate shipment jobs.
+
+## Upload URL And Options
+
+Upload page:
+
+```text
+https://supplier.coupang.com/ibs/shipment/parcel/bulk-creation/upload
+```
+
+Ready selector:
+
+```text
+#upload-btn
+```
+
+Current option contract:
+
+- `#deliveryCompany` = `D000006`
+- trigger Chosen UI update with `chosen:updated`
+- `#shipLocation` = `81745`
+- `#shipDate` = arrival date minus one day
+- `#shipTime` = `18:00`
+
+## File Source
+
+The use case generates the Coupang shipment bulk-register workbook and uploads it to S3 first. The Supplier Hub upload step downloads the first S3 key matching:
+
+- arrival date
+- sanitized order type `쉽먼트`
+- search key `일괄등록`
+
+Then it uploads that local file through:
+
+```text
+input[type='file']
+```
+
+Wait until `#upload-btn` exists and is not disabled before clicking.
+
+## Upload Click
+
+Selector:
+
+```text
+#upload-btn
+```
+
+The upload alert is not a required success marker. If no alert appears after clicking, continue to jobs-page verification instead of clicking upload again.
+
+## Status Verification
+
+Jobs page:
+
+```text
+https://supplier.coupang.com/ibs/shipment/parcel/bulk-creation/jobs
+```
+
+Ready selector:
+
+```text
+#shipmentsTable table tbody
+```
+
+Use an anchor time captured immediately before the upload click. The jobs page may display minute-level timestamps, so the verifier accepts rows from two minutes before the anchor.
+
+Success marker:
+
+- latest relevant row status contains `완료`
+- no `button[name='show-failure-btn']`
+- has `button[name='show-generated-shipment-btn']`
+
+In-progress marker:
+
+- status contains `진행중`; reload/poll until timeout.
+
+Failure marker:
+
+- status is not complete, or a failure button exists.
+- include seq, upload time, filename, status, fail/generated button presence, and `data-cause` if present.
+
+## Login Recovery
+
+If the workflow blocks on login before reaching the upload page, no Supplier Hub upload has happened yet. It is safe to complete or repair login and let the same process continue. Once `#upload-btn` is clicked, do not restart the upload path unless the jobs page proves there is no matching upload row.
+
+Field-tested lesson: `2026-05-26` shipment bulk registration completed through CDP on `2026-05-20 17:30` KST. The run recovered from a login/password error before upload; after login recovery, the workflow clicked upload once and verified jobs status `완료`, no fail button, generated shipment button present.

--- a/agent-workspace/domain-skills/supplier-coupang/side-effect-boundaries.md
+++ b/agent-workspace/domain-skills/supplier-coupang/side-effect-boundaries.md
@@ -1,0 +1,47 @@
+# Side-effect Boundaries And Legacy Selenium
+
+## Classification
+
+Treat these as side-effecting:
+
+- Supplier Hub registration.
+- Save buttons.
+- File upload.
+- Download flows that also rename, merge, upload to S3, or write Google Sheets.
+- Slack/UI completion notifications.
+
+Treat these as read/status only:
+
+- Table extraction.
+- Saved-state verification.
+- Preflight row counts.
+- Login-state detection.
+
+## No Selenium Fallback Rule
+
+For side-effecting Supplier Hub public methods, CDP failure must capture artifacts, close the CDP session, and raise. Do not start Selenium after a failed CDP action. A second browser stack can duplicate downloads, S3 uploads, sheet writes, registrations, or saves.
+
+For idempotent read-only legacy paths, Selenium compatibility may remain temporarily, but the public route should make the boundary obvious.
+
+## Saved-state Verification
+
+Before deciding to click a business save button again, verify state:
+
+- Bulk milkrun registration: `completeRegistration_*` count.
+- Split milkrun: milkrun list has the expected `양주시_1` row.
+- Pallet company: saved form/list shows the expected pallet rental company.
+- Downloads: deterministic target file exists, has non-zero size, and downstream merge/upload saw the expected file.
+
+If the saved state cannot be proven, fail fast and report artifacts instead of retrying through a fallback.
+
+## Current Legacy Map
+
+Known retained Selenium areas in `bot_coupang_1p.py` include:
+
+- Login/cookie compatibility helpers.
+- Older milkrun Selenium helper variants retained for comparison.
+- Shipment registration/upload/status helpers.
+- Some raw order/SKU/order-list Selenium variants retained as legacy helper code even when public routes are CDP.
+- Non-Supplier-Hub or adjacent automation such as Sabanet/fullfillment should be classified separately before applying this skill.
+
+Do not infer that a retained `_selenium` helper is safe to call from a side-effecting public method. The public method's CDP wrapper and tests define the contract.

--- a/agent-workspace/domain-skills/supplier-coupang/side-effect-boundaries.md
+++ b/agent-workspace/domain-skills/supplier-coupang/side-effect-boundaries.md
@@ -30,6 +30,7 @@ Before deciding to click a business save button again, verify state:
 - Bulk milkrun registration: `completeRegistration_*` count.
 - Split milkrun: milkrun list has the expected `양주시_1` row.
 - Pallet company: saved form/list shows the expected pallet rental company.
+- Shipment bulk registration: jobs page latest relevant row is `완료`, has no failure button, and has generated shipment button.
 - Downloads: deterministic target file exists, has non-zero size, and downstream merge/upload saw the expected file.
 
 If the saved state cannot be proven, fail fast and report artifacts instead of retrying through a fallback.
@@ -40,7 +41,7 @@ Known retained Selenium areas in `bot_coupang_1p.py` include:
 
 - Login/cookie compatibility helpers.
 - Older milkrun Selenium helper variants retained for comparison.
-- Shipment registration/upload/status helpers.
+- Older shipment registration/upload/status Selenium helper variants retained for comparison; public shipment registration is CDP-only.
 - Some raw order/SKU/order-list Selenium variants retained as legacy helper code even when public routes are CDP.
 - Non-Supplier-Hub or adjacent automation such as Sabanet/fullfillment should be classified separately before applying this skill.
 


### PR DESCRIPTION
## What changed
- Adds a `supplier-coupang` browser-harness domain skill under `agent-workspace/domain-skills/`.
- Captures Coupang Supplier Hub auth/session, milkrun, shipment, failure-artifact, and side-effect boundary knowledge.
- Adds shipment bulk-register upload guidance based on the proven CDP jobs-page verification path.

## Why
The nc-tools Coupang 1P migration uses browser-harness/CDP. The domain-specific lessons need to be visible to browser-harness agents, not only to nc-tools local code or logs.

## Validation
- `git diff --check`
- Reference mirror compared against the nc-tools `supplier-coupang` skill, except for the browser-harness-specific `overview.md`.
- Live shipment bulk upload was validated from the nc-tools workflow for 2026-05-26.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `supplier-coupang` domain skill for `supplier.coupang.com`, mirroring the nc-tools agent skill so browser-harness agents can follow the proven CDP workflows. Documents CDP-only routes, side-effect boundaries, and jobs-page verification to reduce flaky retries and duplicate actions.

- **New Features**
  - New `agent-workspace/domain-skills/supplier-coupang/` with browser-harness/CDP guidance mirroring the canonical nc-tools skill.
  - Auth/session rules: dedicated Chrome profile, workflow-scoped reuse, manual handoff, close session on failure.
  - Milkrun flows: list parsing, bulk registration, split + pallet company save, pallet attachment labels, transaction statement PDFs.
  - Shipment bulk registration: upload URL/options, single upload click, jobs-page status verification; CDP-only (no Selenium fallback).
  - Failure artifacts and side-effect boundaries: required evidence, selector probes, and saved-state checks before re-running actions.

<sup>Written for commit ae42eeacb79417f0ac173c870dbbd2dff34f7f0a. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/383?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

