### PR TITLE
fix(doctor): compare HEAD against origin/main when no Releases exist

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -125,8 +125,10 @@ _load_env()
 NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"
 GH_RELEASES = "https://api.github.com/repos/browser-use/browser-harness/releases/latest"
+GH_COMMITS_MAIN = "https://api.github.com/repos/browser-use/browser-harness/commits/main"
 VERSION_CACHE = Path(tempfile.gettempdir()) / "bu-version-cache.json"
 VERSION_CACHE_TTL = 24 * 3600
+SHORT_SHA_LEN = 12
 DOCTOR_TEXT_LIMIT = 140
 
 
@@ -618,9 +620,12 @@ def _version():
 
 
 def _repo_dir():
-    """Return the repo root if this install is an editable git clone, else None."""
+    """Return the repo root if this install is an editable git clone, else None.
+
+    Accepts both regular clones (`.git/` directory) and linked worktrees
+    (`.git` gitlink file) so editable installs in either still detect as git."""
     for p in Path(__file__).resolve().parents:
-        if (p / ".git").is_dir():
+        if (p / ".git").exists():
             return p
     return None
 
@@ -662,6 +667,38 @@ def _latest_release_tag(force=False):
     return tag or None
 
 
+def _local_head_sha():
+    """Short SHA of HEAD for an editable clone. None if not a git install or git is unavailable."""
+    repo = _repo_dir()
+    if not repo:
+        return None
+    try:
+        import subprocess
+        out = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True, timeout=2)
+    except Exception:
+        return None
+    return out.strip()[:SHORT_SHA_LEN] or None
+
+
+def _latest_main_sha(force=False):
+    """Return short SHA of origin/main from GitHub, or None. Cached for 24h.
+
+    Used in place of `_latest_release_tag` for editable git installs, so the
+    update banner works before the project has cut any GitHub Releases."""
+    cache = _cache_read()
+    now = time.time()
+    if not force and cache.get("main_sha") and now - cache.get("main_sha_fetched_at", 0) < VERSION_CACHE_TTL:
+        return cache["main_sha"]
+    try:
+        req = urllib.request.Request(GH_COMMITS_MAIN, headers={"Accept": "application/vnd.github+json"})
+        sha = json.loads(urllib.request.urlopen(req, timeout=5).read()).get("sha") or ""
+    except Exception:
+        return cache.get("main_sha")  # fall back to last known
+    sha = sha[:SHORT_SHA_LEN]
+    _cache_write({**cache, "main_sha": sha, "main_sha_fetched_at": now})
+    return sha or None
+
+
 def _version_tuple(v):
     """Best-effort semver parse. Non-numeric components sort as 0, so pre-releases may not rank perfectly."""
     parts = []
@@ -677,7 +714,16 @@ def _version_tuple(v):
 
 
 def check_for_update():
-    """(current, latest, newer_available). latest may be None if the API was unreachable and no cache exists."""
+    """(current, latest, newer_available). latest may be None if the API was unreachable and no cache exists.
+
+    For editable git installs, compares local HEAD SHA against origin/main —
+    this works even when the project hasn't tagged releases yet. Falls back to
+    the release-tag check for pypi installs (or when the git probe fails)."""
+    if _install_mode() == "git":
+        local = _local_head_sha()
+        remote = _latest_main_sha()
+        if local and remote:
+            return local, remote, local != remote
     cur = _version()
     latest = _latest_release_tag()
     newer = bool(cur and latest and _version_tuple(latest) > _version_tuple(cur))
@@ -746,10 +792,6 @@ def run_doctor():
     connections = browser_connections()
     profile_use = shutil.which("profile-use") is not None
     api_key = bool(os.environ.get("BROWSER_USE_API_KEY"))
-    latest = _latest_release_tag()
-    # Only claim an update when we know the installed version — `cur or "(unknown)"`
-    # for display would otherwise be parsed as (0,) and flag every latest as newer.
-    newer = bool(cur and latest and _version_tuple(latest) > _version_tuple(cur))
     cur_display = cur or "(unknown)"
     doc_url = _snap_linux_headless_doc_url()
 
@@ -761,10 +803,25 @@ def run_doctor():
     print(f"  platform          {platform.system()} {platform.release()}")
     print(f"  python            {sys.version.split()[0]}")
     print(f"  version           {cur_display} ({mode})")
-    if latest:
-        print(f"  latest release    {latest}" + (" (update available)" if newer else ""))
+    if mode == "git":
+        local_sha = _local_head_sha()
+        remote_sha = _latest_main_sha()
+        if remote_sha and local_sha:
+            suffix = " (update available)" if local_sha != remote_sha else " (up to date)"
+            print(f"  origin/main       {remote_sha}{suffix}")
+        elif remote_sha:
+            print(f"  origin/main       {remote_sha}")
+        else:
+            print("  origin/main       (could not reach github)")
     else:
-        print("  latest release    (could not reach github)")
+        latest = _latest_release_tag()
+        # Only claim an update when we know the installed version — `cur or "(unknown)"`
+        # for display would otherwise be parsed as (0,) and flag every latest as newer.
+        newer = bool(cur and latest and _version_tuple(latest) > _version_tuple(cur))
+        if latest:
+            print(f"  latest release    {latest}" + (" (update available)" if newer else ""))
+        else:
+            print("  latest release    (could not reach github)")
     if platform.system() == "Linux":
         bname, bpath = _doctor_probe_chrome_binary_for_snap()
         if bname and bpath and _is_snap_browser(bpath):

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -196,6 +196,8 @@ def test_run_doctor_prints_snap_detect_on_linux_when_probe_is_snap(monkeypatch, 
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
     monkeypatch.setattr(admin, "browser_connections", lambda: [])
     monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "abcdef012345")
     monkeypatch.setattr(admin, "_doctor_probe_chrome_binary_for_snap", lambda: ("chromium", "/snap/chromium/1/usr/bin/chromium"))
     monkeypatch.setattr("platform.system", lambda: "Linux")
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
@@ -217,6 +219,8 @@ def test_run_doctor_skips_snap_detect_on_non_linux(monkeypatch, capsys):
     monkeypatch.setattr(admin, "daemon_alive", lambda: True)
     monkeypatch.setattr(admin, "browser_connections", lambda: [])
     monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "abcdef012345")
     monkeypatch.setattr(admin, "_doctor_probe_chrome_binary_for_snap", lambda: ("chromium", "/snap/chromium/1/usr/bin/chromium"))
     monkeypatch.setattr("platform.system", lambda: "Darwin")
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
@@ -253,6 +257,8 @@ def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypat
         },
     ])
     monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "abcdef012345")
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
     monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
 
@@ -277,6 +283,8 @@ def test_doctor_page_output_truncates_long_text(monkeypatch, capsys):
         }
     ])
     monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "abcdef012345")
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
     monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
 
@@ -285,6 +293,135 @@ def test_doctor_page_output_truncates_long_text(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "A very long page ..." in out
     assert "https://example.t..." in out
+
+
+def _stub_doctor(monkeypatch):
+    """Set up the rest of run_doctor's side effects so SHA-comparison tests only exercise that code path."""
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+
+def test_repo_dir_detects_regular_clone(tmp_path, monkeypatch):
+    (tmp_path / ".git").mkdir()
+    pkg = tmp_path / "src" / "browser_harness"
+    pkg.mkdir(parents=True)
+    fake_file = pkg / "admin.py"
+    fake_file.write_text("")
+    monkeypatch.setattr(admin, "__file__", str(fake_file))
+
+    assert admin._repo_dir() == tmp_path
+
+
+def test_repo_dir_detects_linked_worktree(tmp_path, monkeypatch):
+    # Linked worktrees store `.git` as a gitlink *file*, not a directory.
+    (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/foo\n")
+    pkg = tmp_path / "src" / "browser_harness"
+    pkg.mkdir(parents=True)
+    fake_file = pkg / "admin.py"
+    fake_file.write_text("")
+    monkeypatch.setattr(admin, "__file__", str(fake_file))
+
+    assert admin._repo_dir() == tmp_path
+
+
+def test_check_for_update_git_uses_sha_comparison(monkeypatch):
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "aaaaaaaaaaaa")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "bbbbbbbbbbbb")
+    # _latest_release_tag must not be consulted in git mode when SHA is available
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: pytest.fail("should not fetch release tag in git mode"))
+
+    cur, latest, newer = admin.check_for_update()
+
+    assert cur == "aaaaaaaaaaaa"
+    assert latest == "bbbbbbbbbbbb"
+    assert newer is True
+
+
+def test_check_for_update_git_reports_up_to_date_when_shas_match(monkeypatch):
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: pytest.fail("should not fetch release tag in git mode"))
+
+    cur, latest, newer = admin.check_for_update()
+
+    assert (cur, latest, newer) == ("abcdef012345", "abcdef012345", False)
+
+
+def test_check_for_update_git_falls_back_to_release_tag_when_sha_unavailable(monkeypatch):
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: None)
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: None)
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.2.0")
+
+    cur, latest, newer = admin.check_for_update()
+
+    assert (cur, latest, newer) == ("0.1.0", "0.2.0", True)
+
+
+def test_check_for_update_pypi_still_uses_release_tag(monkeypatch):
+    monkeypatch.setattr(admin, "_install_mode", lambda: "pypi")
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: pytest.fail("should not probe git in pypi mode"))
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: pytest.fail("should not probe origin/main in pypi mode"))
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.2.0")
+
+    cur, latest, newer = admin.check_for_update()
+
+    assert (cur, latest, newer) == ("0.1.0", "0.2.0", True)
+
+
+def test_run_doctor_prints_origin_main_with_update_available(monkeypatch, capsys):
+    _stub_doctor(monkeypatch)
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "aaaaaaaaaaaa")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "bbbbbbbbbbbb")
+
+    admin.run_doctor()
+
+    out = capsys.readouterr().out
+    assert "origin/main       bbbbbbbbbbbb (update available)" in out
+    assert "latest release" not in out
+
+
+def test_run_doctor_prints_origin_main_up_to_date_when_shas_match(monkeypatch, capsys):
+    _stub_doctor(monkeypatch)
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: "abcdef012345")
+
+    admin.run_doctor()
+
+    out = capsys.readouterr().out
+    assert "origin/main       abcdef012345 (up to date)" in out
+
+
+def test_run_doctor_prints_could_not_reach_github_for_git_install(monkeypatch, capsys):
+    _stub_doctor(monkeypatch)
+    monkeypatch.setattr(admin, "_local_head_sha", lambda: "abcdef012345")
+    monkeypatch.setattr(admin, "_latest_main_sha", lambda: None)
+
+    admin.run_doctor()
+
+    out = capsys.readouterr().out
+    assert "origin/main       (could not reach github)" in out
+
+
+def test_run_doctor_pypi_install_still_shows_latest_release(monkeypatch, capsys):
+    _stub_doctor(monkeypatch)
+    monkeypatch.setattr(admin, "_install_mode", lambda: "pypi")
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.2.0")
+
+    admin.run_doctor()
+
+    out = capsys.readouterr().out
+    assert "latest release    0.2.0 (update available)" in out
+    assert "origin/main" not in out
 
 
 def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monkeypatch):


### PR DESCRIPTION
## Summary

Doctor reports `latest release    (could not reach github)` even on a healthy network, because `releases/latest` 404s on this repo (no Releases cut). The daily update banner is silent for the same reason.

This repo ships via merges to `main`, so for editable git installs I switched the check over to `GET /commits/main` and compare against local `HEAD`. Pypi installs keep the existing release-tag path, so nothing changes if you start cutting Releases later.

Doctor output for an editable clone now reads:

- version: `0.1.0` (git)
- origin/main: `6d20866664ea` (up to date)

Small drive-by: `_repo_dir` was checking `(p / ".git").is_dir()`, which misses linked worktrees (gitlink file). Swapped to `.exists()` so worktree-based reviews exercise the git path too.

## Test plan

- [x] `uv run pytest` (117 passing, 6 new)
- [x] Ran the patched `run_doctor()` against an editable clone, shows the
      new `origin/main` line

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Doctor update checks for repos without Releases by comparing local HEAD to `origin/main` for editable git installs. Restores the daily update banner; PyPI installs still use release tags.

- **Bug Fixes**
  - Doctor fetches `commits/main`, caches the short SHA for 24h, and shows an `origin/main` line with “up to date” or “update available”.
  - Falls back to release-tag checks for PyPI installs or when git probing fails.
  - `_repo_dir` now recognizes linked worktrees by checking `.git` existence, not only directories.
  - Added unit tests for SHA comparison paths, output, and worktree detection.

<sup>Written for commit 12c1a42ddeaa53140c84271d05af765f1f75bf9b. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-harness/pull/386?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

