### PR TITLE
Add Helium browser profile path to discovery list

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -36,6 +36,7 @@ BUF = 500
 PROFILES = [
     Path.home() / "Library/Application Support/Google/Chrome",
     Path.home() / "Library/Application Support/Google/Chrome Canary",
+    Path.home() / "Library/Application Support/net.imput.helium",
     Path.home() / "Library/Application Support/Comet",
     Path.home() / "Library/Application Support/Arc/User Data",
     Path.home() / "Library/Application Support/Dia/User Data",


### PR DESCRIPTION
## Summary

Helium ([helium.computer](https://helium.computer), bundle id `net.imput.helium`) is a Chromium-based browser on macOS. Its user-data-dir lives at `~/Library/Application Support/net.imput.helium`, which was missing from `PROFILES` in `daemon.py`.

Without this entry, Way 1 attaches (chrome://inspect/#remote-debugging checkbox) fail with `DevToolsActivePort not found ...` even when Helium has remote debugging enabled and is listening on `127.0.0.1:9222`, because `_ws_from_devtools_active_port` and the local-discovery loop both iterate `PROFILES` and can't find Helium's `DevToolsActivePort` file.

## Test plan

- [x] Confirmed Helium 148 with `chrome://inspect/#remote-debugging` checkbox ticked exposes `~/Library/Application Support/net.imput.helium/DevToolsActivePort` containing port `9222` + ws path.
- [x] Before patch: `browser-harness` raises `DevToolsActivePort not found in [...]`.
- [x] After patch: `browser-harness <<< 'print(page_info())'` returns the active Helium tab's page info; `new_tab(...)` + `wait_for_load()` work end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Helium (`net.imput.helium`) profile path `~/Library/Application Support/net.imput.helium` to the macOS discovery list. This fixes “DevToolsActivePort not found” and allows attaching to Helium via chrome://inspect when remote debugging is enabled.

<sup>Written for commit c15c5fb5ca22b699ea8c13cb7abb94063234e4e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/394?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

