### PR TITLE
Add Robinhood agentic trading MCP note

### DIFF
--- a/domain-skills/robinhood/agentic-trading.md
+++ b/domain-skills/robinhood/agentic-trading.md
@@ -1,0 +1,31 @@
+# Robinhood Agentic Trading MCP
+
+`https://robinhood.com/us/en/support/articles/agentic-trading-overview/#ConnectyourAIagent`
+
+Robinhood documents the Trading MCP as a Streamable HTTP endpoint:
+
+```bash
+codex mcp add robinhood-trading --url https://agent.robinhood.com/mcp/trading
+```
+
+For Codex Desktop, use Settings -> MCP servers -> Streamable HTTP and the same URL:
+
+```text
+https://agent.robinhood.com/mcp/trading
+```
+
+## OAuth and rollout behavior
+
+`codex mcp add` may detect OAuth and start a browser authorization flow. If the account is not yet in the Agentic Trading rollout, the OAuth URL redirects to:
+
+```text
+https://robinhood.com/mcp/trading?...oauth params...
+```
+
+The page shows "Coming soon: Agentic trading" and "We'll email you once you have access." In that state, Robinhood does not redirect back to the localhost OAuth callback, so the Codex CLI remains waiting and the MCP entry stays configured but `Not logged in`.
+
+Stop the waiting CLI process after confirming the page state, then retry `codex mcp login robinhood-trading` later after access is granted.
+
+## Boundaries
+
+Do not enter Robinhood credentials, MFA codes, or accept financial/account disclosures for the user. Stop at login, MFA, OAuth authorization, or Agentic account onboarding steps and let the user complete those directly.


### PR DESCRIPTION
Adds a Robinhood domain skill note for Agentic Trading MCP setup and the no-access OAuth rollout behavior observed during authorization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Robinhood Agentic Trading setup note covering how to connect to the Streamable HTTP endpoint `https://agent.robinhood.com/mcp/trading` via `codex mcp add` and Codex Desktop. Explains OAuth rollout behavior when access isn’t enabled yet (no redirect, CLI waits), recommends stopping and retrying `codex mcp login` later, and clarifies boundaries around user-auth steps (no credentials/MFA/disclosures).

<sup>Written for commit 82718c8d5adb7bd6d7e477fb0b1a2fd3adb8c11b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

