### PR TITLE
docs: document Pi skill installation in install.md

### DIFF
--- a/install.md
+++ b/install.md
@@ -32,7 +32,13 @@ After the repo is installed, register this repo's `SKILL.md` with the agent you 
 
 - **Claude Code**: add an import to `~/.claude/CLAUDE.md` that points at this repo's `SKILL.md`, for example `@~/Developer/browser-harness/SKILL.md`.
 
-This makes new Codex or Claude Code sessions in other folders load the runtime browser harness instructions automatically.
+- **Pi**: symlink this repository folder into your Pi global skills directory (`~/.agents/skills/` or `~/.pi/agent/skills/`):
+
+  ```bash
+  ln -sf "$PWD" ~/.agents/skills/browser-harness
+  ```
+
+This makes new Codex, Claude Code, or Pi sessions in other folders load the runtime browser harness instructions automatically.
 
 ## Keeping the harness current
 


### PR DESCRIPTION
Small QOL improvement for installing the skill when using [Pi](https://pi.dev) agent. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `Pi` agent setup instructions to install.md, including a symlink command to install the skill into Pi’s global skills directory. This ensures new `Pi`, Codex, and Claude Code sessions load the browser harness instructions automatically.

<sup>Written for commit 208f14867fe453cd17707173ec72091937dd7ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

