### PR TITLE
feat: add capture_screenshot_jpeg helper

### DIFF
--- a/agent-workspace/agent_helpers.py
+++ b/agent-workspace/agent_helpers.py
@@ -5,3 +5,28 @@ load this file when BH_AGENT_WORKSPACE points at this directory, or when this
 repo's default agent-workspace exists.
 """
 
+import base64
+from PIL import Image
+
+
+def capture_screenshot_jpeg(path=None, full=False, max_dim=None, quality=80):
+    """Save a JPEG of the current viewport. Much smaller than PNG — avoids
+    LLM API input-length limits on 2× displays.
+
+    quality: 0–100 (default 80). 80 is visually clean and ~5–10× smaller than PNG.
+    max_dim: proportional downscale if either side exceeds this (e.g. 1800).
+    """
+    # Lazy import to avoid circular dep: helpers loads us at module init.
+    from browser_harness.helpers import cdp
+    from browser_harness._ipc import _TMP
+
+    path = path or str(_TMP / "shot.jpg")
+    r = cdp("Page.captureScreenshot", format="jpeg", quality=quality,
+            captureBeyondViewport=full)
+    open(path, "wb").write(base64.b64decode(r["data"]))
+    if max_dim:
+        img = Image.open(path)
+        if max(img.size) > max_dim:
+            img.thumbnail((max_dim, max_dim))
+            img.save(path, format="JPEG", quality=quality)
+    return path


### PR DESCRIPTION
## Summary

Add `capture_screenshot_jpeg()` to `agent-workspace/agent_helpers.py` — a JPEG screenshot helper that produces much smaller output than PNG, avoiding LLM API input-length limits on 2× Retina displays.

On a 2× display, PNG screenshots are ~4592×2286 pixels, producing base64 data exceeding 200K chars and hitting API limits. JPEG quality=80 with `max_dim=1800` produces ~64K chars — roughly 2× smaller than PNG with the same downscale, and ~5–10× smaller than raw PNG.

## Details

- Uses CDP `Page.captureScreenshot` with `format="jpeg"` + `quality` parameter
- `max_dim` parameter uses PIL `Image.thumbnail()` for proportional downscaling
- Lazy imports inside function body to avoid circular dependency (helpers loads agent_helpers at module init)
- Lives in `agent_helpers.py` per project convention (task-specific helpers in agent-workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `capture_screenshot_jpeg()` to save downscaled JPEG screenshots, cutting payload size and avoiding LLM API input limits on 2× displays. Outputs are roughly 2–10× smaller than PNG at similar quality.

- **New Features**
  - Captures JPEG via CDP `Page.captureScreenshot` with `quality` (default 80).
  - Optional `max_dim` proportional downscale using `PIL.Image.thumbnail()`.
  - Supports full-page capture and saves to `_TMP/shot.jpg` by default.
  - Lazy imports from `browser_harness.helpers` and `browser_harness._ipc` to avoid circular deps.

<sup>Written for commit 5a8da1b14287b4b823a2d2ab88d46b2c289e2713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

