### PR TITLE
fix(helpers.py): use keyword args for ensure_daemon/restart_daemon

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -18,6 +18,31 @@ def _load_env():
 
 _load_env()
 
+
+def ensure_daemon():
+    """Start the daemon if it's not running. Returns the socket path."""
+    from admin import ensure_daemon as _ensure
+    return _ensure(name=os.environ.get("BU_NAME") or "default")
+
+
+def restart_daemon():
+    """Kill and restart the daemon."""
+    from admin import restart_daemon as _restart
+    return _restart(name=os.environ.get("BU_NAME") or "default")
+
+
+def start_remote_daemon(name=None, **kwargs):
+    """Start a remote (cloud) browser daemon."""
+    from admin import start_remote_daemon as _start
+    return _start(name or os.environ.get("BU_NAME") or "default", **kwargs)
+
+
+def stop_remote_daemon(name=None):
+    """Stop a remote daemon."""
+    from admin import stop_remote_daemon as _stop
+    return _stop(name or os.environ.get("BU_NAME") or "default")
+
+
 NAME = os.environ.get("BU_NAME", "default")
 SOCK = f"/tmp/bu-{NAME}.sock"
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")


### PR DESCRIPTION
## Bug

The wrapper functions `ensure_daemon()` and `restart_daemon()` in `helpers.py` pass the `BU_NAME` value as a **positional argument** to `admin.ensure_daemon(wait, name, env)`:

```python
return _ensure(os.environ.get("BU_NAME") or "default")
```

Since `wait` is the first parameter (type `float`), passing a string name causes:

```
TypeError: unsupported operand type(s) for +: 'float' and 'str'
  File "admin.py", line 81, in ensure_daemon
    deadline = time.time() + wait
```

## Fix

Pass `name=` as a **keyword argument** so it lands in the correct parameter:

```python
return _ensure(name=os.environ.get("BU_NAME") or "default")
```

Also adds `start_remote_daemon()` and `stop_remote_daemon()` wrappers for completeness.

## Testing

After fix:
```
$ BROWSER_USE_API_KEY=*** browser-harness -c "print(page_info())"
{'url': 'about:blank', 'title': ''}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when starting or restarting the daemon by passing the `name` keyword instead of a positional arg. Also adds wrappers to start and stop a remote daemon.

- **Bug Fixes**
  - `ensure_daemon()` and `restart_daemon()` now pass `name=...` to `admin.*`, preventing a TypeError in `admin.ensure_daemon(wait, name, env)`.

- **New Features**
  - Added `start_remote_daemon(name=None, **kwargs)` and `stop_remote_daemon(name=None)` helpers.

<sup>Written for commit 42a4d07db549ff78d2c87dc3f99aaff468bbb32b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

