### PR TITLE
domain-skills: skool — classroom extraction via Next.js data routes

### DIFF
--- a/agent-workspace/domain-skills/skool/extract-classroom.md
+++ b/agent-workspace/domain-skills/skool/extract-classroom.md
@@ -1,0 +1,41 @@
+# Skool - extract classroom content (courses, lessons, rich text)
+
+Field-tested 2026-06-10 on a paid community (member access). Login required for everything;
+anonymous visitors get 404/redirect-to-home even for community About pages.
+
+## The private API: Next.js data routes
+
+Skool is Next.js. DOM scraping is the wrong tool - lesson pages hydrate client-side and
+`main` is nearly empty before hydration. Use the `/_next/data/` JSON routes with the page's
+cookies via in-page `fetch(..., {credentials:'include'})`.
+
+- buildId: `JSON.parse(document.getElementById('__NEXT_DATA__').textContent).buildId`
+- Course list: the `/<group>/classroom` page's `__NEXT_DATA__` -> `props.pageProps.allCourses`
+  (each: `id`, `name` = URL slug, `metadata.title`, `metadata.hasAccess`, `metadata.numModules`)
+- Lesson content: `GET /_next/data/<buildId>/<group>/classroom/<courseSlug>.json?md=<moduleId>`
+  -> `pageProps.course` tree with THAT module's `metadata.desc` hydrated
+
+## Traps
+
+- **`?md=` takes the module ID (32-hex), not the slug.** Slug 404s.
+- **Direct browser navigation to `?md=` URLs is a server-side 404.** The route only exists
+  client-side. Fetch the data route instead; no navigation needed per lesson.
+- **Without `?md=`, the course data route returns a redirect envelope**, not data:
+  `pageProps.__N_REDIRECT = "/<group>/classroom/<slug>?md=<id>"`. Follow it once - extract
+  the `md` from the redirect target and refetch.
+- **`pageProps.selectedModule` is just the module ID string**, not an object. The content
+  lives on the module node inside `pageProps.course` -> `children` tree -> `metadata.desc`.
+- **Tree shape**: course -> `children` (type `set`) -> `children` (type `module`). Nodes are
+  sometimes wrapped: use `u.course || u` before reading `metadata`.
+- **`metadata.desc` is TipTap/ProseMirror JSON prefixed with `[v2]`.** Strip the prefix,
+  parse, walk nodes. Skool uses the NON-standard type `unorderedList` (not `bulletList`) -
+  miss it and every bullet list silently flattens to run-on text.
+- **Locked tiers**: courses without `metadata.hasAccess` are higher-tier; their data routes
+  won't return content. Skip them - do not try to circumvent.
+- **Useful metadata per module**: `videoLink` (YouTube/Loom/etc), `videoLenMs`,
+  `videoThumbnail`, `resources` (JSON string array of attachment links).
+
+## Pacing
+
+One data-route fetch per lesson, ~300ms apart, all from one logged-in tab. ~85 lessons in
+about 2 minutes. No headless browser, no per-lesson navigation.


### PR DESCRIPTION
Field-tested playbook for extracting Skool classroom content (courses, lessons, rich text) as a logged-in member.

Key findings:
- Skool is Next.js; lesson pages hydrate client-side, so DOM scraping gets an empty page. The `/_next/data/<buildId>/...json?md=<moduleId>` routes return the course tree with the requested module's content hydrated — one in-page `fetch` per lesson, no navigation.
- `?md=` takes the module ID, not the slug; direct browser navigation to `?md=` URLs is a server-side 404 (client-only route).
- Without `?md=` the course data route returns a `__N_REDIRECT` envelope — follow it once.
- Lesson body is TipTap/ProseMirror JSON prefixed `[v2]`, with the non-standard node type `unorderedList` (not `bulletList`) — missing it silently flattens every bullet list.
- Locked higher-tier courses are flagged via `metadata.hasAccess` — the skill says skip, not circumvent.

Tested 2026-06-10: 85 lessons across 6 courses extracted in ~2 min from one logged-in tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a field-tested guide for extracting Skool classroom content as a logged-in member using Next.js `/_next/data` routes, replacing DOM scraping. Covers `?md=<moduleId>` hydration, one-time redirect handling, parsing `[v2]` TipTap JSON (with `unorderedList`), access checks via `metadata.hasAccess`, and pacing to fetch ~85 lessons in ~2 minutes.

<sup>Written for commit b57bf5d998935ef33fb09cfe6e81a9ea05b2307b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

