### PR TITLE
Fix cdp() params-dict form and new_tab() blank-tab leak

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -49,9 +49,10 @@ def _send(req):
     return r
 
 
-def cdp(method, session_id=None, **params):
-    """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1)."""
-    return _send({"method": method, "params": params, "session_id": session_id}).get("result", {})
+def cdp(method, params=None, *, session_id=None, **kwargs):
+    """Raw CDP. Kwargs and a params dict both work:
+    cdp('Page.navigate', url='...'), cdp('Target.closeTarget', {'targetId': tid})."""
+    return _send({"method": method, "params": {**(params or {}), **kwargs}, "session_id": session_id}).get("result", {})
 
 
 def drain_events():  return _send({"meta": "drain_events"})["events"]
@@ -319,9 +320,15 @@ def new_tab(url="about:blank"):
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
     tid = cdp("Target.createTarget", url="about:blank")["targetId"]
-    switch_tab(tid)
-    if url != "about:blank":
-        goto_url(url)
+    try:
+        switch_tab(tid)
+        if url != "about:blank":
+            goto_url(url)
+    except Exception:
+        # a failed attach/navigation must not leak the blank tab
+        try: cdp("Target.closeTarget", targetId=tid)
+        except Exception: pass
+        raise
     return tid
 
 def close_tab(target=None):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -350,3 +350,60 @@ def test_wait_for_network_idle_filters_events_to_active_session():
         "session filter, the background rWS/lF pair would have updated "
         "last_activity and prevented the idle window from elapsing."
     )
+
+
+# --- cdp() call forms ---
+
+def _capture_send():
+    sent = []
+    def fake_send(req):
+        sent.append(req)
+        return {"result": {}}
+    return fake_send, sent
+
+
+def test_cdp_kwargs_form():
+    fake_send, sent = _capture_send()
+    with patch("browser_harness.helpers._send", side_effect=fake_send):
+        helpers.cdp("Page.navigate", url="https://x.test")
+    assert sent[0] == {"method": "Page.navigate", "params": {"url": "https://x.test"}, "session_id": None}
+
+
+def test_cdp_params_dict_form():
+    # the form SKILL.md documents: cdp("Domain.method", params)
+    fake_send, sent = _capture_send()
+    with patch("browser_harness.helpers._send", side_effect=fake_send):
+        helpers.cdp("Target.closeTarget", {"targetId": "T1"})
+    assert sent[0]["params"] == {"targetId": "T1"}
+    assert sent[0]["session_id"] is None
+
+
+def test_cdp_dict_and_kwargs_merge_kwargs_win():
+    fake_send, sent = _capture_send()
+    with patch("browser_harness.helpers._send", side_effect=fake_send):
+        helpers.cdp("Runtime.evaluate", {"expression": "1", "returnByValue": False}, returnByValue=True)
+    assert sent[0]["params"] == {"expression": "1", "returnByValue": True}
+
+
+def test_cdp_session_id_stays_keyword():
+    fake_send, sent = _capture_send()
+    with patch("browser_harness.helpers._send", side_effect=fake_send):
+        helpers.cdp("Runtime.evaluate", session_id="S1", expression="1")
+    assert sent[0]["session_id"] == "S1"
+    assert sent[0]["params"] == {"expression": "1"}
+
+
+# --- new_tab() must not leak its about:blank tab ---
+
+def test_new_tab_closes_blank_tab_when_attach_fails():
+    calls = []
+    def fake_cdp(method, params=None, **kwargs):
+        calls.append((method, {**(params or {}), **kwargs}))
+        if method == "Target.createTarget":
+            return {"targetId": "T1"}
+        return {}
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.switch_tab", side_effect=RuntimeError("attach failed")):
+        with pytest.raises(RuntimeError, match="attach failed"):
+            helpers.new_tab("https://x.test")
+    assert ("Target.closeTarget", {"targetId": "T1"}) in calls


### PR DESCRIPTION
## Problem

`SKILL.md` line 93 documents raw CDP as:

> Raw CDP for anything helpers don't cover: `cdp("Domain.method", params)`.

But the implementation is `cdp(method, session_id=None, **params)` — so the documented dict form puts the params dict into `session_id` and sends empty params. Every agent following the skill doc hits this:

```python
cdp("Target.closeTarget", {"targetId": tid})
# RuntimeError: {'code': -32600, 'message': "Message may have string 'sessionId' property"}
# (or, depending on method: "Failed to deserialize params.targetId - BINDINGS: mandatory field missing")
```

A practical consequence: tab-close calls written in the documented style fail, so agents quietly leak tabs.

## Fix

`cdp()` accepts both the documented dict form and the existing kwargs form (kwargs win on key collisions), and `session_id` becomes keyword-only:

```python
def cdp(method, params=None, *, session_id=None, **kwargs):
```

Compatibility: every call site in `src/`, `agent-workspace/`, `interaction-skills/` and `agent-workspace/domain-skills/` already passes `session_id` by keyword (grepped; none positional), so this is non-breaking for the repo and for code following either documented style.

## Related: `new_tab()` leaks its about:blank tab on failure

`new_tab()` deliberately creates `about:blank` first and navigates after (to avoid the createTarget/attach race). If `switch_tab`/`goto_url` then throws, the blank tab is orphaned — over many sessions these accumulate visibly. Now the blank tab is closed before the exception re-raises.

## Tests

5 new unit tests in `tests/unit/test_helpers.py` (kwargs form, dict form, merge precedence, keyword `session_id`, new_tab close-on-fail). Full suite: 112 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cdp()` to accept the documented params-dict form and stops `new_tab()` from leaking the temporary about:blank tab on failures. Aligns behavior with `SKILL.md` and prevents orphaned tabs.

- **Bug Fixes**
  - `cdp()` now accepts both dict and kwargs forms; kwargs win on collisions, and `session_id` is keyword-only. This resolves failures like `Target.closeTarget` when called as `cdp("Domain.method", {...})`. No breaking change.
  - `new_tab()` closes the about:blank tab if attach or navigation fails, then re-raises, preventing tab leaks.

<sup>Written for commit 2d5e40da873b53f8093d6137601f22d1ec6a0803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

