### PR TITLE
Fix duplicated character input in press_key

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -256,7 +256,10 @@ def press_key(key, modifiers=0):
     so listeners checking e.keyCode / e.key all fire."""
     vk, code, text = _KEYS.get(key, (ord(key[0]) if len(key) == 1 else 0, key, key if len(key) == 1 else ""))
     base = {"key": key, "code": code, "modifiers": modifiers, "windowsVirtualKeyCode": vk, "nativeVirtualKeyCode": vk}
-    cdp("Input.dispatchKeyEvent", type="keyDown", **base, **({"text": text} if text else {}))
+    # Printable characters should be inserted by the `char` event only.
+    # Sending text on both keyDown and char duplicates input.
+    keydown_text = text if len(text) > 1 else ""
+    cdp("Input.dispatchKeyEvent", type="keyDown", **base, **({"text": keydown_text} if keydown_text else {}))
     if text and len(text) == 1:
         cdp("Input.dispatchKeyEvent", type="char", text=text, **{k: v for k, v in base.items() if k != "text"})
     cdp("Input.dispatchKeyEvent", type="keyUp", **base)


### PR DESCRIPTION
## Summary

Fix duplicated text entry for printable single-character keys in `press_key()`.

## Problem

`press_key()` was sending printable characters twice:
- once via `Input.dispatchKeyEvent` with `type="keyDown"` and `text=...`
- again via `Input.dispatchKeyEvent` with `type="char"`

That caused helpers like `fill_input(...)` to duplicate every typed character.

## Fix

Only send `text` on `keyDown` for non-single-character cases.
Printable single-character input is now inserted by the `char` event only.

## Verification

Verified locally with `browser-harness` against a real Chrome session:
- `fill_input(...)` now writes normal text without duplication
- form fields on `https://httpbin.org/forms/post` were filled correctly
- navigation and page-reading behavior still worked afterward

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicated character input in `press_key()` by sending printable single-character input via the `char` event only. Prevents double characters in helpers like `fill_input(...)` and normal form entry.

- **Bug Fixes**
  - Skip `text` on `keyDown` for single printable keys; keep `char` event for insertion. Multi-character cases still send `text` on `keyDown`.
  - Verified with `browser-harness` in Chrome: inputs no longer duplicate; navigation and page reading remain unaffected.

<sup>Written for commit ecd10371d9eaf2f3a0938b34d3433725bb129563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

