### PR TITLE
docs: Brave / Chromium 144+ fixed-port connection notes

### DIFF
--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -28,6 +28,25 @@ for t in tabs:
 tab = ensure_real_tab()
 ```
 
+## Brave (and Chromium 144+) on a fixed debug port
+
+The brave://settings "Remote debugging" checkbox opens CDP on `127.0.0.1:9222`, but the HTTP discovery endpoints (`/json/version`, `/json/list`) return **404** — an empty curl response does NOT mean the port is dead. Read the websocket path from the profile dir instead:
+
+```bash
+cat "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort"
+# line 1: port, line 2: /devtools/browser/<uuid>
+```
+
+Then connect with an explicit ws override and a dedicated daemon namespace:
+
+```bash
+BU_NAME=brave BU_CDP_WS="ws://127.0.0.1:9222/devtools/browser/<uuid>" browser-harness <<'PY'
+new_tab("https://example.com")
+PY
+```
+
+If the first call fails with `no close frame received or sent`, remove the stale `/tmp/bu-brave.sock` and `/tmp/bu-brave.pid` and retry — the daemon reconnects cleanly. The browser uuid changes on every Brave restart, so re-read `DevToolsActivePort` when reconnecting after a restart.
+
 ## Bringing Chrome to front
 
 If Chrome is behind other windows or on another desktop:


### PR DESCRIPTION
Adds a section to `interaction-skills/connection.md` covering connecting to Brave (and any Chromium 144+) when remote debugging is enabled via the settings checkbox on a fixed port:

- `/json/version` and `/json/list` return **404** on these builds — an empty curl is not a dead port
- read the ws path from `DevToolsActivePort` in the Brave profile dir
- connect with `BU_NAME` + `BU_CDP_WS` override
- stale-socket recovery for the named daemon, and the note that the browser uuid changes on every restart

Field-tested today against Brave on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add connection notes for Brave and Chromium 144+ when remote debugging is enabled on a fixed port. Covers 404 discovery endpoints, reading the websocket path from `DevToolsActivePort`, connecting via `BU_NAME` + `BU_CDP_WS`, handling stale sockets, and noting the browser UUID changes on each restart.

<sup>Written for commit 147d30b14a2445501497262b12bb0dfb17e280cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

