### PR TITLE
Add aztaxes.gov domain skill (AZ TPT e-file portal)

### DIFF
--- a/domain-skills/aztaxes/portal.md
+++ b/domain-skills/aztaxes/portal.md
@@ -1,0 +1,54 @@
+# AZTaxes.gov (Arizona DOR business portal)
+
+Classic ASP.NET site — native selects, full-page posts, `element.click()` from `js()` works
+everywhere. No React/iframe tricks needed. Field-tested 2026-06 on the TPT e-file flow.
+
+## Routes
+
+```text
+https://www.aztaxes.gov/Home/Page                 # public home
+https://www.aztaxes.gov/Home/Login                # Business User Login (email -> Next -> password)
+https://www.aztaxes.gov/Home/BusinessList         # post-login landing
+https://www.aztaxes.gov/Home/BusinessDetails?id_internal_business=<id>
+https://www.aztaxes.gov/Home/LocationListStatic?...&licenseNumber=...&idAcct=...
+https://www.aztaxes.gov/Home/EFileHistory         # all e-filed returns
+https://www.aztaxes.gov/Home/FormDisplay?formId=<guid>&formType=FormTPT2&ViewerType=TptViewer
+https://www.aztaxes.gov/Home/ChooseLicense        # File a TPT return: license/year/month
+https://www.aztaxes.gov/Home/TPT2LocationList?formId=<guid>      # draft return: per-location
+https://www.aztaxes.gov/Home/EnterLineItems?formId=<guid>&locationCd=001
+https://www.aztaxes.gov/Home/AddLineItem?formId=<guid>&locationCd=001&regionCode=MAR&busClass=025&redirectCmd=Edit
+```
+
+`/Security/Login.aspx` redirects to `/Home/Login` — use the latter.
+
+## Traps
+
+- **DataTables pagination**: tables (e-file history, locations) keep only the CURRENT page's
+  rows in the DOM. Searching rows by text silently misses entries on other pages. Fix first:
+
+  ```js
+  const s = document.querySelector('select');           // the "Show N entries" select
+  s.value = s.options[s.options.length-1].value;
+  s.dispatchEvent(new Event('change', {bubbles:true}));
+  ```
+
+- **Filed returns render on `<canvas>`** (PDF.js-style viewer, one canvas per page, ~5 pages
+  for a TPT-2). Viewport clip-screenshots only catch page 1 — the rest scroll inside a
+  container. Extract every page losslessly instead:
+
+  ```python
+  data = js("document.querySelectorAll('canvas')[0].toDataURL('image/png').slice(22)")
+  open("/tmp/p1.png","wb").write(base64.b64decode(data))
+  ```
+
+- **Period selection selects** (`/Home/ChooseLicense`): ids `licenseId`, `yearId`, `monthId`.
+  `licenseId` option VALUE is an internal account id, not the license number (label shows the
+  license). `monthId` values are `1`–`12`, not zero-padded. Set value + dispatch `change`.
+
+- **TPT-2 line-item form** (`AddLineItem`): inputs `gross_0`, `deduction_0`, `nettaxable_0`,
+  `taxrate_0`, `totaltax_0`. Set `gross_0` and dispatch `input`+`change`+`blur` — the page
+  recomputes net taxable and total tax automatically. "Save And Close" persists into the draft;
+  nothing is filed until the separate review/submit flow.
+
+- A filing-period banner (`Filing Period: MM/DD/YYYY - MM/DD/YYYY`) is on every draft screen —
+  verify it before entering data; drafts for the wrong period look identical otherwise.


### PR DESCRIPTION
Adds `domain-skills/aztaxes/portal.md` covering the Arizona DOR business portal (AZTaxes.gov), field-tested on the TPT-2 e-file flow:

- Route map for login → business list → e-file history → draft return → per-location line items
- **DataTables pagination trap**: tables keep only the current page in the DOM — expand "Show entries" before searching rows by text
- **Canvas form viewer**: filed returns render on `<canvas>` pages that scroll inside a container; clip-screenshots miss pages — extract via `canvas.toDataURL()`
- Period-selection select ids/values (`licenseId` uses an internal account id, months not zero-padded) and TPT-2 line-item input ids with required events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new AZTaxes.gov domain skill documenting the Arizona DOR business portal TPT-2 e-file flow. Provides routes and practical notes to automate navigation and data extraction reliably.

- **New Features**
  - Route map from login to e-file history, draft return, and per-location line items (incl. `formId` usage).
  - `DataTables` pagination caveat and fix: expand "Show entries" before searching/filtering.
  - Canvas-based filed return viewer: extract pages via `canvas.toDataURL()` instead of screenshots.
  - Period selection details: `licenseId`, `yearId`, `monthId` behavior (internal id, 1–12), plus verify the filing-period banner on drafts.
  - TPT-2 line-item form fields (`gross_0`, `deduction_0`, `nettaxable_0`, `taxrate_0`, `totaltax_0`) and required `input`/`change`/`blur` events for correct recalculation.

<sup>Written for commit 3039a1161fab037290589728ede47c59d2878b9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

