### PR TITLE
Add Cashfree merchant payouts + BulkPe dashboard domain skills

### DIFF
--- a/domain-skills/bulkpe/dashboard.md
+++ b/domain-skills/bulkpe/dashboard.md
@@ -1,0 +1,20 @@
+# BulkPe Dashboard (app.bulkpe.in)
+
+**Flutter Web app rendered to canvas — there is NO DOM.** `document.querySelectorAll('input')` returns nothing; the body only has `flt-semantics-placeholder`. Forget selectors and JS clicks entirely: drive it with `screenshot()` → `click(x, y)` → `screenshot()` at the compositor level. Screenshots here are 1:1 CSS px (no retina scaling observed), but always re-screenshot to verify a click landed.
+
+The operating company behind BulkPe virtual accounts is **Chaseout Technologies** (bank NEFTs to a BulkPe VA show as `CHASEOUT TECHNOLOGIES` / IFSC `YESB0CMSNOC`).
+
+## Getting a statement (Virtual Account report)
+
+1. Sidebar → `Report` (`/app/reports`).
+2. Top-right `Generate` button → modal with `Generate Report for: Virtual Account | PG Collection | …`, quick filters, and From/To date fields.
+3. Date fields open a Material date picker. The month back-chevron clicks are flaky — clicks may appear ignored but actually register; alternatively the **pencil icon** (bottom-left of picker) switches to typed input. After picking From it flows into To, then submits.
+4. Report row appears with status `Pending` → `Completed` (~1 min). Click `Refresh`, then the download icon in the row. Direct CSV download.
+
+## Report CSV traps
+
+- Contains **NUL bytes** mid-file and non-UTF8 chars: read binary, `.replace(b'\x00', b'')`, decode `latin-1`.
+- Columns: `Transaction Id, Reference Id, Beneficiary Name, ..., Amount, Payment Mode, Status, Status Description, UTR, Payment type (Credit/Debit), Charges, GST, Settelment Amount [sic], VA Closing Balance, ...`.
+- `Payment type` = `Credit` (VA loads) vs `Debit` (payouts). Status `SUCCESS` / `FAILED` (`Insufficient Balance` is common — failed rows have Amount but were never paid; exclude them from payout totals).
+- Penny-drop verification rows appear as `BulkpePenny…` beneficiaries with Amount 0.
+- Charges + GST columns are per-transfer fees (only on SUCCESS rows).

--- a/domain-skills/cashfree/merchant-payouts.md
+++ b/domain-skills/cashfree/merchant-payouts.md
@@ -1,0 +1,25 @@
+# Cashfree Merchant Dashboard — Payouts (merchant.cashfree.com)
+
+React SPA. DOM selectors work, but custom selects don't respond to plain coordinate clicks reliably — dispatch `mousedown`/`mouseup`/`click` on the option element.
+
+## Getting a statement / transfer data
+
+There is no inline date-filtered transaction table worth scraping. Use **Reports**:
+
+1. Sidebar → `Reports` (`/payouts/reports`).
+2. `Report Type` select → e.g. **Account Statement** (all credits + debits + per-txn service charge & tax — best single export). `Transfer` = payouts only.
+3. **Date Range** select → `Custom Date Range` opens a dual-month calendar. Click start day, end day, then `Apply`.
+4. **Fund Source is required.** The `Generate Report` button is styled active but stays `disabled=true` until a Fund Source is chosen from its dropdown. If clicks seem ignored, check `button.disabled` via JS.
+5. Report lands in the "Generated Reports" table (status `Processing` → ready in ~1 min). Download via the `⋮` actions menu → `Download`. CSV downloads directly.
+
+## Account Statement CSV shape
+
+Columns: `Added On, Debit/Credit, Particulars, Charged Amount (INR), Amount (INR), Service Charge (INR), Service Tax (INR), Closing Balance (INR), Event Id, Remarks`.
+
+- `Particulars` values: `PAYOUT_TRANSFER` (user payouts), `SELF_WITHDRAWAL` (money pulled back to bank).
+- Wallet loads appear as credits; payouts as debits. Service charge + tax are per-transfer (flat ₹ per IMPS/UPI transfer, so fee % is large on small tickets).
+
+## Traps
+
+- The date-picker dropdown closes on stray clicks and the click can land on checkboxes *behind* the (transparent-edged) popover — re-verify checkbox state after any miss.
+- "Choose Columns" checkboxes: `Show All` re-checks everything in one click.


### PR DESCRIPTION
Two new domain skills from a real finance-ops session:

**Cashfree merchant dashboard (merchant.cashfree.com/payouts)**
- Reports flow for statements (no scrapeable txn table)
- Gotcha: `Generate Report` is styled active but stays `disabled=true` until a Fund Source is selected
- Account Statement CSV column shape + PAYOUT_TRANSFER / SELF_WITHDRAWAL semantics

**BulkPe (app.bulkpe.in)**
- It's a Flutter Web canvas app — no DOM at all, coordinate clicks only
- Virtual Account report generation flow + flaky date-picker notes
- CSV export contains NUL bytes and non-UTF8 chars (parse recipe included)
- Penny-drop and FAILED-row semantics so payout totals come out right

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds domain skills for the Cashfree merchant payouts dashboard and BulkPe dashboard. Covers report generation, automation gotchas, and CSV parsing so payout totals stay accurate.

- **New Features**
  - Cashfree (`merchant.cashfree.com/payouts`): Use Reports; Fund Source must be set or Generate stays disabled; Account Statement CSV columns and `PAYOUT_TRANSFER`/`SELF_WITHDRAWAL` meanings; reliable clicks for custom selects.
  - BulkPe (`app.bulkpe.in`): Flutter Web canvas (no DOM) → automate with screenshots and coordinate clicks; Virtual Account report flow; CSV cleanup for NUL/non‑UTF8; handle FAILED rows and penny-drops correctly.

<sup>Written for commit 3b46a043166af02eaf8dbf5aa536307e773a2abe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

