### PR TITLE
Add Gmail compose domain skill

### DIFF
--- a/domain-skills/gmail/compose.md
+++ b/domain-skills/gmail/compose.md
@@ -1,0 +1,40 @@
+# Gmail — compose & drafts
+
+## Account routing
+
+Multi-account sessions: `https://mail.google.com/mail/u/<email>/` routes to that signed-in account directly — no clicking through the account switcher. Works with `#drafts`, `#sent`, etc. appended. First load sometimes lands on a "Temporary Error" page title that resolves itself; wait a beat and re-check `page_info()` before assuming failure.
+
+## Compose window
+
+- Open: click `[gh="cm"]` (stable attr on the Compose button). Fallback: `div[role=button]` with text `Compose`.
+- The window can open **minimized**: `div[aria-label='Message Body']` exists but `offsetParent` is null. Click the `New Message` header bar to restore before filling.
+- Fields:
+  - To: `input[aria-label='To recipients']` (older UIs: `textarea[name=to]`)
+  - Subject: `input[name=subjectbox]`
+  - Body: `div[aria-label='Message Body']` (contenteditable)
+- Plain text into To/Subject: `.focus()` then `document.execCommand('insertText', false, text)` — works fine.
+
+## Trap: Trusted Types blocks HTML insertion into the body
+
+Gmail ships a `require-trusted-types-for 'script'` CSP. Both of these throw `TypeError: This document requires 'TrustedHTML' assignment`:
+
+- `document.execCommand('insertHTML', false, html)`
+- `body.innerHTML = html`
+
+**Fix:** Gmail does not restrict Trusted Types policy names, so create your own:
+
+```js
+const p = window.trustedTypes.createPolicy('fill-' + Math.floor(Math.random()*1e6), {createHTML: s => s});
+const b = document.querySelector("div[aria-label='Message Body']");
+b.focus();
+b.innerHTML = p.createHTML(html);   // hyperlinks, <p>, <br> all preserved
+b.dispatchEvent(new InputEvent('input', {bubbles: true, inputType: 'insertText'}));
+```
+
+The dispatched `input` event is required — without it Gmail's autosave doesn't register the change and the draft saves empty.
+
+## Saving drafts
+
+- Autosave fires off input events; the draft (with subject) appears in `#drafts` within seconds.
+- Close-and-save: Escape, or click `img[aria-label='Save & close']` (also matches `.Ha`).
+- Verify a draft's body actually saved by reading the list row snippets: `tr.zA` innerText includes the body preview after the subject.


### PR DESCRIPTION
Adds `domain-skills/gmail/compose.md` covering field-tested compose mechanics:

- `/mail/u/<email>/` account routing for multi-account sessions (+ transient "Temporary Error" on first load)
- Stable selectors: `[gh="cm"]` compose button, To/Subject/Body fields
- Minimized-compose state detection (`offsetParent` null) and restore
- **Trap:** Gmail's `require-trusted-types-for` CSP blocks `insertHTML`/`innerHTML` — documented the `trustedTypes.createPolicy` bypass (policy names are unrestricted) plus the `InputEvent` dispatch required for autosave to register the change
- Draft save/close/verify patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Gmail compose domain skill documenting a stable, end-to-end flow for opening, filling, and saving drafts, including a Trusted Types-safe HTML insert. This reduces flakiness by using robust selectors and covers autosave nuances.

- **New Features**
  - Multi-account routing via /mail/u/<email>/ with note on transient “Temporary Error” on first load.
  - Stable selectors for Compose button and To/Subject/Body fields.
  - Detection and restore of minimized compose windows before filling.
  - Trusted Types CSP workaround using `trustedTypes.createPolicy` and `InputEvent` dispatch so autosave registers content.
  - Draft save/close patterns and verification via list row snippets.

<sup>Written for commit 575b71149129de0eea8bb646af860300daef5ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

