### PR TITLE
reddit: document blanket 403 walls + JSON-via-browser fallback

### DIFF
--- a/agent-workspace/domain-skills/reddit/scraping.md
+++ b/agent-workspace/domain-skills/reddit/scraping.md
@@ -29,6 +29,32 @@ Fails on:
 - Private / quarantined subreddits (401)
 - NSFW posts without an authenticated session
 - Anti-scraping 429s under load — back off or switch to the browser path
+- **Blanket 403 walls (observed June 2026):** reddit.com can 403 *every* anonymous `.json` request from a network it dislikes (datacenter/VPN IPs), browser User-Agent or not. The response is an HTML challenge page, not JSON. When this happens, Path 1 is dead for the whole session — don't retry/back off, switch to Path 1.5.
+
+## Path 1.5: JSON endpoints through the browser (beats IP blocks)
+
+The `.json` endpoints render as plain text in a real tab, and requests from the user's Chrome carry their cookies + real TLS fingerprint, so they pass where `http_get` 403s. No DOM scraping needed — navigate and parse `document.body.innerText`:
+
+```python
+import json
+ensure_real_tab()
+goto_url("https://www.reddit.com/r/Bogleheads/search.json?q=tax%20loss%20harvesting&restrict_sr=on&sort=top&t=month&limit=15&raw_json=1")
+wait_for_load()
+data = json.loads(js("document.body.innerText"))
+posts = [c["data"] for c in data["data"]["children"]]
+# fields: title, selftext, score, num_comments, permalink, created_utc
+```
+
+Useful JSON endpoints beyond single posts:
+
+- **Subreddit search:** `/r/<sub>/search.json?q=<query>&restrict_sr=on&sort=top&t=month&limit=25&raw_json=1` — `q` supports quoted phrases and `OR` (`q=tax efficient OR "tax loss harvesting"`, URL-encoded). `t` ∈ hour/day/week/month/year/all.
+- **Thread + top comments:** `/r/<sub>/comments/<id>.json?limit=10&sort=top&depth=1&raw_json=1` — `data[1]["data"]["children"]` are top-level comments (`body`, `score`, `author`); filter out `stickied`.
+- `raw_json=1` stops Reddit HTML-escaping `&`, `<`, `>` in text fields.
+
+Gotchas for this path:
+
+- **Loop over many URLs with retry.** Mid-loop `Runtime.evaluate timed out; expression: document.readyState` means the tab session went stale; calling `ensure_real_tab()` again and re-navigating recovers it. Wrap each fetch in a 2-3 attempt retry rather than failing the whole sweep.
+- Single quotes inside f-strings break `browser-harness -c '...'` shell quoting — use `.format()` / double quotes, or pass the script via `"$(cat file.py)"`.
 
 ## Path 2: Browser DOM extraction (logged-in)
 


### PR DESCRIPTION
## What

Adds a **Path 1.5** to the reddit scraping skill: fetching reddit's `.json` endpoints by navigating them in the user's Chrome and parsing `document.body.innerText`.

## Why

Field-tested 2026-06-11: reddit.com returned **403 for every anonymous `.json` request** from a datacenter IP - browser User-Agent made no difference, and the response is an HTML challenge page, not JSON. The existing Path 1 (`http_get`) only documents 401/429 failure modes, so an agent hitting the blanket 403 wall has no documented recovery. Navigating the same URLs in the user's real browser session passes cleanly.

Also adds:
- the subreddit **search.json** endpoint (`q` supports `OR` and quoted phrases, `t=month` etc.) for topic sweeps
- thread-comments params (`?limit=10&sort=top&depth=1&raw_json=1`)
- stale-session recovery (`Runtime.evaluate timed out` mid-loop → `ensure_real_tab()` + retry)
- the single-quote f-string trap inside `browser-harness -c '...'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented Reddit’s blanket 403 on anonymous `.json` requests and added a JSON‑via‑browser fallback (Path 1.5) that uses the user’s Chrome to fetch `.json` and parse `document.body.innerText`. This gives the scraping skill a reliable path when `http_get` is blocked.

- **New Features**
  - Path 1.5: navigate `.json` in a real tab and parse `document.body.innerText` to bypass CDN 403s.
  - Documented endpoints: subreddit search (`/r/<sub>/search.json` with `q`, `t`, `limit`, `raw_json=1`) and thread + top comments (`/comments/<id>.json?...`).
  - Retry guidance: if the tab goes stale (`Runtime.evaluate timed out`), call `ensure_real_tab()` and retry.
  - Shell note: avoid single quotes in f-strings with `browser-harness -c`; use double quotes or `.format()`.

<sup>Written for commit 39bfbb054aa329cb68f2faeb60f1853f91c38008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

