### PR TITLE
Add Intercom domain skill: filing a support ticket via the in-app Fin messenger

### DIFF
--- a/domain-skills/intercom/support-ticket.md
+++ b/domain-skills/intercom/support-ticket.md
@@ -1,0 +1,36 @@
+# Intercom (app.intercom.com) — filing a support ticket with Intercom itself
+
+How to report a bug / open a ticket with Intercom support from inside the admin app.
+
+## Entry point
+
+- The admin app has Intercom's own messenger for admin support: a dark circular
+  launcher pinned to the bottom-right corner of the viewport. Click it to open the
+  "Fin" support panel. No URL route for it — it's an overlay widget.
+- The messenger identifies the **logged-in admin** (greets them by first name).
+  Replies to the conversation are delivered to that admin's messenger AND their
+  login email — check who you're logged in as before filing if follow-up routing
+  matters.
+- The workspace (app) ID is in the inbox URL: `app.intercom.com/a/inbox/<workspace-id>/...`.
+  Include it in bug reports.
+
+## Flow
+
+1. Fin (AI agent) answers first. Give it a complete bug report in ONE message:
+   steps to reproduce, expected vs actual, workspace ID. It will validate against
+   documented behavior — useful confirmation that what you're seeing is a bug.
+2. Fin does NOT create a ticket on its own. Explicitly ask it to "escalate this
+   conversation to your support team so it is logged as a bug ticket." It then
+   hands off: "connecting you with a human agent" → categorizes the conversation
+   → confirms team reply time (~4 hours) and the email replies will go to.
+3. There's no ticket number surfaced at handoff time — the human team provides
+   references later in the same conversation.
+
+## Composer quirks
+
+- The message input is single-line-styled and **sends on Enter**. Type the whole
+  message via `type_text()` with no newline characters, then `press_key('Enter')`.
+- Fin's longer replies overflow the panel; scroll inside the messenger panel
+  (mouse over it) to read the full response before replying.
+- Fin responses stream in over ~10-15s with a typing indicator — wait before
+  screenshotting or you'll capture a partial reply.


### PR DESCRIPTION
New domain skill capturing the durable mechanics of opening a support ticket with Intercom from inside app.intercom.com, learned while filing a real bug report:

- The admin app's own support messenger (Fin) is the entry point — dark circular launcher, bottom-right overlay; no URL route.
- The messenger identifies the logged-in admin and routes replies to their messenger + login email, so account identity matters before filing.
- Workspace ID lives in the inbox URL path.
- Fin validates bug reports against documented behavior but does not create tickets unprompted — you must explicitly ask it to escalate to the support team, which triggers the human handoff (~4h reply time).
- Composer quirks: sends on Enter (no newlines in type_text), streaming replies need a 10-15s wait before screenshotting, long replies require scrolling within the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an Intercom domain skill that explains how to file a support ticket from app.intercom.com using the in-app Fin messenger. It covers the launcher entry point, identity and workspace ID context, the explicit “escalate to support” step, and composer quirks (Enter-to-send, scrolling, 10–15s streaming) for reliable automation.

<sup>Written for commit e391fee1a657084396f2c46ce6ff20711cc8c9b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

