### PR TITLE
Fix MS Store dialog when opening chrome://inspect on Windows

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -730,6 +730,20 @@ def _open_chrome_inspect():
             return
         except Exception:
             pass
+    if platform.system() == "Windows":
+        # ShellExecute can't resolve chrome:// URIs (no protocol handler -> MS Store
+        # dialog); pass the URL as an argument to the Chrome binary instead.
+        for chrome in (
+            os.path.expandvars(r"%ProgramFiles%\Google\Chrome\Application\chrome.exe"),
+            os.path.expandvars(r"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"),
+            os.path.expandvars(r"%LocalAppData%\Google\Chrome\Application\chrome.exe"),
+        ):
+            if os.path.exists(chrome):
+                try:
+                    subprocess.Popen([chrome, url])
+                    return
+                except Exception:
+                    pass
     try:
         webbrowser.open(url, new=2)
     except Exception:


### PR DESCRIPTION
## Problem

On Windows, `_open_chrome_inspect()` ends up at `webbrowser.open("chrome://inspect/#remote-debugging")`. Python's `webbrowser` module hands the URL to ShellExecute, which resolves the scheme through the registry — and Windows has no protocol handler registered for `chrome://`. The result is that the inspect page never opens; instead Windows pops a **"You'll need a new app to open this chrome link"** Microsoft Store dialog. Since `_open_chrome_inspect()` runs on every failed daemon attach, Windows users get this dialog over and over while trying to set up the remote-debugging checkbox.

## Fix

Add a Windows branch that locates `chrome.exe` in the three standard install locations (machine-wide 64-bit, machine-wide 32-bit, per-user) and passes the URL as a process argument instead:

```python
subprocess.Popen([chrome, url])
```

Chrome resolves `chrome://` URLs natively when they arrive as arguments, and when an instance is already running the new process just forwards the URL to it as a new tab — which is exactly the desired behavior here, since the user's Chrome is normally already open.

This mirrors the existing macOS special case in the same function, which already routes around the OS default-handler path for the same reason (AppleScript `open location` instead of `open`).

## Behavior when Chrome isn't found

If `chrome.exe` isn't in any of the three locations (e.g. an Edge- or Brave-only machine, or a portable install), the function falls through to the existing `webbrowser.open()` call — identical to current behavior, no regression. Unset environment variables are also safe: `os.path.expandvars` leaves the `%VAR%` text literal, which simply fails the `os.path.exists` check.

## Testing

- Windows 10 (build 19045), Chrome installed machine-wide: before the patch, every failed daemon attach popped the Store dialog; with the patch the inspect page opens as a tab in the running Chrome.
- Verified all three path expansions resolve correctly and that the fallback is reached when no path matches.
- macOS and Linux code paths are untouched (the new block is gated on `platform.system() == "Windows"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows opening of chrome://inspect by launching `chrome.exe` directly from standard install paths, avoiding the Microsoft Store “You'll need a new app to open this chrome link” dialog. Falls back to `webbrowser.open()` if Chrome isn’t found; macOS/Linux unchanged.

<sup>Written for commit 8cc4a289a063b94aa936017980c0e4529202d2c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

