### PR TITLE
Detect Brave in _chrome_running()

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -707,10 +707,10 @@ def _chrome_running():
     try:
         if system == "Windows":
             out = subprocess.check_output(["tasklist"], text=True, timeout=5)
-            names = ("chrome.exe", "msedge.exe", "helium.exe")
+            names = ("chrome.exe", "msedge.exe", "helium.exe", "brave.exe")
         else:
             out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, timeout=5)
-            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium")
+            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium", "Brave Browser", "brave")
         return any(n.lower() in out.lower() for n in names)
     except Exception:
         return False


### PR DESCRIPTION
## Summary

`_chrome_running()` checks for a running Chromium-based browser by process name, but Brave isn't in either list. On a machine where Brave is the only Chromium browser, the harness concludes no browser is running.

This adds Brave to both branches of the check:

- Windows: `brave.exe` in the `tasklist` names
- macOS / Linux: `Brave Browser` / `brave` in the `ps` names

## Testing

- Hit in the field on Windows 10 with Brave as the only running Chromium browser: `tasklist` lists `brave.exe`, and with this change `_chrome_running()` returns `True` (it returned `False` before).
- macOS/Linux names added for parity: Brave's process name is `Brave Browser` on macOS and `brave` on Linux; the check is the same case-insensitive substring match used for the existing entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `_chrome_running()` to detect Brave on Windows, macOS, and Linux. Adds `brave.exe` (Windows) and "Brave Browser"/"brave" (macOS/Linux) to the process checks, preventing false negatives when Brave is the only Chromium browser.

<sup>Written for commit 8472a4e17f14645365e4ed4373f832b9ba82f53a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

