### PR TITLE
Decode piped stdin as UTF-8 and strip any BOM (PowerShell 5.1 compat)

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -103,7 +103,7 @@ def main():
         os.environ["BH_DEBUG_CLICKS"] = "1"
         args = args[1:]
     if not args and not sys.stdin.isatty():
-        code = sys.stdin.read()
+        code = sys.stdin.buffer.read().decode('utf-8-sig')  # utf-8-sig strips BOM if present (PowerShell 5.1 compat)
         if not code.strip():
             sys.exit(USAGE)
     else:


### PR DESCRIPTION
## Problem

On Windows PowerShell 5.1, piped text often arrives with a UTF-8 BOM (`EF BB BF`): the stock `[Text.Encoding]::UTF8` `$OutputEncoding` emits its preamble when piping to native commands, and files written by PS 5.1 (`Out-File -Encoding utf8`) carry BOMs that survive re-piping. `sys.stdin.read()` keeps that BOM in the decoded source — `U+FEFF`, or `ï»¿` when decoded via the locale code page — so `exec()` fails on line 1 of every piped script:

```
SyntaxError: invalid non-printable character U+FEFF (<string>, line 1)
```

Since piping code into `browser-harness` is the documented (and only) usage mode, this breaks the harness entirely for PowerShell 5.1 callers.

## Fix

Read stdin as raw bytes and decode with `utf-8-sig`, which strips one leading UTF-8 BOM when present and is byte-for-byte identical to `utf-8` otherwise.

## Compatibility notes (each verified against CPython)

- **bash / cmd / heredoc input is unchanged.** With no BOM present, `utf-8-sig` decodes exactly like `utf-8`.
- **Newline translation is not lost.** Text-mode stdin used to translate `\r\n` to `\n`; `compile()`/`exec()` normalize newlines themselves, including inside string literals (`exec('s="""a\r\nb"""')` yields `'a\nb'`), so CRLF input behaves identically.
- **UTF-16 stdin: deliberately out of scope.** CPython rejects UTF-16 source files (`SyntaxError: Non-UTF-8 code starting with '\xff' ... see PEP 263`), so the harness keeps the same contract for piped source. A UTF-16 pipe now fails loudly at decode time (`UnicodeDecodeError`, or `ValueError: source code string cannot contain null bytes`) instead of producing mojibake.
- **Side benefit:** non-ASCII piped source now decodes as UTF-8 on Windows instead of the locale code page (cp1252), matching how Python defines source encoding (PEP 3120).

This mirrors the existing UTF-8 normalization the file already does for stdout (run.py lines 3–8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stdin decoding so piped scripts work on Windows PowerShell 5.1. We now read bytes and decode as UTF‑8 while stripping a BOM, preventing the first-line SyntaxError when piping into `browser-harness`.

- **Bug Fixes**
  - Read from `sys.stdin.buffer` and decode with `utf-8-sig` to drop a leading BOM from PowerShell 5.1 pipes.
  - No change for non-BOM input; newline handling unchanged. UTF‑16 stdin remains unsupported and now fails early.

<sup>Written for commit 29655f1b54ce58ca4d36c06205d520e9140a4d4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

