### PR TITLE
Add Luma domain skill: internal admin API for events and guest lists

### DIFF
--- a/domain-skills/luma/admin-api.md
+++ b/domain-skills/luma/admin-api.md
@@ -1,0 +1,58 @@
+# Luma (luma.com) — calendar admin & guest lists
+
+Event platform. Public event pages scrape fine; anything admin (guest lists with
+emails, full event management) needs the **internal cookie-authed API** described here.
+The official API (`public-api.luma.com`, `x-luma-api-key` header) requires a paid
+Luma Plus subscription per calendar — the internal API below works with any
+logged-in host session.
+
+## Internal API: `https://api.luma.com`
+
+Cookie auth with SameSite cookies, so **fetches must run from a luma.com page
+context** — `js("fetch(...)", ...)` from any other origin returns 400. Ensure a
+luma.com tab first:
+
+```python
+if "luma.com" not in (page_info().get("url") or ""):
+    tabs = [t for t in list_tabs(include_chrome=False) if "luma.com" in t["url"]]
+    switch_tab(tabs[0]["targetId"]) if tabs else (new_tab("https://luma.com/home"), wait_for_load())
+```
+
+A 400 right after opening/navigating the tab can also just be the page still
+settling — wait ~3s and retry once before concluding auth is broken.
+
+### List a calendar's events
+
+```
+GET /calendar/admin/get-events?calendar_api_id=cal-XXXX&pagination_limit=20&period=past
+```
+
+- `period` is `past` or `future`. **`upcoming` is invalid and returns 400** (easy trap).
+- Returns `{entries: [{api_id: "calev-...", event: {api_id: "evt-...", name, start_at,
+  end_at, url, geo_address_info, ...}, guest_count}], has_more, next_cursor}`.
+- Paginate with `&pagination_cursor=<next_cursor>`.
+- Calendar id is in the manage URL: `luma.com/calendar/manage/cal-XXXX`.
+
+### Full guest list with emails (host only)
+
+```
+GET /event/admin/get-guests?event_api_id=evt-XXXX&pagination_limit=100
+```
+
+- Returns `{entries: [...], has_more, next_cursor}`; paginate with `pagination_cursor`.
+- Each guest: `name`, `email`, `approval_status`, `registered_at`, `checked_in_at`,
+  `registration_answers`, social handles, `user_api_id`.
+- **`approval_status` semantics:** `approved` / `going` = actually registered;
+  `invited` = host sent an invite, never registered (these dominate the list —
+  a 24-guest event can return 238 rows, 210 of them `invited`); `declined` = declined.
+  Filter on status or your "guest list" will be 10x the real size.
+- `checked_in_at` is null unless the host scanned people in — for casual events,
+  registered ≠ attended.
+
+## Traps
+
+- The event page UI count ("24 guests") = approved only, not the raw entries count.
+- Email notifications to hosts (`noreply@luma-mail.com`) contain per-guest
+  register/cancel updates — usable as a fallback data source but not complete.
+- CSV export exists at Manage Event → Guests → ⋯ → Download if you only need a
+  one-off list and don't want the API.

--- a/helpers.py
+++ b/helpers.py
@@ -143,6 +143,14 @@ def new_tab(url="about:blank"):
         goto(url)
     return tid
 
+def close_tab(target_id=None):
+    # Close a tab (default: the agent's current one) and clean up after
+    # yourself in the user's Chrome. Target.closeTarget must get the page
+    # targetId — the attached session's id is not closable directly.
+    tid = target_id or current_tab()["targetId"]
+    cdp("Target.closeTarget", targetId=tid)
+    ensure_real_tab()
+
 def ensure_real_tab():
     """Switch to a real user tab if current is chrome:// / internal / stale."""
     tabs = list_tabs(include_chrome=False)


### PR DESCRIPTION
Adds `domain-skills/luma/admin-api.md` covering the cookie-authed internal API at `api.luma.com` for calendar admins:

- Fetches must run from a luma.com page context (SameSite cookies) — includes the ensure-tab snippet
- `calendar/admin/get-events`: `period=past|future` only; `upcoming` 400s (field-tested trap)
- `event/admin/get-guests`: pagination, and the `approval_status` semantics — `invited` rows can outnumber real registrations 10:1, so unfiltered lists are wildly inflated
- `checked_in_at` caveat (registered ≠ attended for casual events), CSV-export fallback, official-API-needs-Luma-Plus note

All field-tested against a real host calendar this week. No user-specific IDs or secrets — placeholders only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Luma domain skill documenting the internal cookie-authed admin API and a `close_tab()` helper. This enables reliable event and guest-list retrieval from a host session and helps agents clean up tabs after running.

- **New Features**
  - Added `domain-skills/luma/admin-api.md` covering `https://api.luma.com` for calendar admins. Includes an ensure-tab snippet since SameSite cookies require fetches to run from a `luma.com` tab.
  - Documented key endpoints and pitfalls:
    - `GET /calendar/admin/get-events` with `period=past|future` (note: `upcoming` 400s) and pagination via cursor.
    - `GET /event/admin/get-guests` with pagination, `approval_status` semantics (filter out `invited` to avoid 10x inflation), and `checked_in_at` caveat.
    - Notes on CSV export fallback and that the official API needs Luma Plus.
  - Added `close_tab(target_id=None)` in `helpers.py` to close a page via CDP `Target.closeTarget` and then `ensure_real_tab()` to keep the session stable.

<sup>Written for commit ced64224614072d030713b77271de56c99b5d340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

