### PR TITLE
docs(klaviyo): popup-forms domain skill — openForm, DOM map, display:none teaser trap

### DIFF
--- a/domain-skills/klaviyo/popup-forms.md
+++ b/domain-skills/klaviyo/popup-forms.md
@@ -1,0 +1,62 @@
+# Klaviyo onsite signup forms (popups embedded on host sites)
+
+Klaviyo popups are injected into the host page's DOM by `klaviyo.js` (no
+iframe). Everything below applies on any site running them.
+
+## Force-open a form (no waiting for triggers)
+
+Popups fire on Klaviyo-side targeting (delay/exit-intent/once-per-visitor
+cookies). Skip all of it:
+
+```python
+js("window._klOnsite.push(['openForm', '<FORM_ID>'])")
+```
+
+The form ID is the suffix of the teaser class (`kl-teaser-<FORM_ID>`) or of
+`.klaviyo-form-<FORM_ID>` embed divs.
+
+## DOM map
+
+- Every Klaviyo node carries `kl-private-reset-css-<hash>`; layout/skin
+  classes are obfuscated (`go<digits>`) — don't select on those.
+- Popup overlay: `div[role=dialog][aria-label="Form Dialog"]` — inline-styled
+  `position:fixed; z-index:90000` full-viewport flex container, direct
+  child of a plain div under `<body>`.
+- The form: `form.klaviyo-form` inside `[data-testid="POPUP"]`.
+- Close button: `button[aria-label="Close dialog"]`.
+- Teaser (minimized bubble after dismissal): fixed div classed
+  `kl-teaser-<FORM_ID>`, contains `[data-testid="animated-teaser"]` and a
+  `span[role=button][tabindex=0]`.
+- While the popup is open Klaviyo puts `klaviyo-prevent-body-scrolling` on
+  `<body>` — a reliable open/closed signal.
+
+## Trap: hiding the teaser with display:none freezes the whole page
+
+The popup-close sequence hands off to the teaser and only finalizes cleanup
+once the teaser renders. If host CSS sets the teaser `display:none`, close
+stalls forever: the full-viewport overlay stays mounted at `opacity:0` with
+`pointer-events:auto` (z-index 90000) and the body scroll-lock class stays
+on — every click on the page is swallowed until reload, with zero console
+errors. Diagnose with `document.elementFromPoint(x, y)` returning a
+`kl-private-reset-css-*` div over page chrome.
+
+To hide the teaser safely, keep it rendered:
+
+```css
+div[class*='kl-teaser-'] { opacity: 0 !important; pointer-events: none !important; }
+div[class*='kl-teaser-'] * { visibility: hidden !important; pointer-events: none !important; }
+```
+
+`opacity` must go on the wrapper (descendants can't undo a composited parent
+opacity). Plain `visibility:hidden` on the wrapper does NOT work — Klaviyo's
+reset CSS re-sets `visibility:visible` on every descendant (without
+`!important`, so an `!important` descendant rule still wins).
+
+## Other notes
+
+- Klaviyo injects styles via CSSOM `insertRule` into empty `<style>` tags, so
+  its forms render even under strict CSP; the host page's own cross-origin
+  stylesheets are the ones whose `cssRules` you can't read.
+- After closing a popup, verify cleanup before trusting further clicks:
+  no fixed `kl-private-reset-css` div wider than the viewport remains and
+  `document.body.className` no longer contains `klaviyo-prevent-body-scrolling`.


### PR DESCRIPTION
## What

New domain skill `domain-skills/klaviyo/popup-forms.md` for Klaviyo onsite signup popups (injected by klaviyo.js on host sites).

## Why

Debugged a production storefront where any interaction with the Klaviyo signup popup left the entire page unclickable until refresh — with zero console errors. Root cause is a genuinely non-obvious trap worth sharing: host CSS hiding the minimized teaser bubble with `display:none` stalls Klaviyo's popup-close handoff, leaving an invisible full-viewport `pointer-events:auto` overlay (z-index 90000) and a body scroll-lock class behind.

## Captured

- `window._klOnsite.push(['openForm', '<FORM_ID>'])` to force-open forms deterministically (skips Klaviyo-side targeting/cookies)
- Stable selectors: `[aria-label="Form Dialog"]`, `[data-testid="POPUP"]`, `button[aria-label="Close dialog"]`, `kl-teaser-<FORM_ID>`; avoid the obfuscated `go<digits>` classes
- The display:none teaser trap + the safe hiding pattern (composited wrapper `opacity` — Klaviyo's reset CSS re-sets `visibility` on every descendant)
- `klaviyo-prevent-body-scrolling` on `<body>` as the open/closed signal and post-close cleanup assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Klaviyo popup-forms domain skill doc that shows how to open forms on demand, map the DOM, and avoid a `display:none` teaser bug that leaves an invisible overlay blocking clicks. Helps debug and safely customize Klaviyo onsite signup popups.

- New Features
  - Force-open forms with `window._klOnsite.push(['openForm', '<FORM_ID>'])`.
  - Stable selectors for popup, form, close button, and teaser (`kl-teaser-<FORM_ID>`); avoid obfuscated `go<digits>` classes.
  - Documents the `display:none` teaser trap (stuck overlay + body scroll lock) and the safe hide pattern using wrapper `opacity` and `pointer-events:none`.
  - Post-close checks: `klaviyo-prevent-body-scrolling` removed and no full-viewport overlay remains.

<sup>Written for commit 535e44c7b0c026cb63744f6ce59523eba62fdb45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

