### PR TITLE
domain-skills: add Dynadot DNS editing skill

### DIFF
--- a/agent-workspace/domain-skills/dynadot/dns.md
+++ b/agent-workspace/domain-skills/dynadot/dns.md
@@ -1,0 +1,40 @@
+# Dynadot — editing DNS records
+
+Dynadot is a domain registrar (dynadot.com). Editing a domain's DNS requires being **logged in** — every account/DNS page behind the login is gated. There is no anonymous path to the DNS editor.
+
+## Hard prerequisites (don't skip)
+
+- **You must be on a Chrome profile that already has a Dynadot session.** The harness's isolated profile (`~/.browser-harness-chrome`) is a clean profile with no Dynadot cookies — it will only ever show the public marketing site. Connect to the user's real Chrome (where they're logged in) or have the user log in first. This is an auth wall: do **not** type credentials from a screenshot.
+- There is **no Dynadot API key** in this environment by default. The registrar does offer an API (`https://api.dynadot.com/api3.html`, key-gated) — if a key exists, prefer it over the browser for DNS edits.
+
+## URL / navigation map (durable)
+
+- Marketing/public site is a **Vue SPA**. Header is `div.navbar` (`data-v-*`). The "Login" control is **not a light-DOM text node** — `querySelectorAll`/TreeWalker text searches for "Login" return nothing. Don't hunt for it by text; click it by screenshot coordinates, or just navigate to a deep account URL while authenticated.
+- **Guessed login URLs 404.** All of these return the custom "Oops! Page Not Found" page (HTTP 200 SPA shell, not a redirect): `/account/sign_in`, `/account/sign_in.html`, `/account/signin`, `/login`, `/account/index.html`. Do not rely on them. Reach the dashboard via the homepage Login button after auth, or the post-login dashboard URL Dynadot itself lands you on.
+- DNS settings live under the **domain's setting page**, reachable from the logged-in domain manager (Manage → the domain → DNS). The bare `/account/domain/setting/dns.html` without a domain context / session renders the 404 SPA shell.
+
+## `js()` helper gotchas (this harness)
+
+- `js()` evaluates a **single expression**. **IIFEs return `null`/None** — `(function(){...})()` will silently come back as `None`. Use expression style: `Array.from(...).map(...).filter(...)`.
+- `js()` reliably serializes **arrays of strings / primitives**. Arrays of **objects** tend to come back as `None`. Return joined strings (`...map(e => a+'|'+b).join(' || ')`), not object literals.
+- An **empty array** result also surfaces as `None`, so `None` ≠ "query failed" — it may just mean "no matches."
+- Screenshots are **DPR 2**: the PNG is 2× CSS pixels. `click_at_xy` uses CSS pixels (match `page_info` `w`/`h`). Scale screenshot-pixel reads down by the devicePixelRatio before clicking.
+
+## Setting a record (once logged in)
+
+1. Open the domain manager, select the target domain, open **DNS / Nameserver Settings**.
+2. Dynadot DNS modes: **Dynadot DNS** (per-record A/CNAME/TXT/MX rows) vs **Custom Nameservers**. To point records at a host, use **Dynadot DNS** and add record rows; to delegate the whole zone elsewhere, use **Custom Nameservers**.
+3. Add/edit the row(s), **Save**, then verify with `dig +short A <domain>` from a shell (propagation is usually fast on dyna-ns).
+
+## Verify from shell (no login needed)
+
+```bash
+dig +short NS example.com     # ns1/ns2.dyna-ns.net == Dynadot-managed DNS
+dig +short A  example.com     # current apex target
+whois example.com | grep -iE 'Registrar:|Name Server:|Registry Expiry'
+```
+
+## Trap log
+
+- The page `<title>` may be prefixed with a `🟢` emoji from a local browser extension — ignore it; not part of Dynadot.
+- "default Chrome requires approval; using isolated Chrome profile" in harness output means you are NOT on the user's logged-in Chrome. Stop and resolve the connection before assuming you can reach account pages.


### PR DESCRIPTION
Adds a domain skill for editing DNS records on **dynadot.com**.

Captures the durable shape of the site so the next agent doesn't pay the discovery tax:

- **Auth wall** — every DNS/account page is gated; the isolated harness profile only ever sees the public marketing SPA. Don't type credentials from a screenshot.
- **Navigation map** — public site is a Vue SPA; the Login control isn't a light-DOM text node; guessed login URLs (`/account/sign_in`, `/login`, etc.) all return the 200 SPA 404 shell, not redirects.
- **`js()` helper gotchas** — single-expression only; IIFEs and arrays-of-objects come back as `None`; empty arrays also surface as `None`; screenshots are DPR 2 while `click_at_xy` uses CSS pixels.
- **Record-setting flow** — Dynadot DNS vs Custom Nameservers, save, verify.
- **Shell verification** — `dig`/`whois` (no login needed).
- **Trap log** — including the 🟢 tab-title marker and the isolated-profile warning.

No secrets, coordinates, or task narration — just the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Dynadot DNS editing skill with a durable site map and clear steps to update records. This reduces discovery time and avoids auth and harness pitfalls.

- **New Features**
  - Auth/session prerequisites for using a logged-in Chrome; do not type credentials.
  - Notes that no Dynadot API key is provided; prefer the API if a key exists.
  - Navigation map for the Vue SPA: guessed login URLs 404; how to reach DNS via the domain manager.
  - Harness `js()` quirks: single-expression only; arrays of objects and empty arrays return `None`; DPR 2 screenshots vs CSS-pixel clicks.
  - Record flow: choose Dynadot DNS vs Custom Nameservers, add/edit rows, save, verify.
  - Shell verification with `dig`/`whois`; trap log includes tab-title emoji and isolated-profile warning.

<sup>Written for commit 06aaa45d5b40eff2fd61a5bc1a151bab2b4fd76f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

