### PR TITLE
Add stirrup dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,14 @@ uv.lock
 *.egg-info/
 .idea/
 .claude/
+.DS_Store
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+dist/
+build/
+coverage/
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "browser-harness"
 version = "0.1.0"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "cdp-use==1.4.5",
     "fetch-use==0.4.0",
-    "pillow==12.2.0",
+    "pillow>=10.4.0,<12.0",
     "websockets==15.0.1",
+    "stirrup>=0.1.9",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pillow>=10.4.0,<12.0",
     "websockets==15.0.1",
     "stirrup>=0.1.9",
+    "ace-framework>=0.12.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Adds the stirrup dependency and ignores local development artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `stirrup` and `ace-framework` to enable agent integration and bump Python to 3.12. Relax `pillow` version to avoid transitive conflicts and expand `.gitignore` for local artifacts.

- **Dependencies**
  - Add `stirrup>=0.1.9` and `ace-framework>=0.12.0`.
  - Require Python `>=3.12`.
  - Set `pillow` to `>=10.4.0,<12.0` to avoid `moviepy` conflict.

- **Migration**
  - Use Python 3.12+ and recreate your virtualenv.
  - Reinstall dependencies (regenerate lockfile if applicable).

<sup>Written for commit 0b3e2af7dc979cf1a87020e82461d29e874bb8a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

