### PR TITLE
Add plugin manifest and skill for agent marketplaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "browser-harness",
+  "description": "Install browser-harness directly from this repo.",
+  "owner": {
+    "name": "Browser Use",
+    "url": "https://browser-use.com"
+  },
+  "plugins": [
+    {
+      "name": "browser-harness",
+      "description": "Direct CDP browser control for agents: coordinate clicks, screenshots, persistent Python session, local Chrome or Browser Use cloud. Ships skills only; the `browser-harness` CLI is a one-time install prerequisite.",
+      "category": "automation",
+      "source": ".",
+      "homepage": "https://github.com/browser-use/browser-harness",
+      "keywords": [
+        "browser",
+        "automation",
+        "cdp",
+        "chrome",
+        "scraping",
+        "screenshot"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "browser-harness",
+  "version": "0.1.0",
+  "description": "Direct browser control via CDP. Drives the user's real Chrome (or a Browser Use cloud browser) with coordinate clicks, screenshots, and Python helpers — no selector hunting. Requires the one-time `browser-harness` CLI install (see the skill's references/install.md).",
+  "author": {
+    "name": "Browser Use",
+    "url": "https://browser-use.com"
+  },
+  "homepage": "https://github.com/browser-use/browser-harness",
+  "repository": "https://github.com/browser-use/browser-harness",
+  "license": "MIT",
+  "keywords": ["browser", "automation", "cdp", "chrome", "scraping", "screenshot", "browser-use", "browser-harness"]
+}

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "browser-harness",
+  "description": "Install browser-harness directly from this repo.",
+  "owner": { "name": "Browser Use", "url": "https://browser-use.com" },
+  "plugins": [
+    {
+      "name": "browser-harness",
+      "description": "Direct CDP browser control for agents: coordinate clicks, screenshots, persistent Python session, local Chrome or Browser Use cloud. Ships skills only; the `browser-harness` CLI is a one-time install prerequisite.",
+      "category": "automation",
+      "source": { "type": "local", "path": "." },
+      "homepage": "https://github.com/browser-use/browser-harness",
+      "keywords": ["browser", "automation", "cdp", "chrome", "scraping", "screenshot"]
+    }
+  ]
+}

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "browser-harness",
+  "version": "0.1.0",
+  "description": "Direct browser control via CDP. Drives the user's real Chrome (or a Browser Use cloud browser) with coordinate clicks, screenshots, and Python helpers — no selector hunting. Requires the one-time `browser-harness` CLI install (see the skill's references/install.md).",
+  "author": {
+    "name": "Browser Use",
+    "url": "https://browser-use.com"
+  },
+  "homepage": "https://github.com/browser-use/browser-harness",
+  "repository": "https://github.com/browser-use/browser-harness",
+  "license": "MIT",
+  "keywords": ["browser", "automation", "cdp", "chrome", "scraping", "screenshot", "browser-use", "browser-harness"]
+}

--- a/skills/browser-harness/SKILL.md
+++ b/skills/browser-harness/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: browser-harness
+description: Direct browser control via CDP — automate, scrape, test, or interact with web pages by driving the user's already-running Chrome (or a Browser Use cloud browser). Use when the user wants to click, screenshot, fill forms, extract data, or navigate real web pages. Default to screenshots + coordinate clicks, not selector hunting. Requires the one-time `browser-harness` CLI install (see references/install.md).
+---
+
+# browser-harness
+
+Direct browser control via CDP. You drive the user's real browser with Python helpers run through the `browser-harness` command.
+
+## Prerequisite (one-time — NOT part of the AI workflow)
+
+This skill is instructions only. It assumes the `browser-harness` command is already on `$PATH`. If `command -v browser-harness` fails, do the one-time install in [references/install.md](references/install.md) first, then continue. Installation and browser-connection setup are a prerequisite; once `browser-harness <<'PY' … PY` prints page info, never run install/connection steps again as part of normal work.
+
+## Usage
+
+```bash
+browser-harness <<'PY'
+new_tab("https://docs.browser-use.com")
+wait_for_load()
+print(page_info())
+PY
+```
+
+- Invoke as `browser-harness` — it's on `$PATH` after install. No `cd`, no `uv run`.
+- Use the heredoc form for every multi-line command. It prevents shell quote mangling inside Python strings and JavaScript snippets.
+- First navigation is `new_tab(url)`, not `goto_url(url)` — goto runs in the user's active tab and clobbers their work.
+- Helpers are pre-imported and the daemon auto-starts; you never start/stop it manually unless you want to.
+
+## What actually works
+
+- **Screenshots first.** `capture_screenshot()` to understand the page, find visible targets, and decide whether you need a click, a selector, or more navigation.
+- **Clicking.** `capture_screenshot()` → read the pixel off the image → `click_at_xy(x, y)` → `capture_screenshot()` to verify. Suppress the Playwright-habit reflex of "locate first, then click" — no `getBoundingClientRect`, no selector hunt. Drop to DOM only when the target has no visible geometry. Hit-testing happens in Chrome's browser process, so clicks pass through iframes / shadow DOM / cross-origin without extra work.
+- **Bulk HTTP.** `http_get(url)` + `ThreadPoolExecutor`. No browser needed for static pages.
+- **After goto:** `wait_for_load()`.
+- **Wrong/stale tab:** `ensure_real_tab()`.
+- **Verification:** `print(page_info())` is the simplest "is this alive?" check; screenshots are the default way to verify whether a visible action worked.
+- **DOM reads:** use `js(...)` for inspection/extraction when a screenshot shows coordinates are the wrong tool.
+- **Auth wall:** redirected to login → stop and ask the user. Don't type credentials from screenshots.
+- **Raw CDP** for anything helpers don't cover: `cdp("Domain.method", params)`.
+
+After every meaningful action, re-screenshot before assuming it worked.
+
+## Remote / cloud browsers
+
+Use remote for parallel sub-agents (each gets an isolated browser via a distinct `BU_NAME`) or on a headless server. `BROWSER_USE_API_KEY` must be set.
+
+```bash
+browser-harness <<'PY'
+start_remote_daemon("work")   # clean cloud browser; profileName=/profileId= to reuse a logged-in profile
+PY
+
+BU_NAME=work browser-harness <<'PY'
+new_tab("https://example.com")
+print(page_info())
+PY
+```
+
+`start_remote_daemon` prints a `liveUrl` so the user can watch. Running remote daemons bill until timeout.
+
+## Interaction skills (progressive disclosure)
+
+If you struggle with a specific UI mechanic, read the matching file under `${CLAUDE_PLUGIN_ROOT}/interaction-skills/` before inventing an approach. Available: browser-wall, connection, cookies, cross-origin-iframes, dialogs, downloads, drag-and-drop, dropdowns, iframes, network-requests, print-as-pdf, profile-sync, screenshots, scrolling, shadow-dom, tabs, uploads, viewport.
+
+## Task-specific edits
+
+For task-specific helper additions, edit `${CLAUDE_PLUGIN_ROOT}/agent-workspace/agent_helpers.py`. Keep core helpers short.
+
+## Domain skills (opt-in)
+
+Community per-site playbooks live in `${CLAUDE_PLUGIN_ROOT}/agent-workspace/domain-skills/<host>/` and are **off by default**. Set `BH_DOMAIN_SKILLS=1` to enable them; when enabled and the task is site-specific, read every file in the matching `<site>/` directory before inventing an approach.
+
+## Design constraints
+
+- Coordinate clicks default. `Input.dispatchMouseEvent` goes through iframes/shadow/cross-origin at the compositor level.
+- Connect to the user's running Chrome. Don't launch your own browser.
+- Prefer compositor-level actions (screenshots, coordinate clicks, raw key input) over framework/DOM hacks. Reach for `interaction-skills/` only when those are the wrong tool.

--- a/skills/browser-harness/references/install.md
+++ b/skills/browser-harness/references/install.md
@@ -1,0 +1,35 @@
+# browser-harness CLI — one-time install prerequisite
+
+This is a **one-time prerequisite**, not part of the regular AI workflow. Do it once; after `browser-harness` prints page info, never repeat install/connection steps during normal browser work.
+
+## Install the command
+
+```bash
+git clone https://github.com/browser-use/browser-harness
+cd browser-harness
+uv tool install -e .
+command -v browser-harness   # should print a path
+```
+
+Editable (`-e`) keeps the command global while pointing at the real checkout, so edits to `agent-workspace/agent_helpers.py` take effect on the next call. Prefer a durable path (e.g. `~/Developer/browser-harness`), not `/tmp`.
+
+## Connect to a browser
+
+`browser-harness` attaches to a Chrome you already have running, or to a Browser Use cloud browser. Quick check:
+
+```bash
+browser-harness <<'PY'
+print(page_info())
+PY
+```
+
+If that prints page info, you're done. If not, run `browser-harness --doctor` and follow the connection cases. The two connection methods:
+
+- **Way 1 (real profile):** in your Chrome, open `chrome://inspect/#remote-debugging` and tick "Allow remote debugging for this browser instance" (sticky, per-profile). On Chrome 144+, click Allow on the first-attach popup. Inherits your logins/extensions — best when the agent acts in your everyday browser.
+- **Way 2 (isolated profile, no popups):** launch Chrome with `--remote-debugging-port=9222 --user-data-dir=<non-default path>`, then set `BU_CDP_URL=http://127.0.0.1:9222`. Best for unattended automation.
+
+The canonical, fully-detailed connection reference and troubleshooting live in the repo root's `install.md`. Read it if the quick path above fails.
+
+## Keeping current
+
+`browser-harness` prints an update banner when a newer release exists; run `browser-harness --update -y` to pull it.


### PR DESCRIPTION
Makes browser-harness the canonical, no-drift source of its own plugin. The `browser-use/plugins` marketplace remote-sources this repo (pinned to a SHA) rather than vendoring a copy. Additive only: `.grok-plugin/`, `.claude-plugin/`, `skills/browser-harness/`. The skill references this repo's existing `interaction-skills/` and `agent-workspace/` via `${CLAUDE_PLUGIN_ROOT}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude and Grok marketplace manifests and a first-class `browser-harness` skill, making this repo the canonical source for agent marketplaces. Ships skill docs and an install guide; the CLI stays a one-time prerequisite.

- **New Features**
  - Added `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
  - Added `.grok-plugin/plugin.json` and `.grok-plugin/marketplace.json`.
  - Added `skills/browser-harness/SKILL.md` and `skills/browser-harness/references/install.md` (skill references `${CLAUDE_PLUGIN_ROOT}/interaction-skills/` and `/agent-workspace/`).

- **Migration**
  - Marketplaces should remote-source this repo and pin to a SHA instead of vendoring.
  - Users must install the `browser-harness` CLI once; the plugin provides skills only.

<sup>Written for commit 2baa4a25131f5aa1df1b09ca08e4e09a7d731bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

