### PR TITLE
README: add Claude Code plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Click Allow when the per-attach popup appears (Chrome 144+):
 
 See [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for example tasks.
 
+## Install as a Claude Code plugin
+
+browser-harness is also available from the Browser Use plugin marketplace for Claude Code:
+
+```bash
+claude plugin marketplace add browser-use/plugins
+claude plugin install browser-harness@browser-use
+```
+
+This installs the browser-harness skill into Claude Code. The harness CLI itself is a one-time install prerequisite — the skill walks you through it (clone + `uv tool install`, then connect to your browser) on first use.
+
 ## Free Browser Use Cloud browsers
 
 Stealth, sub-agents, or headless deployment.<br>


### PR DESCRIPTION
Adds an "Install as a Claude Code plugin" section documenting:

```
claude plugin marketplace add browser-use/plugins
claude plugin install browser-harness@browser-use
```

Sits right after the existing setup-prompt section. Verified end-to-end on a fresh Linux container (plugin installs over HTTPS, the CLI prerequisite installs, and Claude drives the browser via the skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an “Install as a Claude Code plugin” section to the README that shows how to install `browser-harness` from the `browser-use/plugins` marketplace using the `claude` CLI. It also notes the one-time harness CLI prerequisite that the skill guides you through on first use.

<sup>Written for commit d7b07b23ac470a273478d3afe611c74d156e25b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

