### PR TITLE
docs(domain-skills): reddit .json now 403s anonymously; add afedmonton exam-selector

### DIFF
--- a/agent-workspace/domain-skills/afedmonton/exam-selector.md
+++ b/agent-workspace/domain-skills/afedmonton/exam-selector.md
@@ -1,0 +1,176 @@
+# AF Edmonton — `/af/exam-selector/` exam catalog (Oncord CMS S8)
+
+The Alliance Française d'Edmonton booking system runs on **Oncord CMS**.
+`https://www.afedmonton.com/af/exam-selector/` is the public catalog
+listing every upcoming TCF/TEF/DELF/Evalang exam session with structured
+columns. **No auth, no cookies, no AJAX required to read it** — the HTML
+is server-rendered with all session data inline.
+
+> Note: `afedmonton.ca` and `afedmonton.com` are the same site; `.ca` is a
+> redirect alias. Internal links and form actions normalise to `.com`.
+
+## Endpoint
+
+```
+GET https://www.afedmonton.com/af/exam-selector/
+```
+
+Returns ~97KB HTML. The exam table lives at `table#s8-datatable1` with
+columns:
+
+| Col | Header             | Meaning                                            |
+|-----|--------------------|----------------------------------------------------|
+| 0   | Exam               | "TCF Canada - July 13", "TEF Canada - July 10", … |
+| 1   | Schedules          | Written + Oral session dates and times             |
+| 2   | Registration Dates | reg-open START — reg-close END (a `<br>` separator) |
+| 3   | Location           | Always "Alliance Française of Edmonton - Kingsway" |
+| 4   | Spots left         | Integer, "SOLD OUT!", or "—" before opening        |
+| 5   | Price              | e.g. "$400.00"                                     |
+| 6   | Bookings           | "Open" (clickable Book button) / "Closed" / "—"    |
+
+Asterisk suffix on exam name (e.g. `July 13*`) marks afternoon sessions.
+
+## The cap
+
+The server returns at most **15 rows per request**. `s8-datatable1_rows`
+beyond 15 is silently capped. Pagination via `s8-datatable1_start=15/30/…`
+on a plain GET is **ignored**; the server-side state is set via the
+filter AJAX (see below). For monitoring purposes the 15-row cap rarely
+matters because AF Edmonton typically only has one season's batch active
+at a time (e.g. 8 TCF + 7 TEF for July 2026, all in view).
+
+## Filter AJAX (when you need >15 rows or specific filters)
+
+The filter form posts to a generic Oncord AJAX gateway:
+
+```
+POST https://www.afedmonton.com/_public/Framework/HTTP/AJAX/server.php
+Content-Type: application/x-www-form-urlencoded;charset=UTF-8
+Referer: https://www.afedmonton.com/af/exam-selector/
+X-Requested-With: XMLHttpRequest
+
+_ajaxsenderid=
+_ajaxevent=change
+_ajaxeventid=exam_filter_ajax_event
+_ajaxeventparameter=undefined
+_ajaxjs=<js1>|<js2>
+_ajaxcss=|<css>
+_ajaxurl=/af/exam-selector/
+s8-datatable1_rows=15
+s8-datatable1_start=0
+exam_type_filter_combobox=any|tcf|tef|delf|delf-adults|delf-junior|delf-prim|evalang
+exam_year_filter_combobox=any|2026|2027|…
+exam_location_filter_combobox=any
+exam_filter_form=submit
+exam_filter_form_csrf_token=<from initial GET>
+```
+
+Get `js1`, `js2`, `css` cache-bust IDs by regex-extracting from the prime
+GET response:
+```python
+js1, js2 = re.findall(r"JavaScript/server\.php\?js=(\d+)", html)[:2]
+css = re.search(r"css=(\d+)", html).group(1)
+```
+
+`csrf_token` comes from `input[name="exam_filter_form_csrf_token"]`.
+
+**Response:** `text/plain` but the body is JS source. The new table HTML
+is embedded as a string literal assigned to `.innerHTML`. Extract with:
+```python
+m = re.search(r"\.innerHTML\s*=\s*'((?:[^'\\]|\\.)*)'", resp_body, re.S)
+html_frag = m.group(1).replace(r"\/","/").replace(r"\'","'").replace(r"\n","\n")
+```
+
+The combobox value names — observed valid choices for `exam_type_filter_combobox`:
+- `any`, `tcf`, `tef`, `delf`, `delf-adults`, `delf-junior`, `delf-prim`, `evalang`
+
+## Booking intake
+
+Each row's "Book" button submits to:
+```
+POST /af/exam-selector/order/?exam_id=<N>
+```
+`exam_id` is a small integer (saw `exam_id=20` for one July 2026 TCF row).
+Don't actually submit unless you intend to enter the checkout flow.
+
+## Why this beats sitemap.xml for monitoring new spots
+
+`sitemap.xml` only tells you a URL appeared / `<lastmod>` updated. It
+doesn't tell you *whether spots are open*. The exam-selector table is
+the authoritative per-session signal:
+
+- **New row appearing** → admin scheduled a session (also surfaces in
+  sitemap eventually, but here you see structured row data immediately).
+- **Bookings column flipping `Closed` → `Open`** → registration window
+  opened. This is the moment that matters.
+- **Spots-left column flipping** `SOLD OUT!` → integer, or integer
+  decreasing — actionable seat changes.
+- **Row disappearing** → session pulled.
+
+Suggested monitor schema (rows keyed by exam name):
+```
+key:        normalized exam name (e.g. "tcf-canada-july-13")
+fields:     spots_left, booking_status, reg_open_ts, reg_close_ts, price, schedule
+events:     NEW_ROW | BOOKING_OPEN | SPOTS_DELTA | SOLD_OUT | GONE
+```
+
+## Other endpoints under `/_public/`
+
+Discovered but not deeply probed:
+
+- `/_public/Framework/Assets/JavaScript/server.php?js=<hash>` — bundled JS
+- `/_public/Framework/Assets/CSS/server.php?css=<hash>` — bundled CSS
+- `/_public/Framework/I18N/Addresses/address_layouts.json` — JSON of
+  address form layouts per country. The only true JSON endpoint exposed.
+- `/_public/Components/Website/_keepalive` — session keepalive ping
+- `/_public/Components/Website/t.php` — analytics tracker
+- `/_public/Controls/Data/DataControlABC/datacontrol.php` — generic data
+  control AJAX endpoint (Oncord internal)
+- `/_public/Controls/Forms/DialogBox/dialogbox.php` — dialog control
+
+## Anti-traps
+
+- **`/af/exam-selector/?exam_type_filter_combobox=tcf` does not filter
+  via GET.** The combobox values only take effect via POST with CSRF.
+- **`s8-datatable1_rows` > 15 is silently capped.** Don't bother asking
+  for more — paginate via `s8-datatable1_start`.
+- **Schedule column has embedded `<br>` and "▸"**. Be lenient parsing.
+- **Registration Dates uses `-` separator**, but the range may also
+  contain `-` in the date text — split on `\s+-\s+` not just `-`.
+- **`*` suffix** on exam name distinguishes afternoon sessions; don't
+  treat as wildcard or trim it.
+- **`SOLD OUT!`** is a literal string (with exclamation mark) in the
+  Spots column, not "Sold Out" or "0".
+
+## Minimal scraper
+
+```python
+import re, httpx
+from bs4 import BeautifulSoup
+
+UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/127.0.0.0 Safari/537.36"
+
+def fetch_sessions():
+    with httpx.Client(headers={"User-Agent": UA}, timeout=20) as c:
+        r = c.get("https://www.afedmonton.com/af/exam-selector/")
+    s = BeautifulSoup(r.text, "html.parser")
+    out = []
+    for tr in s.select("table tr"):
+        if tr.find("th"):
+            continue
+        cells = [td.get_text(" ", strip=True) for td in tr.find_all("td")]
+        if not cells or len(cells) < 7:
+            continue
+        name, schedule, regwin, location, spots, price, booking = cells[:7]
+        reg_start, reg_end = (None, None)
+        m = re.match(r"(.+?)\s+-\s+(.+)", regwin)
+        if m:
+            reg_start, reg_end = m.group(1).strip(), m.group(2).strip()
+        out.append({
+            "name": name, "schedule": schedule,
+            "reg_start": reg_start, "reg_end": reg_end,
+            "location": location, "spots_left": spots,
+            "price": price, "booking": booking,
+        })
+    return out
+```

--- a/agent-workspace/domain-skills/reddit/scraping.md
+++ b/agent-workspace/domain-skills/reddit/scraping.md
@@ -2,7 +2,7 @@
 
 Reddit's "new" web UI (`reddit.com`) is a Lit / web-components SPA built around custom elements (`shreddit-post`, `shreddit-comment`, `faceplate-*`). This makes DOM extraction unusually reliable — the custom element tags are stable and exposed on the element itself (no hashed class names).
 
-Use the browser when you're logged in (private subreddits, NSFW gates, rate-limit avoidance). For fully public content, the JSON API path below is faster.
+Use the browser when you're logged in (private subreddits, NSFW gates, rate-limit avoidance). **As of 2026 the browser DOM path is also the only reliable path for anonymous public content** — Reddit now hard-blocks the `.json` API for anonymous clients (see Path 1).
 
 ## URL patterns
 
@@ -11,24 +11,39 @@ Use the browser when you're logged in (private subreddits, NSFW gates, rate-limi
 - Old Reddit: append `/.json` to any post URL for anonymous JSON: `https://www.reddit.com/r/<sub>/comments/<id>/.json`.
 - Old UI (simpler DOM, no web components): `https://old.reddit.com/r/<sub>/comments/<id>/` — useful fallback when `shreddit-*` selectors change.
 
-## Path 1: JSON API (fastest for public posts)
+## Path 1: JSON API — ⚠️ DEAD for anonymous clients (2026)
+
+The old `append /.json` trick **no longer works anonymously**. Reddit returns **HTTP 403** with a block page (`"You've been blocked by network security. To continue, log in to your Reddit account or use your developer token"`) for `www.reddit.com/.../​.json` and `old.reddit.com/.../​.json` alike. Confirmed dead even with:
+
+- A real browser User-Agent or unique descriptive UA
+- Full browser request headers (Accept, Referer, etc.)
+- `curl_cffi` Chrome/Safari **TLS impersonation** (still 403 — it's not just a TLS-fingerprint check)
+- Fresh **residential proxy** IPs (the IP isn't the trip — the *endpoint* is gated)
+
+The block is endpoint-level: Reddit wants OAuth (a developer token) or a logged-in session for the JSON API. So for anonymous scraping there are two live options:
+
+1. **Browser DOM extraction** (Path 2) — works anonymously. From a datacenter IP you still need a residential proxy *and* a real browser (see the headless+proxy recipe below); the fingerprint and IP must both look human.
+2. **Official OAuth API** — register a script app at `reddit.com/prefs/apps`, get `client_id`/`secret`, exchange for a bearer token, then hit `https://oauth.reddit.com/r/<sub>/new?limit=...` with `Authorization: bearer <token>` + a unique UA. Supported, ~100 QPM free, works from datacenter IPs.
+
+### Headless browser + residential proxy (cron-friendly, no GUI)
+
+What revived a server-side bot (Playwright Chromium through an IPRoyal residential proxy). A datacenter-IP browser alone gets the same 403 block page; the residential proxy is what gets you past the network wall.
 
 ```python
-from helpers import http_get
-import json
-
-url = "https://www.reddit.com/r/cursor/comments/1l0u9y7/claude_code_prompt_to_autogenerate_full_cursor/.json"
-data = json.loads(http_get(url, headers={"User-Agent": "Mozilla/5.0"}))
-post = data[0]["data"]["children"][0]["data"]
-# post fields: title, selftext, author, score, num_comments, created_utc, url, permalink
-comments = data[1]["data"]["children"]  # list of { kind: "t1", data: {...} } or { kind: "more" }
+from playwright.sync_api import sync_playwright
+UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+with sync_playwright() as p:
+    b = p.chromium.launch(headless=True, args=["--no-sandbox"],
+        proxy={"server": "http://geo.iproyal.com:12321", "username": "<user>", "password": "<pass>"})
+    ctx = b.new_context(user_agent=UA, locale="en-US", viewport={"width": 1280, "height": 1400})
+    pg = ctx.new_page()
+    pg.goto("https://www.reddit.com/r/<sub>/new/", wait_until="domcontentloaded", timeout=45000)
+    pg.wait_for_timeout(3500)  # SPA hydration
+    blocked = pg.evaluate("document.body.innerText.indexOf('blocked by network security') >= 0")
+    posts = pg.evaluate("document.querySelectorAll('shreddit-post').length")  # 0 + blocked => bad proxy, rotate
 ```
 
-Fails on:
-
-- Private / quarantined subreddits (401)
-- NSFW posts without an authenticated session
-- Anti-scraping 429s under load — back off or switch to the browser path
+Probe each proxy session by checking `blocked` / `shreddit-post count`, and rotate to the next session on failure. `pip install playwright` then `python -m playwright install chromium` — note Playwright pins an exact build revision; a version bump that isn't followed by `playwright install` leaves the browser binary missing (`Executable doesn't exist at .../chromium_headless_shell-<rev>`).
 
 ## Path 2: Browser DOM extraction (logged-in)
 
@@ -87,6 +102,23 @@ PY
 | Top-level comment      | `shreddit-comment[depth="0"]`                                         | Depth is an attribute — `depth="1"` is a reply, etc.                                                    |
 | Comment body           | `shreddit-comment [slot="comment"] .md`                               | Same pattern as post body.                                                                              |
 | Comment author / score | `shreddit-comment` attributes: `author`, `score`, `created-timestamp` | Use `getAttribute`, not DOM descendants.                                                                |
+
+### Feed / listing extraction (`/r/<sub>/new/`, `/hot/`, etc.)
+
+The feed renders one `<shreddit-post>` per card with everything you need as **attributes** (no detail-page visit required for a listing digest):
+
+| Attribute            | Example                                    |
+| -------------------- | ------------------------------------------ |
+| `id`                 | `t3_1ts8jb7` (strip `t3_` for the bare id) |
+| `post-title`         | `Kids sports or summer camp?`              |
+| `permalink`          | `/r/ThunderBay/comments/1ts8jb7/.../`      |
+| `score`              | `5` (exact, not abbreviated)               |
+| `comment-count`      | `2`                                        |
+| `created-timestamp`  | `2026-05-30T19:08:22.655000+0000`          |
+| `post-type`          | `text` / `image` / `link`                  |
+| `author`             | `Double-Control7332`                       |
+
+`/new/` is newest-first and lazy-loads on scroll — `page.mouse.wheel(0, 24000)` + wait, looping until the oldest loaded `created-timestamp` passes your time window. Parse the timestamp by normalizing `+0000`→`+00:00` then `datetime.fromisoformat`. Promoted/ad cards may carry a `promoted` attribute or lack a `t3_` id — filter those out.
 
 ### Share links
 


### PR DESCRIPTION
Two domain-skill updates from field work, contributed back per the harness's "always contribute back" guidance.

## `reddit/scraping.md` — `.json` API is dead for anonymous clients (2026)
The classic *append `/.json`* trick now returns **HTTP 403** with a network-security block page for anonymous clients on both `www.reddit.com` and `old.reddit.com`. Verified it's **endpoint-level**, not a fingerprint/IP check — still 403 with a real browser UA, full headers, `curl_cffi` Chrome/Safari TLS impersonation, and fresh residential-proxy IPs.

Documents the two live anonymous paths:
- **Headless Chromium + residential proxy** (cron-friendly recipe, with a `blocked` / `shreddit-post`-count probe to rotate bad proxy sessions, and the Playwright `playwright install` pinned-revision gotcha).
- **Official OAuth API** (`oauth.reddit.com` + bearer token) as the datacenter-IP alternative.

Plus a feed/listing attribute table (`<shreddit-post>` exposes `id` / `post-title` / `permalink` / … as attributes — no detail-page visit needed for a listing digest).

## `afedmonton/exam-selector.md` — new skill
Alliance Française d'Edmonton booking catalog (`/af/exam-selector/`, Oncord CMS S8). Covers:
- The server-rendered exam table (`table#s8-datatable1`) and its column semantics.
- The **15-row cap** and why GET-param pagination/filtering is silently ignored.
- The filter **AJAX gateway** (`_public/Framework/HTTP/AJAX/server.php`) — payload shape, cache-bust IDs, CSRF token sourcing, and how the response body is JS with the new table HTML as a string literal.
- Booking intake endpoint, a suggested monitor schema, anti-traps, and a minimal `httpx` + `bs4` scraper.

Docs-only; no secrets or user-specific state (proxy creds are placeholders, CSRF/UA values are obtained at runtime).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs update: Reddit `/.json` now returns 403 for anonymous clients; added the working paths (headless Chromium + residential proxy, or OAuth) and a feed `<shreddit-post>` attribute map. Added `afedmonton/exam-selector` skill for the Oncord exam catalog with the 15-row cap, filter AJAX (CSRF + cache-bust ids), booking endpoint, and a minimal scraper.

<sup>Written for commit 1a77d23bc43ff6f783c81514f506eead1f448adb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

