### PR TITLE
docs: add translated README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 # Browser Harness ♞
 
+<!-- Keep these links, translations synced daily. -->
+
+[Deutsch](https://zdoc.app/de/browser-use/browser-harness) |
+[Español](https://zdoc.app/es/browser-use/browser-harness) |
+[français](https://zdoc.app/fr/browser-use/browser-harness) |
+[日本語](https://zdoc.app/ja/browser-use/browser-harness) |
+[한국어](https://zdoc.app/ko/browser-use/browser-harness) |
+[Português](https://zdoc.app/pt/browser-use/browser-harness) |
+[Русский](https://zdoc.app/ru/browser-use/browser-harness) |
+[中文](https://zdoc.app/zh/browser-use/browser-harness)
+
 Connect an LLM directly to your real browser with a thin, editable CDP harness. For browser tasks where you need **complete freedom**.
 
 One websocket to Chrome, nothing between. The agent writes what's missing during execution. The harness improves itself every run.


### PR DESCRIPTION
This PR adds links to translated versions of the README to help non-English-speaking users access translated documentation.

Supported languages:

- German
- Spanish
- French
- Japanese
- Korean
- Portuguese
- Russian
- Chinese

Translations are automatically synchronized and require no maintenance effort from project maintainers.

This change only affects README documentation and does not modify project code, dependencies, CI workflows, or repository settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added translated README links for German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese to make the docs more accessible. Links sync daily and this is docs-only (no code, CI, or dependency changes).

<sup>Written for commit ec4de1324d2a5a3b9018971c9fa51693e6401c7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

