### PR TITLE
local Chrome connect: classify state, defer marker tab, stay in selected profile

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,6 +25,12 @@ PY
 - Use the heredoc form for every multi-line command. It prevents shell quote mangling inside Python strings and JavaScript snippets.
 - First navigation is new_tab(url), not goto_url(url) — goto runs in the user's active tab and clobbers their work.
 
+## Local profiles
+
+When multiple local Chrome profiles exist, do not choose one yourself. Run `browser-harness local-profiles` and `browser-harness default-profile`. If no default is configured, ask the user which listed profile to use before any page work. Only run `browser-harness default-profile --profile <id-or-name>` after the user explicitly names or confirms the profile.
+
+Once a default is configured, startup opens a temporary marker tab in that profile, waits for the marker target over CDP, attaches to it to capture the Chrome `browserContextId`, then the first `new_tab()` opens the task tab in that same context and closes the marker tab. That task tab remains the controlled target across later commands. Future `new_tab()` calls stay pinned to that context, stale context ids are reacquired with a new marker, and target switches into a different profile context are refused.
+
 ## Tool call shape
 
 ```bash

--- a/skills/browser-harness/SKILL.md
+++ b/skills/browser-harness/SKILL.md
@@ -26,6 +26,19 @@ PY
 - First navigation is `new_tab(url)`, not `goto_url(url)` — goto runs in the user's active tab and clobbers their work.
 - Helpers are pre-imported and the daemon auto-starts; you never start/stop it manually unless you want to.
 
+## Target a Specific Local Profile
+
+When multiple local Chrome profiles exist, do not choose one yourself. Run:
+
+```bash
+browser-harness local-profiles
+browser-harness default-profile
+```
+
+If `default-profile` says no default is configured, show the profile list to the user and ask which profile to use before running any page work. Only run `browser-harness default-profile --profile <id-or-name>` after the user explicitly names or confirms the profile. If a default already exists, use it unless the user asks to switch.
+
+After a default is configured, normal startup handles profile targeting in code: it opens a temporary marker tab in the selected profile, waits for that marker target over CDP, attaches to it to capture the Chrome `browserContextId`, then the first `new_tab()` opens the task tab in that same context and closes the marker tab. That task tab remains the controlled target across later commands. Future `new_tab()` calls stay pinned to that context, stale context ids are reacquired with a new marker, and switches to targets from another profile context are refused.
+
 ## What actually works
 
 - **Screenshots first.** `capture_screenshot()` to understand the page, find visible targets, and decide whether you need a click, a selector, or more navigation.

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -141,7 +141,11 @@ def _needs_chrome_remote_debugging_prompt(msg):
     """True when Chrome needs the inspect-page permission/profile flow."""
     lower = (msg or "").lower()
     return (
-        "devtoolsactiveport not found" in lower
+        # state tokens from browser.py's connection classifier
+        "permission-blocked" in lower
+        or "cdp-disabled" in lower
+        or "browser-closed" in lower
+        or "devtoolsactiveport not found" in lower
         or "enable chrome://inspect" in lower
         or "not live yet" in lower
         or (
@@ -153,6 +157,32 @@ def _needs_chrome_remote_debugging_prompt(msg):
                 or "timeout" in lower
             )
         )
+    )
+
+
+def _configured_profile_remote_debugging_enabled():
+    try:
+        from .browser import configured_profile_remote_debugging_enabled
+        return configured_profile_remote_debugging_enabled()
+    except Exception:
+        return None
+
+
+def _focus_configured_profile():
+    try:
+        from .browser import open_configured_profile
+        return open_configured_profile()
+    except Exception:
+        return None
+
+
+def _permission_blocked(msg):
+    lower = (msg or "").lower()
+    return (
+        "permission-blocked" in lower
+        or "403" in lower
+        or "forbidden" in lower
+        or "server rejected websocket connection" in lower
     )
 
 
@@ -298,15 +328,23 @@ def run_doctor_fix_snap():
 def ensure_daemon(wait=60.0, name=None, env=None):
     """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
-        # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
-        # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
+        # Warm startup must not re-probe Chrome with fresh CDP command
+        
         # Must go through ipc.connect so this works on Windows (TCP loopback) too;
         # raw AF_UNIX here would fail on every warm call and churn the daemon.
+        s = None
         try:
             s, token = ipc.connect(name or NAME, timeout=3.0)
-            resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
-            if "result" in resp: return
+            capabilities = ipc.request(s, token, {"meta": "capabilities"}).get("capabilities", [])
+            if "create_target" in capabilities and "verify_profile" in capabilities:
+                # Re-anchor to the selected profile before the command runs. This
+                # is in-daemon over the existing websocket, so it won't re-prompt
+                ipc.request(s, token, {"meta": "verify_profile"})
+                return
         except Exception: pass
+        finally:
+            if s:
+                s.close()
         restart_daemon(name)
 
     import subprocess, sys
@@ -324,8 +362,31 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             time.sleep(0.2)
         msg = _log_tail(name) or ""
         if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
-            _open_chrome_inspect()
-            print('browser-harness: at chrome://inspect/#remote-debugging, tick "Allow remote debugging for this browser instance" and click Allow on the popup that appears', file=sys.stderr)
+            if _permission_blocked(msg):
+                # 403 means endpoint exists but Chrome gating it behind
+                # "Allow remote debugging?" popup
+                # Focus the profile to surface
+                # the dialog and return a blocked state instead of looping setup.
+                _focus_configured_profile()
+                enabled = _configured_profile_remote_debugging_enabled()
+                detail = (
+                    "remote debugging is already enabled"
+                    if enabled is True
+                    else "remote debugging must be enabled for the connection to be rejected this way"
+                )
+                raise RuntimeError(
+                    "permission-blocked: Chrome rejected the CDP websocket with HTTP 403. "
+                    f"The selected profile is focused and {detail}; "
+                    "do not run setup or reload. Retry after the Chrome security dialog is accepted."
+                )
+            if "browser-closed" in msg.lower():
+                # No running Chrome to expose chrome://inspect, so open/focus the
+                # profile to give the user a window to enable debugging in.
+                _focus_configured_profile()
+                print('browser-harness: opened the selected Chrome profile — enable remote debugging at chrome://inspect/#remote-debugging, then retry', file=sys.stderr)
+            else:
+                _open_chrome_inspect()
+                print('browser-harness: at chrome://inspect/#remote-debugging, tick "Allow remote debugging for this browser instance" and click Allow on the popup that appears', file=sys.stderr)
             restart_daemon(name)
             continue
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
@@ -548,13 +609,14 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
 
 
 def list_local_profiles():
-    """Detected local browser profiles on this machine. Shells out to `profile-use list --json`.
-    Returns [{BrowserName, BrowserPath, ProfileName, ProfilePath, DisplayName}, ...].
-    Requires `profile-use` (see interaction-skills/profile-sync.md for install)."""
-    import json, shutil, subprocess
-    if not shutil.which("profile-use"):
-        raise RuntimeError("profile-use not installed -- curl -fsSL https://browser-use.com/profile.sh | sh")
-    return json.loads(subprocess.check_output(["profile-use", "list", "--json"], text=True))
+    """Detected local Chromium-family profiles on this machine.
+
+    Native Python port of terminal's filesystem detector: reads known browser
+    install/profile roots and Chrome's Local State profile names. Does not
+    require profile-use.
+    """
+    from .browser import list_local_profiles as _list_local_profiles
+    return _list_local_profiles()
 
 
 def sync_local_profile(profile_name, browser=None, cloud_profile_id=None,
@@ -738,13 +800,16 @@ def _open_chrome_inspect():
 
 def run_doctor():
     """Read-only diagnostics. Exit 0 iff everything looks healthy."""
-    import platform, shutil, sys
+    import platform, sys
     cur = _version()
     mode = _install_mode()
     chrome = _chrome_running()
     daemon = daemon_alive()
     connections = browser_connections()
-    profile_use = shutil.which("profile-use") is not None
+    try:
+        local_profiles = list_local_profiles()
+    except Exception:
+        local_profiles = []
     api_key = bool(os.environ.get("BROWSER_USE_API_KEY"))
     latest = _latest_release_tag()
     # Only claim an update when we know the installed version — `cur or "(unknown)"`
@@ -783,9 +848,9 @@ def run_doctor():
             print(f"        {conn['name']} — active page: {title} — {url}")
         else:
             print(f"        {conn['name']} — active page: (no real page)")
-    row("profile-use installed", profile_use, "" if profile_use else "optional: curl -fsSL https://browser-use.com/profile.sh | sh")
+    row("local profiles detected", bool(local_profiles), str(len(local_profiles)))
     row("BROWSER_USE_API_KEY set", api_key, "" if api_key else "optional: needed only for cloud browsers / profile sync")
-    # Core health = chrome + daemon. Profile-use/api-key are optional.
+    # Core health = chrome + daemon. Local profiles/api-key are optional.
     return 0 if (chrome and daemon) else 1
 
 

--- a/src/browser_harness/browser.py
+++ b/src/browser_harness/browser.py
@@ -1,0 +1,777 @@
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+from uuid import uuid4
+
+
+PROFILE_MARKER_URL_PREFIX = "https://browser-use.com/browser-use-profile-target/"
+PROFILE_ROOTS = [
+    Path.home() / "Library/Application Support/Google/Chrome",
+    Path.home() / "Library/Application Support/Google/Chrome Canary",
+    Path.home() / "Library/Application Support/Comet",
+    Path.home() / "Library/Application Support/Arc/User Data",
+    Path.home() / "Library/Application Support/Dia/User Data",
+    Path.home() / "Library/Application Support/Microsoft Edge",
+    Path.home() / "Library/Application Support/Microsoft Edge Beta",
+    Path.home() / "Library/Application Support/Microsoft Edge Dev",
+    Path.home() / "Library/Application Support/Microsoft Edge Canary",
+    Path.home() / "Library/Application Support/BraveSoftware/Brave-Browser",
+    Path.home() / ".config/google-chrome",
+    Path.home() / ".config/chromium",
+    Path.home() / ".config/chromium-browser",
+    Path.home() / ".config/microsoft-edge",
+    Path.home() / ".config/microsoft-edge-beta",
+    Path.home() / ".config/microsoft-edge-dev",
+    Path.home() / ".var/app/org.chromium.Chromium/config/chromium",
+    Path.home() / ".var/app/com.google.Chrome/config/google-chrome",
+    Path.home() / ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
+    Path.home() / ".var/app/com.microsoft.Edge/config/microsoft-edge",
+    Path.home() / "AppData/Local/Google/Chrome/User Data",
+    Path.home() / "AppData/Local/Google/Chrome SxS/User Data",
+    Path.home() / "AppData/Local/Chromium/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge Beta/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge Dev/User Data",
+    Path.home() / "AppData/Local/Microsoft/Edge SxS/User Data",
+    Path.home() / "AppData/Local/BraveSoftware/Brave-Browser/User Data",
+]
+
+
+@dataclass
+class ManagedBrowser:
+    process: subprocess.Popen
+    profile_dir: tempfile.TemporaryDirectory | None
+    marker_path: Path
+    persist: bool = False
+
+    def stop(self):
+        if self.persist:
+            return
+        if self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+        try:
+            self.marker_path.unlink()
+        except FileNotFoundError:
+            pass
+        if self.profile_dir is not None:
+            self.profile_dir.cleanup()
+
+
+@dataclass
+class BrowserEndpoint:
+    ws_url: str
+    http_url: str | None = None
+    kind: str = "cdp-ws"
+    managed: ManagedBrowser | None = None
+    target_marker: str | None = None
+    # Profile to open a marker tab in after the websocket connects. Deferred so a
+    # failed connection doesn't leave a stray tab in the user's Chrome.
+    marker_profile_id: str | None = None
+
+
+@dataclass
+class LocalBrowserInstall:
+    browser_name: str
+    browser_path: Path
+    user_data_dir: Path
+
+
+@dataclass
+class LocalBrowserProfile:
+    id: str
+    browser_name: str
+    browser_path: Path
+    user_data_dir: Path
+    profile_dir: str
+    profile_name: str
+    profile_path: Path
+    display_name: str
+
+    def to_json(self):
+        return {
+            "id": self.id,
+            "browserName": self.browser_name,
+            "browserPath": str(self.browser_path),
+            "userDataDir": str(self.user_data_dir),
+            "profileDir": self.profile_dir,
+            "profileName": self.profile_name,
+            "profilePath": str(self.profile_path),
+            "displayName": self.display_name,
+            # Compatibility with profile-use output names.
+            "BrowserName": self.browser_name,
+            "BrowserPath": str(self.browser_path),
+            "ProfileName": self.profile_name,
+            "ProfilePath": str(self.profile_path),
+            "DisplayName": self.display_name,
+        }
+
+
+def profile_marker_target_url(marker):
+    return f"{PROFILE_MARKER_URL_PREFIX}{marker}"
+
+
+def _config_path():
+    return Path(os.environ.get("BH_CONFIG", Path.home() / ".browser-harness" / "config.json"))
+
+
+def _load_config():
+    path = _config_path()
+    try:
+        return json.loads(path.read_text())
+    except (FileNotFoundError, OSError, ValueError):
+        return {}
+
+
+def _save_config(config):
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+
+
+def default_profile():
+    profile_id = _load_config().get("defaultProfileId")
+    if not profile_id:
+        return None
+    try:
+        return resolve_local_profile(profile_id).to_json()
+    except Exception:
+        return None
+
+
+def set_default_profile(profile_ref, browser_name=None):
+    profile = resolve_local_profile(profile_ref, browser_name=browser_name)
+    config = _load_config()
+    config["defaultProfileId"] = profile.id
+    config["defaultBrowserName"] = profile.browser_name
+    _save_config(config)
+    return profile.to_json()
+
+
+def _browser_slug(name):
+    out = []
+    dash = False
+    for ch in name.lower():
+        if ch.isalnum():
+            out.append(ch)
+            dash = False
+        elif not dash:
+            out.append("-")
+            dash = True
+    return "".join(out).strip("-")
+
+
+def _profile_dir_sort_key(profile_dir):
+    return (0, "") if profile_dir == "Default" else (1, profile_dir)
+
+
+def _known_browser_installs():
+    home = Path.home()
+    program_files = Path(os.environ.get("ProgramFiles", "C:/Program Files"))
+    program_files_x86 = Path(os.environ.get("ProgramFiles(x86)", "C:/Program Files (x86)"))
+    local_app_data = Path(os.environ.get("LOCALAPPDATA", str(home / "AppData/Local")))
+    candidates = [
+        ("Google Chrome", Path("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"), home / "Library/Application Support/Google/Chrome"),
+        ("Chrome Canary", Path("/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"), home / "Library/Application Support/Google/Chrome Canary"),
+        ("Brave", Path("/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"), home / "Library/Application Support/BraveSoftware/Brave-Browser"),
+        ("Microsoft Edge", Path("/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"), home / "Library/Application Support/Microsoft Edge"),
+        ("Chromium", Path("/Applications/Chromium.app/Contents/MacOS/Chromium"), home / "Library/Application Support/Chromium"),
+        ("Arc", Path("/Applications/Arc.app/Contents/MacOS/Arc"), home / "Library/Application Support/Arc/User Data"),
+        ("Dia", Path("/Applications/Dia.app/Contents/MacOS/Dia"), home / "Library/Application Support/Dia"),
+        ("Comet", Path("/Applications/Comet.app/Contents/MacOS/Comet"), home / "Library/Application Support/Comet"),
+        ("Helium", Path("/Applications/Helium.app/Contents/MacOS/Helium"), home / "Library/Application Support/Helium"),
+        ("Sidekick", Path("/Applications/Sidekick.app/Contents/MacOS/Sidekick"), home / "Library/Application Support/Sidekick"),
+        ("Thorium", Path("/Applications/Thorium.app/Contents/MacOS/Thorium"), home / "Library/Application Support/Thorium"),
+        ("SigmaOS", Path("/Applications/SigmaOS.app/Contents/MacOS/SigmaOS"), home / "Library/Application Support/SigmaOS/User Data"),
+        ("Wavebox", Path("/Applications/Wavebox.app/Contents/MacOS/Wavebox"), home / "Library/Application Support/WaveboxApp"),
+        ("Ghost Browser", Path("/Applications/Ghost Browser.app/Contents/MacOS/Ghost Browser"), home / "Library/Application Support/Ghost Browser"),
+        ("Blisk", Path("/Applications/Blisk.app/Contents/MacOS/Blisk"), home / "Library/Application Support/Blisk"),
+        ("Opera", Path("/Applications/Opera.app/Contents/MacOS/Opera"), home / "Library/Application Support/com.operasoftware.Opera"),
+        ("Vivaldi", Path("/Applications/Vivaldi.app/Contents/MacOS/Vivaldi"), home / "Library/Application Support/Vivaldi"),
+        ("Yandex", Path("/Applications/Yandex.app/Contents/MacOS/Yandex"), home / "Library/Application Support/Yandex/YandexBrowser"),
+        ("Iridium", Path("/Applications/Iridium.app/Contents/MacOS/Iridium"), home / "Library/Application Support/Iridium"),
+        ("Google Chrome", Path("/usr/bin/google-chrome"), home / ".config/google-chrome"),
+        ("Google Chrome", Path("/usr/bin/google-chrome-stable"), home / ".config/google-chrome"),
+        ("Brave", Path("/usr/bin/brave-browser"), home / ".config/BraveSoftware/Brave-Browser"),
+        ("Brave", Path("/usr/bin/brave"), home / ".config/BraveSoftware/Brave-Browser"),
+        ("Brave", Path("/snap/bin/brave"), home / ".config/BraveSoftware/Brave-Browser"),
+        ("Microsoft Edge", Path("/usr/bin/microsoft-edge"), home / ".config/microsoft-edge"),
+        ("Microsoft Edge", Path("/usr/bin/microsoft-edge-stable"), home / ".config/microsoft-edge"),
+        ("Chromium", Path("/usr/bin/chromium"), home / ".config/chromium"),
+        ("Chromium", Path("/usr/bin/chromium-browser"), home / ".config/chromium"),
+        ("Chromium", Path("/snap/bin/chromium"), home / ".config/chromium"),
+        ("Opera", Path("/usr/bin/opera"), home / ".config/opera"),
+        ("Vivaldi", Path("/usr/bin/vivaldi"), home / ".config/vivaldi"),
+        ("Vivaldi", Path("/usr/bin/vivaldi-stable"), home / ".config/vivaldi"),
+        ("Google Chrome", program_files / "Google/Chrome/Application/chrome.exe", local_app_data / "Google/Chrome/User Data"),
+        ("Google Chrome", program_files_x86 / "Google/Chrome/Application/chrome.exe", local_app_data / "Google/Chrome/User Data"),
+        ("Google Chrome", local_app_data / "Google/Chrome/Application/chrome.exe", local_app_data / "Google/Chrome/User Data"),
+        ("Brave", program_files / "BraveSoftware/Brave-Browser/Application/brave.exe", local_app_data / "BraveSoftware/Brave-Browser/User Data"),
+        ("Brave", local_app_data / "BraveSoftware/Brave-Browser/Application/brave.exe", local_app_data / "BraveSoftware/Brave-Browser/User Data"),
+        ("Microsoft Edge", program_files / "Microsoft/Edge/Application/msedge.exe", local_app_data / "Microsoft/Edge/User Data"),
+        ("Microsoft Edge", program_files_x86 / "Microsoft/Edge/Application/msedge.exe", local_app_data / "Microsoft/Edge/User Data"),
+        ("Chromium", local_app_data / "Chromium/Application/chrome.exe", local_app_data / "Chromium/User Data"),
+    ]
+    installs = []
+    seen = {}
+    for browser_name, browser_path, user_data_dir in candidates:
+        if not browser_path.exists() and not user_data_dir.exists():
+            continue
+        key = (browser_name, user_data_dir)
+        install = LocalBrowserInstall(browser_name, browser_path, user_data_dir)
+        if key in seen:
+            idx = seen[key]
+            if not installs[idx].browser_path.exists() and browser_path.exists():
+                installs[idx] = install
+        else:
+            seen[key] = len(installs)
+            installs.append(install)
+    return installs
+
+
+def _profile_names_from_local_state(user_data_dir):
+    try:
+        value = json.loads((user_data_dir / "Local State").read_text())
+    except (FileNotFoundError, OSError, ValueError):
+        return {}
+    info = value.get("profile", {}).get("info_cache", {})
+    if not isinstance(info, dict):
+        return {}
+    return {
+        profile_dir: item.get("name")
+        for profile_dir, item in info.items()
+        if isinstance(item, dict) and item.get("name")
+    }
+
+
+def _remote_debugging_user_enabled(user_data_dir):
+    try:
+        value = json.loads((user_data_dir / "Local State").read_text())
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    return value.get("devtools", {}).get("remote_debugging", {}).get("user-enabled")
+
+
+def _valid_profile_dir(path):
+    return any((path / rel).exists() for rel in ("Preferences", "Cookies", "History", "Network/Cookies"))
+
+
+def detect_local_profiles():
+    profiles = []
+    seen = set()
+    for install in _known_browser_installs():
+        if not install.user_data_dir.exists():
+            continue
+        names = _profile_names_from_local_state(install.user_data_dir)
+        try:
+            entries = list(install.user_data_dir.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if not entry.is_dir() or not _valid_profile_dir(entry):
+                continue
+            profile_dir = entry.name
+            key = (install.user_data_dir, profile_dir)
+            if key in seen:
+                continue
+            seen.add(key)
+            profile_name = names.get(profile_dir) or profile_dir
+            profiles.append(LocalBrowserProfile(
+                id=f"{_browser_slug(install.browser_name)}:{profile_dir}",
+                browser_name=install.browser_name,
+                browser_path=install.browser_path,
+                user_data_dir=install.user_data_dir,
+                profile_dir=profile_dir,
+                profile_name=profile_name,
+                profile_path=entry,
+                display_name=f"{install.browser_name} - {profile_name}",
+            ))
+    profiles.sort(key=lambda p: (p.browser_name, _profile_dir_sort_key(p.profile_dir), p.profile_name))
+    return profiles
+
+
+def list_local_profiles():
+    return [profile.to_json() for profile in detect_local_profiles()]
+
+
+def list_local_browsers():
+    by_name = {}
+    for profile in detect_local_profiles():
+        item = by_name.setdefault(profile.browser_name, {
+            "name": profile.browser_name,
+            "browserPath": str(profile.browser_path),
+            "profileCount": 0,
+            "managedHeaded": False,
+            "managedHeadless": False,
+        })
+        item["profileCount"] += 1
+    managed_headed = bool(_browser_paths())
+    if managed_headed:
+        item = by_name.setdefault("Chromium", {
+            "name": "Chromium",
+            "browserPath": _browser_paths()[0],
+            "profileCount": 0,
+            "managedHeaded": False,
+            "managedHeadless": False,
+        })
+        item["managedHeaded"] = True
+        item["managedHeadless"] = True
+    return sorted(by_name.values(), key=lambda item: item["name"])
+
+
+def resolve_local_profile(profile_ref, browser_name=None):
+    profiles = detect_local_profiles()
+    if browser_name:
+        profiles = [p for p in profiles if p.browser_name == browser_name]
+    for profile in profiles:
+        if profile.id == profile_ref:
+            return profile
+    matches = [
+        p for p in profiles
+        if profile_ref in {p.profile_name, p.profile_dir, p.display_name}
+    ]
+    if not matches:
+        raise RuntimeError(f"no local profile matched {profile_ref!r}")
+    if len(matches) > 1:
+        raise RuntimeError(f"multiple local profiles matched {profile_ref!r}; pass the exact profile id")
+    return matches[0]
+
+
+def _profile_value(profile, *names):
+    for name in names:
+        if profile.get(name):
+            return profile[name]
+    return None
+
+
+def open_local_profile(profile_name, browser_name=None, url=None):
+    profile = resolve_local_profile(profile_name, browser_name=browser_name)
+    args = [str(profile.browser_path)]
+    if sys.platform == "darwin":
+        args.append(f"--user-data-dir={profile.user_data_dir}")
+    args.append(f"--profile-directory={profile.profile_dir}")
+    if url:
+        args.append(url)
+    subprocess.Popen(args, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return profile.to_json()
+
+
+def open_local_profile_marker(profile_name, browser_name=None, marker=None):
+    marker = marker or uuid4().hex
+    target_url = profile_marker_target_url(marker)
+    profile = open_local_profile(profile_name, browser_name=browser_name, url=target_url)
+    return {"marker": marker, "url": target_url, "profile": profile}
+
+
+def _endpoint_from_user_data_dir(user_data_dir, wait=30):
+    deadline = time.time() + wait
+    last_err = None
+    active = user_data_dir / "DevToolsActivePort"
+    while time.time() < deadline:
+        try:
+            lines = active.read_text().splitlines()
+            port = lines[0].strip() if lines else ""
+            path = lines[1].strip() if len(lines) > 1 else ""
+            if not port:
+                raise RuntimeError(f"{active} did not contain a port")
+            http = f"http://127.0.0.1:{port}"
+            try:
+                return BrowserEndpoint(ws_from_http(http, timeout=1), http, "devtools-active-port")
+            except urllib.error.HTTPError as e:
+                if e.code == 404 and path:
+                    return BrowserEndpoint(f"ws://127.0.0.1:{port}{path}", http, "devtools-active-port")
+                last_err = e
+            except Exception as e:
+                last_err = e
+        except (FileNotFoundError, OSError, RuntimeError) as e:
+            last_err = e
+        time.sleep(0.25)
+    raise RuntimeError(
+        f"selected profile did not expose a reachable DevTools endpoint after {wait}s: {last_err}. "
+        "Open chrome://inspect/#remote-debugging in that profile and allow remote debugging, then retry."
+    )
+
+
+def _configured_profile_ref():
+    return (
+        os.environ.get("BH_PROFILE")
+        or os.environ.get("BH_BROWSER_PROFILE")
+        or os.environ.get("BH_LOCAL_PROFILE")
+        or _load_config().get("defaultProfileId")
+    )
+
+
+def _configured_browser_name():
+    return os.environ.get("BH_BROWSER") or os.environ.get("BH_BROWSER_NAME")
+
+
+def configured_local_profile():
+    profile_ref = _configured_profile_ref()
+    if not profile_ref:
+        return None
+    browser_name = _configured_browser_name()
+    return resolve_local_profile(profile_ref, browser_name=browser_name)
+
+
+def configured_profile_remote_debugging_enabled():
+    profile = configured_local_profile()
+    return _remote_debugging_user_enabled(profile.user_data_dir) if profile else None
+
+
+def open_configured_profile(marker=None):
+    profile = configured_local_profile()
+    if not profile:
+        return None
+    return open_local_profile(profile.id)
+
+
+def open_configured_profile_marker(marker=None):
+    profile = configured_local_profile()
+    if not profile:
+        return None
+    return open_local_profile_marker(profile.id, marker=marker)
+
+
+def _classify_profile_connection(profile, timeout=2):
+    """Classify the selected profile's connection state from DevToolsActivePort
+    and Local State, without opening a tab. Returns (endpoint, state):
+
+      "ok"                 reachable, endpoint set
+      "permission-blocked" reachable but Chrome rejected DevTools with 403
+      "cdp-disabled"       Chrome running, remote-debugging checkbox off
+      "browser-closed"     no reachable DevTools port
+
+    Only "ok" carries an endpoint; the caller raises a blocked error otherwise.
+    """
+    enabled = _remote_debugging_user_enabled(profile.user_data_dir)
+    active = profile.user_data_dir / "DevToolsActivePort"
+    try:
+        lines = active.read_text().splitlines()
+    except (FileNotFoundError, OSError):
+        lines = []
+    port = lines[0].strip() if lines else ""
+    path = lines[1].strip() if len(lines) > 1 else ""
+    if port:
+        http = f"http://127.0.0.1:{port}"
+        try:
+            return BrowserEndpoint(ws_from_http(http, timeout=timeout), http, "devtools-active-port"), "ok"
+        except urllib.error.HTTPError as e:
+            if e.code == 404 and path:
+                return BrowserEndpoint(f"ws://127.0.0.1:{port}{path}", http, "devtools-active-port"), "ok"
+            if e.code == 403:
+                return None, "permission-blocked"
+            # answered but unhealthy: fall through to the checkbox/closed split
+        except Exception:
+            # stale port file: nothing listening
+            pass
+    if enabled is False:
+        return None, "cdp-disabled"
+    return None, "browser-closed"
+
+
+def _profile_connection_blocked_message(profile, state):
+    label = profile.display_name or profile.id
+    if state == "permission-blocked":
+        return (
+            f"permission-blocked: Chrome rejected the CDP websocket with HTTP 403 for {label}. "
+            "Accept Chrome's 'Allow remote debugging?' dialog, then retry. Do not run setup or reload."
+        )
+    if state == "cdp-disabled":
+        return (
+            f"cdp-disabled: Chrome is open for {label}, but remote debugging is turned off. "
+            "Enable chrome://inspect/#remote-debugging — tick 'Allow remote debugging for this browser instance' — then retry. Relay this and retry; do not reload or diagnose."
+        )
+    return (
+        f"browser-closed: DevToolsActivePort not found for {label}. "
+        "Open the selected Chrome profile and enable remote debugging at chrome://inspect/#remote-debugging, then retry. Relay this and retry; do not reload or diagnose."
+    )
+
+
+def open_configured_profile_endpoint():
+    profile = configured_local_profile()
+    if not profile:
+        return None
+    endpoint, state = _classify_profile_connection(profile)
+    if state != "ok":
+        raise RuntimeError(_profile_connection_blocked_message(profile, state))
+    # Reuse a marker the profile-target command already opened (BH_TARGET_MARKER);
+    # otherwise let the daemon open it after the websocket connects.
+    env_marker = os.environ.get("BH_TARGET_MARKER")
+    if env_marker:
+        endpoint.target_marker = env_marker
+    else:
+        endpoint.marker_profile_id = profile.id
+    return endpoint
+
+
+def _ambiguous_profile_error():
+    profiles = list_local_profiles()
+    if len(profiles) <= 1:
+        return None
+    lines = [
+        "No default local browser profile is configured; refusing to attach to an arbitrary Chrome profile.",
+        "Set one with: browser-harness default-profile --profile <id-or-name>",
+        "Available profiles:",
+    ]
+    for profile in profiles:
+        lines.append(f"  {profile['id']}\t{profile['displayName']}\t{profile['profilePath']}")
+    return "\n".join(lines)
+
+
+def _truthy_env(name):
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return None
+    return value.lower() not in {"0", "false", "no", "off"}
+
+
+def _urlopen_json(url, timeout):
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return json.loads(r.read())
+
+
+def ws_from_http(http_url, timeout=15):
+    value = _urlopen_json(f"{http_url.rstrip('/')}/json/version", timeout=timeout)
+    ws = value.get("webSocketDebuggerUrl")
+    if not ws:
+        raise RuntimeError(f"{http_url}/json/version missing webSocketDebuggerUrl")
+    return ws
+
+
+def _host_for_ws_url(http_url):
+    p = urlparse(http_url)
+    host = p.hostname or "127.0.0.1"
+    if ":" in host:
+        return f"[{host}]"
+    return host
+
+
+def _ws_from_devtools_active_port(http_url):
+    p = urlparse(http_url)
+    want_port = str(p.port) if p.port else ""
+    if not want_port:
+        return None
+    host = _host_for_ws_url(http_url)
+    for base in PROFILE_ROOTS:
+        try:
+            active = (base / "DevToolsActivePort").read_text().splitlines()
+        except (FileNotFoundError, NotADirectoryError, OSError):
+            continue
+        port = active[0].strip() if active else ""
+        path = active[1].strip() if len(active) > 1 else ""
+        if port == want_port and path:
+            return f"ws://{host}:{port}{path}"
+    return None
+
+
+def resolve_http_endpoint(http_url, wait=30, request_timeout=5):
+    base = http_url.rstrip("/")
+    deadline = time.time() + wait
+    last_err = None
+    while time.time() < deadline:
+        try:
+            return BrowserEndpoint(
+                ws_url=ws_from_http(base, timeout=request_timeout),
+                http_url=base,
+                kind="cdp-url",
+            )
+        except urllib.error.HTTPError as e:
+            last_err = e
+            if e.code == 404:
+                ws = _ws_from_devtools_active_port(base)
+                if ws:
+                    return BrowserEndpoint(ws_url=ws, http_url=base, kind="devtools-active-port")
+        except Exception as e:
+            last_err = e
+        time.sleep(0.25)
+    raise RuntimeError(f"BU_CDP_URL={http_url} unreachable after {wait}s: {last_err}")
+
+
+def _devtools_active_port_endpoints():
+    seen = set()
+    for base in PROFILE_ROOTS:
+        try:
+            active = (base / "DevToolsActivePort").read_text().splitlines()
+        except (FileNotFoundError, NotADirectoryError, OSError):
+            continue
+        port = active[0].strip() if active else ""
+        path = active[1].strip() if len(active) > 1 else ""
+        if not port or not path:
+            continue
+        http = f"http://127.0.0.1:{port}"
+        key = (http, path)
+        if key in seen:
+            continue
+        seen.add(key)
+        yield base, http, f"ws://127.0.0.1:{port}{path}"
+
+
+def find_existing_endpoint():
+    for _base, http, ws in _devtools_active_port_endpoints():
+        try:
+            return BrowserEndpoint(ws_from_http(http, timeout=1), http, "devtools-active-port")
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return BrowserEndpoint(ws, http, "devtools-active-port")
+        except Exception:
+            continue
+    for port in (9222, 9223):
+        http = f"http://127.0.0.1:{port}"
+        try:
+            return BrowserEndpoint(ws_from_http(http, timeout=1), http, "port-probe")
+        except Exception:
+            continue
+    return None
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _has_gui():
+    if sys.platform == "darwin" or sys.platform == "win32":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _browser_paths():
+    out = []
+    for name in ("BH_CHROME_PATH", "CHROME_PATH"):
+        value = os.environ.get(name)
+        if value:
+            out.append(value)
+    candidates = [
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "/opt/homebrew/Caskroom/chromium/latest/chrome-mac/Chromium.app/Contents/MacOS/Chromium",
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/microsoft-edge",
+        "/usr/bin/brave-browser",
+    ]
+    out.extend(p for p in candidates if Path(p).exists())
+    for name in (
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+        "microsoft-edge",
+        "brave-browser",
+    ):
+        path = shutil.which(name)
+        if path:
+            out.append(path)
+    deduped = []
+    seen = set()
+    for path in out:
+        if path not in seen:
+            seen.add(path)
+            deduped.append(path)
+    return deduped
+
+
+def launch_managed_browser(headless=None):
+    paths = _browser_paths()
+    if not paths:
+        raise RuntimeError("No Chromium executable found. Set BH_CHROME_PATH or CHROME_PATH.")
+    if headless is None:
+        headless = _truthy_env("BH_MANAGED_HEADLESS")
+    if headless is None:
+        headless = not _has_gui()
+    errors = []
+    for executable in paths:
+        try:
+            return _launch_managed_browser(executable, bool(headless))
+        except Exception as e:
+            errors.append(f"{executable}: {e}")
+    raise RuntimeError("No Chromium executable successfully exposed DevTools:\n" + "\n".join(errors))
+
+
+def _launch_managed_browser(executable, headless):
+    port = _free_port()
+    profile = tempfile.TemporaryDirectory(prefix="browser-harness-managed.")
+    profile_path = Path(profile.name)
+    marker_path = profile_path / "BrowserHarnessManagedChrome.json"
+    args = [
+        f"--remote-debugging-port={port}",
+        "--remote-debugging-address=127.0.0.1",
+        f"--user-data-dir={profile_path}",
+        "--no-first-run",
+        "--no-default-browser-check",
+    ]
+    if headless:
+        args += ["--headless=new", "--window-size=1280,720"]
+    else:
+        args += ["--new-window", "--window-size=1512,900"]
+    args += ["about:blank"]
+    process = subprocess.Popen(
+        [executable, *args],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    managed = ManagedBrowser(process=process, profile_dir=profile, marker_path=marker_path)
+    marker_path.write_text(json.dumps({
+        "pid": process.pid,
+        "port": port,
+        "executable": executable,
+        "profile_path": str(profile_path),
+        "started_at": time.time(),
+    }, indent=2))
+    http = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 20
+    last_err = None
+    while time.time() < deadline:
+        if process.poll() is not None:
+            managed.stop()
+            raise RuntimeError("managed browser exited before DevTools became available")
+        try:
+            ws = ws_from_http(http, timeout=1)
+            return BrowserEndpoint(ws_url=ws, http_url=http, kind="managed", managed=managed)
+        except Exception as e:
+            last_err = e
+            time.sleep(0.25)
+    managed.stop()
+    raise RuntimeError(f"managed browser DevTools did not become available: {last_err}")
+
+
+def get_browser_endpoint():
+    if url := os.environ.get("BU_CDP_WS"):
+        return BrowserEndpoint(ws_url=url, kind="cdp-ws")
+    if url := os.environ.get("BU_CDP_URL"):
+        return resolve_http_endpoint(url)
+    endpoint = open_configured_profile_endpoint()
+    if endpoint:
+        return endpoint
+    ambiguous = _ambiguous_profile_error()
+    if ambiguous and not _truthy_env("BH_ALLOW_ARBITRARY_PROFILE"):
+        raise RuntimeError(ambiguous)
+    endpoint = find_existing_endpoint()
+    if endpoint:
+        return endpoint
+    if _truthy_env("BH_NO_MANAGED_BROWSER"):
+        raise RuntimeError(
+            "No local Chrome CDP endpoint found. Enable chrome://inspect/#remote-debugging, "
+            "set BU_CDP_WS/BU_CDP_URL, or unset BH_NO_MANAGED_BROWSER to allow managed Chrome."
+        )
+    return launch_managed_browser()

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,10 +1,11 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.error, urllib.request
-from urllib.parse import urlparse
+import asyncio, json, os, socket, sys, urllib.request
 from collections import deque
 from pathlib import Path
+from uuid import uuid4
 
 from . import _ipc as ipc
+from .browser import get_browser_endpoint, open_configured_profile_marker, open_local_profile_marker
 from cdp_use.client import CDPClient
 
 
@@ -33,37 +34,8 @@ SOCK = ipc.sock_addr(NAME)
 LOG = str(ipc.log_path(NAME))
 PID = str(ipc.pid_path(NAME))
 BUF = 500
-PROFILES = [
-    Path.home() / "Library/Application Support/Google/Chrome",
-    Path.home() / "Library/Application Support/Google/Chrome Canary",
-    Path.home() / "Library/Application Support/Comet",
-    Path.home() / "Library/Application Support/Arc/User Data",
-    Path.home() / "Library/Application Support/Dia/User Data",
-    Path.home() / "Library/Application Support/Microsoft Edge",
-    Path.home() / "Library/Application Support/Microsoft Edge Beta",
-    Path.home() / "Library/Application Support/Microsoft Edge Dev",
-    Path.home() / "Library/Application Support/Microsoft Edge Canary",
-    Path.home() / "Library/Application Support/BraveSoftware/Brave-Browser",
-    Path.home() / ".config/google-chrome",
-    Path.home() / ".config/chromium",
-    Path.home() / ".config/chromium-browser",
-    Path.home() / ".config/microsoft-edge",
-    Path.home() / ".config/microsoft-edge-beta",
-    Path.home() / ".config/microsoft-edge-dev",
-    Path.home() / ".var/app/org.chromium.Chromium/config/chromium",
-    Path.home() / ".var/app/com.google.Chrome/config/google-chrome",
-    Path.home() / ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
-    Path.home() / ".var/app/com.microsoft.Edge/config/microsoft-edge",
-    Path.home() / "AppData/Local/Google/Chrome/User Data",
-    Path.home() / "AppData/Local/Google/Chrome SxS/User Data",
-    Path.home() / "AppData/Local/Chromium/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge Beta/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge Dev/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge SxS/User Data",
-    Path.home() / "AppData/Local/BraveSoftware/Brave-Browser/User Data",
-]
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
+PROFILE_MARKER_URL_PREFIX = "https://browser-use.com/browser-use-profile-target/"
 BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 API_KEY = os.environ.get("BROWSER_USE_API_KEY")
@@ -78,86 +50,6 @@ async def _silent(coro):
         await coro
     except Exception:
         pass
-
-
-def _ws_from_devtools_active_port(http_url: str) -> str | None:
-    """When /json/version returns 404 (Chrome 147+ default profile), match DevToolsActivePort by port."""
-    p = urlparse(http_url)
-    want_port = str(p.port) if p.port else ""
-    if not want_port:
-        return None
-    host = p.hostname or "127.0.0.1"
-    if ":" in host:  # urlparse strips IPv6 brackets; restore them for the ws:// URL
-        host = f"[{host}]"
-    for base in PROFILES:
-        try:
-            active = (base / "DevToolsActivePort").read_text().splitlines()
-        except (FileNotFoundError, NotADirectoryError):
-            continue
-        port = active[0].strip() if active else ""
-        ws_path = active[1].strip() if len(active) > 1 else ""
-        if port == want_port and ws_path:
-            return f"ws://{host}:{port}{ws_path}"
-    return None
-
-
-def get_ws_url():
-    if url := os.environ.get("BU_CDP_WS"):
-        return url
-    if url := os.environ.get("BU_CDP_URL"):
-        # HTTP DevTools endpoint (e.g. http://127.0.0.1:9333) — resolve to ws via /json/version.
-        # Use this for a dedicated automation Chrome on a non-default profile, which avoids the
-        # M144 "Allow remote debugging" dialog and the M136 default-profile lockdown.
-        deadline = time.time() + 30
-        last_err = None
-        base_url = url.rstrip("/")
-        while time.time() < deadline:
-            try:
-                return json.loads(urllib.request.urlopen(f"{base_url}/json/version", timeout=5).read())["webSocketDebuggerUrl"]
-            except urllib.error.HTTPError as e:
-                last_err = e
-                if e.code == 404 and (ws := _ws_from_devtools_active_port(url)):
-                    return ws
-                time.sleep(1)
-            except Exception as e:
-                last_err = e
-                time.sleep(1)
-        raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- is the dedicated automation Chrome running?")
-    for base in PROFILES:
-        try:
-            active = (base / "DevToolsActivePort").read_text().splitlines()
-        except (FileNotFoundError, NotADirectoryError):
-            continue
-        port = active[0].strip() if active else ""
-        ws_path = active[1].strip() if len(active) > 1 else ""
-        if not port:
-            continue
-        # Resolve the live WS URL via /json/version instead of trusting the path stored
-        # alongside the port in DevToolsActivePort: if Chrome was previously launched
-        # with a different --user-data-dir on the same port, that file is left behind
-        # with a stale browser UUID and the WS upgrade returns 404.
-        deadline = time.time() + 30
-        while time.time() < deadline:
-            try:
-                return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1).read())["webSocketDebuggerUrl"]
-            except urllib.error.HTTPError as e:
-                # Chrome 147+ disables /json/* HTTP discovery on the default user-data-dir;
-                # the ws path Chrome wrote to DevToolsActivePort still works.
-                if e.code == 404 and ws_path:
-                    return f"ws://127.0.0.1:{port}{ws_path}"
-                time.sleep(1)
-            except (OSError, KeyError, ValueError):
-                time.sleep(1)
-        raise RuntimeError(
-            f"Chrome's remote-debugging page is open, but DevTools is not live yet on 127.0.0.1:{port} — if Chrome opened a profile picker, choose your normal profile first, then tick the checkbox and click Allow if shown"
-        )
-    for probe_port in (9222, 9223):
-        try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{probe_port}/json/version", timeout=1) as r:
-                return json.loads(r.read())["webSocketDebuggerUrl"]
-        except (OSError, KeyError, ValueError):
-            continue
-    raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 
 def stop_remote():
@@ -179,6 +71,35 @@ def is_real_page(t):
     return t["type"] == "page" and not t.get("url", "").startswith(INTERNAL)
 
 
+def is_page_target(t):
+    return t.get("type") == "page"
+
+
+def is_profile_marker_target(t):
+    return is_page_target(t) and "browser-use-profile-target" in t.get("url", "")
+
+
+def profile_marker_target_url(marker):
+    return f"{PROFILE_MARKER_URL_PREFIX}{marker}"
+
+
+def target_url_contains_marker(t, marker):
+    return is_profile_marker_target(t) and marker in t.get("url", "")
+
+
+def stale_browser_context_error(msg):
+    lower = str(msg).lower()
+    return "failed to find browser context with id" in lower or ("browser context" in lower and "not found" in lower)
+
+
+def select_initial_page_target(targets):
+    real = [t for t in targets if is_real_page(t) and not is_profile_marker_target(t)]
+    if real:
+        return real[0]
+    pages = [t for t in targets if is_page_target(t)]
+    return pages[0] if pages else None
+
+
 class Daemon:
     def __init__(self):
         self.cdp = None
@@ -187,23 +108,170 @@ class Daemon:
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
+        self.managed_browser = None
+        self.preferred_target_marker = os.environ.get("BH_TARGET_MARKER") or None
+        self.preferred_browser_context_id = None
 
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
-        targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
-        pages = [t for t in targets if is_real_page(t)]
-        if not pages:
+        target = None
+        attached_marker = False
+        if self.preferred_target_marker:
+            deadline = asyncio.get_running_loop().time() + 8
+            while asyncio.get_running_loop().time() < deadline:
+                targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+                target = next(
+                    (t for t in targets if target_url_contains_marker(t, self.preferred_target_marker)),
+                    None,
+                )
+                if target:
+                    self.preferred_target_marker = None
+                    self.preferred_browser_context_id = target.get("browserContextId")
+                    attached_marker = True
+                    break
+                await asyncio.sleep(0.15)
+            if target is None:
+                raise RuntimeError("selected Chrome profile target did not appear; refusing to attach to an arbitrary existing profile")
+        else:
+            targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+            target = select_initial_page_target(targets)
+            self.preferred_browser_context_id = None
+        if not target:
             # No real pages — create one instead of attaching to omnibox popup
-            tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+            params = {"url": "about:blank"}
+            if self.preferred_browser_context_id:
+                params["browserContextId"] = self.preferred_browser_context_id
+            tid = (await self.cdp.send_raw("Target.createTarget", params))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
-            pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
+            target = {"targetId": tid, "url": "about:blank", "type": "page"}
         self.session = (await self.cdp.send_raw(
-            "Target.attachToTarget", {"targetId": pages[0]["targetId"], "flatten": True}
+            "Target.attachToTarget", {"targetId": target["targetId"], "flatten": True}
         ))["sessionId"]
-        self.target_id = pages[0]["targetId"]
-        log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
+        self.target_id = target["targetId"]
+        log(f"attached {target['targetId']} ({target.get('url','')[:80]}) session={self.session}")
         await self._enable_default_domains(self.session)
-        return pages[0]
+        if attached_marker:
+            log("profile marker attached; waiting for first task target before closing marker")
+        return target
+
+    async def close_profile_marker_targets(self, browser_context_id=None, keep_target_id=None):
+        try:
+            targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+        except Exception:
+            return
+        for target in targets:
+            if not is_profile_marker_target(target):
+                continue
+            if browser_context_id and target.get("browserContextId") != browser_context_id:
+                continue
+            target_id = target.get("targetId")
+            if not target_id or target_id == keep_target_id:
+                continue
+            try:
+                await self.cdp.send_raw("Target.closeTarget", {"targetId": target_id})
+            except Exception:
+                pass
+
+    async def target_context_id(self, target_id):
+        info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": target_id}))["targetInfo"]
+        return info.get("browserContextId")
+
+    async def ensure_target_context(self, target_id):
+        if not self.preferred_browser_context_id:
+            return
+        actual = await self.target_context_id(target_id)
+        if actual and actual != self.preferred_browser_context_id:
+            raise RuntimeError("refusing to switch to a target from a different Chrome profile context")
+
+    async def reacquire_profile_context(self):
+        opened = await asyncio.to_thread(open_configured_profile_marker)
+        if not opened:
+            raise RuntimeError("cannot recover stale Chrome profile context: no default profile is configured")
+        marker = opened["marker"]
+        deadline = asyncio.get_running_loop().time() + 8
+        while asyncio.get_running_loop().time() < deadline:
+            targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+            target = next((t for t in targets if target_url_contains_marker(t, marker)), None)
+            if target:
+                self.preferred_browser_context_id = target.get("browserContextId")
+                log(f"reacquired profile context {self.preferred_browser_context_id or '(none)'} via marker {marker}")
+                return target
+            await asyncio.sleep(0.15)
+        raise RuntimeError("selected Chrome profile target did not appear while recovering stale browser context")
+
+    async def verify_profile_target(self):
+        """Re-anchor the controlled target into the selected profile if it has
+        drifted to another context or closed. The daemon is reused across CLI
+        commands, so without this it could keep driving a tab in the wrong
+        profile. Uses only Target.* calls over the existing websocket, so it
+        can't trigger Chrome's debugging popup. If the target still exists in the
+        selected context it's left as-is (we keep the same tab across commands).
+        """
+        if not self.preferred_browser_context_id:
+            return {"status": "no-profile"}
+        try:
+            targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+        except Exception as e:
+            return {"status": "cdp_disconnected", "reason": str(e)}
+        by_id = {t.get("targetId"): t for t in targets}
+        current = by_id.get(self.target_id) if self.target_id else None
+        if current and current.get("browserContextId") == self.preferred_browser_context_id:
+            return {"status": "ok", "target_id": self.target_id}
+        previous = self.target_id
+        # Prefer a real page in the selected context, then any non-marker page;
+        # if none, re-open a marker to reacquire the context (closed window).
+        in_ctx = [
+            t for t in targets
+            if is_page_target(t) and t.get("browserContextId") == self.preferred_browser_context_id
+        ]
+        chosen = next((t for t in in_ctx if is_real_page(t) and not is_profile_marker_target(t)), None)
+        chosen = chosen or next((t for t in in_ctx if not is_profile_marker_target(t)), None)
+        if chosen is None:
+            try:
+                target = await self.reacquire_profile_context()
+            except Exception as e:
+                return {"status": "context-stale", "previous": previous, "reason": str(e)}
+            chosen = target
+        self.session = (await self.cdp.send_raw(
+            "Target.attachToTarget", {"targetId": chosen["targetId"], "flatten": True}
+        ))["sessionId"]
+        self.target_id = chosen["targetId"]
+        await self._enable_default_domains(self.session)
+        await self.close_profile_marker_targets(self.preferred_browser_context_id, keep_target_id=self.target_id)
+        reason = "target-gone" if previous and previous not in by_id else "wrong-context"
+        log(f"reanchored controlled target {previous} -> {self.target_id} ({reason}) in profile context {self.preferred_browser_context_id}")
+        return {"status": "reanchored", "target_id": self.target_id, "previous": previous, "reason": reason}
+
+    async def recover_controlled_session(self):
+        """Refresh the CDP session after a stale-session error. Re-attaches the
+        same controlled target when it's still open in the selected context (so
+        we don't switch tabs on a dropped session); re-anchors only when it's
+        gone or drifted. Returns True when a usable session was restored.
+        """
+        if self.target_id:
+            try:
+                targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+            except Exception:
+                targets = []
+            current = next((t for t in targets if t.get("targetId") == self.target_id), None)
+            in_context = current is not None and (
+                not self.preferred_browser_context_id
+                or current.get("browserContextId") == self.preferred_browser_context_id
+            )
+            if in_context:
+                try:
+                    self.session = (await self.cdp.send_raw(
+                        "Target.attachToTarget", {"targetId": self.target_id, "flatten": True}
+                    ))["sessionId"]
+                    await self._enable_default_domains(self.session)
+                    log(f"reattached same controlled target {self.target_id} session={self.session}")
+                    return True
+                except Exception as e:
+                    log(f"reattach same target {self.target_id} failed: {e}")
+        if self.preferred_browser_context_id:
+            res = await self.verify_profile_target()
+            return res.get("status") in ("ok", "reanchored")
+        return bool(await self.attach_first_page())
 
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.
@@ -231,9 +299,12 @@ class Daemon:
 
     async def start(self):
         self.stop = asyncio.Event()
-        url = get_ws_url()
-        log(f"connecting to {url}")
-        self.cdp = CDPClient(url)
+        endpoint = get_browser_endpoint()
+        self.managed_browser = endpoint.managed
+        if endpoint.target_marker:
+            self.preferred_target_marker = endpoint.target_marker
+        log(f"connecting to {endpoint.ws_url} (kind={endpoint.kind}, http={endpoint.http_url or ''})")
+        self.cdp = CDPClient(endpoint.ws_url)
         try:
             await self.cdp.start()
         except Exception as e:
@@ -243,7 +314,13 @@ class Daemon:
                     "This can happen when network policy blocks the connection, the WS URL is wrong or expired, or the remote endpoint is down. "
                     "If you use Browser Use cloud, verify BROWSER_USE_API_KEY and get a fresh URL via start_remote_daemon()."
                 )
-            raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
+            raise RuntimeError(f"CDP WS handshake failed: {e}")
+        # Open the marker now that the websocket is live, so a failed connection
+        # leaves no stray tab. profile-target pre-opens its own (target_marker).
+        if not self.preferred_target_marker and endpoint.marker_profile_id:
+            opened = await asyncio.to_thread(open_local_profile_marker, endpoint.marker_profile_id)
+            self.preferred_target_marker = opened["marker"]
+            log(f"opened profile marker {opened['marker']} in {endpoint.marker_profile_id} after connect")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         mark_js = "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"
@@ -271,10 +348,18 @@ class Daemon:
         # `pid` lets restart_daemon() verify the live daemon's identity before
         # signaling — protects against SIGTERM-by-stale-pid-file after PID reuse.
         if meta == "ping":        return {"pong": True, "pid": os.getpid()}
+        if meta == "capabilities":
+            return {"capabilities": ["create_target", "profile_marker", "context_guard", "verify_profile"]}
+        if meta == "verify_profile":
+            return await self.verify_profile_target()
         if meta == "drain_events":
             out = list(self.events); self.events.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
+        if meta == "profile_marker":
+            marker = req.get("marker") or uuid4().hex
+            self.preferred_target_marker = marker
+            return {"marker": marker, "url": profile_marker_target_url(marker)}
         if meta == "current_tab":
             # Resolve the attached page's target info server-side. Helpers can't
             # send Target.getTargetInfo themselves: daemon strips session_id for
@@ -304,8 +389,14 @@ class Daemon:
             return {"target_id": self.target_id, "session_id": self.session, "page": page}
         if meta == "set_session":
             old_session = self.session
+            new_target_id = req.get("target_id") or self.target_id
+            if new_target_id:
+                try:
+                    await self.ensure_target_context(new_target_id)
+                except Exception as e:
+                    return {"error": str(e)}
             self.session = req.get("session_id")
-            self.target_id = req.get("target_id") or self.target_id
+            self.target_id = new_target_id
             # Run the old-session Network.disable (defense in depth — keeps
             # background-tab traffic out of the global event buffer; the
             # consumer-side filter in wait_for_network_idle is the actual
@@ -337,6 +428,26 @@ class Daemon:
                 timeout=2,
             )))
             return {"session_id": self.session}
+        if meta == "create_target":
+            params = {"url": req.get("url") or "about:blank"}
+            if self.preferred_browser_context_id:
+                params["browserContextId"] = self.preferred_browser_context_id
+            for attempt in (0, 1):
+                try:
+                    target_id = (await self.cdp.send_raw("Target.createTarget", params))["targetId"]
+                    await self.close_profile_marker_targets(self.preferred_browser_context_id, keep_target_id=target_id)
+                    return {"targetId": target_id}
+                except Exception as e:
+                    if attempt == 0 and self.preferred_browser_context_id and stale_browser_context_error(e):
+                        try:
+                            await self.reacquire_profile_context()
+                        except Exception as recover_error:
+                            return {"error": f"{e}; failed to recover selected Chrome profile context: {recover_error}"}
+                        params = {"url": req.get("url") or "about:blank"}
+                        if self.preferred_browser_context_id:
+                            params["browserContextId"] = self.preferred_browser_context_id
+                        continue
+                    return {"error": str(e)}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}
 
@@ -351,7 +462,7 @@ class Daemon:
             msg = str(e)
             if "Session with given id not found" in msg and sid == self.session and sid:
                 log(f"stale session {sid}, re-attaching")
-                if await self.attach_first_page():
+                if await self.recover_controlled_session():
                     return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
             return {"error": msg}
 
@@ -391,8 +502,12 @@ async def serve(d):
 
 async def main():
     d = Daemon()
-    await d.start()
-    await serve(d)
+    try:
+        await d.start()
+        await serve(d)
+    finally:
+        if d.managed_browser:
+            d.managed_browser.stop()
 
 
 def already_running():

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -295,6 +295,15 @@ def current_tab():
     r = _send({"meta": "current_tab"})
     return {"targetId": r["targetId"], "url": r["url"], "title": r["title"]}
 
+def profile_marker(marker=None):
+    """Return a marker URL for opening/identifying a specific Chrome profile.
+
+    Open the returned URL in the desired Chrome profile/window, then restart or
+    start the daemon. On attach, the daemon waits for that marker target and
+    pins future new_tab()/switch_tab() calls to the same browser context.
+    """
+    return _send({"meta": "profile_marker", "marker": marker})
+
 def _mark_tab():
     """Prepend horse emoji to tab title so the user can see which tab the agent controls."""
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
@@ -318,7 +327,7 @@ def new_tab(url="about:blank"):
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
+    tid = _send({"meta": "create_target", "url": "about:blank"})["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -24,6 +24,14 @@ from .admin import (
     sync_local_profile,
 )
 from .helpers import *
+from .browser import (
+    default_profile as native_default_profile,
+    find_existing_endpoint,
+    list_local_browsers as native_local_browsers,
+    list_local_profiles as native_local_profiles,
+    open_local_profile_marker,
+    set_default_profile as native_set_default_profile,
+)
 
 HELP = """Browser Harness
 
@@ -44,6 +52,14 @@ Commands:
   browser-harness doctor --fix-snap   print how to fix Snap Chromium blocking CDP (Linux)
   browser-harness --update [-y]    pull the latest version (agents: pass -y)
   browser-harness --reload         stop the daemon so next call picks up code changes
+  browser-harness profile-target --profile NAME [--browser NAME]
+                                   open a local profile marker and pin daemon to it
+  browser-harness local-profiles [--json]
+                                   list detected local browser profiles
+  browser-harness local-browsers [--json]
+                                   list detected local browsers
+  browser-harness default-profile [--profile NAME_OR_ID] [--browser NAME] [--json]
+                                   show or set deterministic default local profile
 """
 
 USAGE = """Usage:
@@ -62,6 +78,10 @@ def _local_chrome_listening():
             urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=0.3).close()
             return True
         except OSError: pass
+    try:
+        return find_existing_endpoint() is not None
+    except Exception:
+        return False
     return False
 
 
@@ -98,6 +118,72 @@ def main():
     if args and args[0] == "--reload":
         restart_daemon()
         print("daemon stopped — will restart fresh on next call")
+        return
+    if args and args[0] == "profile-target":
+        rest = args[1:]
+        profile = None
+        browser = None
+        marker = None
+        i = 0
+        while i < len(rest):
+            if rest[i] == "--profile" and i + 1 < len(rest):
+                profile = rest[i + 1]; i += 2; continue
+            if rest[i] == "--browser" and i + 1 < len(rest):
+                browser = rest[i + 1]; i += 2; continue
+            if rest[i] == "--marker" and i + 1 < len(rest):
+                marker = rest[i + 1]; i += 2; continue
+            print("usage: browser-harness profile-target --profile NAME [--browser NAME] [--marker MARKER]", file=sys.stderr)
+            sys.exit(2)
+        if not profile:
+            print("usage: browser-harness profile-target --profile NAME [--browser NAME] [--marker MARKER]", file=sys.stderr)
+            sys.exit(2)
+        opened = open_local_profile_marker(profile, browser_name=browser, marker=marker)
+        restart_daemon()
+        ensure_daemon(env={"BH_TARGET_MARKER": opened["marker"]})
+        print(opened["url"])
+        return
+    if args and args[0] == "local-profiles":
+        data = native_local_profiles()
+        if "--json" in args[1:]:
+            import json
+            print(json.dumps(data, indent=2))
+        else:
+            for profile in data:
+                print(f"{profile['id']}\t{profile['displayName']}\t{profile['profilePath']}")
+        return
+    if args and args[0] == "local-browsers":
+        data = native_local_browsers()
+        if "--json" in args[1:]:
+            import json
+            print(json.dumps(data, indent=2))
+        else:
+            for browser in data:
+                print(f"{browser['name']}\tprofiles={browser['profileCount']}\t{browser.get('browserPath') or ''}")
+        return
+    if args and args[0] == "default-profile":
+        rest = args[1:]
+        profile = None
+        browser = None
+        as_json = "--json" in rest
+        i = 0
+        while i < len(rest):
+            if rest[i] == "--json":
+                i += 1; continue
+            if rest[i] == "--profile" and i + 1 < len(rest):
+                profile = rest[i + 1]; i += 2; continue
+            if rest[i] == "--browser" and i + 1 < len(rest):
+                browser = rest[i + 1]; i += 2; continue
+            print("usage: browser-harness default-profile [--profile NAME_OR_ID] [--browser NAME] [--json]", file=sys.stderr)
+            sys.exit(2)
+        selected = native_set_default_profile(profile, browser_name=browser) if profile else native_default_profile()
+        if as_json:
+            import json
+            print(json.dumps(selected, indent=2))
+        elif selected:
+            print(f"{selected['id']}\t{selected['displayName']}\t{selected['profilePath']}")
+        else:
+            print("no default profile configured", file=sys.stderr)
+            sys.exit(1)
         return
     if args and args[0] == "--debug-clicks":
         os.environ["BH_DEBUG_CLICKS"] = "1"


### PR DESCRIPTION
- Classify the connection up front (browser.py): read DevToolsActivePort + Local State and return ok / cdp-disabled / permission-blocked / browser-closed in ~0.01s, without opening a tab. Each blocked state's error carries its own fix, so the agent relays one line and retries instead of hanging or exploring.
- Defer the marker tab until after the websocket connects, so a failed connection doesn't leave a stray tab.
- Reuse stays in the right profile: on daemon reuse, verify the controlled tab still belongs to the selected context and re-anchor if it drifted or closed (verify_profile). On a stale session, re-attach the same tab instead of grabbing an arbitrary page.
- admin.py routing: a 403 is permission-blocked on its own (focus the profile, don't tell the user to re-tick the checkbox); browser-closed opens/focuses the selected profile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make local Chrome connections fast, reliable, and profile-aware. We classify CDP state up front, avoid stray tabs on failure, and keep the daemon anchored to the user-selected profile across runs.

- **New Features**
  - Instant local connection classification from DevToolsActivePort + Local State; returns ok/cdp-disabled/permission-blocked/browser-closed with one-line, actionable errors (no tab is opened).
  - Marker tab deferred until after the WebSocket connects, so failed connects don’t leave stray tabs.
  - Profile pinning across reuse: verify and re-anchor the controlled tab to the selected `browserContextId`; reattach the same tab on stale sessions; refuse cross-profile target switches.
  - Admin routing: 403 is treated as permission-blocked (focus/open the selected profile), and browser-closed opens/focuses the profile instead of prompting to re-tick the checkbox.
  - Native local profile/browser detection (no `profile-use` dependency) and new CLI: `local-profiles`, `local-browsers`, `default-profile`, and `profile-target`; helper `profile_marker`; daemon supports `create_target` and `verify_profile`.

- **Migration**
  - When multiple local profiles exist, do not auto-pick. Use `browser-harness local-profiles` and `browser-harness default-profile` before any page work (only set a default after the user chooses).
  - Remove `BH_CLOUD_ONLY` if you set it; it’s no longer used.
  - `profile-use` is no longer required for local profile discovery.

<sup>Written for commit ff049266b1af64a3392fcd862c5b649c50dd6de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

