### PR TITLE
Add Medium publishing domain skill

### DIFF
--- a/agent-workspace/domain-skills/medium/publishing.md
+++ b/agent-workspace/domain-skills/medium/publishing.md
@@ -1,0 +1,94 @@
+# Medium — Publishing a Story
+
+Composing and publishing a Medium story by driving the editor. For *reading* Medium, see `scraping.md` (APIs) and `article-hydration.md` (DOM extraction) — this file is the write path.
+
+There is **no public API for publishing** (the legacy Medium API stopped issuing integration tokens), so the editor must be browser-driven.
+
+## URLs
+
+- `https://medium.com/new-story` — creates a draft; once it autosaves it redirects to `/p/<id>/edit`. **If it never redirects, the draft isn't saving** (see throttle trap).
+- `https://medium.com/p/<id>/edit` — the editor for one draft.
+- `https://medium.com/p/<id>/submission?...` — the publish panel (preview card, topics/tags, Publish button).
+- `https://medium.com/me/stories/drafts` — drafts list; each row's hover "Toggle actions" (kebab) menu has **Delete story**.
+- Published canonical: `https://medium.com/@<handle>/<slug>-<id>` (short form `https://medium.com/p/<id>`).
+
+## Editor structure (classic "graf" editor)
+
+One big contenteditable: `div.js-postField` (class `postArticle-content js-postField … editable`, `role=textbox`, `data-default-value="Title\nTell your story…"`). Blocks are `.graf` elements whose class names carry the type:
+
+| graf class | meaning |
+| :-- | :-- |
+| `graf--title` | the story title — the FIRST block (an `h3` styled as title) |
+| `graf--h3` | big heading |
+| `graf--h4` | small heading |
+| `graf--p` | paragraph |
+| `graf--li` | list item |
+| `graf--pre graf--preV2` | code block (syntax-highlighted) |
+| `graf--blockquote` | quote |
+
+Inline runs: `<strong>`, `<em>`, and **`<code>` (inline code is preserved as monospace)**.
+
+## The key mechanic: inject content via a synthetic paste
+
+Medium converts pasted HTML into `.graf` blocks. Focus the contenteditable, then dispatch a `paste` `ClipboardEvent` with a `DataTransfer` holding `text/html` (run via `js(...)`):
+
+```js
+var ed  = document.querySelector('.js-postField,[contenteditable="true"]');
+var tgt = document.activeElement && document.activeElement.isContentEditable ? document.activeElement : ed;
+var dt = new DataTransfer();
+dt.setData('text/html', htmlString);
+dt.setData('text/plain', plainString);
+tgt.dispatchEvent(new ClipboardEvent('paste', {clipboardData: dt, bubbles:true, cancelable:true}));
+```
+
+HTML → graf mapping (verified):
+
+- **First `<h1>` of a paste into a *fresh* editor → `graf--title`** (the title). Subsequent `<h1>/<h2>/<h3>` → `graf--h3` (big heading); `<h4>` → `graf--h4` (small heading).
+- `<p>` with `<strong>/<em>/<code>` → paragraph with inline runs.
+- `<ul><li>` → bullet list; `<blockquote>` → blockquote.
+- `<pre>` → code block (`graf--pre`). **Newlines inside one `<pre>` are collapsed** — and so are `<br>` and `<pre><code>…</code></pre>`. For multi-line code, emit **one `<pre>` per line** (consecutive `<pre>` stay as separate code blocks).
+
+Converting markdown for this editor: `##`→`<h3>`, `###`→`<h4>`, inline code `` `x` ``→`<code>`, `**x**`→`<strong>`, tables → bullet list (`<li><code>cmd</code> — desc</li>`), code fences → one `<pre>` per line.
+
+## Setting the title reliably
+
+The title is finicky. Two working options:
+
+1. **Prepend `<h1>{title}</h1>`** to the body HTML and paste into a *fresh* editor with the caret at the top — the first `<h1>` becomes `graf--title`. (If you click into the body first, that `<h1>` becomes a body heading instead and the title stays empty.)
+2. **Place the caret in the title block via JS, then `type_text`:**
+   ```js
+   var t = document.querySelector('.graf--title');
+   var ed = document.querySelector('.js-postField'); ed.focus();
+   var r = document.createRange(); r.selectNodeContents(t); r.collapse(true);
+   var s = getSelection(); s.removeAllRanges(); s.addRange(r);
+   ```
+   Clicking the empty title block does **not** focus it (it has near-zero height when empty). If this leaves a duplicate heading, select that block's contents with a JS range and delete it with **real** `Backspace` key events (not `execCommand`).
+
+## Adding tags (publish panel)
+
+Topic input is `input[placeholder^="Add a topic"]` (becomes `Add more topics…` after the first tag). Commit each tag with **JS `.focus()` + a char-less trusted Enter**:
+
+```python
+js("document.querySelector('input[placeholder^=\"Add\"]').focus()")
+cdp("Input.dispatchKeyEvent", type="keyDown", windowsVirtualKeyCode=13, key="Enter", code="Enter")
+cdp("Input.dispatchKeyEvent", type="keyUp",   windowsVirtualKeyCode=13, key="Enter", code="Enter")
+```
+
+`press_key("Enter")` does **not** commit (its synthetic `char` event defeats it), and **comma is rejected** ("Tags only support letters, numbers, spaces and dashes"). Up to 5 tags.
+
+## Publish flow
+
+1. Click the top-bar **Publish** → the submission page opens.
+2. Preview title/subtitle auto-populate from the story title; add tags.
+3. Click the **Publish** ("Publish now") button at the bottom of the panel.
+4. Redirects to `/p/<id>?postPublishedType=initial`; read `link[rel="canonical"]` for the public URL.
+
+## Traps
+
+- **No publishing API** — browser-drive only.
+- **New-draft creation throttles.** After creating several drafts quickly, `/new-story` stops redirecting to `/p/<id>/edit` and won't save (no error, just no persistence). **Editing an existing draft still saves fine** — reuse a known-good draft, or space out creation.
+- **`execCommand('delete')` to clear the editor corrupts Medium's save model** → red banner "Something is wrong and we cannot save your story." Don't clear that way. A single clean paste into a fresh/empty editor saves fine; for edits use real key events.
+- **`Cmd+A` select-all doesn't register via CDP** (even with `commands:["selectAll"]`), same as other rich editors.
+- **`beforeunload` freezes navigation** when there are unsaved changes — `Page.navigate`/`goto_url` times out. Recover with `cdp("Page.handleJavaScriptDialog", accept=True)`, then continue. Opening a fresh tab avoids the dialog entirely.
+- The per-code-block **"Auto (C#)" language label is an in-editor hover artifact** — the published view is clean.
+- **Retina DPR=2**: read coordinates from `getBoundingClientRect`, never off a screenshot (`click_at_xy` takes CSS pixels).


### PR DESCRIPTION
Adds `agent-workspace/domain-skills/medium/publishing.md` — the **write path** for Medium, complementing the existing read-oriented `scraping.md` (APIs) and `article-hydration.md` (DOM extraction).

### Why
There is **no public API for publishing** to Medium (the legacy API stopped issuing integration tokens), so a story has to be composed by driving the editor. The mechanics are non-obvious and cost a lot of exploration to work out.

### What it captures
- **URLs**: `/new-story` → `/p/<id>/edit` → `/p/<id>/submission` → `/@handle/<slug>-<id>`, plus the drafts list + delete path.
- **Editor structure**: the classic `.js-postField` contenteditable and the `.graf--*` block-type table (`graf--title`, `graf--h3/h4`, `graf--p`, `graf--li`, `graf--pre`, `graf--blockquote`).
- **The key mechanic**: inject content with a synthetic `paste` `ClipboardEvent` carrying `text/html` — Medium converts HTML → graf blocks. Includes the verified HTML→graf mapping (incl. inline `<code>` surviving as monospace).
- **Title handling**: the first `<h1>` of a fresh-editor paste becomes `graf--title`; or JS-place the caret in the title block and type (clicking the empty title block won't focus it).
- **Multi-line code**: newlines inside one `<pre>` collapse (also `<br>` and `<pre><code>`), so emit **one `<pre>` per line**.
- **Tags**: commit each via JS `.focus()` + a **char-less trusted Enter** — `press_key("Enter")` doesn't commit and comma is rejected.
- **Traps**: no API; new-draft creation throttles (editing an existing draft still saves); `execCommand('delete')` clearing corrupts the save model; `beforeunload` freezes navigation; `Cmd+A` won't register via CDP; retina DPR.

No run narration, pixel coordinates, or secrets — just the durable site map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Medium publishing domain skill that documents how to compose and publish stories by driving the classic editor (no public publish API). Complements the read skills and shares the reliable write flow and pitfalls.

- **New Features**
  - Adds `agent-workspace/domain-skills/medium/publishing.md`.
  - Maps the publish flow: `/new-story` → `/p/<id>/edit` → `/p/<id>/submission` → canonical URL.
  - Details HTML-based synthetic paste to create graf blocks, including title handling and inline code.
  - Covers multi-line code (one `<pre>` per line) and committing tags with a focused Enter.
  - Notes traps: draft throttling, `execCommand('delete')` save issues, `beforeunload` dialogs, `Cmd+A` via CDP, and DPR tips.

<sup>Written for commit ad39448e2f1dc655b8695f43135343c84d77f674. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

