### PR TITLE
Link packaged skill to install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Try browser-harness in [Browser Use Cloud](https://cloud.browser-use.com/v4?utm_
 Paste into Claude Code or Codex:
 
 ```text
-Install browser-harness with uv, register the skill from `browser-harness skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
+Install or upgrade browser-harness to the latest stable version with uv, register the skill from `browser-harness skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
 ```
 
 The agent will open `chrome://inspect/#remote-debugging`. Tick the checkbox so the agent can connect to your browser:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Try browser-harness in [Browser Use Cloud](https://cloud.browser-use.com/v4?utm_
 Paste into Claude Code or Codex:
 
 ```text
-Install browser-harness with uv, register the skill from `browser-harness skill`, and connect it to my browser.
+Install browser-harness with uv, register the skill from `browser-harness skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
 ```
 
 The agent will open `chrome://inspect/#remote-debugging`. Tick the checkbox so the agent can connect to your browser:

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@ description: Always use browser-harness for any web interaction: automation, scr
 
 # browser-harness
 
-Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py`. For setup, install, or connection problems, read `install.md`.
+Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py`. For setup, install, or connection problems, read https://github.com/browser-use/browser-harness/blob/main/install.md.
 
 Domain skills are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.
 
@@ -71,7 +71,7 @@ When the task is done and a cloud browser is still running, ask directly: "Shoul
 
 Do not start a remote daemon and then keep using the default daemon. Use the same name for `BU_NAME`.
 
-Cloud profiles for cookie sync live in `interaction-skills/profile-sync.md`.
+Cloud profile cookie sync reference: https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md.
 
 ## Page Workflow
 
@@ -85,7 +85,7 @@ Cloud profiles for cookie sync live in `interaction-skills/profile-sync.md`.
 
 ## Interaction Skills
 
-If you get stuck on a browser mechanic, check `interaction-skills/`:
+If you get stuck on a browser mechanic, check https://github.com/browser-use/browser-harness/tree/main/interaction-skills.
 
 - connection.md
 - cookies.md

--- a/install.md
+++ b/install.md
@@ -10,7 +10,7 @@ Use once. For browser work, read `SKILL.md`.
 ## Fast Path
 
 ```bash
-uv tool install browser-harness
+uv tool install --upgrade --force browser-harness
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness"
 browser-harness skill > "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness/SKILL.md"
 browser-harness <<'PY'
@@ -19,6 +19,8 @@ PY
 ```
 
 If `page_info()` prints, stop. Setup is done.
+
+`--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
 
 For Claude Code or other agents: install `browser-harness`, register a skill named `browser-harness`, use `browser-harness skill` as the body, and use this trigger:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.1rc1"
+version = "0.1.1"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/browser-harness/references/install.md
+++ b/skills/browser-harness/references/install.md
@@ -5,9 +5,11 @@ This is a **one-time prerequisite**, not part of the regular AI workflow. Do it 
 ## Install the command
 
 ```bash
-uv tool install browser-harness
+uv tool install --upgrade --force browser-harness
 command -v browser-harness   # should print a path
 ```
+
+`--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
 
 For browser-harness development, clone the repo into a durable path and run `uv tool install -e .` from the checkout.
 


### PR DESCRIPTION
## Summary
- Link the setup prompt to the canonical install guide.
- Make packaged skill references use GitHub URLs.
- Update install docs for existing installs.

## Verification
- `git diff --check`
- `BH_TELEMETRY=0 uv run browser-harness skill`
