### PR TITLE
Pin browser-harness install command to supported Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Try browser-harness in [Browser Use Cloud](https://cloud.browser-use.com/v4?utm_
 Paste into Claude Code or Codex:
 
 ```text
-Install or upgrade browser-harness to the latest stable version with uv, register the skill from `browser-harness skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
+Install or upgrade browser-harness to the latest stable version with uv using Python 3.12, register the skill from `browser-harness skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
 ```
 
 The agent will open `chrome://inspect/#remote-debugging`. Tick the checkbox so the agent can connect to your browser:

--- a/install.md
+++ b/install.md
@@ -10,7 +10,7 @@ Use once. For browser work, read `SKILL.md`.
 ## Fast Path
 
 ```bash
-uv tool install --upgrade --force browser-harness
+uv tool install --python 3.12 --upgrade --force browser-harness
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness"
 browser-harness skill > "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness/SKILL.md"
 browser-harness <<'PY'
@@ -20,7 +20,7 @@ PY
 
 If `page_info()` prints, stop. Setup is done.
 
-`--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
+`--python 3.12` prevents uv from selecting old releases that support older Python versions. `--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
 
 For Claude Code or other agents: install `browser-harness`, register a skill named `browser-harness`, use `browser-harness skill` as the body, and use this trigger:
 

--- a/skills/browser-harness/references/install.md
+++ b/skills/browser-harness/references/install.md
@@ -5,11 +5,11 @@ This is a **one-time prerequisite**, not part of the regular AI workflow. Do it 
 ## Install the command
 
 ```bash
-uv tool install --upgrade --force browser-harness
+uv tool install --python 3.12 --upgrade --force browser-harness
 command -v browser-harness   # should print a path
 ```
 
-`--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
+`--python 3.12` prevents uv from selecting old releases that support older Python versions. `--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
 
 For browser-harness development, clone the repo into a durable path and run `uv tool install -e .` from the checkout.
 


### PR DESCRIPTION
## Summary
- Use Python 3.12 for uv tool installs.
- Keep setup prompt wording aligned with install docs.

## Verification
- `git diff --check`
- isolated uv tool install resolves `browser-harness==0.1.1`
- `BH_TELEMETRY=0 uv run browser-harness skill`
