### PR TITLE
Fix skill frontmatter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-harness
-description: Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work.
+description: "Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work."
 ---
 
 # browser-harness

--- a/tests/unit/test_skill.py
+++ b/tests/unit/test_skill.py
@@ -1,0 +1,35 @@
+from importlib import resources
+
+
+def _frontmatter(text: str) -> str:
+    assert text.startswith("---\n")
+    end = text.find("\n---\n", 4)
+    assert end != -1
+    return text[4:end]
+
+
+def test_packaged_skill_frontmatter_is_valid_simple_yaml():
+    text = resources.files("browser_harness").joinpath("SKILL.md").read_text()
+    metadata = {}
+
+    for line in _frontmatter(text).splitlines():
+        key, separator, value = line.partition(":")
+        assert separator == ":", line
+        assert key in {"name", "description"}
+        assert key.strip() == key
+        value = value.strip()
+        assert value, key
+
+        if value[0] in {"'", '"'}:
+            assert value[-1] == value[0], line
+            parsed = value[1:-1]
+        else:
+            parsed = value
+            assert ": " not in parsed, line
+
+        metadata[key] = parsed
+
+    assert metadata == {
+        "name": "browser-harness",
+        "description": "Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work.",
+    }


### PR DESCRIPTION
## Summary
- Quote the skill description in YAML frontmatter.
- Add a regression test for packaged skill frontmatter.

## Verification
- `git diff --check`
- `uv run python -m py_compile $(rg --files src tests -g '*.py')`
- `uv run --with pytest pytest`
- generated `browser-harness skill` output parses with PyYAML


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote the SKILL.md `description` in YAML frontmatter to ensure valid parsing for the packaged `browser-harness` skill. Adds a regression test to prevent frontmatter regressions.

- **Bug Fixes**
  - Quote `description` in SKILL.md so `PyYAML` parses it reliably.
  - Add unit test validating the packaged `browser-harness` frontmatter as simple YAML.

<sup>Written for commit 5447f2a6013ca9506ee279ccb8d2c592d5210d3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

