### PR TITLE
Release 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.2"
+version = "0.1.3"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump package version to 0.1.3.

## Verification
- `git diff --check`
- `uv run python -m py_compile $(rg --files src tests -g '*.py')`
- `uv run --with pytest pytest`
- `rm -rf dist && uv build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `browser-harness` 0.1.3 by bumping the package version in pyproject.toml from 0.1.2 to 0.1.3. No code changes; this prepares the package for publication.

<sup>Written for commit a0db945d3a174c9aae8a0821d933ac2274621489. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

