### PR TITLE
Add BH_NO_ACTIVATE to stop new_tab/switch_tab from stealing OS focus

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -385,7 +385,10 @@ class Daemon:
                 take_over = inspect_tabs[0]["targetId"]
         if not pages:
             # No usable pages - create one instead of attaching to omnibox popup.
-            tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+            create_params = {"url": "about:blank"}
+            if os.environ.get("BH_NO_ACTIVATE") == "1":
+                create_params["background"] = True  # Mac-only: don't raise the window.
+            tid = (await self.cdp.send_raw("Target.createTarget", create_params))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
         self.session = (await self.cdp.send_raw(

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -299,7 +299,11 @@ def switch_tab(target):
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    # Target.activateTarget raises and focuses the OS window on macOS, stealing
+    # focus from whatever the user is typing in. Skip it when BH_NO_ACTIVATE=1;
+    # the horse-emoji title still marks which tab the agent controls.
+    if os.environ.get("BH_NO_ACTIVATE") != "1":
+        cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
@@ -323,7 +327,10 @@ def new_tab(url="about:blank"):
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
+    params = {"url": "about:blank"}
+    if os.environ.get("BH_NO_ACTIVATE") == "1":
+        params["background"] = True  # Mac-only: open the tab without raising the window.
+    tid = cdp("Target.createTarget", **params)["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)


### PR DESCRIPTION
## Problem

When driving a *visible* browser (e.g. an isolated debug Chrome you're
watching), every `new_tab()` and `switch_tab()` raises the Chrome window to the
OS foreground and steals keyboard focus from whatever you're typing in. Two CDP
calls cause this on macOS:

- `switch_tab()` → `Target.activateTarget` raises + focuses the window.
- `new_tab()` → `Target.createTarget` opens the tab in the foreground
  (foreground is the Mac default; `createTarget` takes a Mac-only `background`
  flag).

## Change

Gate both behind an opt-in `BH_NO_ACTIVATE=1` env flag. **Default behavior is
unchanged** — activation still happens unless the flag is set.

- `switch_tab` skips `Target.activateTarget`.
- `new_tab` and the daemon's no-real-pages bootstrap pass `background: true`
  to `Target.createTarget`.

The flag is read client-side, so callers just prefix runs with
`BH_NO_ACTIVATE=1` — no daemon restart needed. Routing is unaffected:
`set_session` still makes `cdp()`/`js()` default to the controlled tab, and the
🐴 title marker still shows which tab the agent drives.

## Caveat: needs a non-empty window (sentinel tab)

`background: true` only keeps the window backgrounded when the new tab is **not
the window's only tab**. If the automation window has no other *real, loaded*
tab, Chrome raises the window to show its first tab and `background` can't
prevent that:

- Window already has ≥1 real loaded tab → `new_tab()` opens in the background,
  no focus steal.
- Window is empty (just launched, or all tabs closed) → the *first* `new_tab()`
  foregrounds the window once.

For fully focus-free behavior, keep one real loaded "sentinel" tab open in the
automation browser (e.g. launch Chrome pointed at a static local page).
`about:blank` is **not** sufficient — it's treated as internal; the anchor must
be a real loaded page (`http`/`https`/`file`/`data`).

## Relationship to #402

This supersedes #402, which gated only the `switch_tab` `activateTarget` call.
That half alone doesn't stop the steal on `new_tab()` — `Target.createTarget`
raises the window independently. Verified empirically (frontmost app via
`osascript`, macOS / Chrome for Testing): with `activateTarget` skipped but no
`background` flag, the first `new_tab()` still flips frontmost from Finder →
Chrome. This PR adds the `createTarget` `background: true` half so the flag
covers the common `new_tab()` path too.

### Testing

- Empty window: 5/5 `new_tab()` calls stole focus.
- With one real sentinel tab kept open: 6/6 `new_tab()` clean, plus
  `switch_tab` / screenshot / `js()` / `close_tab` all clean.

## Possible follow-up

The empty-window foreground could be eliminated entirely by having the daemon
maintain a persistent keepalive tab, making the flag self-sufficient without a
user-managed sentinel. Happy to add that here or as a follow-up if you'd prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `BH_NO_ACTIVATE` flag to prevent Chrome from stealing OS focus on macOS during `new_tab()` and `switch_tab()`. Default behavior is unchanged.

- **New Features**
  - With `BH_NO_ACTIVATE=1`, `switch_tab()` skips `Target.activateTarget`.
  - `new_tab()` and the daemon’s first-page attach pass `background: true` to `Target.createTarget` to open tabs in the background.
  - Flag is read client-side; no daemon restart needed.

- **Migration**
  - Enable by prefixing runs with `BH_NO_ACTIVATE=1`.
  - If the window is empty, the first tab may still foreground; keep one real loaded sentinel tab open (`about:blank` is not sufficient).

<sup>Written for commit 554e92aef506c970b07469e8a27ec906b1193f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

