### PR TITLE
fix: reuse existing blank tab in browser harness

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -186,6 +186,11 @@ def is_real_page(t):
     return t["type"] == "page" and not t.get("url", "").startswith(INTERNAL)
 
 
+def is_reusable_empty_page(t):
+    """True for visible empty tabs we can attach to instead of creating another one."""
+    return t["type"] == "page" and t.get("url", "") in {"about:blank", "about:newtab", "chrome://newtab/"}
+
+
 class Daemon:
     def __init__(self):
         self.cdp = None
@@ -200,9 +205,11 @@ class Daemon:
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         pages = [t for t in targets if is_real_page(t)]
         if not pages:
-            # No real pages - create one instead of attaching to omnibox popup.
+            pages = [t for t in targets if is_reusable_empty_page(t)]
+        if not pages:
+            # No attachable pages - create one instead of attaching to omnibox popup.
             tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
-            log(f"no real pages found, created about:blank ({tid})")
+            log(f"no attachable pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
         self.session = (await self.cdp.send_raw(
             "Target.attachToTarget", {"targetId": pages[0]["targetId"], "flatten": True}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -309,19 +309,39 @@ def new_tab(url="about:blank"):
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
+    try:
+        previous = current_tab()
+    except Exception:
+        previous = None
     if url != "about:blank":
         try:
-            cur = current_tab()
+            cur = previous or current_tab()
             cur_url = cur.get("url") or ""
-            if cur_url in ("", "about:blank") or cur_url.startswith("about:blank#"):
+            if cur_url in ("", "about:blank", "about:newtab", "chrome://newtab/") or cur_url.startswith("about:blank#"):
                 goto_url(url)
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
     tid = cdp("Target.createTarget", url="about:blank")["targetId"]
-    switch_tab(tid)
-    if url != "about:blank":
-        goto_url(url)
+    try:
+        switch_tab(tid)
+        if url != "about:blank":
+            goto_url(url)
+    except Exception:
+        try: cdp("Target.closeTarget", targetId=tid)
+        except Exception: pass
+        if previous and previous.get("targetId") and previous.get("targetId") != tid:
+            try: switch_tab(previous)
+            except Exception: pass
+        else:
+            try:
+                tabs = list_tabs(include_chrome=False)
+                if tabs:
+                    switch_tab(tabs[0])
+                else:
+                    switch_tab(cdp("Target.createTarget", url="about:blank")["targetId"])
+            except Exception: pass
+        raise
     return tid
 
 def close_tab(target=None):

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -21,6 +21,30 @@ def _fresh_daemon():
     return d
 
 
+def test_attach_first_page_reuses_existing_blank_tab_instead_of_creating_another():
+    class _BlankTabCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Target.getTargets":
+                return {"targetInfos": [
+                    {"targetId": "inspect", "type": "page", "url": "chrome://inspect"},
+                    {"targetId": "blank", "type": "page", "url": "about:blank"},
+                ]}
+            if method == "Target.attachToTarget":
+                return {"sessionId": "session-blank"}
+            return {}
+
+    d = daemon.Daemon()
+    d.cdp = _BlankTabCDP()
+
+    attached = asyncio.run(d.attach_first_page())
+
+    assert attached["targetId"] == "blank"
+    assert d.target_id == "blank"
+    assert d.session == "session-blank"
+    assert not any(method == "Target.createTarget" for method, _params, _sid in d.cdp.calls)
+
+
 def test_set_session_enables_all_four_default_domains_on_new_session():
     """Regression: switch_tab() / new_tab() in helpers.py route through the
     `set_session` IPC, which previously only enabled Page on the new

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -53,6 +53,92 @@ def test_goto_url_includes_domain_skills_when_enabled(tmp_path, monkeypatch):
     assert result == {"frameId": "f", "domain_skills": ["scraping.md"]}
 
 
+def test_new_tab_reuses_chrome_newtab_without_creating_another_target():
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Page.navigate":
+            return {"frameId": "frame-1"}
+        return {}
+
+    def fake_send(req):
+        if req.get("meta") == "current_tab":
+            return {"targetId": "newtab-target", "url": "chrome://newtab/", "title": "New Tab"}
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers._send", side_effect=fake_send):
+        assert helpers.new_tab("https://example.com") == "newtab-target"
+
+    assert ("Page.navigate", {"url": "https://example.com"}) in calls
+    assert not any(method == "Target.createTarget" for method, _kwargs in calls)
+
+
+def test_new_tab_closes_created_blank_and_restores_previous_when_navigation_fails():
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.getTargetInfo":
+            return {"targetInfo": {"targetId": "previous-target", "url": "https://before.example", "title": "Before"}}
+        if method == "Target.createTarget":
+            return {"targetId": "blank-target"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-{kwargs['targetId']}"}
+        if method == "Page.navigate":
+            raise RuntimeError("navigation failed")
+        return {}
+
+    def fake_send(req):
+        if req.get("meta") == "current_tab":
+            return {"targetId": "previous-target", "url": "https://before.example", "title": "Before"}
+        if req.get("meta") == "set_session":
+            return {"session_id": req["session_id"]}
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers._send", side_effect=fake_send), \
+         pytest.raises(RuntimeError, match="navigation failed"):
+        helpers.new_tab("https://example.com")
+
+    assert ("Target.closeTarget", {"targetId": "blank-target"}) in calls
+    assert ("Target.activateTarget", {"targetId": "previous-target"}) in calls
+
+
+def test_new_tab_recovers_to_fallback_tab_when_previous_is_unavailable():
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.createTarget":
+            if len([c for c in calls if c[0] == "Target.createTarget"]) == 1:
+                return {"targetId": "failed-target"}
+            return {"targetId": "fallback-target"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-{kwargs['targetId']}"}
+        if method == "Target.getTargets":
+            return {"targetInfos": []}
+        if method == "Page.navigate":
+            raise RuntimeError("navigation failed")
+        return {}
+
+    def fake_send(req):
+        if req.get("meta") == "current_tab":
+            raise RuntimeError("no current tab")
+        if req.get("meta") == "set_session":
+            return {"session_id": req["session_id"]}
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers._send", side_effect=fake_send), \
+         pytest.raises(RuntimeError, match="navigation failed"):
+        helpers.new_tab("https://example.com")
+
+    assert ("Target.closeTarget", {"targetId": "failed-target"}) in calls
+    assert ("Target.activateTarget", {"targetId": "fallback-target"}) in calls
+
+
 def test_page_info_raises_clear_error_on_js_exception():
     def fake_send(req):
         return {}


### PR DESCRIPTION
Summary
- Reuse an existing blank/newtab page before creating a new target
- Close a newly-created tab if new_tab(url) navigation fails
- Update usage docs to prefer ensure_real_tab()+goto_url and add regressions

Test plan
- py -3.13 -m pytest tests/unit/test_daemon.py tests/unit/test_helpers.py -q
- py -3.13 -m pytest tests/unit -q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse existing blank/new-tab pages to avoid tab spam. On navigation failure, close the new tab and restore the previous tab, or fall back to a safe tab. Docs now prefer `ensure_real_tab()` + `goto_url()`, with regression tests.

- **Bug Fixes**
  - `Daemon.attach_first_page` now attaches to existing `about:blank`/`about:newtab`/`chrome://newtab/` pages before creating one.
  - `helpers.new_tab()` reuses a current blank/new-tab when possible; on navigation failure it closes the created tab, restores the previous tab if available, otherwise switches to an existing tab or creates a fresh blank tab.

<sup>Written for commit 2a67bf5c2d7bc8ff086a34c68dd22cfc21c0e322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

