### PR TITLE
Add Min browser (Electron) interaction skill

### DIFF
--- a/interaction-skills/min-browser.md
+++ b/interaction-skills/min-browser.md
@@ -1,0 +1,29 @@
+# Min browser (Electron-based browsers generally)
+
+Driving [Min](https://minbrowser.org/) (and most Electron-shell browsers) with the harness via `BU_CDP_WS`.
+
+## Enabling CDP
+
+- Min has no persistent remote-debugging setting — it must be **launched** with the flag:
+  `/Applications/Min.app/Contents/MacOS/Min --remote-debugging-port=9224 &`
+- Min holds a **single-instance lock**: if it's already running, launching with the flag just pings the existing instance and CDP never comes up. Kill first, then relaunch.
+- Min **ignores AppleScript `quit`** (`osascript -e 'quit app "Min"'` is a no-op). Use `pkill -f "Min.app/Contents/MacOS/Min"`, poll until the process is gone, then relaunch. Tabs restore automatically.
+- Resolve the ws URL from `http://127.0.0.1:9224/json/version` → `webSocketDebuggerUrl`, then:
+  `BU_NAME=min BU_CDP_WS=<ws url> browser-harness <<'PY' ...`
+
+## Target landscape (the trap)
+
+`Target.getTargets` shows several `page` targets that are NOT normal tabs:
+
+- `min://app/index.html` — Min's own UI (the browser chrome). Don't drive it.
+- `file://.../Min.app/.../placesService.html` — internal history service.
+- An **empty-URL `page` target** — a hidden background webContents. You *can* attach and navigate it and JS eval works, but `page_info()` reports a **0×0 viewport**, `Page.captureScreenshot` times out, and coordinate clicks are meaningless. Easy to mistake for a real tab.
+
+## Opening real tabs
+
+- `new_tab()` / `Target.createTarget` is unreliable in Electron shells — it may create a hidden webContents instead of a visible tab.
+- Open pages as visible tabs from the shell instead: `open -a Min "<url>"` (works for `file://` too).
+- Then pick the target where `type == "page"`, the URL matches what you opened, and the URL is neither `min://` nor under `/Applications/Min.app/`. `switch_tab()` to it.
+- **Sanity-check `page_info()` shows a non-zero viewport before clicking or screenshotting** — that's the reliable "this is a visible tab" test.
+
+Everything else (js, click_at_xy, capture_screenshot, wait_for_load) works normally once you're attached to a visible tab.


### PR DESCRIPTION
Adds `interaction-skills/min-browser.md` — field-tested notes for driving Min (and Electron-shell browsers generally) over CDP:

- Min's single-instance lock + no persistent debug setting → must pkill and relaunch with `--remote-debugging-port` (AppleScript quit is ignored)
- The hidden empty-URL `page` target trap: JS eval works but viewport is 0×0, screenshots time out, clicks are meaningless
- Open real visible tabs with `open -a Min "<url>"` and select the target by URL match + non-zero `page_info()` viewport
- `Target.createTarget`/`new_tab()` unreliability in Electron shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `interaction-skills/min-browser.md`, a field-tested guide for driving Min (and other Electron-shell browsers) over CDP. Covers reliable CDP enablement (kill and relaunch with `--remote-debugging-port`), the hidden 0×0 `page` target trap that breaks screenshots/clicks, and opening/selecting real visible tabs via `open -a Min "<url>"` with a non-zero viewport check.

<sup>Written for commit ef0391f064a31ce27384c3b16778aa5d2b04ead7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

