### PR TITLE
interaction-skills: verifying speculation-rules prerender under CDP

### DIFF
--- a/interaction-skills/prerendering.md
+++ b/interaction-skills/prerendering.md
@@ -1,0 +1,32 @@
+# Verifying speculation-rules prefetch/prerender
+
+You **cannot** observe a speculation-rules prerender activate while the harness is attached:
+Chrome disables prerendering whenever a CDP debugger is connected. Every attempt fails with
+`PrerenderingDisabledByDevTools`, and after navigation
+`performance.getEntriesByType('navigation')[0].activationStart` is `0`. This is the harness
+causing the failure, not the page — do not "fix" the site's rules based on this signal.
+
+What you CAN verify over CDP:
+
+```python
+import time, json
+cdp("Preload.enable")
+js("location.reload()")
+wait_for_load()
+time.sleep(5)
+evs = [e for e in drain_events() if e.get("method", "").startswith("Preload")]
+for e in evs:
+    if e["method"] == "Preload.prerenderStatusUpdated":
+        p = e["params"]
+        print(p["key"]["url"], p.get("status"), p.get("prerenderStatus"))
+```
+
+- `Preload.ruleSetUpdated` fires → the `<script type=speculationrules>` parsed correctly.
+- `Preload.prerenderStatusUpdated` with your target URLs → Chrome accepted the candidates.
+- Status `Failure` + `PrerenderingDisabledByDevTools` → rules are fine; they will prerender
+  in normal (non-automated) browsing. Any *other* failure reason is a real problem worth
+  fixing (e.g. cross-origin URL, `no-store`, exceeded candidate limits).
+
+Related limits worth knowing when writing rules: Chrome caps `immediate`/`eager` prerenders
+at 10 and `moderate`/`conservative` at 2 (FIFO), and skips prerendering entirely under Data
+Saver, battery saver, or low memory.


### PR DESCRIPTION
Field-tested: speculation-rules prerendering can never be observed activating while the harness (any CDP debugger) is attached — Chrome reports `PrerenderingDisabledByDevTools` for every candidate and `activationStart` stays 0. Easy to misread as broken rules on the page.

This skill documents the observer effect and the `Preload` CDP domain recipe (`Preload.enable` + `drain_events()`) to verify that rules parsed and candidates registered, plus which failure reasons are real vs. harness-induced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a concise guide to verify speculation‑rules prefetch/prerender under CDP. Explains that DevTools disables prerendering and shows how to validate rules via the `Preload` domain instead.

- **New Features**
  - Added `interaction-skills/prerendering.md` with steps to use `Preload.enable` and drain CDP events to confirm rule parsing and candidate registration.
  - Clarifies reading `Preload.ruleSetUpdated` / `Preload.prerenderStatusUpdated`, and that `PrerenderingDisabledByDevTools` is harness-induced, not a site bug.
  - Notes Chrome prerender limits and conditions that disable prerendering (Data Saver, battery saver, low memory).

<sup>Written for commit ee40411216abcd90cc35390518b6b7ce900d3006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

