### PR TITLE
rename to browser-harness

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: browser-use
-description: "Always use browser-use for any web interaction: automation, scraping, testing, or site/app work."
+name: browser-harness
+description: "Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work."
 ---
 
-# Browser Use
+# browser-harness
 
 Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py`. For setup, install, or connection problems, read https://github.com/browser-use/browser-harness/blob/main/install.md.
 

--- a/tests/unit/test_skill.py
+++ b/tests/unit/test_skill.py
@@ -30,6 +30,6 @@ def test_packaged_skill_frontmatter_is_valid_simple_yaml():
         metadata[key] = parsed
 
     assert metadata == {
-        "name": "browser-use",
-        "description": "Always use browser-use for any web interaction: automation, scraping, testing, or site/app work.",
+        "name": "browser-harness",
+        "description": "Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work.",
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rename the skill from `browser-use` to `browser-harness` and update tests to match, keeping docs accurate and tests green.

- Updated `SKILL.md` frontmatter (name/description) and heading to `browser-harness`.
- Adjusted `tests/unit/test_skill.py` expected metadata for the new name and description.

<sup>Written for commit 20d3cbd1d57c6b314182aedbacd5fec199253e2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

