### PR TITLE
fix Windows: daemon self-crash on non-UTF-8 locales, empty logs, errs

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -57,7 +57,7 @@ def _sock_path(name): return _RUNTIME / f"{_runtime_stem(name)}.sock"
 def _read_port_file(name):
     """(port, token) from the Windows port file, or (None, None) on any failure."""
     try:
-        d = json.loads(port_path(name).read_text())
+        d = json.loads(port_path(name).read_text(encoding="utf-8"))
         return int(d["port"]), d["token"]
     except (FileNotFoundError, ValueError, KeyError, TypeError, OSError):
         return None, None
@@ -181,7 +181,7 @@ async def serve(name, handler):
     pf = port_path(name)
     # Atomic write so a concurrent reader never sees a half-written file.
     tmp = pf.with_name(pf.name + ".tmp")
-    tmp.write_text(json.dumps({"port": port, "token": _server_token}))
+    tmp.write_text(json.dumps({"port": port, "token": _server_token}), encoding="utf-8")
     os.replace(tmp, pf)
     try:
         async with server: await asyncio.Event().wait()

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -114,7 +114,7 @@ def _load_env():
 
 
 def _load_env_file(p):
-    for line in p.read_text().splitlines():
+    for line in p.read_text(encoding="utf-8-sig", errors="replace").splitlines():
         line = line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
@@ -134,8 +134,8 @@ DOCTOR_TEXT_LIMIT = 140
 
 def _log_tail(name):
     try:
-        return ipc.log_path(name or NAME).read_text().strip().splitlines()[-1]
-    except (FileNotFoundError, IndexError):
+        return ipc.log_path(name or NAME).read_text(encoding="utf-8", errors="replace").strip().splitlines()[-1]
+    except (FileNotFoundError, IndexError, OSError):
         return None
 
 
@@ -327,10 +327,16 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     local = _is_local_chrome_mode(env)
     for attempt in (0, 1):
         e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
+        try:
+            stderr_sink = open(ipc.log_path(name or NAME), "ab")
+        except OSError:
+            stderr_sink = subprocess.DEVNULL
         p = subprocess.Popen(
             [sys.executable, "-m", "browser_harness.daemon"],
-            env=e, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
+            env=e, stdout=subprocess.DEVNULL, stderr=stderr_sink, **ipc.spawn_kwargs(),
         )
+        if stderr_sink is not subprocess.DEVNULL:
+            stderr_sink.close()
         deadline = time.time() + wait
         while time.time() < deadline:
             if daemon_alive(name): return
@@ -570,7 +576,7 @@ def list_local_profiles():
     import json, shutil, subprocess
     if not shutil.which("profile-use"):
         raise RuntimeError("profile-use not installed -- curl -fsSL https://browser-use.com/profile.sh | sh")
-    return json.loads(subprocess.check_output(["profile-use", "list", "--json"], text=True))
+    return json.loads(subprocess.check_output(["profile-use", "list", "--json"], text=True, encoding="utf-8", errors="replace"))
 
 
 def sync_local_profile(profile_name, browser=None, cloud_profile_id=None,
@@ -605,7 +611,7 @@ def sync_local_profile(profile_name, browser=None, cloud_profile_id=None,
         cmd += ["--domain", d]
     for d in exclude_domains or []:
         cmd += ["--exclude-domain", d]
-    r = subprocess.run(cmd, text=True, capture_output=True, env={**os.environ, "BROWSER_USE_API_KEY": key})
+    r = subprocess.run(cmd, text=True, encoding="utf-8", errors="replace", capture_output=True, env={**os.environ, "BROWSER_USE_API_KEY": key})
     sys.stdout.write(r.stdout)
     sys.stderr.write(r.stderr)
     if r.returncode != 0:
@@ -724,10 +730,10 @@ def _chrome_running():
     system = platform.system()
     try:
         if system == "Windows":
-            out = subprocess.check_output(["tasklist"], text=True, timeout=5)
+            out = subprocess.check_output(["tasklist"], text=True, errors="replace", timeout=5)
             names = ("chrome.exe", "msedge.exe", "helium.exe")
         else:
-            out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, timeout=5)
+            out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, errors="replace", timeout=5)
             names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium")
         return any(n.lower() in out.lower() for n in names)
     except Exception:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -655,8 +655,8 @@ def _install_mode():
 
 def _cache_read():
     try:
-        return json.loads(VERSION_CACHE.read_text())
-    except (FileNotFoundError, ValueError):
+        return json.loads(VERSION_CACHE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
         return {}
 
 

--- a/src/browser_harness/auth.py
+++ b/src/browser_harness/auth.py
@@ -133,7 +133,7 @@ def auth_path() -> Path:
 def load_auth_file(path: Path | None = None) -> dict:
     path = path or auth_path()
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}
     except json.JSONDecodeError as e:

--- a/src/browser_harness/auth.py
+++ b/src/browser_harness/auth.py
@@ -136,7 +136,7 @@ def load_auth_file(path: Path | None = None) -> dict:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
         raise AuthError(f"auth file is not valid JSON: {path}") from e
 
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
-import asyncio, json, os, socket, sys, time, urllib.error, urllib.request
+import asyncio, json, os, platform, socket, sys, time, urllib.error, urllib.request
 from urllib.parse import urlparse
 from collections import deque
 from pathlib import Path
@@ -20,7 +20,7 @@ def _load_env():
 
 
 def _load_env_file(p):
-    for line in p.read_text().splitlines():
+    for line in p.read_text(encoding="utf-8-sig", errors="replace").splitlines():
         line = line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
@@ -35,43 +35,62 @@ SOCK = ipc.sock_addr(NAME)
 LOG = str(ipc.log_path(NAME))
 PID = str(ipc.pid_path(NAME))
 BUF = 500
-PROFILES = [
-    Path.home() / "Library/Application Support/Google/Chrome",
-    Path.home() / "Library/Application Support/Google/Chrome Canary",
-    Path.home() / "Library/Application Support/Comet",
-    Path.home() / "Library/Application Support/Arc/User Data",
-    Path.home() / "Library/Application Support/Dia/User Data",
-    Path.home() / "Library/Application Support/Microsoft Edge",
-    Path.home() / "Library/Application Support/Microsoft Edge Beta",
-    Path.home() / "Library/Application Support/Microsoft Edge Dev",
-    Path.home() / "Library/Application Support/Microsoft Edge Canary",
-    Path.home() / "Library/Application Support/BraveSoftware/Brave-Browser",
-    Path.home() / ".config/google-chrome",
-    Path.home() / ".config/chromium",
-    Path.home() / ".config/chromium-browser",
-    Path.home() / ".config/microsoft-edge",
-    Path.home() / ".config/microsoft-edge-beta",
-    Path.home() / ".config/microsoft-edge-dev",
-    Path.home() / ".var/app/org.chromium.Chromium/config/chromium",
-    Path.home() / ".var/app/com.google.Chrome/config/google-chrome",
-    Path.home() / ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
-    Path.home() / ".var/app/com.microsoft.Edge/config/microsoft-edge",
-    Path.home() / "AppData/Local/Google/Chrome/User Data",
-    Path.home() / "AppData/Local/Google/Chrome SxS/User Data",
-    Path.home() / "AppData/Local/Chromium/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge Beta/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge Dev/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge SxS/User Data",
-    Path.home() / "AppData/Local/BraveSoftware/Brave-Browser/User Data",
-]
+_MAC_PROFILES = (
+    "Library/Application Support/Google/Chrome",
+    "Library/Application Support/Google/Chrome Canary",
+    "Library/Application Support/Comet",
+    "Library/Application Support/Arc/User Data",
+    "Library/Application Support/Dia/User Data",
+    "Library/Application Support/Microsoft Edge",
+    "Library/Application Support/Microsoft Edge Beta",
+    "Library/Application Support/Microsoft Edge Dev",
+    "Library/Application Support/Microsoft Edge Canary",
+    "Library/Application Support/BraveSoftware/Brave-Browser",
+)
+_LINUX_PROFILES = (
+    ".config/google-chrome",
+    ".config/chromium",
+    ".config/chromium-browser",
+    ".config/microsoft-edge",
+    ".config/microsoft-edge-beta",
+    ".config/microsoft-edge-dev",
+    ".var/app/org.chromium.Chromium/config/chromium",
+    ".var/app/com.google.Chrome/config/google-chrome",
+    ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
+    ".var/app/com.microsoft.Edge/config/microsoft-edge",
+)
+_WINDOWS_PROFILES = (  # relative to %LOCALAPPDATA%; SxS = Canary channel
+    "Google/Chrome/User Data",
+    "Google/Chrome SxS/User Data",
+    "Google/Chrome Beta/User Data",
+    "Google/Chrome Dev/User Data",
+    "Chromium/User Data",
+    "Microsoft/Edge/User Data",
+    "Microsoft/Edge Beta/User Data",
+    "Microsoft/Edge Dev/User Data",
+    "Microsoft/Edge SxS/User Data",
+    "BraveSoftware/Brave-Browser/User Data",
+)
+
+
+def profile_dirs(system=None):
+    system = system or platform.system()
+    if system == "Windows":
+        local = Path(os.environ.get("LOCALAPPDATA") or Path.home() / "AppData/Local")
+        return [local / p for p in _WINDOWS_PROFILES]
+    if system == "Darwin":
+        return [Path.home() / p for p in _MAC_PROFILES]
+    return [Path.home() / p for p in _LINUX_PROFILES]
+
+
+PROFILES = profile_dirs()
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 
 
 def log(msg):
-    open(LOG, "a").write(f"{msg}\n")
+    open(LOG, "a", encoding="utf-8", errors="replace").write(f"{msg}\n")
 
 
 async def _silent(coro):
@@ -92,7 +111,7 @@ def _ws_from_devtools_active_port(http_url: str) -> str | None:
         host = f"[{host}]"
     for base in PROFILES:
         try:
-            active = (base / "DevToolsActivePort").read_text().splitlines()
+            active = (base / "DevToolsActivePort").read_text(encoding="utf-8", errors="replace").splitlines()
         except (FileNotFoundError, NotADirectoryError):
             continue
         port = active[0].strip() if active else ""
@@ -125,12 +144,15 @@ def get_ws_url():
             except Exception as e:
                 last_err = e
                 time.sleep(1)
-        raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- is the dedicated automation Chrome running?")
+        hint = "is the dedicated automation Chrome running? Launch it with --remote-debugging-port=<port> --user-data-dir=<dedicated dir>"
+        if platform.system() == "Windows":
+            hint += "; on Windows also check that a firewall/antivirus isn't blocking localhost connections"
+        raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- {hint}")
     deadline = time.time() + 30
     while time.time() < deadline:
         for base in PROFILES:
             try:
-                active = (base / "DevToolsActivePort").read_text().splitlines()
+                active = (base / "DevToolsActivePort").read_text(encoding="utf-8", errors="replace").splitlines()
             except (FileNotFoundError, NotADirectoryError):
                 continue
             port = active[0].strip() if active else ""

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -25,7 +25,7 @@ def _load_env():
 
 
 def _load_env_file(p):
-    for line in p.read_text().splitlines():
+    for line in p.read_text(encoding="utf-8-sig", errors="replace").splitlines():
         line = line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -1,12 +1,14 @@
 import os, sys, time, urllib.request
 from io import StringIO
 
-# Windows default stdout encoding is cp1252, which can't encode the 🐴 marker
-# helpers prepend to tab titles (or anything else outside Latin-1). Force UTF-8
-# so `print(page_info())` doesn't UnicodeEncodeError on Windows. Issue #124(4).
-if hasattr(sys.stdout, "reconfigure"):
-    try: sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-    except Exception: pass
+# Windows default stdout/stderr encoding is cp1252
+# which can't encode the 🐴 marker helpers prepend to tab titles (or anything
+# else outside the locale charset). Force UTF-8 so `print(page_info())` and
+# tracebacks carrying page titles don't UnicodeEncodeError on Windows. #124(4).
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try: _stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception: pass
 
 from .admin import (
     _version,
@@ -92,7 +94,8 @@ def _cloud_auth_configured():
 
 def _print_skill():
     from importlib import resources
-    print(resources.files("browser_harness").joinpath("SKILL.md").read_text(), end="")
+    # SKILL.md is UTF-8 (contains emoji); locale-codec read crashes on gbk Windows
+    print(resources.files("browser_harness").joinpath("SKILL.md").read_text(encoding="utf-8"), end="")
 
 
 def _telemetry_command(args):

--- a/src/browser_harness/telemetry.py
+++ b/src/browser_harness/telemetry.py
@@ -51,7 +51,7 @@ def _config_path() -> Path:
 
 def _load_config() -> dict:
     try:
-        return json.loads(_config_path().read_text())
+        return json.loads(_config_path().read_text(encoding="utf-8"))
     except (FileNotFoundError, OSError, ValueError):
         return {}
 
@@ -63,7 +63,7 @@ def _save_config(data: dict) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         if not parent_existed and platform.system() != "Windows":
             os.chmod(path.parent, 0o700)
-        path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         if platform.system() != "Windows":
             os.chmod(path, 0o600)
     except OSError:


### PR DESCRIPTION
- daemon wrote its log with the locale codec
- daemon spawned with stderr=DEVNULL, so pre-log crashes left an empty log. stderr now appends into the daemon log. startup errors show the real traceback.
- profile discovery checked all 28 paths on every OS, so Windows errors led with macOS paths. Split per-OS, resolve via %LOCALAPPDATA%, add Chrome Beta/Dev.
- audited every file read / subprocess decode to utf-8 (+BOM-safe .env); tasklist/ps keep locale codec but get errors="replace".
- WinError 10061 message now explains --remote-debugging-port + firewall hint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows reliability: the daemon no longer crashes on non‑UTF‑8 locales and startup errors are now logged instead of being lost. Standardizes UTF‑8 across I/O, improves per‑OS profile discovery, and clarifies Windows connection errors.

- **Bug Fixes**
  - Use UTF‑8 for all file reads/writes (BOM‑safe for .env); keep locale for `tasklist`/`ps` with errors="replace"; ensure JSON config/auth/ipc use UTF‑8, and treat undecodable `auth.json` as corrupt.
  - Daemon logging is UTF‑8 and now captures stderr, so pre‑init failures show real tracebacks instead of empty logs.
  - Profile discovery split per‑OS; Windows resolves via %LOCALAPPDATA% and includes Chrome Beta/Dev; `DevToolsActivePort` read is UTF‑8.
  - Clearer Windows “connection refused” error with `--remote-debugging-port` and firewall/antivirus hint.
  - Force UTF‑8 on stdout/stderr and read SKILL.md as UTF‑8 to avoid Unicode errors on Windows.

<sup>Written for commit 7d10d814d71c4ebe362d05f5f0a84d76a4672e51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

