### PR TITLE
improve speed and accuracy with read_page, list_interactive helpers

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -79,8 +79,9 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 
 ## Page Workflow
 
+- `read_page()` (page text as markdown) and `list_interactive()` (visible clickable elements with `x, y` for `click_at_xy`) answer most "what's on this page / what can I click" questions faster than a screenshot; screenshot when layout or imagery matters.
 - Screenshots first: use `capture_screenshot()` to understand visible state.
-- Clicking: screenshot -> read pixel -> `click_at_xy(x, y)` -> screenshot again.
+- Clicking: screenshot -> read pixel -> `click_at_xy(x, y)` -> verify. When a targeted `js(...)` or `page_info()` check can confirm the outcome (cart count, element state, URL), prefer it over another screenshot — it is much faster; screenshot again when you actually need to see the page.
 - After navigation, call `wait_for_load()`.
 - If the current tab is stale or internal, call `ensure_real_tab()`.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "cdp-use==1.4.5",
     "fetch-use==0.4.0",
+    "markdownify==1.2.2",
     "pillow==12.2.0",
     "websockets==15.0.1",
 ]

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -146,6 +146,132 @@ def page_info():
     expression = "JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})"
     return json.loads(_runtime_evaluate(expression))
 
+def _preprocess_markdown_content(content, max_newlines=3):
+    import re
+    content = re.sub(r'`\{["\w].*?\}`', "", content, flags=re.DOTALL)
+    content = re.sub(r'\{"\$type":[^}]{100,}\}', "", content)
+    content = re.sub(r'\{"[^"]{5,}":\{[^}]{100,}\}', "", content)
+    content = re.sub(r"\n{4,}", "\n" * max_newlines, content)
+    filtered_lines = []
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if len(stripped) > 100 and stripped[0] in "{[":
+            try:
+                json.loads(stripped)
+                continue
+            except ValueError:
+                pass
+        filtered_lines.append(line)
+    return "\n".join(filtered_lines).strip()
+
+
+def _convert_html_to_markdown(page_html):
+    import re
+    from markdownify import markdownify as md
+    page_html = re.sub(r"<(script|style|noscript)\b.*?</\1>", "", page_html, flags=re.DOTALL | re.IGNORECASE)
+    content = md(
+        page_html,
+        heading_style="ATX",
+        strip=["script", "style"],
+        bullets="-",
+        code_language="",
+        escape_asterisks=False,
+        escape_underscores=False,
+        escape_misc=False,
+        autolinks=False,
+        default_title=False,
+        keep_inline_images_in=[],
+    )
+    return _preprocess_markdown_content(content)
+
+
+def read_page(max_chars=4000):
+    html = js("document.documentElement ? document.documentElement.outerHTML : ''")
+    try:
+        content = _convert_html_to_markdown(html)
+    except ImportError:
+        content = js("document.body ? document.body.innerText : ''") or ""
+        import re
+        content = _preprocess_markdown_content(re.sub(r"\n{4,}", "\n\n\n", content))
+    return content[:int(max_chars)]
+
+
+_IS_INTERACTIVE_JS = r"""
+  const INTERACTIVE_TAGS = new Set(['button','input','select','textarea','a','details','summary','option','optgroup']);
+  const INTERACTIVE_ROLES = new Set(['button','link','menuitem','option','radio','checkbox','tab','textbox','combobox','slider','spinbutton','search','searchbox','row','cell','gridcell']);
+  const INTERACTIVE_ATTRS = ['onclick','onmousedown','onmouseup','onkeydown','onkeyup','tabindex'];
+  const SEARCH_INDICATORS = ['search','magnify','glass','lookup','find','query','search-icon','search-btn','search-button','searchbox'];
+  const hasFormControlDescendant = (el, depth) => {
+    if (depth <= 0) return false;
+    for (const c of el.children) {
+      const t = c.tagName.toLowerCase();
+      if (t === 'input' || t === 'select' || t === 'textarea') return true;
+      if (hasFormControlDescendant(c, depth - 1)) return true;
+    }
+    return false;
+  };
+  const isInteractive = (el) => {
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'html' || tag === 'body') return false;
+    if (el.disabled || el.getAttribute('aria-disabled') === 'true') return false;
+    if (el.getAttribute('aria-hidden') === 'true') return false;
+    if (tag === 'label') {
+      if (el.getAttribute('for')) return false;
+      if (hasFormControlDescendant(el, 2)) return true;
+    }
+    if (tag === 'span' && hasFormControlDescendant(el, 2)) return true;
+    const cls = (el.getAttribute('class') || '').toLowerCase();
+    const id = (el.getAttribute('id') || '').toLowerCase();
+    if (SEARCH_INDICATORS.some(sI => cls.includes(sI) || id.includes(sI))) return true;
+    for (const a of el.attributes) {
+      if (a.name.startsWith('data-') && SEARCH_INDICATORS.some(sI => a.value.toLowerCase().includes(sI))) return true;
+    }
+    if (INTERACTIVE_TAGS.has(tag)) return true;
+    if (INTERACTIVE_ATTRS.some(a => el.hasAttribute(a))) return true;
+    const role = el.getAttribute('role');
+    if (role && INTERACTIVE_ROLES.has(role)) return true;
+    const r = el.getBoundingClientRect();
+    if (r.width >= 10 && r.width <= 50 && r.height >= 10 && r.height <= 50 &&
+        ['class','role','onclick','data-action','aria-label'].some(a => el.hasAttribute(a))) return true;
+    if (getComputedStyle(el).cursor === 'pointer') return true;
+    return false;
+  };
+"""
+
+
+def list_interactive(limit=60, viewport_only=True):
+    """Visible interactive elements with viewport coordinates for click_at_xy."""
+    expr = r"""(() => {
+%s
+  const out = [];
+  const seen = [];
+  for (const e of document.querySelectorAll('*')) {
+    const r = e.getBoundingClientRect();
+    if (r.width < 4 || r.height < 4) continue;
+    const off = r.bottom < 0 || r.top > innerHeight || r.right < 0 || r.left > innerWidth;
+    if (VIEWPORT_ONLY && off) continue;
+    if (!isInteractive(e)) continue;
+    const st = getComputedStyle(e);
+    if (st.visibility === 'hidden' || st.display === 'none' || +st.opacity === 0) continue;
+    if (seen.some(a => a.contains(e))) continue;  // ancestor already listed (paint-order style dedup)
+    const x = Math.round(r.left + r.width / 2), y = Math.round(r.top + Math.min(r.height / 2, 40));
+    if (!off) {
+      const t = document.elementFromPoint(Math.min(Math.max(x, 0), innerWidth - 1), Math.min(Math.max(y, 0), innerHeight - 1));
+      if (!t || (t !== e && !e.contains(t) && !t.contains(e))) continue;
+    }
+    const text = (e.innerText || e.value || e.placeholder || (e.getAttribute && e.getAttribute('aria-label')) || e.alt || '').trim().replace(/\s+/g, ' ').slice(0, 60);
+    out.push({x, y, tag: e.tagName.toLowerCase() + (e.id ? '#' + e.id : ''), text});
+    seen.push(e);
+    if (out.length >= LIMIT) break;
+  }
+  return out;
+})()""" % _IS_INTERACTIVE_JS
+    expr = expr.replace("VIEWPORT_ONLY", "true" if viewport_only else "false").replace("LIMIT", str(int(limit)))
+    return js(expr)
+
+
 # --- input ---
 _debug_click_counter = 0
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -198,78 +198,50 @@ def read_page(max_chars=4000):
     return content[:int(max_chars)]
 
 
-_IS_INTERACTIVE_JS = r"""
-  const INTERACTIVE_TAGS = new Set(['button','input','select','textarea','a','details','summary','option','optgroup']);
-  const INTERACTIVE_ROLES = new Set(['button','link','menuitem','option','radio','checkbox','tab','textbox','combobox','slider','spinbutton','search','searchbox','row','cell','gridcell']);
-  const INTERACTIVE_ATTRS = ['onclick','onmousedown','onmouseup','onkeydown','onkeyup','tabindex'];
-  const SEARCH_INDICATORS = ['search','magnify','glass','lookup','find','query','search-icon','search-btn','search-button','searchbox'];
-  const hasFormControlDescendant = (el, depth) => {
-    if (depth <= 0) return false;
-    for (const c of el.children) {
-      const t = c.tagName.toLowerCase();
-      if (t === 'input' || t === 'select' || t === 'textarea') return true;
-      if (hasFormControlDescendant(c, depth - 1)) return true;
-    }
-    return false;
-  };
-  const isInteractive = (el) => {
-    const tag = el.tagName.toLowerCase();
-    if (tag === 'html' || tag === 'body') return false;
-    if (el.disabled || el.getAttribute('aria-disabled') === 'true') return false;
-    if (el.getAttribute('aria-hidden') === 'true') return false;
-    if (tag === 'label') {
-      if (el.getAttribute('for')) return false;
-      if (hasFormControlDescendant(el, 2)) return true;
-    }
-    if (tag === 'span' && hasFormControlDescendant(el, 2)) return true;
-    const cls = (el.getAttribute('class') || '').toLowerCase();
-    const id = (el.getAttribute('id') || '').toLowerCase();
-    if (SEARCH_INDICATORS.some(sI => cls.includes(sI) || id.includes(sI))) return true;
-    for (const a of el.attributes) {
-      if (a.name.startsWith('data-') && SEARCH_INDICATORS.some(sI => a.value.toLowerCase().includes(sI))) return true;
-    }
-    if (INTERACTIVE_TAGS.has(tag)) return true;
-    if (INTERACTIVE_ATTRS.some(a => el.hasAttribute(a))) return true;
-    const role = el.getAttribute('role');
-    if (role && INTERACTIVE_ROLES.has(role)) return true;
-    const r = el.getBoundingClientRect();
-    if (r.width >= 10 && r.width <= 50 && r.height >= 10 && r.height <= 50 &&
-        ['class','role','onclick','data-action','aria-label'].some(a => el.hasAttribute(a))) return true;
-    if (getComputedStyle(el).cursor === 'pointer') return true;
-    return false;
-  };
-"""
+_INTERACTIVE_AX_ROLES = {
+    "button", "link", "textbox", "searchbox", "checkbox", "radio", "combobox",
+    "switch", "slider", "spinbutton", "menuitem", "menuitemcheckbox",
+    "menuitemradio", "tab", "option", "listbox", "textfield",
+    "popupbutton", "togglebutton", "disclosuretriangle",
+}
 
 
 def list_interactive(limit=60, viewport_only=True):
     """Visible interactive elements with viewport coordinates for click_at_xy."""
-    expr = r"""(() => {
-%s
-  const out = [];
-  const seen = [];
-  for (const e of document.querySelectorAll('*')) {
-    const r = e.getBoundingClientRect();
-    if (r.width < 4 || r.height < 4) continue;
-    const off = r.bottom < 0 || r.top > innerHeight || r.right < 0 || r.left > innerWidth;
-    if (VIEWPORT_ONLY && off) continue;
-    if (!isInteractive(e)) continue;
-    const st = getComputedStyle(e);
-    if (st.visibility === 'hidden' || st.display === 'none' || +st.opacity === 0) continue;
-    if (seen.some(a => a.contains(e))) continue;  // ancestor already listed (paint-order style dedup)
-    const x = Math.round(r.left + r.width / 2), y = Math.round(r.top + Math.min(r.height / 2, 40));
-    if (!off) {
-      const t = document.elementFromPoint(Math.min(Math.max(x, 0), innerWidth - 1), Math.min(Math.max(y, 0), innerHeight - 1));
-      if (!t || (t !== e && !e.contains(t) && !t.contains(e))) continue;
-    }
-    const text = (e.innerText || e.value || e.placeholder || (e.getAttribute && e.getAttribute('aria-label')) || e.alt || '').trim().replace(/\s+/g, ' ').slice(0, 60);
-    out.push({x, y, tag: e.tagName.toLowerCase() + (e.id ? '#' + e.id : ''), text});
-    seen.push(e);
-    if (out.length >= LIMIT) break;
-  }
-  return out;
-})()""" % _IS_INTERACTIVE_JS
-    expr = expr.replace("VIEWPORT_ONLY", "true" if viewport_only else "false").replace("LIMIT", str(int(limit)))
-    return js(expr)
+    ax_nodes = cdp("Accessibility.getFullAXTree").get("nodes", [])
+    snap = cdp("DOMSnapshot.captureSnapshot", computedStyles=[])
+    vp = json.loads(js("JSON.stringify({w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY})"))
+
+    # backendNodeId -> absolute layout bounds, main document only (sub-document
+    # bounds are in the iframe's own coordinate space and would need offsetting)
+    rects = {}
+    docs = snap.get("documents") or []
+    if docs:
+        doc = docs[0]
+        backend_ids = doc["nodes"]["backendNodeId"]
+        layout = doc["layout"]
+        for i, node_index in enumerate(layout["nodeIndex"]):
+            rects[backend_ids[node_index]] = layout["bounds"][i]
+
+    out = []
+    for n in ax_nodes:
+        if n.get("ignored"):
+            continue
+        role = ((n.get("role") or {}).get("value") or "").lower()
+        if role not in _INTERACTIVE_AX_ROLES:
+            continue
+        b = rects.get(n.get("backendDOMNodeId"))
+        if not b or b[2] < 4 or b[3] < 4:
+            continue
+        x = b[0] - vp["sx"] + b[2] / 2
+        y = b[1] - vp["sy"] + min(b[3] / 2, 40)
+        if viewport_only and not (0 <= x <= vp["w"] and 0 <= y <= vp["h"]):
+            continue
+        name = ((n.get("name") or {}).get("value") or "").strip()[:60]
+        out.append({"x": round(x), "y": round(y), "role": role, "name": name})
+        if len(out) >= int(limit):
+            break
+    return out
 
 
 # --- input ---

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -156,6 +156,9 @@ def _preprocess_markdown_content(content, max_newlines=3):
     for line in content.split("\n"):
         stripped = line.strip()
         if not stripped:
+            # keep one blank line so markdown paragraphs stay separated
+            if filtered_lines and filtered_lines[-1] != "":
+                filtered_lines.append("")
             continue
         if len(stripped) > 100 and stripped[0] in "{[":
             try:
@@ -201,13 +204,26 @@ def read_page(max_chars=4000):
 _INTERACTIVE_AX_ROLES = {
     "button", "link", "textbox", "searchbox", "checkbox", "radio", "combobox",
     "switch", "slider", "spinbutton", "menuitem", "menuitemcheckbox",
-    "menuitemradio", "tab", "option", "listbox", "textfield",
+    "menuitemradio", "tab", "option", "listbox", "textfield", "gridcell",
     "popupbutton", "togglebutton", "disclosuretriangle",
 }
 
+# AX containers that report focusable=true without being click targets
+_NON_TARGET_FOCUSABLE_ROLES = {"rootwebarea", "webarea", "iframe", "document"}
+
+
+def _ax_focusable(node):
+    for prop in node.get("properties") or []:
+        if prop.get("name") == "focusable":
+            return bool((prop.get("value") or {}).get("value"))
+    return False
+
 
 def list_interactive(limit=60, viewport_only=True):
-    """Visible interactive elements with viewport coordinates for click_at_xy."""
+    """Visible interactive elements with viewport coordinates for click_at_xy.
+
+    Roles/names come from the AX tree; custom widgets count when focusable.
+    With viewport_only=False, off-screen entries need scrolling before use."""
     ax_nodes = cdp("Accessibility.getFullAXTree").get("nodes", [])
     snap = cdp("DOMSnapshot.captureSnapshot", computedStyles=[])
     vp = json.loads(js("JSON.stringify({w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY})"))
@@ -228,7 +244,9 @@ def list_interactive(limit=60, viewport_only=True):
         if n.get("ignored"):
             continue
         role = ((n.get("role") or {}).get("value") or "").lower()
-        if role not in _INTERACTIVE_AX_ROLES:
+        if role not in _INTERACTIVE_AX_ROLES and not (
+            _ax_focusable(n) and role not in _NON_TARGET_FOCUSABLE_ROLES
+        ):
             continue
         b = rects.get(n.get("backendDOMNodeId"))
         if not b or b[2] < 4 or b[3] < 4:
@@ -241,6 +259,19 @@ def list_interactive(limit=60, viewport_only=True):
         out.append({"x": round(x), "y": round(y), "role": role, "name": name})
         if len(out) >= int(limit):
             break
+    # Focusable custom widgets often have no AX name; backfill from the DOM
+    # text under their coordinates in a single evaluate
+    unnamed = [e for e in out if not e["name"] and 0 <= e["x"] <= vp["w"] and 0 <= e["y"] <= vp["h"]]
+    if unnamed:
+        pts = json.dumps([[e["x"], e["y"]] for e in unnamed])
+        texts = js(
+            "(%s).map(([x,y]) => {const el = document.elementFromPoint(x,y);"
+            "return el ? (el.innerText || el.getAttribute('aria-label') || '').trim()"
+            ".replace(/\\s+/g, ' ').slice(0, 60) : '';})" % pts
+        )
+        if isinstance(texts, list):
+            for e, t in zip(unnamed, texts):
+                e["name"] = t or ""
     return out
 
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -208,71 +208,100 @@ _INTERACTIVE_AX_ROLES = {
     "popupbutton", "togglebutton", "disclosuretriangle",
 }
 
-# AX containers that report focusable=true without being click targets
-_NON_TARGET_FOCUSABLE_ROLES = {"rootwebarea", "webarea", "iframe", "document"}
 
 
-def _ax_focusable(node):
-    for prop in node.get("properties") or []:
-        if prop.get("name") == "focusable":
-            return bool((prop.get("value") or {}).get("value"))
-    return False
+def _snapshot_text(node_idx, children, node_name, node_value, strings):
+    """Concatenated descendant text of a DOMSnapshot node (its label)."""
+    parts, stack, budget = [], [children.get(node_idx, [])[:]], 0
+    flat = children.get(node_idx, [])[:]
+    while flat and budget < 400:
+        i = flat.pop(0); budget += 1
+        if strings[node_name[i]] == "#text":
+            v = node_value[i]
+            if v >= 0:
+                parts.append(strings[v])
+        flat.extend(children.get(i, []))
+    return " ".join(" ".join(parts).split())[:60]
 
 
 def list_interactive(limit=60, viewport_only=True):
     """Visible interactive elements with viewport coordinates for click_at_xy.
 
-    Roles/names come from the AX tree; custom widgets count when focusable.
+    Elements with an interactive AX role come first; roleless custom widgets are added
+    only when the snapshot marks them clickable (a real click listener).
     With viewport_only=False, off-screen entries need scrolling before use."""
     ax_nodes = cdp("Accessibility.getFullAXTree").get("nodes", [])
     snap = cdp("DOMSnapshot.captureSnapshot", computedStyles=[])
-    vp = json.loads(js("JSON.stringify({w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY})"))
+    vp = cdp("Page.getLayoutMetrics").get("cssLayoutViewport", {})
+    vw, vh = vp.get("clientWidth", 0), vp.get("clientHeight", 0)
 
-    # backendNodeId -> absolute layout bounds, main document only (sub-document
-    # bounds are in the iframe's own coordinate space and would need offsetting)
-    rects = {}
     docs = snap.get("documents") or []
-    if docs:
-        doc = docs[0]
-        backend_ids = doc["nodes"]["backendNodeId"]
-        layout = doc["layout"]
-        for i, node_index in enumerate(layout["nodeIndex"]):
-            rects[backend_ids[node_index]] = layout["bounds"][i]
+    if not docs:
+        return []
+    doc = docs[0]
+    strings = snap["strings"]
+    nodes = doc["nodes"]
+    node_name, node_value, parent = nodes["nodeName"], nodes["nodeValue"], nodes["parentIndex"]
+    # main document only — sub-document bounds are in the iframe's own space
+    sx, sy = doc.get("scrollOffsetX", 0), doc.get("scrollOffsetY", 0)
 
-    out = []
+    # backendNodeId -> layout bounds, and node index -> backendNodeId
+    idx_bounds = {}
+    layout = doc["layout"]
+    for i, node_index in enumerate(layout["nodeIndex"]):
+        idx_bounds[node_index] = layout["bounds"][i]
+    backend_ids = nodes["backendNodeId"]
+    id_to_idx = {bid: i for i, bid in enumerate(backend_ids)}
+    clickable = set((nodes.get("isClickable") or {}).get("index") or [])
+    children = {}
+    for i, par in enumerate(parent):
+        if par >= 0:
+            children.setdefault(par, []).append(i)
+
+    def emit(node_idx, role, name):
+        b = idx_bounds.get(node_idx)
+        if not b or b[2] < 4 or b[3] < 4:
+            return None
+        x = b[0] - sx + b[2] / 2
+        y = b[1] - sy + min(b[3] / 2, 40)
+        if viewport_only and not (0 <= x <= vw and 0 <= y <= vh):
+            return None
+        if not name:
+            name = _snapshot_text(node_idx, children, node_name, node_value, strings)
+        return {"x": round(x), "y": round(y), "role": role, "name": name}
+
+    primary, seen = [], set()
     for n in ax_nodes:
         if n.get("ignored"):
             continue
         role = ((n.get("role") or {}).get("value") or "").lower()
-        if role not in _INTERACTIVE_AX_ROLES and not (
-            _ax_focusable(n) and role not in _NON_TARGET_FOCUSABLE_ROLES
-        ):
+        if role not in _INTERACTIVE_AX_ROLES:
             continue
-        b = rects.get(n.get("backendDOMNodeId"))
-        if not b or b[2] < 4 or b[3] < 4:
+        ni = id_to_idx.get(n.get("backendDOMNodeId"))
+        if ni is None:
             continue
-        x = b[0] - vp["sx"] + b[2] / 2
-        y = b[1] - vp["sy"] + min(b[3] / 2, 40)
-        if viewport_only and not (0 <= x <= vp["w"] and 0 <= y <= vp["h"]):
+        entry = emit(ni, role, ((n.get("name") or {}).get("value") or "").strip()[:60])
+        if entry:
+            seen.add(ni)
+            primary.append(entry)
+            if len(primary) >= int(limit):
+                return primary
+
+    # roleless custom widgets Chrome flagged clickable (onclick / click listener);
+    # scroll and focus-management wrappers are not flagged, so they never leak
+    fallback = []
+    for ni in clickable:
+        if ni in seen:
             continue
-        name = ((n.get("name") or {}).get("value") or "").strip()[:60]
-        out.append({"x": round(x), "y": round(y), "role": role, "name": name})
-        if len(out) >= int(limit):
-            break
-    # Focusable custom widgets often have no AX name; backfill from the DOM
-    # text under their coordinates in a single evaluate
-    unnamed = [e for e in out if not e["name"] and 0 <= e["x"] <= vp["w"] and 0 <= e["y"] <= vp["h"]]
-    if unnamed:
-        pts = json.dumps([[e["x"], e["y"]] for e in unnamed])
-        texts = js(
-            "(%s).map(([x,y]) => {const el = document.elementFromPoint(x,y);"
-            "return el ? (el.innerText || el.getAttribute('aria-label') || '').trim()"
-            ".replace(/\\s+/g, ' ').slice(0, 60) : '';})" % pts
-        )
-        if isinstance(texts, list):
-            for e, t in zip(unnamed, texts):
-                e["name"] = t or ""
-    return out
+        b = idx_bounds.get(ni)
+        # a delegated listener on a big container isn't a click target
+        if b and b[2] * b[3] > 0.4 * vw * vh:
+            continue
+        entry = emit(ni, "clickable", "")
+        if entry:
+            fallback.append(entry)
+
+    return (primary + fallback)[: int(limit)]
 
 
 # --- input ---

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -212,7 +212,7 @@ _INTERACTIVE_AX_ROLES = {
 
 def _snapshot_text(node_idx, children, node_name, node_value, strings):
     """Concatenated descendant text of a DOMSnapshot node (its label)."""
-    parts, stack, budget = [], [children.get(node_idx, [])[:]], 0
+    parts, budget = [], 0
     flat = children.get(node_idx, [])[:]
     while flat and budget < 400:
         i = flat.pop(0); budget += 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `read_page()` and `list_interactive()` to quickly summarize page content and list visible, clickable elements with coordinates, reducing screenshots and speeding up actions. `list_interactive()` uses the Accessibility tree with a clickable-widget fallback for higher accuracy; prefer verifying outcomes with `js(...)`/`page_info()` over extra screenshots.

- **New Features**
  - `read_page(max_chars=4000)`: converts HTML to clean markdown, strips scripts/styles/JSON, keeps paragraph breaks; falls back to `innerText` if needed.
  - `list_interactive(limit=60, viewport_only=True)`: AX tree + `DOMSnapshot`; includes `gridcell` and roleless clickable widgets; backfills missing names from DOM text; filters by size/viewport and ignores large container delegates; returns `x, y`, `role`, and short `name`.

- **Dependencies**
  - Added `markdownify==1.2.2`.

<sup>Written for commit 3d7332e41f24c24c77af1e9a722304f44469512c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

