### PR TITLE
Add chargepoint domain skill: Datadome blocks password login, use coulomb_sess cookie

### DIFF
--- a/domain-skills/chargepoint/auth.md
+++ b/domain-skills/chargepoint/auth.md
@@ -14,19 +14,24 @@ token from a real browser instead.
 - Name: `coulomb_sess` (~43-char opaque value)
 - Present whenever the user is logged in at https://driver.chargepoint.com
 - Related cookies you'll see alongside it: `auth-session`, `ci_ui_session`,
-  `datadome` — `coulomb_sess` is the one API clients (python-chargepoint,
-  ha-chargepoint) accept as a session token.
+  `datadome` — `coulomb_sess` is what API clients (python-chargepoint,
+  ha-chargepoint) use as the session token. The `auth-session` JWT is also a
+  valid login path: python-chargepoint's `login_with_sso_session(sso_jwt)`
+  exchanges it for a `coulomb_sess` token, useful for SSO accounts when
+  `coulomb_sess` is absent.
 
 Grab it from the user's logged-in browser without navigating anywhere:
 
 ```python
 cookies = cdp("Storage.getCookies")["cookies"]
-tok = next(c["value"] for c in cookies
-           if c["name"] == "coulomb_sess" and "chargepoint" in c["domain"])
+tok = next((c["value"] for c in cookies
+            if c["name"] == "coulomb_sess" and "chargepoint" in c["domain"]),
+           None)
 ```
 
-If no `coulomb_sess` cookie exists, the user isn't logged in — stop and ask
-them to log in at driver.chargepoint.com first (don't type credentials).
+If `tok` is None, the user isn't logged in (though an SSO account may still
+have an `auth-session` cookie to exchange, per above) — stop and ask them to
+log in at driver.chargepoint.com first (don't type credentials).
 
 ## Trap
 

--- a/domain-skills/chargepoint/auth.md
+++ b/domain-skills/chargepoint/auth.md
@@ -1,0 +1,36 @@
+# ChargePoint — session auth (driver.chargepoint.com)
+
+## Datadome blocks programmatic password login
+
+ChargePoint fronts its login API with Datadome bot protection. Server-side
+password logins (e.g. from the Home Assistant `chargepoint` custom integration,
+or any script POSTing credentials) get blocked with a bot challenge even when
+the credentials are correct. Don't retry the password path — use a session
+token from a real browser instead.
+
+## The session token is the `coulomb_sess` cookie
+
+- Domain: `.chargepoint.com` (shared across driver.chargepoint.com and na.chargepoint.com)
+- Name: `coulomb_sess` (~43-char opaque value)
+- Present whenever the user is logged in at https://driver.chargepoint.com
+- Related cookies you'll see alongside it: `auth-session`, `ci_ui_session`,
+  `datadome` — `coulomb_sess` is the one API clients (python-chargepoint,
+  ha-chargepoint) accept as a session token.
+
+Grab it from the user's logged-in browser without navigating anywhere:
+
+```python
+cookies = cdp("Storage.getCookies")["cookies"]
+tok = next(c["value"] for c in cookies
+           if c["name"] == "coulomb_sess" and "chargepoint" in c["domain"])
+```
+
+If no `coulomb_sess` cookie exists, the user isn't logged in — stop and ask
+them to log in at driver.chargepoint.com first (don't type credentials).
+
+## Trap
+
+The HA chargepoint integration's reauth dialog offers both a password field
+and a token field. The password path fails through HA's server (Datadome
+again); paste the `coulomb_sess` value into the token field instead —
+succeeds immediately.


### PR DESCRIPTION
ChargePoint fronts login with Datadome bot protection, so server-side password logins (e.g. the Home Assistant chargepoint integration's reauth flow) fail even with correct credentials. The reliable path is the `coulomb_sess` cookie from a logged-in browser session at driver.chargepoint.com — this skill documents the cookie, how to grab it via `Storage.getCookies`, and the trap in the HA reauth dialog.

Field-tested today while re-authenticating the HA chargepoint integration after an upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a ChargePoint auth guide: Datadome blocks server-side password logins; use the `coulomb_sess` cookie from driver.chargepoint.com. Includes a `Storage.getCookies` snippet, the `auth-session` SSO JWT fallback when `coulomb_sess` is missing, and to use the token field (not password) in Home Assistant `chargepoint` reauth.

<sup>Written for commit 240ec041e96e1c70f648c7490805c722dfa6489d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

