### PR TITLE
Add attach_tab() and new_tab(background=True) for focus-preserving automation

### DIFF
--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -7,8 +7,10 @@ Use **CDP for control**, **UI automation for user-visible order**.
 ```python
 tabs = list_tabs()                    # includes chrome:// pages too
 real_tabs = list_tabs(include_chrome=False)
-tid = new_tab("https://example.com")  # create + attach
-switch_tab(tid)                       # attach harness to tab
+tid = new_tab("https://example.com")  # create + attach (activates the tab)
+tid = new_tab("https://example.com", background=True)  # create + attach WITHOUT stealing the user's focus
+switch_tab(tid)                       # activate + attach
+attach_tab(tid)                       # attach only — never activates
 cdp("Target.activateTarget", targetId=tid)  # show it in Chrome
 print(current_tab())
 print(page_info())
@@ -63,6 +65,7 @@ Typical tools:
 
 - `switch_tab()` is **not enough** if the user expects Chrome to visibly change.
 - `Target.activateTarget` is the CDP-side "show this tab".
+- Driving a user's **live** browser? Use `new_tab(url, background=True)` / `attach_tab()` so automation doesn't yank them out of the tab they're working in.
 - `list_tabs()` includes `chrome://newtab/` by default; ask for `include_chrome=False` when you want only real pages.
 - `chrome://omnibox-popup.top-chrome/` can appear as a fake page target; ignore it for user-facing tab lists.
 - If a page has `w=0 h=0`, you may be attached to the wrong target or a non-window surface.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -300,16 +300,23 @@ def switch_tab(target):
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
     cdp("Target.activateTarget", targetId=target_id)
+    return attach_tab(target_id)
+
+def attach_tab(target):
+    """Attach to a tab WITHOUT activating it (no focus steal). switch_tab = activate + attach."""
+    target_id = target.get("targetId") if isinstance(target, dict) else target
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
     return sid
 
-def new_tab(url="about:blank"):
+def new_tab(url="about:blank", background=False):
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    if url != "about:blank":
+    # Reuse a current blank tab — but never when background=True: the current
+    # tab may be the user's visible one, and background asks us not to touch it.
+    if url != "about:blank" and not background:
         try:
             cur = current_tab()
             cur_url = cur.get("url") or ""
@@ -318,8 +325,13 @@ def new_tab(url="about:blank"):
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
-    switch_tab(tid)
+    # background=True opens the tab without activating it, so automation against
+    # a user's live browser doesn't yank them out of their active tab.
+    tid = cdp("Target.createTarget", url="about:blank", background=background)["targetId"]
+    if background:
+        attach_tab(tid)
+    else:
+        switch_tab(tid)
     if url != "about:blank":
         goto_url(url)
     return tid


### PR DESCRIPTION
## Motivation

When the harness drives a **user's live browser** (the daemon attached to their real Chrome), `new_tab()` and `switch_tab()` activate the target — which visibly yanks the user out of whatever tab they're working in every time automation runs. For background/batch workflows (CSV imports, polling a web app's UI, scraping a logged-in dashboard) the automation has no reason to be visible at all.

## Changes

- **`attach_tab(target)`** — attach a session to a tab *without* activating it. `switch_tab()` keeps its exact behavior and is now literally activate + `attach_tab()`.
- **`new_tab(url, background=False)`** — with `background=True`, the tab is created via `Target.createTarget`'s `background` flag and only attached, never activated. Default behavior unchanged.
- The reuse-a-blank-current-tab shortcut in `new_tab()` is skipped when `background=True`: the current tab may be the user's visible one, and `background` is an explicit request not to touch what they see.
- Documented both in `interaction-skills/tabs.md` (code block + a "rules that held up" line).

## Notes

Running this against a live daily-driver Chrome for a few weeks now — background CSV-import/enrichment runs no longer steal focus while the user keeps browsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds attach_tab() and new_tab(background=True) so automation can attach to tabs without activating them, preventing focus theft in a user’s live browser. Default behavior remains unchanged.

- New Features
  - attach_tab(target): attach session without activating; switch_tab = activate + attach.
  - new_tab(url, background=True): create target with CDP background flag and attach only.
  - Skip “reuse current blank tab” when background=True to avoid touching the visible tab.
  - Docs: updated interaction-skills/tabs.md with examples and guidance.

<sup>Written for commit 5702b581e1a48a52fb6f194e253a8f630aa7fb4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

