### PR TITLE
Release 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.4"
+version = "0.1.5"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bump package version to 0.1.5 for release.

Changes since v0.1.4:
- Rename packaged skill identity back to browser-harness (#493)
- More robust CLI telemetry: skip daemon ping when telemetry is off, log browser type (#494)
- Suggest cloud browser when no local browser is available (#495)
- Windows reliability: UTF-8 daemon logging, per-OS Chrome profile discovery, clearer connection errors, tolerate corrupt auth.json (#496)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `browser-harness` v0.1.5. Adds smarter telemetry and a cloud browser suggestion, plus multiple Windows stability fixes.

- **New Features**
  - More robust CLI telemetry: skip daemon ping when telemetry is off; log browser type.
  - Suggest a cloud browser when no local browser is detected.

- **Bug Fixes**
  - Windows reliability: UTF-8 daemon logs, per-OS Chrome profile discovery, clearer connection errors, tolerate corrupt `auth.json`.
  - Packaging: restore packaged skill identity to `browser-harness`.

<sup>Written for commit 295a9728cd7e8418e37f0f5e220c64a085f58ce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

