### PR TITLE
feat(content-extraction): page archiving + structured extraction helpers

### DIFF
--- a/agent-workspace/agent_helpers.py
+++ b/agent-workspace/agent_helpers.py
@@ -5,3 +5,21 @@ load this file when BH_AGENT_WORKSPACE points at this directory, or when this
 repo's default agent-workspace exists.
 """
 
+import os
+import sys
+
+_AGENT_WORKSPACE_DIR = os.path.dirname(__file__)
+if _AGENT_WORKSPACE_DIR not in sys.path:
+    sys.path.insert(0, _AGENT_WORKSPACE_DIR)
+
+from content_extraction import (
+    archive_current_page,
+    extract_cards,
+    extract_links,
+    extract_lists,
+    extract_markdown_from_current_page,
+    extract_outline,
+    extract_tables,
+    extract_virtualized_container,
+)
+

--- a/agent-workspace/content_extraction.py
+++ b/agent-workspace/content_extraction.py
@@ -1,0 +1,792 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TypeAlias, TypedDict
+from urllib.parse import urlparse
+
+JSONScalar: TypeAlias = None | bool | int | float | str
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+
+_SLUG_PARTS = re.compile(r"[^a-z0-9]+")
+
+
+class ArchivePaths(TypedDict):
+    dir: str
+    metadata: str
+    html: str
+    text: str
+    links: str
+    screenshot: str
+    markdown: str
+
+
+class ArchiveResult(TypedDict):
+    status: str
+    manifestPath: str
+    archiveDir: str
+
+
+class DefuddleResult(TypedDict, total=False):
+    status: str
+    markdownPath: str
+    stdout: str
+    stderr: str
+    stats: dict[str, JSONValue]
+
+
+class CollectionResult(TypedDict):
+    status: str
+    items: list[dict[str, JSONValue]]
+
+
+class TablesResult(TypedDict):
+    status: str
+    tables: list[dict[str, JSONValue]]
+
+
+class VirtualizedResult(TypedDict):
+    status: str
+    items: list[dict[str, JSONValue]]
+    scrollAttempts: int
+    stableRounds: int
+    partial: bool
+    stopReason: str
+
+
+class ArchivePhaseError(RuntimeError):
+    def __init__(self, phase: str, detail: str) -> None:
+        super().__init__(f"archive_current_page failed during {phase}: {detail}")
+        self.phase = phase
+
+
+_LINKS_JS = (
+    'return Array.from(document.querySelectorAll("a[href]")).map((link) => ({'
+    "href: link.href,"
+    'text: (link.innerText || link.textContent || "").trim(),'
+    'title: link.title || ""'
+    "}));"
+)
+
+
+def _outline_js(scope_selector: str | None) -> str:
+    return (
+        "const selector = "
+        + json.dumps(scope_selector)
+        + ";const root = selector ? document.querySelector(selector) : document;"
+        "if (!root) return {status:'empty', items:[]};"
+        "const items = Array.from(root.querySelectorAll('h1,h2,h3,h4,h5,h6')).map((heading) => ({"
+        "level: Number(heading.tagName.slice(1)),"
+        "text: (heading.innerText || heading.textContent || '').trim(),"
+        "id: heading.id || ''"
+        "}));"
+        "return {status: items.length ? 'success' : 'empty', items};"
+    )
+
+
+def _extract_links_js(scope_selector: str | None, include_empty: bool) -> str:
+    return (
+        "const selector = "
+        + json.dumps(scope_selector)
+        + ";const includeEmpty = "
+        + json.dumps(include_empty)
+        + ";const root = selector ? document.querySelector(selector) : document;"
+        "if (!root) return {status:'empty', items:[]};"
+        "const seen = new Set(); const items = [];"
+        "for (const link of Array.from(root.querySelectorAll('a[href]'))) {"
+        "const text = (link.innerText || link.textContent || '').trim();"
+        "if (!includeEmpty && !text) continue;"
+        "const href = link.href;"
+        "const key = href + '\\n' + text;"
+        "if (seen.has(key)) continue;"
+        "seen.add(key);"
+        "let sameOrigin = false;"
+        "try { sameOrigin = new URL(href, location.href).origin === location.origin; } catch (e) {}"
+        "items.push({text, href, rel: link.rel || '', target: link.target || '', sameOrigin});"
+        "}"
+        "return {status: items.length ? 'success' : 'empty', items};"
+    )
+
+
+def _tables_js(scope_selector: str | None) -> str:
+    return (
+        "const selector = "
+        + json.dumps(scope_selector)
+        + ";const root = selector ? document.querySelector(selector) : document;"
+        "if (!root) return {status:'empty', tables:[]};"
+        "const tables = Array.from(root.querySelectorAll('table')).map((table) => {"
+        "const rows = Array.from(table.rows).map((row) => Array.from(row.cells).map((cell) => "
+        "(cell.innerText || cell.textContent || '').trim()));"
+        "const firstRow = table.rows[0];"
+        "const hasHeaders = !!firstRow && Array.from(firstRow.cells).some((cell) => cell.tagName.toLowerCase() === 'th');"
+        "const headers = hasHeaders ? rows[0] : [];"
+        "const dataRows = hasHeaders ? rows.slice(1) : rows;"
+        "const rowObjects = hasHeaders ? dataRows.map((row) => Object.fromEntries(headers.map((header, index) => "
+        "[header, row[index] || '']))) : [];"
+        "const caption = table.caption ? (table.caption.innerText || table.caption.textContent || '').trim() : '';"
+        "return {caption, headers, rows, rowObjects};"
+        "});"
+        "return {status: tables.length ? 'success' : 'empty', tables};"
+    )
+
+
+def _lists_js(scope_selector: str | None) -> str:
+    return (
+        "const selector = "
+        + json.dumps(scope_selector)
+        + ";const root = selector ? document.querySelector(selector) : document;"
+        "if (!root) return {status:'not_found', items:[]};"
+        "const lists = Array.from(root.querySelectorAll('ul,ol,[role=\"list\"]')).map((list) => {"
+        "const itemNodes = Array.from(list.querySelectorAll(':scope > li, :scope > [role=\"listitem\"]'));"
+        "const items = itemNodes.map((item) => (item.innerText || item.textContent || '').trim()).filter(Boolean);"
+        "const type = list.getAttribute('role') || list.tagName.toLowerCase();"
+        "return {type, items, ariaLabel: list.getAttribute('aria-label') || ''};"
+        "}).filter((list) => list.items.length);"
+        "return {status: lists.length ? 'success' : 'empty', items: lists};"
+    )
+
+
+def _cards_js(card_selector: str, fields: list[str], link_selector: str) -> str:
+    return (
+        "const cards = Array.from(document.querySelectorAll("
+        + json.dumps(card_selector)
+        + "));"
+        "if (!cards.length) return {status:'not_found', items:[]};"
+        "const fields = new Set("
+        + json.dumps(fields)
+        + ");"
+        "const linkSelector = "
+        + json.dumps(link_selector)
+        + ";"
+        "const items = cards.map((card) => {"
+        "const visible = !!(card.offsetWidth || card.offsetHeight || card.getClientRects().length);"
+        "const headingNode = card.querySelector('h1,h2,h3,h4,h5,h6');"
+        "const links = Array.from(card.querySelectorAll(linkSelector)).map((link) => ({"
+        "href: link.href, text: (link.innerText || link.textContent || '').trim()"
+        "}));"
+        "const data = Object.assign({}, card.dataset);"
+        "const item = {visible};"
+        "if (fields.has('text')) item.text = (card.innerText || card.textContent || '').trim();"
+        "if (fields.has('links')) item.links = links;"
+        "if (fields.has('heading')) item.heading = headingNode ? (headingNode.innerText || headingNode.textContent || '').trim() : '';"
+        "if (fields.has('ariaLabel')) item.ariaLabel = card.getAttribute('aria-label') || '';"
+        "if (fields.has('data')) item.data = data;"
+        "return item;"
+        "}).filter((item) => item.visible);"
+        "return {status: items.length ? 'success' : 'empty', items};"
+    )
+
+
+def _virtualized_js(
+    container_selector: str | None,
+    item_selector: str,
+    max_scrolls: int,
+    stable_rounds: int,
+) -> str:
+    return (
+        "return (async () => {"
+        "const containerSelector = "
+        + json.dumps(container_selector)
+        + ";const itemSelector = "
+        + json.dumps(item_selector)
+        + ";const maxScrolls = "
+        + json.dumps(max_scrolls)
+        + ";const requiredStable = "
+        + json.dumps(stable_rounds)
+        + ";const container = containerSelector ? document.querySelector(containerSelector) : "
+        "(document.scrollingElement || document.documentElement);"
+        "if (!container) return {status:'not_found', items:[], scrollAttempts:0, stableRounds:0, partial:true, stopReason:'not_found'};"
+        "const seen = new Map(); let stable = 0; let lastCount = -1;"
+        "const collect = () => {"
+        "for (const item of Array.from(container.querySelectorAll(itemSelector))) {"
+        "const text = (item.innerText || item.textContent || '').trim();"
+        "const key = item.id || item.getAttribute('data-id') || text;"
+        "if (key && !seen.has(key)) seen.set(key, {text, id: item.id || '', data: Object.assign({}, item.dataset)});"
+        "}"
+        "};"
+        "for (let attempt = 0; attempt < maxScrolls; attempt++) {"
+        "collect();"
+        "stable = seen.size === lastCount ? stable + 1 : 0;"
+        "lastCount = seen.size;"
+        "if (stable >= requiredStable) {"
+        "const items = Array.from(seen.values());"
+        "const status = items.length ? 'success' : 'empty';"
+        "const reason = items.length ? 'stable' : 'empty';"
+        "return {status, items, scrollAttempts:attempt + 1, stableRounds:stable, partial:false, stopReason:reason};"
+        "}"
+        "container.scrollTop = container.scrollTop + container.clientHeight;"
+        "await new Promise((resolve) => setTimeout(resolve, 40));"
+        "}"
+        "collect();"
+        "const items = Array.from(seen.values());"
+        "if (!items.length) return {status:'empty', items, scrollAttempts:maxScrolls, stableRounds:stable, partial:false, stopReason:'empty'};"
+        "return {status:'partial', items, scrollAttempts:maxScrolls, stableRounds:stable, partial:true, stopReason:'max_scrolls'};"
+        "})()"
+    )
+
+
+def safe_slug(value: str, fallback: str) -> str:
+    slug = _SLUG_PARTS.sub("-", value.strip().lower()).strip("-")
+    if slug:
+        return slug
+    return _SLUG_PARTS.sub("-", fallback.strip().lower()).strip("-") or "page"
+
+
+def archive_paths(
+    output_dir: str | Path,
+    page_info: Mapping[str, JSONScalar],
+    timestamp: str | None = None,
+) -> ArchivePaths:
+    captured_at = timestamp or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    url_value = page_info.get("url")
+    title_value = page_info.get("title")
+    url = url_value if isinstance(url_value, str) else ""
+    title = title_value if isinstance(title_value, str) else ""
+    host = urlparse(url).hostname or "page"
+    page_slug = safe_slug(f"{safe_slug(host, 'page')}-{safe_slug(title, 'page')}", "page")
+    archive_dir = Path(output_dir) / f"{captured_at}-{page_slug}"
+    return {
+        "dir": str(archive_dir),
+        "metadata": str(archive_dir / "metadata.json"),
+        "html": str(archive_dir / "page.html"),
+        "text": str(archive_dir / "text.txt"),
+        "links": str(archive_dir / "links.json"),
+        "screenshot": str(archive_dir / "screenshot.png"),
+        "markdown": str(archive_dir / "markdown.md"),
+    }
+
+
+def page_info() -> Mapping[str, JSONScalar]:
+    from browser_harness.helpers import page_info as runtime_page_info
+
+    return runtime_page_info()
+
+
+def js(expression: str) -> JSONValue:
+    from browser_harness.helpers import js as runtime_js
+
+    return runtime_js(expression)
+
+
+def capture_screenshot(path: str | Path) -> str | None:
+    from browser_harness.helpers import capture_screenshot as runtime_capture_screenshot
+
+    return runtime_capture_screenshot(str(path))
+
+
+def json_dump(path: str | Path, data: JSONValue) -> None:
+    path_obj = Path(path)
+    path_obj.parent.mkdir(parents=True, exist_ok=True)
+    with path_obj.open("w", encoding="utf-8") as out:
+        json.dump(data, out, ensure_ascii=False, indent=2, sort_keys=True)
+        out.write("\n")
+
+
+def _default_markdown_path(html_path: Path) -> Path:
+    if html_path.parent.name == "raw":
+        return html_path.parent.parent / "processed" / "page.md"
+    return html_path.parent / "processed" / "page.md"
+
+
+def _defuddle_failed(message: str, *, fail_soft: bool) -> DefuddleResult:
+    if not fail_soft:
+        raise RuntimeError(message)
+    return {"status": "failed", "stderr": message}
+
+
+def defuddle_html_file(
+    html_path: str | Path,
+    *,
+    output_path: str | Path | None = None,
+    fail_soft: bool = True,
+    timeout: int = 30,
+) -> DefuddleResult:
+    source = Path(html_path)
+    if "://" in str(html_path):
+        return _defuddle_failed("Defuddle source must be a local HTML file path", fail_soft=fail_soft)
+    if not source.exists() or not source.is_file():
+        return _defuddle_failed(f"HTML file not found: {source}", fail_soft=fail_soft)
+
+    executable = shutil.which("defuddle")
+    if executable is None:
+        message = "Defuddle executable not found"
+        if not fail_soft:
+            raise RuntimeError(message)
+        return {"status": "unavailable", "stderr": message}
+
+    target = Path(output_path) if output_path is not None else _default_markdown_path(source)
+    existed_before = target.exists()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        executable,
+        "parse",
+        "--markdown",
+        "--output",
+        str(target),
+        str(source),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _defuddle_failed(f"Defuddle timed out after {timeout}s: {exc}", fail_soft=fail_soft)
+    except OSError as exc:
+        return _defuddle_failed(f"Defuddle failed to start: {exc}", fail_soft=fail_soft)
+
+    if completed.returncode != 0:
+        if target.exists() and not existed_before:
+            target.unlink()
+        message = completed.stderr.strip() or f"Defuddle exited {completed.returncode}"
+        return _defuddle_failed(message, fail_soft=fail_soft)
+
+    if not target.exists():
+        return _defuddle_failed("Defuddle exited 0 without writing markdown", fail_soft=fail_soft)
+
+    markdown = target.read_text(encoding="utf-8")
+    return {
+        "status": "success",
+        "markdownPath": str(target),
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "stats": {
+            "markdownChars": len(markdown),
+            "sourceHtmlBytes": source.stat().st_size,
+        },
+    }
+
+
+def _created_at() -> tuple[str, str]:
+    now = datetime.now(UTC)
+    return now.isoformat().replace("+00:00", "Z"), now.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _archive_dir(
+    output_dir: str | Path,
+    info: Mapping[str, JSONScalar],
+    timestamp: str,
+    *,
+    overwrite: bool,
+) -> Path:
+    target = Path(output_dir)
+    if target.exists() and not target.is_dir():
+        raise ArchivePhaseError("prepare", f"{target} exists and is not a directory")
+    if overwrite or not target.exists():
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    child = Path(archive_paths(target, info, timestamp=timestamp)["dir"])
+    if not child.exists():
+        child.mkdir(parents=True)
+        return child
+
+    suffix = 2
+    while True:
+        candidate = Path(f"{child}-{suffix}")
+        if not candidate.exists():
+            candidate.mkdir(parents=True)
+            return candidate
+        suffix += 1
+
+
+def _clear_managed_files(archive_dir: Path) -> None:
+    for path in [
+        archive_dir / "manifest.json",
+        archive_dir / "raw" / "page-info.json",
+        archive_dir / "raw" / "page.html",
+        archive_dir / "raw" / "body.txt",
+        archive_dir / "raw" / "links.json",
+        archive_dir / "raw" / "screenshot.png",
+        archive_dir / "processed" / "page.md",
+        archive_dir / "processed" / "status.json",
+    ]:
+        if path.exists() and path.is_file():
+            path.unlink()
+
+
+def _read_text_phase(phase: str, expression: str) -> str:
+    try:
+        value = js(expression)
+    except (RuntimeError, OSError, TypeError, ValueError) as exc:
+        raise ArchivePhaseError(phase, str(exc)) from exc
+    if not isinstance(value, str):
+        raise ArchivePhaseError(phase, f"expected string result, got {type(value).__name__}")
+    return value
+
+
+def _read_links() -> list[dict[str, JSONValue]]:
+    try:
+        value = js(_LINKS_JS)
+    except (RuntimeError, OSError, TypeError, ValueError) as exc:
+        raise ArchivePhaseError("links", str(exc)) from exc
+    if not isinstance(value, list):
+        raise ArchivePhaseError("links", f"expected list result, got {type(value).__name__}")
+
+    links: list[dict[str, JSONValue]] = []
+    for item in value:
+        if isinstance(item, dict):
+            href = item.get("href")
+            text = item.get("text")
+            title = item.get("title")
+            links.append({
+                "href": href if isinstance(href, str) else "",
+                "text": text if isinstance(text, str) else "",
+                "title": title if isinstance(title, str) else "",
+            })
+    return links
+
+
+def _info_json(info: Mapping[str, JSONScalar]) -> dict[str, JSONValue]:
+    return {str(key): value for key, value in info.items()}
+
+
+def _collection_result(value: JSONValue, key: str) -> tuple[str, list[dict[str, JSONValue]]]:
+    if not isinstance(value, dict):
+        return "failed", []
+    status_value = value.get("status")
+    status = status_value if isinstance(status_value, str) else "success"
+    raw_items = value.get(key)
+    if not isinstance(raw_items, list):
+        return status, []
+    items = [item for item in raw_items if isinstance(item, dict)]
+    if items:
+        return status, items
+    if status in {"not_found", "failed", "partial"}:
+        return status, items
+    return "empty", items
+
+
+def _status_for_count(status: str, count: int) -> str:
+    if count:
+        return status
+    if status in {"not_found", "failed", "partial"}:
+        return status
+    return "empty"
+
+
+def extract_outline(scope_selector: str | None = None) -> CollectionResult:
+    status, raw_items = _collection_result(js(_outline_js(scope_selector)), "items")
+    items: list[dict[str, JSONValue]] = []
+    for item in raw_items:
+        level_value = item.get("level")
+        text_value = item.get("text")
+        id_value = item.get("id")
+        items.append({
+            "level": level_value if isinstance(level_value, int) else 0,
+            "text": text_value if isinstance(text_value, str) else "",
+            "id": id_value if isinstance(id_value, str) else "",
+        })
+    return {"status": _status_for_count(status, len(items)), "items": items}
+
+
+def extract_links(scope_selector: str | None = None, include_empty: bool = False) -> CollectionResult:
+    status, raw_items = _collection_result(js(_extract_links_js(scope_selector, include_empty)), "items")
+    items: list[dict[str, JSONValue]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in raw_items:
+        href_value = item.get("href")
+        text_value = item.get("text")
+        rel_value = item.get("rel")
+        target_value = item.get("target")
+        same_origin_value = item.get("sameOrigin")
+        href = href_value if isinstance(href_value, str) else ""
+        text = text_value if isinstance(text_value, str) else ""
+        if not include_empty and not text:
+            continue
+        key = (href, text)
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append({
+            "href": href,
+            "text": text,
+            "rel": rel_value if isinstance(rel_value, str) else "",
+            "target": target_value if isinstance(target_value, str) else "",
+            "sameOrigin": same_origin_value if isinstance(same_origin_value, bool) else False,
+        })
+    return {"status": _status_for_count(status, len(items)), "items": items}
+
+
+def extract_tables(scope_selector: str | None = None) -> TablesResult:
+    status, raw_tables = _collection_result(js(_tables_js(scope_selector)), "tables")
+    tables: list[dict[str, JSONValue]] = []
+    for table in raw_tables:
+        caption_value = table.get("caption")
+        headers_value = table.get("headers")
+        rows_value = table.get("rows")
+        row_objects_value = table.get("rowObjects")
+        headers = [value for value in headers_value if isinstance(value, str)] if isinstance(headers_value, list) else []
+        rows = rows_value if isinstance(rows_value, list) else []
+        row_objects = row_objects_value if isinstance(row_objects_value, list) else []
+        tables.append({
+            "caption": caption_value if isinstance(caption_value, str) else "",
+            "headers": headers,
+            "rows": rows,
+            "rowObjects": row_objects,
+        })
+    return {"status": _status_for_count(status, len(tables)), "tables": tables}
+
+
+def extract_lists(scope_selector: str | None = None) -> CollectionResult:
+    status, raw_items = _collection_result(js(_lists_js(scope_selector)), "items")
+    items: list[dict[str, JSONValue]] = []
+    for item in raw_items:
+        type_value = item.get("type")
+        items_value = item.get("items")
+        aria_value = item.get("ariaLabel")
+        list_items = [value for value in items_value if isinstance(value, str)] if isinstance(items_value, list) else []
+        if list_items:
+            items.append({
+                "type": type_value if isinstance(type_value, str) else "",
+                "items": list_items,
+                "ariaLabel": aria_value if isinstance(aria_value, str) else "",
+            })
+    return {"status": _status_for_count(status, len(items)), "items": items}
+
+
+def extract_cards(
+    card_selector: str,
+    fields: list[str] | None = None,
+    link_selector: str = "a[href]",
+) -> CollectionResult:
+    selected_fields = fields or ["text", "links", "heading", "ariaLabel", "data"]
+    status, raw_items = _collection_result(js(_cards_js(card_selector, selected_fields, link_selector)), "items")
+    items: list[dict[str, JSONValue]] = []
+    for item in raw_items:
+        visible_value = item.get("visible")
+        if visible_value is False:
+            continue
+        normalized: dict[str, JSONValue] = {}
+        for field in selected_fields:
+            value = item.get(field)
+            if isinstance(value, (str, bool, int, float)) or value is None or isinstance(value, list) or isinstance(value, dict):
+                normalized[field] = value
+        items.append(normalized)
+    return {"status": _status_for_count(status, len(items)), "items": items}
+
+
+def extract_virtualized_container(
+    container_selector: str | None,
+    item_selector: str,
+    *,
+    max_scrolls: int = 20,
+    stable_rounds: int = 2,
+) -> VirtualizedResult:
+    value = js(_virtualized_js(container_selector, item_selector, max_scrolls, stable_rounds))
+    if not isinstance(value, dict):
+        return {
+            "status": "failed",
+            "items": [],
+            "scrollAttempts": 0,
+            "stableRounds": 0,
+            "partial": True,
+            "stopReason": "invalid_result",
+        }
+    items_value = value.get("items")
+    items = [item for item in items_value if isinstance(item, dict)] if isinstance(items_value, list) else []
+    attempts_value = value.get("scrollAttempts")
+    stable_value = value.get("stableRounds")
+    partial_value = value.get("partial")
+    reason_value = value.get("stopReason")
+    status_value = value.get("status")
+    return {
+        "status": status_value if isinstance(status_value, str) else ("partial" if partial_value else "success"),
+        "items": items,
+        "scrollAttempts": attempts_value if isinstance(attempts_value, int) else 0,
+        "stableRounds": stable_value if isinstance(stable_value, int) else 0,
+        "partial": partial_value if isinstance(partial_value, bool) else True,
+        "stopReason": reason_value if isinstance(reason_value, str) else "",
+    }
+
+
+def _processed_failure(status: str, message: str) -> dict[str, JSONValue]:
+    return {"status": status, "stderr": message}
+
+
+def _run_markdown(
+    html_path: str | Path | None,
+    processed_dir: Path,
+    markdown_engine: str,
+) -> tuple[dict[str, JSONValue], dict[str, JSONValue], dict[str, JSONValue] | None]:
+    status_path = processed_dir / "status.json"
+    processed_paths: dict[str, JSONValue] = {"status": str(status_path)}
+    if html_path is None:
+        status = _processed_failure("failed", "raw HTML artifact is unavailable")
+        json_dump(status_path, status)
+        return processed_paths, status, {"phase": "markdown", "message": "raw HTML artifact is unavailable"}
+    if markdown_engine != "defuddle":
+        status = _processed_failure("failed", f"unsupported markdown engine: {markdown_engine}")
+        json_dump(status_path, status)
+        return processed_paths, status, {"phase": "markdown", "message": status["stderr"]}
+
+    markdown_path = processed_dir / "page.md"
+    result = defuddle_html_file(html_path, output_path=markdown_path)
+    status: dict[str, JSONValue] = {str(key): value for key, value in result.items()}
+    result_status = result.get("status")
+    result_path = result.get("markdownPath")
+    if result_status == "success" and isinstance(result_path, str):
+        markdown_file = Path(result_path)
+        markdown_text = markdown_file.read_text(encoding="utf-8") if markdown_file.exists() else ""
+        if markdown_text.strip():
+            processed_paths["markdown"] = result_path
+            json_dump(status_path, status)
+            return processed_paths, status, None
+        markdown_file.unlink(missing_ok=True)
+        status = _processed_failure("failed", "Defuddle produced empty markdown")
+
+    message_value = status.get("stderr") or status.get("status") or "markdown conversion failed"
+    message = message_value if isinstance(message_value, str) else "markdown conversion failed"
+    json_dump(status_path, status)
+    return processed_paths, status, {"phase": "markdown", "message": message}
+
+
+def archive_current_page(
+    output_dir: str | Path = "evidence/archive",
+    *,
+    screenshot: bool = False,
+    full_html: bool = True,
+    text: bool = True,
+    metadata: bool = True,
+    links: bool = True,
+    max_text_chars: int | None = None,
+    overwrite: bool = False,
+    markdown: bool = False,
+    markdown_engine: str = "defuddle",
+) -> ArchiveResult:
+    try:
+        info = page_info()
+    except (RuntimeError, OSError, TypeError, ValueError) as exc:
+        raise ArchivePhaseError("page_info", str(exc)) from exc
+
+    created_at, timestamp = _created_at()
+    archive_dir = _archive_dir(output_dir, info, timestamp, overwrite=overwrite)
+    if overwrite:
+        _clear_managed_files(archive_dir)
+    raw_dir = archive_dir / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    raw_artifact_paths: dict[str, JSONValue] = {}
+    processed_artifact_paths: dict[str, JSONValue] = {}
+    stats: dict[str, JSONValue] = {}
+    errors: list[dict[str, JSONValue]] = []
+
+    if metadata:
+        page_info_path = raw_dir / "page-info.json"
+        json_dump(page_info_path, _info_json(info))
+        raw_artifact_paths["pageInfo"] = str(page_info_path)
+
+    if full_html:
+        html = _read_text_phase("html", "document.documentElement.outerHTML")
+        html_path = raw_dir / "page.html"
+        html_path.write_text(html, encoding="utf-8")
+        raw_artifact_paths["html"] = str(html_path)
+        stats["htmlChars"] = len(html)
+
+    if text:
+        body_text = _read_text_phase("text", "document.body ? document.body.innerText : ''")
+        truncated = False
+        if max_text_chars is not None and len(body_text) > max_text_chars:
+            body_text = body_text[:max_text_chars]
+            truncated = True
+        text_path = raw_dir / "body.txt"
+        text_path.write_text(body_text, encoding="utf-8")
+        raw_artifact_paths["text"] = str(text_path)
+        stats["textChars"] = len(body_text)
+        stats["textTruncated"] = truncated
+
+    if links:
+        link_data = _read_links()
+        links_path = raw_dir / "links.json"
+        json_dump(links_path, link_data)
+        raw_artifact_paths["links"] = str(links_path)
+        stats["links"] = len(link_data)
+
+    if screenshot:
+        screenshot_path = raw_dir / "screenshot.png"
+        try:
+            capture_screenshot(screenshot_path)
+            raw_artifact_paths["screenshot"] = str(screenshot_path)
+        except (RuntimeError, OSError, TypeError, ValueError) as exc:
+            errors.append({"phase": "screenshot", "message": str(exc)})
+
+    processed_status: dict[str, JSONValue] = {"status": "skipped"}
+    if markdown:
+        processed_dir = archive_dir / "processed"
+        processed_dir.mkdir(parents=True, exist_ok=True)
+        html_artifact = raw_artifact_paths.get("html")
+        html_path = html_artifact if isinstance(html_artifact, str) else None
+        processed_artifact_paths, processed_status, markdown_error = _run_markdown(
+            html_path,
+            processed_dir,
+            markdown_engine,
+        )
+        if markdown_error is not None:
+            errors.append(markdown_error)
+
+    status = "partial" if errors else "success"
+    url_value = info.get("url")
+    title_value = info.get("title")
+    manifest: dict[str, JSONValue] = {
+        "schemaVersion": 1,
+        "createdAt": created_at,
+        "sourceUrl": url_value if isinstance(url_value, str) else "",
+        "title": title_value if isinstance(title_value, str) else "",
+        "artifactPaths": {
+            "raw": raw_artifact_paths,
+            "processed": processed_artifact_paths,
+        },
+        "raw": {"artifactPaths": raw_artifact_paths},
+        "processed": processed_status,
+        "stats": stats,
+        "privacy": {
+            "localOnly": True,
+            "externalUpload": False,
+            "rawArtifactsRedacted": False,
+        },
+        "status": status,
+    }
+    if errors:
+        manifest["errors"] = errors
+
+    manifest_path = archive_dir / "manifest.json"
+    json_dump(manifest_path, manifest)
+    return {
+        "status": status,
+        "manifestPath": str(manifest_path),
+        "archiveDir": str(archive_dir),
+    }
+
+
+def extract_markdown_from_current_page(
+    output_dir: str | Path = "evidence/archive",
+    *,
+    screenshot: bool = False,
+    full_html: bool = True,
+    text: bool = True,
+    metadata: bool = True,
+    links: bool = True,
+    max_text_chars: int | None = None,
+    overwrite: bool = False,
+    markdown_engine: str = "defuddle",
+) -> ArchiveResult:
+    return archive_current_page(
+        output_dir,
+        screenshot=screenshot,
+        full_html=full_html,
+        text=text,
+        metadata=metadata,
+        links=links,
+        max_text_chars=max_text_chars,
+        overwrite=overwrite,
+        markdown=True,
+        markdown_engine=markdown_engine,
+    )

--- a/agent-workspace/domain-skills/example/content-extraction.md
+++ b/agent-workspace/domain-skills/example/content-extraction.md
@@ -1,0 +1,41 @@
+# Example Content Extraction
+
+## Purpose
+Read and archive public `example.com` pages as a safe smoke target for content
+extraction helpers.
+
+## URL patterns
+- `https://example.com/`
+- `https://www.example.com/`
+
+## Auth state
+No authentication is required. Stop if the page is not the public Example Domain
+page.
+
+## Use these helpers
+```python
+archive_current_page("evidence/example-archive", overwrite=True)
+extract_outline()
+extract_links()
+extract_markdown_from_current_page("evidence/example-md", overwrite=True)
+```
+
+## Selectors/API
+- Main page text is static HTML.
+- Links can be read with `extract_links()`.
+- Headings can be read with `extract_outline()`.
+
+## Failure modes
+- If navigation leaves `example.com`, stop and record the unexpected URL.
+- If markdown conversion is unavailable, keep the raw archive and inspect
+  `processed/status.json`.
+
+## Evidence examples
+- `evidence/example-archive/manifest.json`
+- `evidence/example-md/processed/status.json`
+
+## Do not
+- Do not add credentials, private access material, personal data, or task narration.
+- Do not store screenshots with private data.
+- Do not store pixel coordinates.
+- Do not click or submit anything; this skill is read-only.

--- a/interaction-skills/content-extraction.md
+++ b/interaction-skills/content-extraction.md
@@ -1,0 +1,145 @@
+# Content Extraction
+
+Use the cheapest reliable route that preserves the page state you need. Browser
+control and content extraction are separate jobs: drive the real page with
+`browser-harness`, then archive and clean the rendered result.
+
+## Route Selection
+
+1. Static pages or JSON/API endpoints: use `http_get()` and parse the response.
+2. Authenticated, personalized, or rendered pages: use the user's real Chrome
+   session through `browser-harness`.
+3. Before summarizing or cleaning anything, save a raw archive with
+   `archive_current_page()` once that helper is available. Screenshots are
+   disabled by default; enable them only for public/redacted pages or when the
+   user explicitly approves screenshot capture for that run.
+4. Article or documentation pages: run Defuddle on the local rendered HTML
+   archive to produce markdown. Defuddle cleans content; it does not control the
+   browser, click, log in, or replace CDP.
+5. Tables, cards, lists, dashboards, and SPAs: use JavaScript structured
+   extractors against the rendered DOM, then include partial-extraction status
+   when lazy or virtualized content is detected.
+6. Repeated domain-specific pages: promote the route into a domain skill with
+   fixtures and a regression smoke.
+7. Public high-scale scraping: use Firecrawl, Stagehand, Playwright, or similar
+   auxiliary lanes only after an explicit privacy check. Do not upload private,
+   authenticated, internal, or user-session snapshots to external services
+   unless the user explicitly approves that page and run.
+
+## Attach Smoke
+
+The real-profile smoke must pass before extracting authenticated or rendered
+content:
+
+```bash
+env -u BU_CDP_URL browser-harness -c 'ensure_real_tab(); print(page_info())'
+```
+
+Pass means the output includes `url`, `title`, `w`, `h`, `sx`, `sy`, `pw`, and
+`ph` for a non-internal tab. `browser-harness --doctor` is useful context but is
+not enough by itself.
+
+If the real Chrome attach is missing, failing, or blocked by a Chrome prompt,
+stop and record the blocker. Do not fall through to cloud browsers or isolated
+profiles when the task needs the user's logged-in session.
+
+## Evidence
+
+Write milestone artifacts under `evidence/`:
+
+- `evidence/task-N-pre-status.txt` for the dirty-worktree baseline.
+- `evidence/task-N-*.txt` or `evidence/task-N-*.json` for command output and
+  parser results.
+- `evidence/task-N-archive/` for raw page HTML, text, metadata, links, and
+  explicitly enabled screenshots.
+- `evidence/task-N-*-blocker.txt` when a required browser/user action prevents
+  extraction.
+
+Raw archive files are the source of truth. Markdown, tables, cards, and lists
+are derived artifacts and must not hide empty or partial extraction.
+
+## Markdown
+
+For rendered articles or docs, archive first and then derive markdown from the
+local HTML artifact:
+
+```bash
+env -u BU_CDP_URL browser-harness -c 'ensure_real_tab(); print(extract_markdown_from_current_page("evidence/current-page-md", screenshot=False, overwrite=True))'
+```
+
+The returned archive keeps `raw/page.html` even when Defuddle is missing or
+markdown conversion fails. Check `processed/status.json` before treating
+`processed/page.md` as usable.
+
+## Domain Skills
+
+Promote a repeated site into `agent-workspace/domain-skills/` only when at least
+one of these is true:
+
+- Two successful extraction artifacts exist for the same domain.
+- The user explicitly asks for a recurring domain workflow.
+
+Before creating the skill, identify stable URL patterns, API endpoints or DOM
+selectors, auth requirements, known traps, and the privacy boundary. Domain
+skills should call helpers such as `archive_current_page()`, `extract_links()`,
+`extract_tables()`, `extract_cards()`, and `extract_virtualized_container()`
+instead of storing one-off page text.
+
+Current lookup convention: `goto_url()` strips a leading `www.` from the host and
+uses the first hostname label as the domain-skill folder. For
+`https://www.example.com/`, lookup uses `agent-workspace/domain-skills/example/`.
+Avoid dotted folder names such as `example.com/` unless the lookup behavior and
+tests are updated together.
+
+Use this template:
+
+```text
+# <domain> Content Extraction
+
+## Purpose
+## URL patterns
+## Auth state
+## Use these helpers
+## Selectors/API
+## Failure modes
+## Evidence examples
+## Do not
+```
+
+Do not include secrets, personal data, task narration, credentials, screenshots
+with private data, or pixel coordinates in domain skills.
+
+## Auxiliary Lanes
+
+The core pipeline is local Chrome state plus raw archive, optional local
+Defuddle, and JavaScript structured extractors. No API key is required for that
+core path.
+
+Use auxiliary tools only when their lane fits the page and privacy boundary:
+
+- Playwright: deterministic E2E QA and semantic locator checks with role, text,
+  label, and test-id locators. It is not required for core extraction.
+  Source: https://playwright.dev/docs/locators
+- Stagehand: optional LLM `act` / `observe` / `extract` workflows for high-value
+  public or explicitly approved pages. It is not the private-page default.
+  Source: https://docs.stagehand.dev/v3/basics/extract
+- Firecrawl: public, unauthenticated pages at scale. Never send private,
+  authenticated, internal, or user-session snapshots without explicit approval
+  for that page and run.
+  Source: https://docs.firecrawl.dev/api-reference/endpoint/scrape
+- Browser Use CLI: optional alternate browser/session lane when a task is better
+  suited to that stack. It does not replace local `browser-harness` for the core
+  archive path.
+  Source: https://docs.browser-use.com/open-source/browser-use-cli
+- agent-browser: optional CLI/browser automation lane for agent-driven browsing.
+  Treat it as an auxiliary lane, not a required dependency.
+  Source: https://github.com/vercel-labs/agent-browser/blob/main/README.md
+
+Privacy gate before using an external lane:
+
+```bash
+rg -n "firecrawl|stagehand|browser-use|agent-browser|api[_-]?key|requests|httpx|urllib.request" agent-workspace/content_extraction.py tests/unit/test_content_extraction.py
+```
+
+Expected for the core path: no external-service calls, no API-key requirement,
+and no upload path from raw authenticated artifacts.

--- a/tests/unit/test_content_extraction.py
+++ b/tests/unit/test_content_extraction.py
@@ -1,0 +1,516 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+
+AGENT_WORKSPACE = Path(__file__).resolve().parents[2] / "agent-workspace"
+if str(AGENT_WORKSPACE) not in sys.path:
+    sys.path.insert(0, str(AGENT_WORKSPACE))
+
+from content_extraction import (
+    archive_current_page,
+    archive_paths,
+    defuddle_html_file,
+    extract_cards,
+    extract_markdown_from_current_page,
+    extract_links,
+    extract_lists,
+    extract_outline,
+    extract_tables,
+    extract_virtualized_container,
+    json_dump,
+    safe_slug,
+)
+
+
+def test_safe_slug_normalizes_text_and_uses_fallback():
+    assert safe_slug("  WorldQuant BRAIN / Simulate  ", "page") == "worldquant-brain-simulate"
+    assert safe_slug("!!!", "Untitled Page") == "untitled-page"
+
+
+def test_archive_paths_are_deterministic_and_grouped_by_page(tmp_path):
+    info = {
+        "url": "https://platform.worldquantbrain.com/simulate?foo=bar",
+        "title": "WorldQuant BRAIN",
+    }
+
+    paths = archive_paths(tmp_path, info, timestamp="20260605T021500Z")
+
+    assert paths["dir"] == str(tmp_path / "20260605T021500Z-platform-worldquantbrain-com-worldquant-brain")
+    assert paths["metadata"].endswith("/metadata.json")
+    assert paths["html"].endswith("/page.html")
+    assert paths["text"].endswith("/text.txt")
+    assert paths["links"].endswith("/links.json")
+    assert paths["screenshot"].endswith("/screenshot.png")
+    assert paths["markdown"].endswith("/markdown.md")
+
+
+def test_json_dump_writes_stable_utf8_json(tmp_path):
+    path = tmp_path / "metadata.json"
+
+    json_dump(path, {"title": "한글", "url": "https://example.com"})
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "title": "한글",
+        "url": "https://example.com",
+    }
+    assert "\\u" not in path.read_text(encoding="utf-8")
+
+
+def test_agent_helpers_exposes_archive_current_page(monkeypatch):
+    pkg = types.ModuleType("browser_harness")
+    helpers = types.ModuleType("browser_harness.helpers")
+    helpers.cdp = lambda method, **kwargs: {}
+    helpers._KEYS = {}
+    pkg.helpers = helpers
+    monkeypatch.setitem(sys.modules, "browser_harness", pkg)
+    monkeypatch.setitem(sys.modules, "browser_harness.helpers", helpers)
+
+    path = AGENT_WORKSPACE / "agent_helpers.py"
+    spec = importlib.util.spec_from_file_location("agent_helpers_under_test", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert callable(module.archive_current_page)
+    assert callable(module.extract_markdown_from_current_page)
+    assert callable(module.extract_outline)
+    assert callable(module.extract_links)
+    assert callable(module.extract_tables)
+    assert callable(module.extract_lists)
+    assert callable(module.extract_cards)
+    assert callable(module.extract_virtualized_container)
+
+
+def _patch_runtime(monkeypatch, tmp_path, *, title="Demo", body="alpha beta", screenshot_ok=True):
+    def fake_page_info():
+        return {
+            "url": "https://example.com/demo",
+            "title": title,
+            "w": 1200,
+            "h": 800,
+            "sx": 0,
+            "sy": 0,
+            "pw": 1200,
+            "ph": 1600,
+        }
+
+    def fake_js(expr):
+        if "outerHTML" in expr:
+            return "<html><body><main><p>alpha beta</p></main></body></html>"
+        if "querySelectorAll" in expr:
+            return [{"href": "https://example.com/next", "text": "Next", "title": ""}]
+        if "innerText" in expr:
+            return body
+        raise AssertionError(expr)
+
+    def fake_screenshot(path, **kwargs):
+        if not screenshot_ok:
+            raise RuntimeError("shot failed")
+        Path(path).write_bytes(b"png")
+        return str(path)
+
+    monkeypatch.setattr("content_extraction.page_info", fake_page_info)
+    monkeypatch.setattr("content_extraction.js", fake_js)
+    monkeypatch.setattr("content_extraction.capture_screenshot", fake_screenshot)
+    return tmp_path / "archive"
+
+
+def test_archive_current_page_writes_raw_artifacts(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path)
+
+    result = archive_current_page(output_dir, screenshot=True, overwrite=True)
+
+    archive_dir = Path(result["archiveDir"])
+    raw_dir = archive_dir / "raw"
+    assert result["status"] == "success"
+    assert Path(result["manifestPath"]).exists()
+    assert (raw_dir / "page-info.json").exists()
+    assert (raw_dir / "page.html").read_text(encoding="utf-8").startswith("<html>")
+    assert (raw_dir / "body.txt").read_text(encoding="utf-8") == "alpha beta"
+    assert json.loads((raw_dir / "links.json").read_text(encoding="utf-8"))[0]["text"] == "Next"
+    assert (raw_dir / "screenshot.png").read_bytes() == b"png"
+
+
+def test_archive_current_page_omits_screenshot_by_default(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path)
+
+    result = archive_current_page(output_dir, overwrite=True)
+
+    raw_dir = Path(result["archiveDir"]) / "raw"
+    assert result["status"] == "success"
+    assert not (raw_dir / "screenshot.png").exists()
+    manifest = json.loads(Path(result["manifestPath"]).read_text(encoding="utf-8"))
+    assert "screenshot" not in manifest["artifactPaths"]["raw"]
+
+
+def test_archive_current_page_accepts_empty_title_and_body(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path, title="", body="")
+
+    result = archive_current_page(output_dir, screenshot=False, overwrite=True)
+
+    manifest = json.loads(Path(result["manifestPath"]).read_text(encoding="utf-8"))
+    assert result["status"] == "success"
+    assert manifest["title"] == ""
+    assert manifest["stats"]["textChars"] == 0
+
+
+def test_archive_current_page_does_not_overwrite_existing_target(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path)
+    output_dir.mkdir()
+    old_file = output_dir / "old.txt"
+    old_file.write_text("keep", encoding="utf-8")
+
+    result = archive_current_page(output_dir, screenshot=False, overwrite=False)
+
+    archive_dir = Path(result["archiveDir"])
+    assert old_file.read_text(encoding="utf-8") == "keep"
+    assert archive_dir.parent == output_dir
+    assert archive_dir != output_dir
+    assert (archive_dir / "manifest.json").exists()
+
+
+def test_archive_current_page_marks_screenshot_failure_partial(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path, screenshot_ok=False)
+
+    result = archive_current_page(output_dir, screenshot=True, overwrite=True)
+
+    archive_dir = Path(result["archiveDir"])
+    manifest = json.loads(Path(result["manifestPath"]).read_text(encoding="utf-8"))
+    assert result["status"] == "partial"
+    assert (archive_dir / "raw" / "page.html").exists()
+    assert manifest["status"] == "partial"
+    assert manifest["errors"][0]["phase"] == "screenshot"
+
+
+def test_archive_current_page_markdown_success_updates_manifest(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path)
+
+    def fake_defuddle(html_path, **kwargs):
+        assert Path(html_path).exists()
+        output_path = Path(kwargs["output_path"])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("# Demo\n\nalpha beta", encoding="utf-8")
+        return {
+            "status": "success",
+            "markdownPath": str(output_path),
+            "stats": {"markdownChars": len("# Demo\n\nalpha beta")},
+        }
+
+    monkeypatch.setattr("content_extraction.defuddle_html_file", fake_defuddle)
+
+    result = archive_current_page(output_dir, markdown=True, screenshot=False, overwrite=True)
+
+    manifest = json.loads(Path(result["manifestPath"]).read_text(encoding="utf-8"))
+    assert result["status"] == "success"
+    assert Path(manifest["artifactPaths"]["raw"]["html"]).exists()
+    assert Path(manifest["artifactPaths"]["processed"]["markdown"]).exists()
+    assert Path(manifest["artifactPaths"]["processed"]["status"]).exists()
+    assert manifest["processed"]["status"] == "success"
+
+
+def test_markdown_failure_preserves_raw(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path)
+
+    def fake_defuddle(html_path, **kwargs):
+        return {"status": "failed", "stderr": "empty markdown"}
+
+    monkeypatch.setattr("content_extraction.defuddle_html_file", fake_defuddle)
+
+    result = archive_current_page(output_dir, markdown=True, screenshot=False, overwrite=True)
+
+    archive_dir = Path(result["archiveDir"])
+    manifest = json.loads(Path(result["manifestPath"]).read_text(encoding="utf-8"))
+    assert result["status"] == "partial"
+    assert (archive_dir / "raw" / "page.html").exists()
+    assert not (archive_dir / "processed" / "page.md").exists()
+    assert json.loads((archive_dir / "processed" / "status.json").read_text(encoding="utf-8"))["status"] == "failed"
+    assert manifest["processed"]["status"] == "failed"
+
+
+def test_empty_markdown_output_is_removed(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path)
+
+    def fake_defuddle(html_path, **kwargs):
+        output_path = Path(kwargs["output_path"])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("   \n", encoding="utf-8")
+        return {"status": "success", "markdownPath": str(output_path), "stats": {"markdownChars": 4}}
+
+    monkeypatch.setattr("content_extraction.defuddle_html_file", fake_defuddle)
+
+    result = archive_current_page(output_dir, markdown=True, screenshot=False, overwrite=True)
+
+    archive_dir = Path(result["archiveDir"])
+    assert result["status"] == "partial"
+    assert not (archive_dir / "processed" / "page.md").exists()
+    assert json.loads((archive_dir / "processed" / "status.json").read_text(encoding="utf-8"))["status"] == "failed"
+
+
+def test_extract_markdown_wrapper_enables_markdown(monkeypatch, tmp_path):
+    output_dir = _patch_runtime(monkeypatch, tmp_path)
+
+    def fake_defuddle(html_path, **kwargs):
+        output_path = Path(kwargs["output_path"])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("alpha beta", encoding="utf-8")
+        return {"status": "success", "markdownPath": str(output_path), "stats": {"markdownChars": 10}}
+
+    monkeypatch.setattr("content_extraction.defuddle_html_file", fake_defuddle)
+
+    result = extract_markdown_from_current_page(output_dir, screenshot=False, overwrite=True)
+
+    assert result["status"] == "success"
+    assert (Path(result["archiveDir"]) / "processed" / "page.md").exists()
+
+
+def test_outline_empty_returns_status(monkeypatch):
+    monkeypatch.setattr("content_extraction.js", lambda expr: {"status": "empty", "items": []})
+
+    result = extract_outline()
+
+    assert result == {"status": "empty", "items": []}
+
+
+def test_outline_multiple_headings(monkeypatch):
+    monkeypatch.setattr(
+        "content_extraction.js",
+        lambda expr: {
+            "status": "success",
+            "items": [
+                {"level": 1, "text": "Report", "id": "report"},
+                {"level": 2, "text": "Details", "id": ""},
+            ],
+        },
+    )
+
+    result = extract_outline()
+
+    assert result["items"][0] == {"level": 1, "text": "Report", "id": "report"}
+    json.dumps(result)
+
+
+def test_links_empty_returns_status(monkeypatch):
+    monkeypatch.setattr("content_extraction.js", lambda expr: {"status": "empty", "items": []})
+
+    result = extract_links()
+
+    assert result == {"status": "empty", "items": []}
+
+
+def test_links_deduplicates_exact_href_and_text(monkeypatch):
+    monkeypatch.setattr(
+        "content_extraction.js",
+        lambda expr: {
+            "status": "success",
+            "items": [
+                {"href": "https://example.com/a", "text": "A", "rel": "", "target": "", "sameOrigin": True},
+                {"href": "https://example.com/a", "text": "A", "rel": "", "target": "", "sameOrigin": True},
+                {"href": "https://example.com/a", "text": "Different", "rel": "", "target": "", "sameOrigin": True},
+            ],
+        },
+    )
+
+    result = extract_links()
+
+    assert [item["text"] for item in result["items"]] == ["A", "Different"]
+    json.dumps(result)
+
+
+def test_tables_empty_returns_status(monkeypatch):
+    monkeypatch.setattr("content_extraction.js", lambda expr: {"status": "empty", "tables": []})
+
+    result = extract_tables()
+
+    assert result == {"status": "empty", "tables": []}
+
+
+def test_tables_headers_include_row_objects(monkeypatch):
+    monkeypatch.setattr(
+        "content_extraction.js",
+        lambda expr: {
+            "status": "success",
+            "tables": [
+                {
+                    "caption": "Scores",
+                    "headers": ["Name", "Score"],
+                    "rows": [["Name", "Score"], ["Alpha", "7"]],
+                    "rowObjects": [{"Name": "Alpha", "Score": "7"}],
+                }
+            ],
+        },
+    )
+
+    result = extract_tables()
+
+    assert result["tables"][0]["rowObjects"][0] == {"Name": "Alpha", "Score": "7"}
+    json.dumps(result)
+
+
+def test_lists_extracts_list_items(monkeypatch):
+    monkeypatch.setattr(
+        "content_extraction.js",
+        lambda expr: {"status": "success", "items": [{"type": "ul", "items": ["One", "Two"], "ariaLabel": ""}]},
+    )
+
+    result = extract_lists()
+
+    assert result["items"][0]["items"] == ["One", "Two"]
+    json.dumps(result)
+
+
+def test_cards_missing_selector_returns_not_found(monkeypatch):
+    monkeypatch.setattr("content_extraction.js", lambda expr: {"status": "not_found", "items": []})
+
+    result = extract_cards(".missing")
+
+    assert result == {"status": "not_found", "items": []}
+
+
+def test_cards_hidden_content_is_filtered(monkeypatch):
+    monkeypatch.setattr(
+        "content_extraction.js",
+        lambda expr: {
+            "status": "success",
+            "items": [
+                {"visible": False, "text": "Hidden", "links": [], "heading": "", "ariaLabel": "", "data": {}},
+                {"visible": True, "text": "Shown", "links": [], "heading": "Shown", "ariaLabel": "", "data": {}},
+            ],
+        },
+    )
+
+    result = extract_cards(".card")
+
+    assert [item["text"] for item in result["items"]] == ["Shown"]
+
+
+def test_virtualized_stable_stop(monkeypatch):
+    monkeypatch.setattr(
+        "content_extraction.js",
+        lambda expr: {
+            "status": "success",
+            "items": [{"text": "A"}],
+            "scrollAttempts": 3,
+            "stableRounds": 2,
+            "partial": False,
+            "stopReason": "stable",
+        },
+    )
+
+    result = extract_virtualized_container(".list", ".item", max_scrolls=5, stable_rounds=2)
+
+    assert result["partial"] is False
+    assert result["stopReason"] == "stable"
+
+
+def test_virtualized_empty_items_are_not_success(monkeypatch):
+    def fake_js(expr):
+        assert "const status = items.length ? 'success' : 'empty'" in expr
+        assert "if (!items.length) return {status:'empty'" in expr
+        return {
+            "status": "empty",
+            "items": [],
+            "scrollAttempts": 2,
+            "stableRounds": 1,
+            "partial": False,
+            "stopReason": "empty",
+        }
+
+    monkeypatch.setattr("content_extraction.js", fake_js)
+
+    result = extract_virtualized_container(".list", ".missing", max_scrolls=5, stable_rounds=1)
+
+    assert result["status"] == "empty"
+    assert result["items"] == []
+    assert result["stopReason"] == "empty"
+
+
+def test_virtualized_partial_on_max_scrolls(monkeypatch):
+    monkeypatch.setattr(
+        "content_extraction.js",
+        lambda expr: {
+            "status": "partial",
+            "items": [{"text": "A"}],
+            "scrollAttempts": 2,
+            "stableRounds": 0,
+            "partial": True,
+            "stopReason": "max_scrolls",
+        },
+    )
+
+    result = extract_virtualized_container(".list", ".item", max_scrolls=2, stable_rounds=2)
+
+    assert result["partial"] is True
+    assert result["stopReason"] == "max_scrolls"
+
+
+def test_defuddle_unavailable_returns_structured_fallback(monkeypatch, tmp_path):
+    html_path = tmp_path / "raw" / "page.html"
+    html_path.parent.mkdir()
+    html_path.write_text("<article>alpha</article>", encoding="utf-8")
+    monkeypatch.setattr("content_extraction.shutil.which", lambda name: None)
+
+    result = defuddle_html_file(html_path)
+
+    assert result["status"] == "unavailable"
+    assert "markdownPath" not in result
+
+
+def test_defuddle_unavailable_can_raise(monkeypatch, tmp_path):
+    html_path = tmp_path / "page.html"
+    html_path.write_text("<article>alpha</article>", encoding="utf-8")
+    monkeypatch.setattr("content_extraction.shutil.which", lambda name: None)
+
+    try:
+        defuddle_html_file(html_path, fail_soft=False)
+    except RuntimeError as exc:
+        assert "Defuddle executable not found" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_defuddle_nonzero_returns_failed_without_markdown(monkeypatch, tmp_path):
+    html_path = tmp_path / "raw" / "page.html"
+    html_path.parent.mkdir()
+    html_path.write_text("<article>alpha</article>", encoding="utf-8")
+    output_path = tmp_path / "processed" / "page.md"
+    monkeypatch.setattr("content_extraction.shutil.which", lambda name: "/bin/defuddle")
+    monkeypatch.setattr(
+        "content_extraction.subprocess.run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 2, "", "bad parse"),
+    )
+
+    result = defuddle_html_file(html_path, output_path=output_path)
+
+    assert result["status"] == "failed"
+    assert "bad parse" in result["stderr"]
+    assert "markdownPath" not in result
+    assert not output_path.exists()
+
+
+def test_defuddle_success_writes_markdown_and_stats(monkeypatch, tmp_path):
+    html_path = tmp_path / "raw" / "page.html"
+    html_path.parent.mkdir()
+    html_path.write_text("<article>alpha beta</article>", encoding="utf-8")
+    monkeypatch.setattr("content_extraction.shutil.which", lambda name: "/bin/defuddle")
+
+    def fake_run(args, **kwargs):
+        output_path = Path(args[args.index("--output") + 1])
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("# Alpha\n\nbeta", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr("content_extraction.subprocess.run", fake_run)
+
+    result = defuddle_html_file(html_path)
+
+    markdown_path = Path(result["markdownPath"])
+    assert result["status"] == "success"
+    assert markdown_path == tmp_path / "processed" / "page.md"
+    assert markdown_path.read_text(encoding="utf-8").startswith("# Alpha")
+    assert result["stats"]["markdownChars"] == len("# Alpha\n\nbeta")


### PR DESCRIPTION
## Summary

Adds `agent-workspace/content_extraction.py` — page archiving plus a set of structured content extractors — and re-exports the helpers from `agent_helpers.py`.

## What's included
- `archive_current_page` — snapshot the current page.
- `extract_markdown_from_current_page` — defuddle-backed clean-markdown extraction.
- Structured extractors: `extract_outline`, `extract_links`, `extract_tables`, `extract_lists`, `extract_cards`, `extract_virtualized_container`.
- `interaction-skills/content-extraction.md` documents the mechanics.
- An `example.com` domain-skill smoke target under `agent-workspace/domain-skills/example/`.

## Tests
`pytest tests/unit/test_content_extraction.py` — 29 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local page-archiving pipeline and JS-based extractors to capture rendered pages and pull structured content. Includes optional markdown generation via `defuddle` and re-exports in `agent_helpers` for easy use.

- **New Features**
  - `archive_current_page` saves HTML, text, links, optional screenshot, a manifest, and stats; can run `defuddle` to produce markdown.
  - Structured extractors: `extract_outline`, `extract_links`, `extract_tables`, `extract_lists`, `extract_cards`, `extract_virtualized_container`.
  - Helpers re-exported from `agent_helpers` for direct imports.
  - Added docs (`interaction-skills/content-extraction.md`), an example domain skill (`domain-skills/example/`), and unit tests covering archiving, extractors, and `defuddle` paths.

- **Migration**
  - Import from `agent_helpers` (e.g., `from agent_helpers import archive_current_page`), or use `content_extraction` directly.
  - Install `defuddle` to enable markdown; archives work without it and record status.
  - Screenshots are opt-in; use `screenshot=True` only for public/redacted pages.

<sup>Written for commit 4be17c7ecbfc9461c8cb27d0ff536976d2033760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

