### PR TITLE
docs(screenshots): backgrounded tabs pause rAF — screenshots of animated pages can lie

### DIFF
--- a/interaction-skills/screenshots.md
+++ b/interaction-skills/screenshots.md
@@ -15,3 +15,12 @@ capture_screenshot("/tmp/shot.png", max_dim=1800)
 The downscale only happens when the image actually exceeds `max_dim`, so it's safe to leave on for every shot.
 
 Use full-page screenshots (`full=True`) only when you need to see content below the fold — they are much larger and slower than viewport-only.
+
+## Backgrounded tabs freeze animations
+
+Chrome pauses `requestAnimationFrame` in backgrounded or occluded tabs, so count-ups, reveals, and JS-driven animations render blank or stale in screenshots even though the page is "loaded". Before trusting a screenshot of anything animated:
+
+- Probe `js("document.visibilityState")` — anything but `"visible"` means the screenshot may lie.
+- Foreground the tab (`Target.activateTarget` via `cdp(...)`) and nudge it (scroll 1px or dispatch a mousemove) to restart rAF, then re-screenshot.
+- For numbers and layout, prefer DOM reads (`js(...)` with `getBoundingClientRect` / `scrollHeight`) over pixels — they are immune to the pause.
+- Animated values need two samples a few seconds apart that match before you read them as final.


### PR DESCRIPTION
Field-tested across many QA runs on an animation-heavy React app: Chrome pauses `requestAnimationFrame` in backgrounded/occluded tabs, so screenshots of count-ups and reveals silently show blank or stale frames while the page reports loaded. This adds the gotcha and the recovery recipe (visibilityState probe, foreground + nudge, DOM reads over pixels, two-sample rule for animated values) to the screenshots skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DKKK5uNG9DzvUGtyGViye

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented that Chrome pauses `requestAnimationFrame` in backgrounded or occluded tabs, which can make screenshots of animations show blank or stale frames even when the page reports loaded. Added a short checklist to detect and recover: check `document.visibilityState`, foreground and nudge the tab (`Target.activateTarget`, small scroll or mousemove), prefer DOM reads (`getBoundingClientRect`/`scrollHeight`) over pixels, and confirm animated values with two matching samples a few seconds apart.

<sup>Written for commit 9c2075e34e99a2e0638d707c1f2757930fb2ab23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

