### PR TITLE
docs(interaction-skills): React controlled inputs ignore .value assignment

### DIFF
--- a/interaction-skills/react-controlled-inputs.md
+++ b/interaction-skills/react-controlled-inputs.md
@@ -1,0 +1,20 @@
+# React controlled inputs
+
+Assigning `el.value = "..."` to a React-controlled input does nothing — React overwrites it from state on the next render because the assignment never fires React's own change tracking.
+
+What works, in order of preference:
+
+1. **Real input**: click the field, then type via key events. Most robust.
+2. **Native setter + input event** when typing is impractical:
+
+```python
+js("""
+const el = document.querySelector('#amount');
+const setter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype, 'value').set;
+setter.call(el, '87300');
+el.dispatchEvent(new Event('input', { bubbles: true }));
+""")
+```
+
+The same trick applies to `HTMLTextAreaElement` and `HTMLSelectElement` (swap the prototype). Symptom that you need this: the field visually shows your value for a frame, then snaps back — or downstream state never updates.


### PR DESCRIPTION
Classic trap when filling forms on React apps: direct `.value` assignment is reverted on the next render and downstream state never updates. Adds a small interaction skill with the two working approaches (real key input; native prototype setter + bubbling input event) and the tell-tale symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DKKK5uNG9DzvUGtyGViye

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an interaction-skill doc on working with `React`-controlled inputs. It explains why direct `.value` assignments are ignored and shows two working methods: real typing via key events, or using the native `value` setter with a bubbling `input` event (also applies to textarea/select), plus the common flicker/state-not-updating symptom.

<sup>Written for commit 1803e01c18e1919d2e052e654cf3c33f2b8362c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

