### PR TITLE
Add opt-in OS focus preservation

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -224,7 +224,10 @@ class Daemon:
         pages = [t for t in targets if is_real_page(t)]
         if not pages:
             # No real pages - create one instead of attaching to omnibox popup.
-            tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+            params = {"url": "about:blank"}
+            if os.environ.get("BU_PRESERVE_OS_FOCUS", "").strip().lower() in {"1", "true", "yes", "on"}:
+                params["background"] = True
+            tid = (await self.cdp.send_raw("Target.createTarget", params))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
         self.session = (await self.cdp.send_raw(

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -291,6 +291,10 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
+def _preserve_os_focus():
+    return os.environ.get("BU_PRESERVE_OS_FOCUS", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def switch_tab(target):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
@@ -299,7 +303,8 @@ def switch_tab(target):
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    if not _preserve_os_focus():
+        cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
@@ -318,7 +323,10 @@ def new_tab(url="about:blank"):
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
+    params = {"url": "about:blank"}
+    if _preserve_os_focus():
+        params["background"] = True
+    tid = cdp("Target.createTarget", **params)["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, sys, time, urllib.request
+import base64, functools, importlib.util, json, math, os, shutil, subprocess, sys, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -149,6 +149,73 @@ def page_info():
 # --- input ---
 _debug_click_counter = 0
 
+
+def _preserve_os_focus():
+    return os.environ.get("BU_PRESERVE_OS_FOCUS", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _capture_os_focus():
+    """Return the active X11 window id, or None when focus cannot be preserved."""
+    if not _preserve_os_focus() or not sys.platform.startswith("linux") or not os.environ.get("DISPLAY"):
+        return None
+    xdotool = shutil.which("xdotool")
+    if not xdotool:
+        return None
+    try:
+        result = subprocess.run(
+            [xdotool, "getactivewindow"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    window_id = result.stdout.strip()
+    return window_id if result.returncode == 0 and window_id.isdigit() else None
+
+
+def _restore_os_focus(window_id):
+    """Restore a captured X11 window when a CDP input event raised Chrome."""
+    if not window_id or not sys.platform.startswith("linux") or not os.environ.get("DISPLAY"):
+        return
+    xdotool = shutil.which("xdotool")
+    if not xdotool:
+        return
+    try:
+        current = subprocess.run(
+            [xdotool, "getactivewindow"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+        if current.returncode == 0 and current.stdout.strip() == str(window_id):
+            return
+        subprocess.run(
+            [xdotool, "windowactivate", str(window_id)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def _restore_focus_after_input(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        window_id = _capture_os_focus() if _preserve_os_focus() else None
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            if window_id:
+                _restore_os_focus(window_id)
+    return wrapper
+
+
+@_restore_focus_after_input
 def click_at_xy(x, y, button="left", clicks=1):
     if os.environ.get("BH_DEBUG_CLICKS"):
         global _debug_click_counter
@@ -171,6 +238,7 @@ def click_at_xy(x, y, button="left", clicks=1):
     cdp("Input.dispatchMouseEvent", type="mousePressed", x=x, y=y, button=button, clickCount=clicks)
     cdp("Input.dispatchMouseEvent", type="mouseReleased", x=x, y=y, button=button, clickCount=clicks)
 
+@_restore_focus_after_input
 def type_text(text):
     cdp("Input.insertText", text=text)
 
@@ -234,6 +302,7 @@ def press_key(key, modifiers=0):
         cdp("Input.dispatchKeyEvent", type="char", text=text, **{k: v for k, v in base.items() if k != "text"})
     cdp("Input.dispatchKeyEvent", type="keyUp", **base)
 
+@_restore_focus_after_input
 def scroll(x, y, dy=-300, dx=0):
     cdp("Input.dispatchMouseEvent", type="mouseWheel", x=x, y=y, deltaX=dx, deltaY=dy)
 
@@ -290,10 +359,6 @@ def _mark_tab():
     """Prepend horse emoji to tab title so the user can see which tab the agent controls."""
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
-
-def _preserve_os_focus():
-    return os.environ.get("BU_PRESERVE_OS_FOCUS", "").strip().lower() in {"1", "true", "yes", "on"}
-
 
 def switch_tab(target):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -293,3 +293,28 @@ def test_current_tab_meta_returns_not_attached_when_no_target_id():
     assert result == {"error": "not_attached"}
     # No CDP call should have been issued.
     assert d.cdp.calls == []
+
+
+def test_attach_first_page_creates_background_target_when_preserving_focus(monkeypatch):
+    class _AttachCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Target.getTargets":
+                return {"targetInfos": []}
+            if method == "Target.createTarget":
+                return {"targetId": "target-1"}
+            if method == "Target.attachToTarget":
+                return {"sessionId": "session-1"}
+            return {}
+
+    monkeypatch.setenv("BU_PRESERVE_OS_FOCUS", "1")
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+
+    asyncio.run(d.attach_first_page())
+
+    assert (
+        "Target.createTarget",
+        {"url": "about:blank", "background": True},
+        None,
+    ) in d.cdp.calls

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -77,6 +77,63 @@ def test_page_info_raises_clear_error_on_js_exception():
             helpers.page_info()
 
 
+# --- tab focus behavior ---
+
+def test_switch_tab_activates_target_by_default(monkeypatch):
+    monkeypatch.delenv("BU_PRESERVE_OS_FOCUS", raising=False)
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-1"}
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers._send", return_value={}):
+        helpers.switch_tab("target-1")
+
+    assert ("Target.activateTarget", {"targetId": "target-1"}) in calls
+
+
+def test_switch_tab_preserves_os_focus_when_requested(monkeypatch):
+    monkeypatch.setenv("BU_PRESERVE_OS_FOCUS", "1")
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-1"}
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers._send", return_value={}):
+        helpers.switch_tab("target-1")
+
+    assert not any(method == "Target.activateTarget" for method, _ in calls)
+    assert ("Target.attachToTarget", {"targetId": "target-1", "flatten": True}) in calls
+
+
+def test_new_tab_is_created_in_background_when_preserving_focus(monkeypatch):
+    monkeypatch.setenv("BU_PRESERVE_OS_FOCUS", "true")
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "target-1"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-1"}
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers._send", return_value={}):
+        helpers.new_tab()
+
+    assert ("Target.createTarget", {"url": "about:blank", "background": True}) in calls
+    assert not any(method == "Target.activateTarget" for method, _ in calls)
+
+
 # --- fill_input ---
 
 def test_fill_input_focuses_types_and_fires_events():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -134,6 +134,39 @@ def test_new_tab_is_created_in_background_when_preserving_focus(monkeypatch):
     assert not any(method == "Target.activateTarget" for method, _ in calls)
 
 
+def test_click_at_xy_restores_operator_focus_after_input(monkeypatch):
+    monkeypatch.setenv("BU_PRESERVE_OS_FOCUS", "1")
+    order = []
+
+    def fake_cdp(method, **kwargs):
+        order.append((method, kwargs.get("type")))
+        return {}
+
+    with patch("browser_harness.helpers._capture_os_focus", side_effect=lambda: order.append(("capture", None)) or "window-7"), \
+         patch("browser_harness.helpers._restore_os_focus", side_effect=lambda token: order.append(("restore", token))), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        helpers.click_at_xy(10, 20)
+
+    assert order == [
+        ("capture", None),
+        ("Input.dispatchMouseEvent", "mousePressed"),
+        ("Input.dispatchMouseEvent", "mouseReleased"),
+        ("restore", "window-7"),
+    ]
+
+
+def test_input_helpers_do_not_probe_os_focus_by_default(monkeypatch):
+    monkeypatch.delenv("BU_PRESERVE_OS_FOCUS", raising=False)
+
+    with patch("browser_harness.helpers._capture_os_focus") as capture, \
+         patch("browser_harness.helpers._restore_os_focus") as restore, \
+         patch("browser_harness.helpers.cdp", return_value={}):
+        helpers.click_at_xy(10, 20)
+
+    capture.assert_not_called()
+    restore.assert_not_called()
+
+
 # --- fill_input ---
 
 def test_fill_input_focuses_types_and_fires_events():


### PR DESCRIPTION
## Summary
- add `BU_PRESERVE_OS_FOCUS` opt-in mode
- create initial and subsequent targets in the background
- attach to tabs without calling `Target.activateTarget`
- preserve existing behavior when the flag is unset

This allows headed automation clients to operate without stealing the operator's active OS window.

## Validation
- `uv run --with pytest pytest -q`
- 118 tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in mode to preserve OS focus so headed automation doesn’t steal the active window. When `BU_PRESERVE_OS_FOCUS` is set, new tabs open in the background, we avoid activating targets, and we restore the operator’s window after CDP input.

- **New Features**
  - `BU_PRESERVE_OS_FOCUS` accepts 1/true/yes/on. Initial and new pages are created with `background: true`, and `switch_tab` skips `Target.activateTarget`.
  - Input helpers (`click_at_xy`, `type_text`, `scroll`) capture and restore the active X11 window (via `xdotool` when available) so Chrome doesn’t pull focus.
  - Behavior is unchanged when the flag is unset or prerequisites are missing.

<sup>Written for commit 5c7dafe2ac8106f314a0bf646c49e2d9a8d9823b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

