### PR TITLE
Add Jira Cloud domain skill (REST via in-tab fetch, multi-site discovery, traps)

### DIFF
--- a/agent-workspace/domain-skills/jira/scraping.md
+++ b/agent-workspace/domain-skills/jira/scraping.md
@@ -1,0 +1,55 @@
+---
+name: jira-cloud-scraping
+description: Jira Cloud (*.atlassian.net) — REST API via in-tab fetch with session cookies, site discovery, JQL search, traps.
+---
+
+# Jira Cloud — *.atlassian.net
+
+Skip DOM scraping entirely. Every logged-in Jira tab can call the REST API with session
+cookies via `js()` fetch — far faster and more complete than reading the board UI.
+
+## The pattern
+
+Open a tab on the Jira site, then fetch same-origin with `credentials: "include"`.
+`js()` doesn't await promises, so stash the result on `window` and poll:
+
+```python
+js("""
+window.__r = null;
+fetch("/rest/api/3/search/jql?jql=" + encodeURIComponent("assignee = currentUser() ORDER BY updated DESC")
+      + "&maxResults=50&fields=summary,status,assignee,priority,issuetype,duedate,updated,project",
+      {headers: {"Accept": "application/json"}, credentials: "include"})
+  .then(r => r.json()).then(d => { window.__r = JSON.stringify(d); })
+  .catch(e => { window.__r = JSON.stringify({error: String(e)}); });
+""")
+result = None
+for _ in range(40):
+    time.sleep(0.5)
+    result = js("window.__r")
+    if result: break
+```
+
+## Endpoints (all same-origin GET unless noted)
+
+| Endpoint | What |
+|---|---|
+| `/rest/api/3/myself` | Who the session is logged in as (displayName, emailAddress, accountId) |
+| `/rest/api/3/search/jql?jql=<JQL>&maxResults=50&fields=...` | JQL search — the workhorse. Paginates via `nextPageToken`; `isLast` flags the final page |
+| `/rest/api/3/project/search?maxResults=50` | List visible projects |
+| `/rest/api/3/issue/<KEY>` | Full single issue incl. description/comments |
+| `/gateway/api/available-sites` | POST `{"products": ["jira-software.ondemand","jira-core.ondemand","jira-servicedesk.ondemand"]}` → all Atlassian sites this account can access |
+
+## Traps
+
+- **The obvious site may be empty.** An account often spans several `*.atlassian.net`
+  sites (e.g. a company site plus a vendor's). If `assignee = currentUser()` returns 0,
+  don't conclude "no tickets" — POST `/gateway/api/available-sites` and check the others.
+  Session cookies are per-subdomain: open a new tab on the other site before fetching.
+- `/jira/your-work` redirects (e.g. to `/jira/projects`) after load; injecting `js()`
+  before the redirect settles loses your `window` state. `wait_for_load()` then sleep ~2s,
+  or just fetch from whatever page it lands on — same origin is all that matters.
+- Empty search results come back as `{"issues": [], "isLast": true}` with HTTP 200 —
+  also check `errorMessages` in the body for JQL errors, which are 200s too on some paths.
+- Service-desk projects (`projectTypeKey: service_desk`) are searchable with plain JQL —
+  no need for the separate Service Management API just to list/read tickets.
+- The old `/rest/api/3/search` (no `/jql`) endpoint is deprecated; use `/search/jql`.


### PR DESCRIPTION
Adds `domain-skills/jira/scraping.md` for Jira Cloud (`*.atlassian.net`).

Field-tested findings:
- Skip DOM scraping: every logged-in tab can call `/rest/api/3/search/jql` same-origin with session cookies — the `js()` + window-stash + poll pattern is included since `js()` doesn't await promises.
- `POST /gateway/api/available-sites` enumerates all Atlassian sites the account can reach — critical because the obvious site can be empty while the real tickets live on a sibling site, and cookies are per-subdomain (open a tab on the other site before fetching).
- Traps: `/jira/your-work` redirects after load (clears injected window state), empty results and JQL errors both return HTTP 200, service-desk projects are plain-JQL searchable, old `/rest/api/3/search` is deprecated in favor of `/search/jql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Jira Cloud domain skill doc for `*.atlassian.net` that uses same-origin REST via in-tab `fetch` with session cookies for fast JQL access, plus multi-site discovery to avoid empty results. Skips DOM scraping and outlines key traps.

- **New Features**
  - In-tab `fetch` pattern with `credentials: "include"` and window-stash + polling since `js()` doesn’t await promises.
  - Multi-site discovery via `POST /gateway/api/available-sites`; cookies are per subdomain — open a tab on the target site first.
  - Key notes: use `/rest/api/3/search/jql`; `/jira/your-work` redirects; empty/JQL-error responses can be HTTP 200; service-desk projects are searchable with plain JQL.

<sup>Written for commit b533f2ae1430fd5f43001de14aeaa3e45296f13b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

