### PR TITLE
docs: add Bing Webmaster Tools audit skill

### DIFF
--- a/agent-workspace/domain-skills/bing-webmaster-tools/auditing.md
+++ b/agent-workspace/domain-skills/bing-webmaster-tools/auditing.md
@@ -1,0 +1,97 @@
+# Bing Webmaster Tools — SEO audits and authenticated APIs
+
+Bing Webmaster Tools (BWT) is a client-rendered app at `https://www.bing.com/webmasters/`. When the user is already signed in, attach browser-harness to that browser and prefer the page's same-origin JSON APIs over scraping tables from the DOM.
+
+## Connect to an authorized Edge profile
+
+Recent Edge builds require the user to enable **Allow remote debugging for this browser instance** at:
+
+`edge://inspect/#remote-debugging`
+
+When the page reports `Server running at: 127.0.0.1:9222`, connect to that existing profile:
+
+```powershell
+$env:BU_NAME = "bing-webmaster-tools"
+$env:BU_CDP_URL = "http://127.0.0.1:9222"
+@'
+ensure_real_tab()
+print(page_info())
+'@ | browser-harness
+```
+
+Do not open `chrome://inspect` through the Windows protocol handler and do not repeatedly run setup. If `/json/version` returns 404 after authorization, browser-harness can discover the Edge profile's `DevToolsActivePort` WebSocket automatically.
+
+## Stable page routes
+
+All routes take a URL-encoded `siteUrl` query parameter. Preserve the property's exact scheme and trailing slash.
+
+- SEO reports: `https://www.bing.com/webmasters/reports/seo?siteUrl=<encoded-property>`
+- Site Scan: `https://www.bing.com/webmasters/sitescan?siteUrl=<encoded-property>`
+- Sitemaps: `https://www.bing.com/webmasters/sitemaps?siteUrl=<encoded-property>`
+- URL submission: `https://www.bing.com/webmasters/submiturls?siteUrl=<encoded-property>`
+
+Open a new tab for the first navigation so the user's active tab is not clobbered.
+
+## Prefer same-origin API reads
+
+The SPA already carries the required cookies and anti-CSRF state. Run `fetch()` inside the BWT tab with `js(...)`; never copy cookies or tokens out of the browser.
+
+Verified endpoints (July 2026):
+
+- `/webmasters/api/reports/seo/overview?siteurl=<encoded-property>` — SEO rule totals, severities, and affected-page counts.
+- `/webmasters/api/indexnow/detectsource?siteurl=<encoded-property>` — whether Bing detects IndexNow (`isAlreadyUsingIndexNow`).
+- `/webmasters/api/sitescan/overview?siteurl=<encoded-property>` — scan sessions and status.
+- `/webmasters/api/sitescan/remainingquota?siteurl=<encoded-property>` — remaining Site Scan quota.
+- `/webmasters/api/sitescan/ignoreurlparams?siteurl=<encoded-property>` — configured URL parameter exclusions.
+- `/webmasters/api/submiturls/listcount` — URL submission quota/count metadata loaded by the SPA.
+
+Example read:
+
+```powershell
+@'
+site = "https://example.com/"
+script = """
+Promise.all([
+  '/webmasters/api/reports/seo/overview?siteurl=' + encodeURIComponent(%s),
+  '/webmasters/api/indexnow/detectsource?siteurl=' + encodeURIComponent(%s),
+  '/webmasters/api/sitescan/overview?siteurl=' + encodeURIComponent(%s)
+].map(url => fetch(url, {credentials: 'include'}).then(async response => ({
+  url,
+  status: response.status,
+  body: await response.json()
+})))).then(JSON.stringify)
+""" % (repr(site), repr(site), repr(site))
+print(js(script))
+'@ | browser-harness
+```
+
+If a new endpoint is needed, inspect the page's resource entries instead of guessing:
+
+```python
+print(js("JSON.stringify(performance.getEntriesByType('resource').map(e => e.name).filter(u => u.includes('/webmasters/api/')))"))
+```
+
+## Site Scan behavior
+
+`sitescan/overview` returns records with fields such as `SessionId`, `ScanUrl`, `ScanName`, `LastScannedUtc`, `PagesScanned`, `Errors`, `Warnings`, and `ScanStatus`. A newly accepted scan can remain `NotStarted` with `PagesScanned: 0` while queued; do not report it as completed. Poll the overview endpoint later.
+
+The account or property can restrict concurrent scans and quota. Capture the SPA's actual request to `/webmasters/api/sitescan/start?...` before automating scan creation; do not invent its method or body.
+
+## IndexNow verification
+
+After publishing the key file and submitting URLs, verify BWT recognition with `indexnow/detectsource`. A successful response looks like:
+
+```json
+{"isAlreadyUsingIndexNow": true}
+```
+
+The public IndexNow aggregator may temporarily return `403 SiteVerificationNotCompleted` immediately after a new key file appears. Check that the key file is public, then submit to Bing's endpoint (`https://www.bing.com/indexnow`). Treat only 200/202 responses as accepted, and re-read `detectsource`; never convert a 403 into a success claim.
+
+## Audit discipline and traps
+
+- BWT SEO warnings can lag the live page. Re-fetch affected URLs and compare title, H1, canonical, description, indexability, and static body before changing code.
+- The Chinese text length can be adequate even when BWT applies a Latin-character description heuristic. Do not pad every description mechanically.
+- A noindex page can still appear in an old H1 warning. Verify the current `X-Robots-Tag` or robots meta and sitemap membership first.
+- Backlink warnings are off-page signals; do not fabricate links or mark them fixed by code.
+- Separate `generated`, `verified`, `deployed`, and `submitted`. A queued Site Scan or accepted code commit is not evidence of live deployment.
+- Keep account email, cookies, request headers, and property verification tokens out of logs and domain skills.

--- a/agent-workspace/domain-skills/bing-webmaster-tools/auditing.md
+++ b/agent-workspace/domain-skills/bing-webmaster-tools/auditing.md
@@ -25,10 +25,10 @@ Do not open `chrome://inspect` through the Windows protocol handler and do not r
 
 All routes take a URL-encoded `siteUrl` query parameter. Preserve the property's exact scheme and trailing slash.
 
-- SEO reports: `https://www.bing.com/webmasters/reports/seo?siteUrl=<encoded-property>`
+- Recommendations: `https://www.bing.com/webmasters/seoreports?siteUrl=<encoded-property>`
 - Site Scan: `https://www.bing.com/webmasters/sitescan?siteUrl=<encoded-property>`
 - Sitemaps: `https://www.bing.com/webmasters/sitemaps?siteUrl=<encoded-property>`
-- URL submission: `https://www.bing.com/webmasters/submiturls?siteUrl=<encoded-property>`
+- URL submission: `https://www.bing.com/webmasters/submiturl?siteUrl=<encoded-property>`
 
 Open a new tab for the first navigation so the user's active tab is not clobbered.
 
@@ -44,6 +44,10 @@ Verified endpoints (July 2026):
 - `/webmasters/api/sitescan/remainingquota?siteurl=<encoded-property>` — remaining Site Scan quota.
 - `/webmasters/api/sitescan/ignoreurlparams?siteurl=<encoded-property>` — configured URL parameter exclusions.
 - `/webmasters/api/submiturls/listcount` — URL submission quota/count metadata loaded by the SPA.
+- `/webmasters/api/sitemaps/overview?siteurl=<encoded-property>` — sitemap totals.
+- `/webmasters/api/sitemaps/list?siteurl=<encoded-property>&pageSize=25&sortBy=UrlCount&sortingOrder=Desc&pageNum=1` — known sitemaps and current crawl status.
+- `/webmasters/api/globalelements/settings` — account-level communication preferences.
+- `/webmasters/api/globalelements/messages` — notification-center messages and their site association.
 
 Example read:
 
@@ -92,6 +96,7 @@ The public IndexNow aggregator may temporarily return `403 SiteVerificationNotCo
 - BWT SEO warnings can lag the live page. Re-fetch affected URLs and compare title, H1, canonical, description, indexability, and static body before changing code.
 - The Chinese text length can be adequate even when BWT applies a Latin-character description heuristic. Do not pad every description mechanically.
 - A noindex page can still appear in an old H1 warning. Verify the current `X-Robots-Tag` or robots meta and sitemap membership first.
+- Discovered sitemap aliases can remain listed after the live aliases become 301 redirects. Count unique URLs from the canonical live sitemap, not the sum of BWT's historical rows.
 - Backlink warnings are off-page signals; do not fabricate links or mark them fixed by code.
 - Separate `generated`, `verified`, `deployed`, and `submitted`. A queued Site Scan or accepted code commit is not evidence of live deployment.
 - Keep account email, cookies, request headers, and property verification tokens out of logs and domain skills.

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -761,6 +761,25 @@ def _chrome_running():
 def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
     import platform, subprocess, webbrowser
+    if platform.system() == "Windows":
+        for process_name, scheme in (("msedge", "edge"), ("chrome", "chrome")):
+            try:
+                executable = subprocess.check_output(
+                    [
+                        "powershell",
+                        "-NoProfile",
+                        "-Command",
+                        f"(Get-Process {process_name} -ErrorAction SilentlyContinue | Select-Object -First 1).Path",
+                    ],
+                    text=True,
+                    timeout=5,
+                ).strip()
+                if executable:
+                    subprocess.Popen([executable, f"{scheme}://inspect/#remote-debugging"])
+                    return
+            except Exception:
+                continue
+        return
     url = "chrome://inspect/#remote-debugging"
     if platform.system() == "Darwin":
         try:

--- a/tests/unit/test_edge_discovery.py
+++ b/tests/unit/test_edge_discovery.py
@@ -1,0 +1,49 @@
+import urllib.error
+
+from browser_harness import admin, daemon
+
+
+def test_edge_devtools_active_port_falls_back_to_recorded_websocket_on_json_404(tmp_path, monkeypatch):
+    (tmp_path / "DevToolsActivePort").write_text(
+        "9222\n/devtools/browser/edge-live-session\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(daemon, "PROFILES", [tmp_path])
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    times = iter([0.0, 0.0, 31.0])
+    monkeypatch.setattr(daemon.time, "time", lambda: next(times))
+    monkeypatch.setattr(daemon.time, "sleep", lambda _seconds: None)
+
+    def json_version_is_hidden(*_args, **_kwargs):
+        raise urllib.error.HTTPError(
+            "http://127.0.0.1:9222/json/version",
+            404,
+            "Not Found",
+            {},
+            None,
+        )
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", json_version_is_hidden)
+
+    assert daemon.get_ws_url() == "ws://127.0.0.1:9222/devtools/browser/edge-live-session"
+
+
+def test_windows_edge_inspect_opens_with_edge_executable_not_system_chrome_protocol(monkeypatch):
+    launches = []
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *_args, **_kwargs: "D:\\Microsoft Edge\\msedge.exe\n",
+    )
+    monkeypatch.setattr("subprocess.Popen", lambda args, **kwargs: launches.append((args, kwargs)))
+    monkeypatch.setattr(
+        "webbrowser.open",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("system protocol must not be used")),
+    )
+
+    admin._open_chrome_inspect()
+
+    assert launches == [
+        (["D:\\Microsoft Edge\\msedge.exe", "edge://inspect/#remote-debugging"], {}),
+    ]


### PR DESCRIPTION
Documents Edge CDP authorization, stable BWT routes, authenticated same-origin API reads, Site Scan queue semantics, IndexNow verification, and stale-warning audit traps. Contains no user-specific state or credentials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Bing Webmaster Tools audit skill with authenticated, same‑origin API reads, refined routes, and clear Site Scan/IndexNow guidance. Also hardens `browser-harness` Edge CDP discovery and Windows inspect flow, with tests.

- **New Features**
  - Docs for attaching to an authorized Edge profile via CDP.
  - Stable BWT routes with `siteUrl` rules (preserve scheme/trailing slash) and open a new tab on first navigation.
  - Verified same-origin API reads for SEO, Site Scan, IndexNow, sitemaps, URL submission, and account messages.

- **Bug Fixes**
  - Fallback to `DevToolsActivePort` WebSocket when `/json/version` returns 404.
  - On Windows, open `edge://inspect/#remote-debugging` using the Edge executable instead of the system protocol handler.
  - Unit tests cover both behaviors.

<sup>Written for commit 0d73182fd3f57f7796611ccc1d0d444298c70abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

