### PR TITLE
fix(macos): stop stealing OS focus when opening/switching tabs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -126,6 +126,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
 - Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow.
 - Omnibox popups are not real work tabs.
+- `Target.activateTarget` steals OS focus on macOS: it raises the browser window, which activates the app. `switch_tab()` therefore does not activate by default, and `new_tab()` creates targets with `background=True` (a foreground `createTarget` also activates the browser when it has zero windows and has to open one). Screenshots, clicks and key input all work on a non-selected tab. Pass `switch_tab(tid, activate=True)` only when a human has to look at the tab (e.g. login).
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.
 - Ask before leaving cloud browsers running; stop them with `stop_remote_daemon(name)` or `PATCH /browsers/{id} {"action":"stop"}`.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -224,7 +224,10 @@ class Daemon:
         pages = [t for t in targets if is_real_page(t)]
         if not pages:
             # No real pages - create one instead of attaching to omnibox popup.
-            tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+            # background=True so creating the window never activates the browser (see new_tab).
+            tid = (await self.cdp.send_raw(
+                "Target.createTarget", {"url": "about:blank", "background": True}
+            ))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
         self.session = (await self.cdp.send_raw(

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -291,7 +291,7 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
-def switch_tab(target):
+def switch_tab(target, activate=False):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
     target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
@@ -299,7 +299,12 @@ def switch_tab(target):
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    # activate=False by default: Target.activateTarget raises the browser window, which on
+    # macOS activates the app and drags the user off whatever they were doing. Screenshots,
+    # clicks and key input all work on a non-selected tab (they go through the CDP session,
+    # not the OS window), so selection is only needed when a human has to look at the tab.
+    if activate:
+        cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
@@ -318,7 +323,10 @@ def new_tab(url="about:blank"):
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
+    # background=True: when the browser has zero windows, a foreground createTarget has to
+    # open a new window, and on macOS that raises it and activates the app — stealing the
+    # user's focus. Background creation never activates the app.
+    tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)


### PR DESCRIPTION
## Problem

On macOS, driving a headful Chrome with browser-harness repeatedly yanks the user's focus (and Space) over to the browser window. It happens on essentially every task, because it fires on tab creation.

Two CDP calls are responsible:

1. **`Target.activateTarget`** — raises the browser window, which on macOS activates the app. `switch_tab()` called it on every switch, and `new_tab()` calls `switch_tab()`, so *every* tab creation stole focus.
2. **`Target.createTarget` in the foreground** (the default) — when the browser has zero windows, it has to open a new one, and macOS raises + activates that window.

## Fix

- `new_tab()` creates targets with `background=True`.
- `switch_tab(target, activate=False)` no longer activates unless the caller explicitly asks. Activation is only needed when a *human* has to look at the tab (e.g. logging in), not for automation.

Screenshots, coordinate clicks and key input all work on a non-selected tab — they go through the CDP session, not the OS window — so nothing is lost.

## Verification (macOS 15, Chrome 150)

Tracked the frontmost app (`System Events`) across each individual CDP call:

| call | frontmost after |
|---|---|
| `Target.createTarget` (background=True) | unchanged |
| `Target.attachToTarget` | unchanged |
| `Target.activateTarget` | **Google Chrome** ← the thief |

End-to-end in the worst case (browser with zero windows open): `new_tab` → `wait_for_load` → `click_at_xy` → `type_text` no longer brings Chrome forward, and the click registered, the typed text landed in the input, and `Page.captureScreenshot` returned the correct content of the non-selected tab in 0.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop macOS from stealing focus when creating or switching tabs in headful Chrome. `switch_tab()` no longer activates the window by default, and `new_tab()` creates background targets so Chrome stays in the background.

- **Bug Fixes**
  - `new_tab()` and daemon `attach_first_page()` call `Target.createTarget` with `background=True` to avoid activating Chrome when no windows exist.
  - `switch_tab(target, activate=False)` only calls `Target.activateTarget` when explicitly requested, keeping automation in the background while clicks, typing, and screenshots still work.

<sup>Written for commit e529bc154783f2b960ec77f21582deeac5d99b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

