### PR TITLE
feat(tabs): cap the number of open tabs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -126,6 +126,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
 - Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow.
 - Omnibox popups are not real work tabs.
+- Tabs are capped: `new_tab()` closes the oldest tabs beyond `BH_MAX_TABS` (default 10, 0 disables). Nothing else ever closes them, so a long session otherwise leaves dozens behind. Call `close_tab()` when you are done with a tab.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.
 - Ask before leaving cloud browsers running; stop them with `stop_remote_daemon(name)` or `PATCH /browsers/{id} {"action":"stop"}`.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -122,6 +122,20 @@ def _ws_from_devtools_active_port(http_url: str) -> str | None:
     return None
 
 
+def http_endpoint_from_ws(ws_url):
+    """The HTTP DevTools base (scheme://host:port) for the ws URL the daemon connected to,
+    so callers can hit /json/* on the *actual* browser instead of guessing a port. Returns
+    None for cloud/remote browsers, which have no local DevTools HTTP endpoint to reap against."""
+    if REMOTE_ID or not ws_url:
+        return None
+    p = urlparse(ws_url)
+    if not p.hostname:
+        return None
+    scheme = "https" if p.scheme == "wss" else "http"
+    host = f"[{p.hostname}]" if ":" in p.hostname else p.hostname
+    return f"{scheme}://{host}{f':{p.port}' if p.port else ''}"
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
@@ -212,6 +226,7 @@ def is_real_page(t):
 class Daemon:
     def __init__(self):
         self.cdp = None
+        self.ws_url = None
         self.session = None
         self.target_id = None
         self.events = deque(maxlen=BUF)
@@ -262,6 +277,7 @@ class Daemon:
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
+        self.ws_url = url
         log(f"connecting to {url}")
         self.cdp = CDPClient(url)
         try:
@@ -367,6 +383,7 @@ class Daemon:
                 timeout=2,
             )))
             return {"session_id": self.session}
+        if meta == "http_endpoint": return {"endpoint": http_endpoint_from_ws(self.ws_url)}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -255,6 +255,42 @@ def capture_screenshot(path=None, full=False, max_dim=None):
 
 
 # --- tabs ---
+MAX_TABS = int(os.environ.get("BH_MAX_TABS", "10"))  # 0 disables reaping
+# Reapable = every page except the browser's own UI. about: is in INTERNAL, but an
+# about:blank tab is a throwaway harness tab, so it has to stay reapable or blank
+# tabs pile up forever.
+_REAP_SKIP = tuple(p for p in INTERNAL if p != "about:")
+
+
+def _reap_tabs(keep_id):
+    """Close the oldest tabs beyond MAX_TABS.
+
+    Nothing else ever closes a tab the agent opened, so a long session leaves dozens
+    of them behind and the browser slows to a crawl. Ordering comes from the DevTools
+    /json/list endpoint (newest first) — Target.getTargets order is not creation order.
+
+    The endpoint is whatever DevTools HTTP base the daemon actually connected to (not a
+    guessed port), so this works for a browser discovered on any port. It is None for
+    cloud/remote browsers, where reaping is skipped.
+    """
+    if MAX_TABS <= 0:
+        return
+    try:
+        base = _send({"meta": "http_endpoint"}).get("endpoint")
+        if not base:
+            return
+        with urllib.request.urlopen(f"{base.rstrip('/')}/json/list", timeout=2) as r:
+            pages = [t for t in json.loads(r.read())
+                     if t.get("type") == "page" and not t.get("url", "").startswith(_REAP_SKIP)]
+    except Exception:
+        return  # can't establish an order -> don't guess which tab to kill
+    for t in pages[MAX_TABS:]:
+        if t["id"] == keep_id:
+            continue
+        try: cdp("Target.closeTarget", targetId=t["id"])
+        except Exception: pass
+
+
 def _is_agent_startup_placeholder(title, url):
     url = str(url or "")
     return str(title or "").startswith("Starting agent ") and (
@@ -320,6 +356,7 @@ def new_tab(url="about:blank"):
             pass
     tid = cdp("Target.createTarget", url="about:blank")["targetId"]
     switch_tab(tid)
+    _reap_tabs(tid)
     if url != "about:blank":
         goto_url(url)
     return tid


### PR DESCRIPTION
## Problem

Nothing ever closes a tab the agent opened. `new_tab()` only creates them and `close_tab()` is opt-in, so a long-running setup just accumulates tabs — I found 50+ open in my automation Chrome, and the browser bogs down well before that.

## Fix

`new_tab()` reaps the oldest tabs beyond `BH_MAX_TABS` (default **10**, `0` disables).

- Ordering comes from the DevTools `/json/list` endpoint, which is newest-first. `Target.getTargets` order is *not* creation order, so it can't be used for this.
- `about:blank` tabs are reapable — they're throwaway harness tabs, and excluding them (they match `INTERNAL`) would let blank tabs pile up forever.
- The browser's own UI pages (`chrome://`, `devtools://`, `chrome-extension://`) are never touched, and the tab the caller just got back is always kept.

## Cost

Negligible. `/json/list` is ~0.6 ms, and in steady state exactly one `Target.closeTarget` is added per `new_tab()`.

| | median `new_tab()` |
|---|---|
| no reaping (baseline) | ~29 ms |
| reaping, nothing to close | ~19 ms |
| reaping, one tab closed (steady state) | ~32 ms |

The differences sit inside the run-to-run noise. Clearing a 30-tab backlog is a one-off ~100 ms.

## Verification (macOS 15, Chrome 150)

With 32 tabs open, the next `new_tab()` settles the browser at 10 tabs and holds there across repeated calls; the tab the caller is working in survives.

Independent of #519 (both touch `new_tab()`, so whichever lands second needs a trivial rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap the number of open tabs by auto-closing the oldest tabs in `new_tab()`. Default limit is 10 (configurable via `BH_MAX_TABS`), reducing tab bloat and keeping Chrome responsive.

- **New Features**
  - `new_tab()` reaps the oldest tabs beyond `BH_MAX_TABS` (0 disables) using DevTools `/json/list` (newest-first); the HTTP base is resolved via daemon `meta: "http_endpoint"` so it works on any discovered port; skipped on cloud/remote (no endpoint).
  - Keeps the newly opened tab; never closes `chrome://`, `devtools://`, or `chrome-extension://` pages; `about:blank` tabs are reapable; negligible overhead (at most one extra `Target.closeTarget` per `new_tab()`).

<sup>Written for commit 5d2e87ac89d98e27b411cb7e385779ca12789b86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

