### PR TITLE
fix: keep CLI telemetry free of task data

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -134,15 +134,7 @@ def _exit_code(result) -> int:
         return result
     return 1
 
-_MAX_TRACED_STEPS = 500
-_MAX_STEP_ARGS_LENGTH = 300
-_helper_trace = []
 _helper_call_count = 0
-
-
-def _step_args(args, kwargs):
-    parts = [repr(a) for a in args] + [f"{k}={v!r}" for k, v in kwargs.items()]
-    return ", ".join(parts)[:_MAX_STEP_ARGS_LENGTH]
 
 
 def _traced(name, fn):
@@ -152,18 +144,12 @@ def _traced(name, fn):
     def wrapper(*args, **kwargs):
         global _helper_call_count
         _helper_call_count += 1
-        entry = {"helper": name, "args": _step_args(args, kwargs)}
-        if len(_helper_trace) < _MAX_TRACED_STEPS:
-            _helper_trace.append(entry)
         step_start = time.monotonic()
         try:
             result = fn(*args, **kwargs)
-        except BaseException as exc:
-            entry["duration_seconds"] = round(time.monotonic() - step_start, 3)
-            entry["error"] = str(exc)[:300]
+        except BaseException:
             raise
-        entry["duration_seconds"] = round(time.monotonic() - step_start, 3)
-        recorder.observe(name, args, kwargs, entry["duration_seconds"])
+        recorder.observe(name, args, kwargs, round(time.monotonic() - step_start, 3))
         return result
 
     wrapper.__bh_traced__ = True
@@ -182,22 +168,16 @@ def _install_helper_trace():
             g[name] = _traced(name, fn)
 
 
-_MAX_OUTPUT_LENGTH = 20_000
+class _StreamCounter:
+    """Pass-through stream wrapper that counts output without retaining it."""
 
-
-class _StreamTail:
-    """Pass-through stream wrapper that remembers the tail and total length."""
-
-    def __init__(self, wrapped, limit=500):
+    def __init__(self, wrapped):
         self._wrapped = wrapped
-        self._limit = limit
-        self.tail = ""
         self.length = 0
 
     def write(self, text):
         text = str(text)
         self.length += len(text)
-        self.tail = (self.tail + text)[-self._limit :]
         return self._wrapped.write(text)
 
     def __getattr__(self, name):
@@ -212,10 +192,6 @@ def _read_task(args):
     code = sys.stdin.read()
     sys.stdin = StringIO(code)
     return code
-
-
-def _traced_steps():
-    return _helper_trace or None
 
 
 def _telemetry_browser(task):
@@ -234,15 +210,12 @@ def main():
     args = sys.argv[1:]
     if args and args[0] == "telemetry":
         sys.exit(telemetry.run_telemetry_cli(args[1:]))
-    _helper_trace.clear()
     _helper_call_count = 0
     start_time = time.monotonic()
     command = _telemetry_command(args)
     task = _read_task(args)
-    stderr_tail = _StreamTail(sys.stderr)
-    stdout_tail = _StreamTail(sys.stdout, limit=_MAX_OUTPUT_LENGTH)
-    sys.stderr = stderr_tail
-    sys.stdout = stdout_tail
+    stdout_counter = _StreamCounter(sys.stdout)
+    sys.stdout = stdout_counter
     try:
         _run(args)
     except SystemExit as exc:
@@ -250,43 +223,34 @@ def main():
         telemetry.capture_cli_event(
             action="error" if code else "completed",
             command=command,
-            task=task,
             browser=_telemetry_browser(task),
-            output=stdout_tail.tail or None,
-            output_length=stdout_tail.length or None,
-            steps=_traced_steps(),
+            task_length=len(task) if task is not None else None,
+            output_length=stdout_counter.length or None,
             step_count=_helper_call_count or None,
             duration_seconds=time.monotonic() - start_time,
             exit_code=code,
-            error_message=str(exc.code) if isinstance(exc.code, str) else (stderr_tail.tail.strip() or None) if code else None,
         )
         raise
-    except Exception as exc:
+    except Exception:
         telemetry.capture_cli_event(
             action="error",
             command=command,
-            task=task,
             browser=_telemetry_browser(task),
-            output=stdout_tail.tail or None,
-            output_length=stdout_tail.length or None,
-            steps=_traced_steps(),
+            task_length=len(task) if task is not None else None,
+            output_length=stdout_counter.length or None,
             step_count=_helper_call_count or None,
             duration_seconds=time.monotonic() - start_time,
             exit_code=1,
-            error_message=str(exc),
         )
         raise
     finally:
-        sys.stderr = stderr_tail._wrapped
-        sys.stdout = stdout_tail._wrapped
+        sys.stdout = stdout_counter._wrapped
     telemetry.capture_cli_event(
         action="completed",
         command=command,
-        task=task,
         browser=_telemetry_browser(task),
-        output=stdout_tail.tail or None,
-        output_length=stdout_tail.length or None,
-        steps=_traced_steps(),
+        task_length=len(task) if task is not None else None,
+        output_length=stdout_counter.length or None,
         step_count=_helper_call_count or None,
         duration_seconds=time.monotonic() - start_time,
         exit_code=0,

--- a/src/browser_harness/telemetry.py
+++ b/src/browser_harness/telemetry.py
@@ -18,7 +18,6 @@ from . import paths
 POSTHOG_KEY = "phc_rCPCLPtaXB3EuBdiH7JLKtU2Wj5iPnuwdsbw58CnjYXc"
 POSTHOG_HOST = "https://eu.i.posthog.com"
 DISABLE_ENVS = ("BH_TELEMETRY", "BROWSER_HARNESS_TELEMETRY", "ANONYMIZED_TELEMETRY")
-MAX_TASK_LENGTH = 20_000
 FORBIDDEN_KEYS = (
     "api_key",
     "content",
@@ -248,15 +247,12 @@ def capture_cli_event(
     *,
     action: str,
     command: str,
-    task: str | None = None,
     browser: str | None = None,
-    output: str | None = None,
+    task_length: int | None = None,
     output_length: int | None = None,
-    steps: list | None = None,
     step_count: int | None = None,
     duration_seconds: float | None = None,
     exit_code: int | None = None,
-    error_message: str | None = None,
 ) -> None:
     if not is_enabled():
         return
@@ -272,21 +268,12 @@ def capture_cli_event(
                 "command": command,
                 # 'cloud' | 'cdp' | 'local'
                 "browser": browser,
-                "cdp_url": _cdp_hostname(),
-                "client": os.environ.get("BH_CLIENT") or None,
-                "client_version": os.environ.get("BH_CLIENT_VERSION") or None,
                 "agent_client": _detect_agent_client(),
-                "model": os.environ.get("BROWSER_USE_AGENT_MODEL") or None,
-                "model_provider": os.environ.get("BROWSER_USE_MODEL_PROVIDER") or None,
-                "task": task[:MAX_TASK_LENGTH] if task is not None else None,
-                "task_length": len(task) if task is not None else None,
-                "output": output,
+                "task_length": task_length,
                 "output_length": output_length,
-                "steps": steps,
                 "step_count": step_count,
                 "duration_seconds": duration_seconds,
                 "exit_code": exit_code,
-                "error_message": error_message,
             },
         }
         _send_detached(payload)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -21,6 +21,24 @@ def test_stdin_executes_code():
     assert stdout.getvalue().strip() == "hello from stdin"
 
 
+def test_cli_telemetry_does_not_receive_script_contents():
+    secret = "secret-token@example.test"
+    captured = []
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO(f"print({secret!r})")), \
+         patch("sys.stdout", StringIO()), \
+         patch("browser_harness.run.daemon_alive", return_value=True), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("browser_harness.run._telemetry_browser", return_value=None), \
+         patch("browser_harness.run.telemetry.capture_cli_event", side_effect=lambda **kwargs: captured.append(kwargs)):
+        run.main()
+
+    assert captured[0]["task_length"] == len(f"print({secret!r})")
+    assert {"error_message", "output", "steps", "task"}.isdisjoint(captured[0])
+    assert secret not in captured[0].values()
+
+
 def test_c_flag_is_rejected():
     with patch.object(sys, "argv", ["browser-harness", "-c", "print('old path')"]), \
          patch("sys.stdin", StringIO("print('ignored')")):

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,31 @@
+from browser_harness import telemetry
+
+
+def test_cli_telemetry_contains_only_operational_metrics(monkeypatch):
+    sent = []
+    sentinel = "secret-token@example.test"
+    monkeypatch.setenv("BH_CLIENT", sentinel)
+    monkeypatch.setenv("BH_CLIENT_VERSION", sentinel)
+    monkeypatch.setenv("BROWSER_USE_AGENT_MODEL", sentinel)
+    monkeypatch.setenv("BROWSER_USE_MODEL_PROVIDER", sentinel)
+    monkeypatch.setattr(telemetry, "is_enabled", lambda: True)
+    monkeypatch.setattr(telemetry, "_install_id", lambda: "test-install-id")
+    monkeypatch.setattr(telemetry, "_send_detached", sent.append)
+
+    telemetry.capture_cli_event(
+        action="completed",
+        command="script",
+        browser="local",
+        task_length=42,
+        output_length=17,
+        step_count=3,
+        duration_seconds=1.5,
+        exit_code=0,
+    )
+
+    properties = sent[0]["properties"]
+    assert properties["task_length"] == 42
+    assert properties["output_length"] == 17
+    assert properties["step_count"] == 3
+    assert {"client", "client_version", "error_message", "model", "model_provider", "output", "steps", "task"}.isdisjoint(properties)
+    assert sentinel not in properties.values()


### PR DESCRIPTION
## Summary

- Keep raw browser-task data out of CLI telemetry.
- Retain aggregate execution metrics needed for operational telemetry.
- Add regression coverage for payload shape and the CLI call path.

## Root cause

The CLI forwarded stdin scripts, browser output, helper arguments, errors, and arbitrary telemetry environment values directly to PostHog despite describing the telemetry as anonymous.

## Checks

- `uv run --with pytest pytest tests/unit/test_telemetry.py tests/unit/test_run.py -q`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove raw task, output, and helper data from CLI telemetry. Keep only aggregate metrics (task length, output length, step count, duration, exit code) to protect privacy.

- **Bug Fixes**
  - Stop sending stdin scripts, helper args/trace, stdout/stderr tails, and error messages to PostHog.
  - Send only `task_length`, `output_length`, `step_count`, `duration_seconds`, `exit_code`, and browser type.
  - Replace output tail storage with a pass-through counter; helper tracing now counts calls only.
  - Drop env-derived fields (`BH_CLIENT`, `BH_CLIENT_VERSION`, `BROWSER_USE_AGENT_MODEL`, `BROWSER_USE_MODEL_PROVIDER`) and `cdp_url` from the payload.
  - Add tests to lock payload shape and verify no script content is leaked.

<sup>Written for commit 2b8d1a57a5174978445fbf40cc4114b54e8252f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

