### PR TITLE
fix: validate local Chrome probe

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -1,4 +1,4 @@
-import os, sys, time, urllib.request
+import json, os, sys, time, urllib.request
 from io import StringIO
 
 # Windows default stdout/stderr encoding is cp1252
@@ -70,9 +70,12 @@ USAGE = """Usage:
 def _local_chrome_listening():
     for port in (9222, 9223):
         try:
-            urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=0.3).close()
-            return True
-        except OSError: pass
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=0.3) as response:
+                version = json.loads(response.read())
+            if isinstance(version, dict) and isinstance(version.get("webSocketDebuggerUrl"), str) and version["webSocketDebuggerUrl"]:
+                return True
+        except (OSError, TypeError, ValueError):
+            pass
     return False
 
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,6 +1,6 @@
 import sys
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -228,12 +228,23 @@ def test_explicit_cdp_configured_helper_falsy(monkeypatch):
 
 def test_local_chrome_listening_rejects_non_chrome():
     """A bare TCP listener on 9222/9223 must not fool the probe — only a real
-    /json/version response counts as Chrome."""
+    /json/version response with a DevTools WebSocket counts as Chrome."""
     with patch("browser_harness.run.urllib.request.urlopen", side_effect=OSError):
         assert run._local_chrome_listening() is False
-    with patch("browser_harness.run.urllib.request.urlopen") as mock_open:
+    for payload in (b"not JSON", b"{}", b"[]", b'{"webSocketDebuggerUrl": ""}', b'{"webSocketDebuggerUrl": 1}'):
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = payload
+        with patch("browser_harness.run.urllib.request.urlopen", return_value=response) as mock_open:
+            assert run._local_chrome_listening() is False
+        assert mock_open.call_count == 2
+
+
+def test_local_chrome_listening_accepts_devtools_response():
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/x"}'
+    with patch("browser_harness.run.urllib.request.urlopen", return_value=response) as mock_open:
         assert run._local_chrome_listening() is True
-        mock_open.assert_called_once()
+    mock_open.assert_called_once()
 
 
 def test_cli_doctor_fix_snap_invokes_guide():


### PR DESCRIPTION
## Summary

- Validate the response from the local DevTools endpoint before treating it as Chrome.
- Cover invalid HTTP payloads and a valid DevTools WebSocket response.

## Root cause

Any HTTP 200 response on ports 9222 or 9223 blocked cloud auto-bootstrap, even when the service was not a CDP browser.

## Checks

- `uv run --with pytest pytest tests/unit/test_run.py -q`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the local DevTools endpoint before treating it as Chrome by checking `/json/version` for a non-empty `webSocketDebuggerUrl`. Fixes false positives from services on ports 9222/9223 that blocked cloud auto-bootstrap.

- **Bug Fixes**
  - Parse JSON from `/json/version`; require `webSocketDebuggerUrl` to be a non-empty string.
  - Ignore non-JSON or invalid payloads; catch `OSError`, `TypeError`, and `ValueError`.
  - Add unit tests to reject invalid responses and accept a valid DevTools response.

<sup>Written for commit fdf433c703fef6e70b234576ce05a9eafbcef016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

