### PR TITLE
fix: avoid retrying user JavaScript errors

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -91,6 +91,10 @@ def _decode_unserializable_js_value(value):
     return value
 
 
+class _IllegalTopLevelReturn(RuntimeError):
+    pass
+
+
 def _runtime_value(response, expression):
     result = response.get("result", {})
     details = response.get("exceptionDetails")
@@ -102,7 +106,8 @@ def _runtime_value(response, expression):
             loc = f" at line {line}, column {col}" if line is not None and col is not None else ""
         else:
             loc = ""
-        raise RuntimeError(f"JavaScript evaluation failed{loc}: {desc}; expression: {_js_snippet(expression)}")
+        error_type = _IllegalTopLevelReturn if _is_illegal_top_level_return(result) else RuntimeError
+        raise error_type(f"JavaScript evaluation failed{loc}: {desc}; expression: {_js_snippet(expression)}")
     if "value" in result:
         return result["value"]
     if "unserializableValue" in result:
@@ -122,8 +127,13 @@ def _wrap_js_function(expression):
     return f"(function(){{{expression}}})()"
 
 
-def _is_illegal_return_error(exc):
-    return "Illegal return statement" in str(exc)
+def _is_illegal_top_level_return(result):
+    return (
+        result.get("type") == "object"
+        and result.get("subtype") == "error"
+        and result.get("className") == "SyntaxError"
+        and result.get("description") == "SyntaxError: Illegal return statement"
+    )
 
 
 # --- navigation / page ---
@@ -443,10 +453,8 @@ def js(expression, target_id=None):
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
     try:
         return _runtime_evaluate(expression, session_id=sid, await_promise=True)
-    except RuntimeError as e:
-        if _is_illegal_return_error(e):
-            return _runtime_evaluate(_wrap_js_function(expression), session_id=sid, await_promise=True)
-        raise
+    except _IllegalTopLevelReturn:
+        return _runtime_evaluate(_wrap_js_function(expression), session_id=sid, await_promise=True)
 
 
 _KC = {"Enter": 13, "Tab": 9, "Escape": 27, "Backspace": 8, " ": 32, "ArrowLeft": 37, "ArrowUp": 38, "ArrowRight": 39, "ArrowDown": 40}

--- a/tests/integration/test_js.py
+++ b/tests/integration/test_js.py
@@ -30,7 +30,12 @@ def _illegal_return_then_success():
         captured.append((method, kwargs))
         if method == "Runtime.evaluate" and len(_evaluated_expressions(captured)) == 1:
             return {
-                "result": {"type": "object", "subtype": "error", "description": "SyntaxError: Illegal return statement"},
+                "result": {
+                    "type": "object",
+                    "subtype": "error",
+                    "className": "SyntaxError",
+                    "description": "SyntaxError: Illegal return statement",
+                },
                 "exceptionDetails": {"text": "Uncaught SyntaxError: Illegal return statement"},
             }
         return {"result": {"value": None}}
@@ -115,6 +120,30 @@ def test_js_raises_on_error_result_without_exception_details():
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
         with pytest.raises(RuntimeError, match="evaluation failed"):
             helpers.js("throw new Error('evaluation failed')")
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"className": "Error", "description": "Error: Illegal return statement\n    at <anonymous>:1:7"},
+        {"className": "SyntaxError", "description": "SyntaxError: Illegal return statement\n    at <anonymous>:1:7"},
+    ],
+)
+def test_js_does_not_retry_user_errors_that_mention_illegal_return(result):
+    captured = []
+
+    def fake_cdp(method, **kwargs):
+        captured.append((method, kwargs))
+        return {
+            "result": {"type": "object", "subtype": "error", **result},
+            "exceptionDetails": {"text": "Uncaught"},
+        }
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        with pytest.raises(RuntimeError):
+            helpers.js("window.count = (window.count || 0) + 1; throw new Error('Illegal return statement')")
+
+    assert len(_evaluated_expressions(captured)) == 1
 
 
 def test_return_word_inside_string_does_not_trigger_wrapping():


### PR DESCRIPTION
## Summary

- Retry a JavaScript snippet only for Chrome's exact top-level-return parser error.
- Avoid a second evaluation after user code throws an error containing the same text.
- Add regressions for user-thrown `Error` and `SyntaxError` values.

## Root cause

The retry decision used a substring of a flattened runtime error. User code could throw that text after changing page state, causing the harness to execute the expression twice.

## Checks

- `uv run --with pytest pytest tests/integration/test_js.py tests/unit/test_helpers.py -q`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only retry JavaScript evaluation for Chrome’s exact top‑level return SyntaxError. This prevents double execution and side effects when user code throws errors that mention “Illegal return statement”.

- **Bug Fixes**
  - Detect Chrome’s top‑level return via `result` fields and raise `_IllegalTopLevelReturn`; `helpers.js` retries once by wrapping the expression.
  - Remove substring-based matching; do not retry on user‑thrown `Error`/`SyntaxError` that include “Illegal return statement”.
  - Add tests covering Chrome’s error path and regressions for user‑thrown errors.

<sup>Written for commit 182783eb986bdf7d1a798bf9b111d9dcb89ddabb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

