### PR TITLE
Document Search Console AI report navigation

### DIFF
--- a/domain-skills/google-search-console/performance-reports.md
+++ b/domain-skills/google-search-console/performance-reports.md
@@ -1,0 +1,31 @@
+# Google Search Console performance reports
+
+Use the user's already-authenticated Chrome session. Stop at the Google sign-in page; never enter credentials from screenshots or local files.
+
+## Stable routes
+
+- Standard Search performance report:
+  `https://search.google.com/search-console/performance/search-analytics?resource_id=<URL-encoded property>`
+- Generative AI performance report:
+  `https://search.google.com/search-console/performance/search-analytics/ai`
+
+For a domain property, encode the complete value such as `sc-domain:example.com` when passing `resource_id`.
+
+## Distinguish the two AI controls
+
+The standard Performance report may show `Customize your Performance report using AI`. This is only an experimental filter/comparison configurator. It is not the separate Generative AI performance report for AI Overviews and AI Mode impressions.
+
+Verify generative-report access independently:
+
+1. Open the normal Performance report and screenshot the left navigation.
+2. Check for a Generative AI, AI Overviews, or AI Mode report item.
+3. Open the direct `/performance/search-analytics/ai` route.
+4. Screenshot the result.
+
+During subset rollout, an unavailable report can redirect to `/search-console/not-found` and visibly render `Page couldn't be found` even while the property is selected and normal Search Console access works. Opening the route without a selected property may instead show `Please select a property`; that is not proof of report access.
+
+## API cross-check limitation
+
+The Search Analytics API `searchAppearance` dimension is useful corroboration, but it is not a substitute for the UI-only Generative AI performance report. Ordinary rows such as `PRODUCT_SNIPPETS` or `TRANSLATED_RESULT` do not indicate AI Overviews or AI Mode report access.
+
+After any navigation, use `page_info()` and a screenshot to verify the selected property, final route, visible report title, and error state.


### PR DESCRIPTION
## Summary
- distinguish Search Console's AI-powered filter configurator from the Generative AI performance report
- document stable report routes and subset-rollout unavailable states
- note that Search Analytics searchAppearance rows are only corroboration

## Verification
- confirmed with an authenticated Search Console property
- verified final routes, visible labels, and unavailable-report screenshot state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a new docs page on Google Search Console performance reports. It lists stable routes for the standard and Generative AI reports, shows how to distinguish the AI filter configurator, gives quick verification steps and subset-rollout "not found" behaviors, and clarifies that `searchAppearance` API rows are only corroboration.

<sup>Written for commit 2d26f1817ab81500897e485edc5ee2b1744005cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

