### PR TITLE
Add X DM reply-batch and spreadsheet paste recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 dist/
 .idea/
 .claude/
+.DS_Store

--- a/SKILL.md
+++ b/SKILL.md
@@ -98,6 +98,7 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 If you get stuck on a browser mechanic, check https://github.com/browser-use/browser-harness/tree/main/interaction-skills.
 
 - connection.md
+- clipboard.md
 - cookies.md
 - cross-origin-iframes.md
 - dialogs.md

--- a/domain-skills/x/direct-messages.md
+++ b/domain-skills/x/direct-messages.md
@@ -1,0 +1,155 @@
+# X — direct-message reply batches (field-tested Jul 2026)
+
+## Routes and stable selectors
+
+Accepted conversations use `https://x.com/i/chat/<participant-ids>`. Message
+requests use `https://x.com/i/chat/requests/<participant-ids>`.
+
+| Purpose | Selector / signal |
+| --- | --- |
+| Conversation is ready | `[data-testid="dm-conversation-panel"]` |
+| Displayed participant | `[data-testid="dm-conversation-username"]` |
+| Composer | `[data-testid="dm-composer-textarea"]` |
+| Send button | `[data-testid="dm-composer-send-button"]` |
+| Accept request | `[data-testid="dm-message-request-accept-button"]` |
+| Message wrappers | `[data-testid^="message-"]`, excluding `message-text-*` |
+
+Message direction is visible on the outer wrapper: sent messages have
+`justify-end`; received messages have `justify-start`.
+
+## Authentication
+
+Try the harness before opening a fresh Chrome window. Its dedicated automation
+profile may already contain the usable X session even when a newly opened
+Default-profile window redirects to login.
+
+```python
+new_tab("https://x.com/i/chat/<participant-ids>")
+wait_for_load()
+wait_for_element('[data-testid="dm-conversation-panel"]', timeout=8)
+print(page_info())
+```
+
+If `page_info()["url"]` contains `/login` or `onboarding`, stop and ask the user
+to sign in. Do not type credentials recovered from the page or machine.
+
+## Read the thread without the timestamp trap
+
+X puts the visible time inside the same message wrapper as the message text,
+often twice. A message that looks like `Thanks` in the UI may read as
+`Thanks\n8:39 PM\n8:39 PM` through `innerText`.
+
+Do not use equality for duplicate detection or send verification. Normalize
+whitespace, then test whether the draft is contained in an outgoing wrapper.
+
+```python
+import json
+import re
+
+
+def normalize(value):
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def thread_snapshot():
+    raw = js(
+        """JSON.stringify((()=>{
+          const messages=[...document.querySelectorAll('[data-testid^="message-"]')]
+            .filter(e=>!e.dataset.testid.startsWith('message-text-'))
+            .map(e=>({
+              direction:e.className.includes('justify-end')?'out':'in',
+              text:(e.innerText||e.textContent||'').trim()
+            }));
+          return {
+            href:location.href,
+            name:(document.querySelector('[data-testid="dm-conversation-username"]')?.innerText||'').trim(),
+            hasComposer:!!document.querySelector('[data-testid="dm-composer-textarea"]'),
+            messages
+          };
+        })())"""
+    )
+    return json.loads(raw or "{}")
+
+
+draft = normalize(draft_text)
+outgoing = [
+    normalize(message["text"])
+    for message in thread_snapshot().get("messages", [])
+    if message["direction"] == "out"
+]
+already_sent = any(draft in message for message in outgoing)
+```
+
+Exact equality caused a duplicate acknowledgement in the field. Treat
+substring containment here as a hard safety rule.
+
+## Accept a request only when a reply is due
+
+A request route has no composer until it is accepted. Do not bulk-accept every
+request. Accept only the rows the reply plan marks for sending.
+
+```python
+snapshot = thread_snapshot()
+if not snapshot.get("hasComposer"):
+    accept = query_deep('[data-testid="dm-message-request-accept-button"]')
+    if accept:
+        click(accept["x"], accept["y"])
+        wait_for_element('[data-testid="dm-composer-textarea"]', timeout=8)
+        snapshot = thread_snapshot()
+
+if not snapshot.get("hasComposer"):
+    raise RuntimeError("conversation has no composer")
+```
+
+## Compose, send, verify
+
+Focus the textarea, insert text through CDP, and confirm the textarea value
+before clicking Send. The send button appears only after the composer contains
+text.
+
+```python
+import time
+
+js("document.querySelector('[data-testid=dm-composer-textarea]').focus()")
+type_text(draft_text)
+wait(0.35)
+
+composed = normalize(
+    js("document.querySelector('[data-testid=dm-composer-textarea]').value") or ""
+)
+if composed != normalize(draft_text):
+    raise RuntimeError(f"composer mismatch: {composed!r}")
+
+send = query_deep('[data-testid="dm-composer-send-button"]')
+if not send:
+    raise RuntimeError("send button unavailable after composing")
+click(send["x"], send["y"])
+
+deadline = time.time() + 12
+while time.time() < deadline:
+    outgoing = [
+        normalize(message["text"])
+        for message in thread_snapshot().get("messages", [])
+        if message["direction"] == "out"
+    ]
+    if any(normalize(draft_text) in message for message in outgoing):
+        break
+    time.sleep(0.4)
+else:
+    raise RuntimeError("sent message was not verified in the thread")
+```
+
+## Batch discipline
+
+- Run one pilot, inspect its screenshot, then continue.
+- Use batches of 5–10 so a selector or rate-limit failure cannot affect the
+  whole queue.
+- Persist one result per candidate after every attempt. Make reruns idempotent
+  by checking for the exact draft substring before composing.
+- Keep no-reply and other-channel rows outside the send list. A row in a sheet
+  is not permission to accept or message its request.
+- Stop the batch on authentication redirects. Log missing composers and other
+  failures instead of improvising a different message.
+- Verify the final sent count from the threads, then update the tracker. Do not
+  infer success from an empty composer alone.
+

--- a/interaction-skills/clipboard.md
+++ b/interaction-skills/clipboard.md
@@ -1,0 +1,60 @@
+# Clipboard paste into browser spreadsheets
+
+Use this when a browser spreadsheet has the correct range selected but ignores
+synthetic Cmd+V. Google Sheets accepted this path reliably in Jul 2026.
+
+## Select the destination range
+
+Google Sheets exposes its name box as `input.waffle-name-box`.
+
+```python
+name_box = query_deep("input.waffle-name-box")
+if not name_box:
+    raise RuntimeError("name box not found")
+
+click(name_box["x"], name_box["y"])
+press_key("a", modifiers=4)  # Cmd+A on macOS
+type_text("G2:H64")
+press_key("Enter")
+wait(0.5)
+```
+
+## Grant clipboard access and perform a user-gesture paste
+
+`Input.dispatchKeyEvent` for Cmd+V may do nothing even when the system
+clipboard and selection are correct. `Browser.setPermission` also rejects the
+permission name `clipboardReadWrite` on current Chrome. Use
+`Browser.grantPermissions`, write the TSV through `navigator.clipboard`, then
+invoke paste with `userGesture=True`.
+
+```python
+import json
+
+tsv = "Sent\t2026-07-14\nSent\t2026-07-14"
+
+cdp(
+    "Browser.grantPermissions",
+    permissions=["clipboardReadWrite", "clipboardSanitizedWrite"],
+    origin="https://docs.google.com",
+)
+js("navigator.clipboard.writeText(" + json.dumps(tsv) + ")")
+
+result = cdp(
+    "Runtime.evaluate",
+    expression="document.execCommand('paste')",
+    returnByValue=True,
+    userGesture=True,
+)
+if result.get("result", {}).get("value") is not True:
+    raise RuntimeError(f"paste was not accepted: {result}")
+```
+
+TSV fills rows and columns; newline-only text fills one column.
+
+## Verification
+
+The name box continuing to display the selected range does not prove the paste
+worked. Re-read the destination with the relevant spreadsheet connector or API
+and count the expected values. A screenshot is useful for layout, not for a
+63-row content assertion.
+


### PR DESCRIPTION
## What changed

- Added an X direct-message recipe covering authenticated session recovery, stable DM selectors, request acceptance, composer verification, bounded batches, and idempotent reruns.
- Added a clipboard recipe for spreadsheet ranges that ignore synthetic Cmd+V.
- Added the clipboard recipe to the Interaction Skills index. The X recipe is discovered through the existing domain-skill routing when `BH_DOMAIN_SKILLS=1`.

## Why

X appends timestamps inside message wrappers. Exact-text verification can therefore miss a successful send and resend the same DM. Google Sheets can also show the intended range as selected while ignoring a synthetic paste.

## Impact

Future reply batches can detect existing outgoing drafts safely, accept only the requests that actually need replies, and verify each send in-thread. Tracker updates have a documented paste fallback plus an explicit live-read verification step.

## Checks

- Compiled all six Python code blocks with Python 3.13 via `uv run python`.
- Ran `git diff --check`.