### PR TITLE
fix: serialize daemon startup on POSIX

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 from . import _ipc as ipc
@@ -327,7 +328,26 @@ def run_doctor_fix_snap():
     return 0
 
 
+@contextmanager
+def _daemon_startup_lock(name):
+    if ipc.IS_WINDOWS:
+        yield
+        return
+    import fcntl
+    with open(ipc.pid_path(name).with_suffix(".lock"), "a+b") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
+
+
 def ensure_daemon(wait=60.0, name=None, env=None):
+    with _daemon_startup_lock(name or NAME):
+        return _ensure_daemon_unlocked(wait, name, env)
+
+
+def _ensure_daemon_unlocked(wait=60.0, name=None, env=None):
     """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,3 +1,6 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from browser_harness import admin
@@ -18,6 +21,35 @@ class FakeSocket:
 
     def close(self):
         self.closed = True
+
+
+def test_concurrent_ensure_daemon_spawns_once(tmp_path, monkeypatch):
+    live = False
+    spawn_count = 0
+
+    def daemon_alive(_name=None):
+        if not live:
+            time.sleep(0.05)
+        return live
+
+    class FakeProcess:
+        def __init__(self, *_args, **_kwargs):
+            nonlocal live, spawn_count
+            spawn_count += 1
+            live = True
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(admin, "daemon_alive", daemon_alive)
+    monkeypatch.setattr(admin.ipc, "connect", lambda *_args, **_kwargs: (FakeSocket(b'{"result":{}}\n'), None))
+    monkeypatch.setattr(admin.ipc, "log_path", lambda _name: tmp_path / "daemon.log")
+    monkeypatch.setattr("subprocess.Popen", FakeProcess)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda _: admin.ensure_daemon(wait=1), range(8)))
+
+    assert spawn_count == 1
 
 
 def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():


### PR DESCRIPTION
## Summary

- serialize `ensure_daemon()` by daemon name with a POSIX `flock`
- prevent concurrent cold-start callers from spawning duplicate detached daemons
- add a regression test covering eight concurrent callers

## Reproduction

On macOS, concurrent harness calls left 211 `python -m browser_harness.daemon` processes adopted by PID 1. `ensure_daemon()` checked daemon state before spawning without a cross-process startup lock, so several callers could observe the same missing endpoint and spawn together.

The regression test fails on current `main` with multiple spawns and passes with this change.

## Verification

- `uv run --with pytest pytest -q`
- 115 passed
- installed the updated editable tool locally
- no orphaned daemons remain after cleanup

Windows behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize daemon startup on POSIX to prevent duplicate spawns when multiple callers invoke `ensure_daemon()`. Adds a per-daemon file lock and a regression test; Windows behavior is unchanged.

- **Bug Fixes**
  - Added `_daemon_startup_lock` using POSIX `flock` on a per-daemon `.lock` file.
  - Wrapped `ensure_daemon` with the lock and split out `_ensure_daemon_unlocked`.
  - Added a regression test that runs 8 concurrent callers and asserts a single spawn.

<sup>Written for commit 092f3d672e4b99327374919ab74a891c2a49e757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

