### PR TITLE
Add ElevenLabs Agents Platform domain skill

### DIFF
--- a/domain-skills/elevenlabs/agents-platform.md
+++ b/domain-skills/elevenlabs/agents-platform.md
@@ -1,0 +1,59 @@
+# ElevenLabs Agents Platform (Conversational AI)
+
+Investigating agents, batch calls, conversations, and webhook health via the web app.
+
+## Residency matters
+
+EU-resident workspaces live on `eu.residency.elevenlabs.io` (API: `api.eu.residency.elevenlabs.io`). The global app (`elevenlabs.io`) will not show EU workspace data — always use the residency host the workspace was created in.
+
+## URL patterns
+
+```
+/app/agents/agents/{agent_id}                                   # agent home
+/app/agents/agents/{agent_id}/batch-calling                     # batch list
+/app/agents/agents/{agent_id}/batch-calling/{batch_id}          # batch detail
+/app/settings/webhooks                                          # workspace webhooks
+```
+
+Navigation appends `?branchId=agtbrch_...` automatically — safe to omit.
+
+## Private APIs (far faster than DOM scraping)
+
+The SPA authenticates with a bearer token from its own state, so plain `js("fetch(...)")` is NOT authorized. Instead capture the app's own XHRs with CDP Network events:
+
+```python
+cdp("Network.enable")
+goto(batch_url)
+wait_for_load(20); wait(4)
+for e in drain_events():
+    if e.get("method") == "Network.responseReceived":
+        u = e["params"]["response"]["url"]
+        if "batch-calling" in u:
+            body = cdp("Network.getResponseBody", requestId=e["params"]["requestId"])["body"]
+```
+
+High-value responses the pages fetch:
+
+- `GET /v1/convai/batch-calling/{batch_id}` — **every recipient** with `status`
+  (`failed` / `voicemail` / `completed`), `conversation_id`, timestamps, and the full
+  `conversation_initiation_client_data.dynamic_variables` (whatever per-call vars the
+  batch CSV carried). One capture replaces clicking through every row.
+- `GET /v1/convai/agents/{agent_id}` — full agent config. Per-agent post-call webhook
+  override lives at `platform_settings.workspace_overrides.webhooks`
+  (`post_call_webhook_id`, `events: ["transcript", "call_initiation_failure"]`).
+- `GET /v1/convai/settings` — workspace-level webhook defaults
+  (`webhooks.post_call_webhook_id` is null when only agent overrides are used).
+- `GET /v1/workspace/webhooks?include_usages=true` — fetched by the settings/webhooks
+  page. Each webhook includes **`most_recent_failure_error_code` +
+  `most_recent_failure_timestamp`** (e.g. a 503 from the receiver) and
+  **`retry_enabled`** — if false, a failed post-call delivery is dropped permanently.
+  This is the fastest way to prove/disprove "the webhook fired but delivery failed".
+
+## Traps
+
+- The UI has no per-delivery webhook log — only the `most_recent_failure_*` fields
+  above. For per-event delivery proof you must check the receiver's logs.
+- All API timestamps are unix seconds (UTC); the UI renders local time.
+- Batch recipient status `failed` means SIP-level failure (no conversation audio) but a
+  `conversation_id` still exists and a `call_initiation_failure` webhook event is
+  emitted (if enabled) instead of `post_call_transcription`.


### PR DESCRIPTION
Adds `domain-skills/elevenlabs/agents-platform.md`, learned during a production batch-calling investigation:

- EU residency host vs global app (data is siloed per residency)
- URL patterns for agents, batch calling, and workspace webhooks
- Private APIs worth capturing via CDP network events instead of DOM scraping: batch recipients (statuses + conversation ids + dynamic variables in one response), per-agent post-call webhook overrides, and `/v1/workspace/webhooks?include_usages=true` which exposes `most_recent_failure_error_code` and `retry_enabled` — the fastest way to prove a post-call webhook delivery failure
- Traps: no per-delivery webhook log in the UI; `failed` recipients still have conversation ids and emit `call_initiation_failure` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a domain-skill doc for the ElevenLabs Agents Platform to speed batch-calling investigations and webhook troubleshooting. It explains residency host rules, key URL patterns, and how to capture private API calls via CDP to fetch batch recipient statuses, agent webhook overrides, and failure/retry signals.

<sup>Written for commit 9abaf1b6ef674a4d2de83ea71e86a6105aa86e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

