### PR TITLE
feat(admin): BU_NO_OPEN to suppress liveUrl auto-open

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -391,12 +391,12 @@ def _has_local_gui():
 
 
 def _show_live_url(url):
-    """Print liveUrl and auto-open it locally if there's a GUI."""
+    """Print liveUrl and auto-open it locally if there's a GUI (unless BU_NO_OPEN)."""
     import sys, webbrowser
     if not url: return
     print(url)
-    if not _has_local_gui():
-        print("(no local GUI — share the liveUrl with the user)", file=sys.stderr)
+    if os.environ.get("BU_NO_OPEN") or not _has_local_gui():
+        print("(liveUrl not auto-opened — share it with the user)", file=sys.stderr)
         return
     try:
         webbrowser.open(url, new=2)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -527,3 +527,20 @@ def test_process_start_time_returns_none_for_invalid_pid():
         )
     # 2**31 - 1 is the largest pid_t; in practice no live process at that PID.
     assert admin._process_start_time((1 << 31) - 1) is None
+
+
+def test_show_live_url_bu_no_open_suppresses_auto_open(monkeypatch):
+    """BU_NO_OPEN keeps _show_live_url from popping a local tab (still prints the URL)."""
+    import webbrowser
+
+    monkeypatch.setattr(admin, "_has_local_gui", lambda: True)
+    calls = []
+    monkeypatch.setattr(webbrowser, "open", lambda *a, **k: calls.append(a))
+
+    monkeypatch.setenv("BU_NO_OPEN", "1")
+    admin._show_live_url("https://example.com/live")
+    assert calls == [], "BU_NO_OPEN should suppress the auto-open"
+
+    monkeypatch.delenv("BU_NO_OPEN")
+    admin._show_live_url("https://example.com/live")
+    assert calls, "without BU_NO_OPEN it should auto-open when a GUI is present"


### PR DESCRIPTION
## What

Adds a `BU_NO_OPEN` env var that stops `start_remote_daemon` from auto-opening the cloud browser's `liveUrl` in the local default browser. The URL is still printed.

## Why

For unattended / headless-style automation (audit runs, batch panels, cron), auto-opening the liveUrl pops a local browser tab and steals window focus every time a cloud browser is provisioned. There's currently no way to opt out short of running on a machine with no GUI.

Concretely: driving many Perplexity/ChatGPT samples on cloud browsers from a macOS workstation, each `start_remote_daemon` opened a tab and grabbed focus mid-run. `BU_NO_OPEN=1` makes the same flow fully background.

## Change

`_show_live_url` skips the `webbrowser.open` when `BU_NO_OPEN` is set (still prints the URL, same as the no-GUI path). One-line guard, plus a unit test covering both branches.

Existing behavior is unchanged when `BU_NO_OPEN` is unset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add BU_NO_OPEN env var to suppress auto-opening the cloud browser liveUrl in the local default browser when running start_remote_daemon. The URL is still printed; default behavior remains when BU_NO_OPEN is unset, avoiding focus-stealing tabs in unattended runs.

<sup>Written for commit b731272037e5e42d7920e91234afdce0b5dc9066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

