### PR TITLE
test(run): isolate cloud-bootstrap tests from ambient env; add pytest dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ Homepage = "https://github.com/browser-use/browser-harness"
 Repository = "https://github.com/browser-use/browser-harness"
 Issues = "https://github.com/browser-use/browser-harness/issues"
 
+# Dev tooling lives in the default `dev` group so `uv run pytest` resolves it
+# from the persistent project env. Running `uv run --with pytest pytest` instead
+# builds a fresh ephemeral overlay venv on every cold cache (~2.8s vs ~0.5s).
+[dependency-groups]
+dev = [
+    "pytest>=8",
+]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -7,6 +7,20 @@ import pytest
 from browser_harness import run
 
 
+@pytest.fixture(autouse=True)
+def _isolate_browser_env(monkeypatch):
+    """run.main()'s cloud-bootstrap guard reads process env directly
+    (BROWSER_USE_API_KEY, BU_AUTOSPAWN, BU_CDP_URL, BU_CDP_WS). A dev box or CI
+    runner that exports any of these leaks it into every test — e.g. an ambient
+    BU_CDP_URL (a running local Chrome debug endpoint) makes
+    _explicit_cdp_configured() true and silently blocks the bootstrap these
+    tests assert on, and an ambient BU_AUTOSPAWN + key would fire the real
+    start_remote_daemon in tests that don't mock it. Start every test from a
+    clean slate; tests that need a var set it themselves."""
+    for var in ("BROWSER_USE_API_KEY", "BU_AUTOSPAWN", "BU_CDP_URL", "BU_CDP_WS"):
+        monkeypatch.delenv(var, raising=False)
+
+
 def test_stdin_executes_code():
     stdout = StringIO()
     fake_stdin = StringIO("print('hello from stdin')")


### PR DESCRIPTION
## What

Two small, independent test/tooling improvements to `run.py`'s cloud-bootstrap coverage.

### 1. Isolate the cloud-bootstrap tests from ambient `BU_*` env

`run.main()`'s auto-bootstrap guard reads process env directly
(`BROWSER_USE_API_KEY`, `BU_AUTOSPAWN`, `BU_CDP_URL`, `BU_CDP_WS`). Any dev box
or CI runner that exports one of these leaks it into the tests:

- `test_cloud_bootstrap_on_headless_server` fails on a machine with an ambient
  `BU_CDP_URL` (e.g. a running local Chrome debug endpoint) — it makes
  `_explicit_cdp_configured()` return true and silently suppresses the
  `start_remote_daemon` call the test asserts on.
- The non-cloud tests (e.g. `test_stdin_executes_code`) don't mock
  `start_remote_daemon`, so a box exporting `BU_AUTOSPAWN` + a key would fire
  the real thing.

Add an autouse fixture that clears those four vars before each test, so every
test starts hermetic and only sets what it needs. Source logic is unchanged —
this only fixes the tests' env assumptions.

### 2. Add `pytest` to a `dev` dependency-group

Running the suite via `uv run --with pytest pytest` builds a fresh ephemeral
overlay venv on every cold uv cache (~2.8s) instead of the persistent project
env (~0.5s). Declaring `pytest` in the default `dev` group lets `uv run pytest`
resolve it from the synced project env, keeping repeat runs sub-second.
`uv.lock` is gitignored, so only `pyproject.toml` changes.

## Testing

`uv run pytest tests/unit -q` → all green on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates cloud-bootstrap tests from ambient env vars and adds `pytest` to the `dev` dependency group to prevent flaky tests and speed up local runs.

- **Bug Fixes**
  - Added an autouse fixture that clears BROWSER_USE_API_KEY, BU_AUTOSPAWN, BU_CDP_URL, and BU_CDP_WS before each test.
  - Prevents false positives in the bootstrap guard and avoids triggering real start_remote_daemon on machines with BU_AUTOSPAWN or a local CDP URL.

- **Dependencies**
  - Added `pytest>=8` to the `dev` group.
  - Allows `uv run pytest` to use the persistent project env for faster repeat runs.

<sup>Written for commit aa4e15a4a4f73001703f07c525ec1339953e2007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

