### PR TITLE
Document read-only Mailchimp journey audits

### DIFF
--- a/agent-workspace/domain-skills/mailchimp/automation-audit.md
+++ b/agent-workspace/domain-skills/mailchimp/automation-audit.md
@@ -1,0 +1,83 @@
+# Mailchimp automation-flow audits
+
+Use this workflow to inspect an existing Mailchimp automation without creating
+contacts, triggering a journey, sending test messages, or changing live state.
+
+## Prefer GET requests for structure and evidence
+
+The Marketing API exposes enough read-only data for most audits even when the
+browser is at a login wall. Authenticate without putting the API key in command
+arguments or output. Build the Basic Authorization header in-process from a
+secret file or environment variable.
+
+Useful endpoints:
+
+```text
+GET /3.0/customer-journeys/journeys
+GET /3.0/customer-journeys/journeys/{journey_id}
+GET /3.0/customer-journeys/journeys/{journey_id}/steps?count=100
+GET /3.0/campaigns/{campaign_id}
+GET /3.0/campaigns/{campaign_id}/content
+GET /3.0/reports/{campaign_id}
+GET /3.0/reports/{campaign_id}/click-details?count=100
+GET /3.0/reports/{campaign_id}/sent-to?count=100
+GET /3.0/lists/{list_id}/segments?count=1000
+GET /3.0/lists/{list_id}/segments/{segment_id}/members?count=100
+```
+
+The customer-journey collection and step reads may not appear in the public
+API reference even when they are available for an account. Treat them as a
+read-only capability probe and fall back to the app if they return an error.
+
+Never probe the documented journey trigger with POST. That endpoint enrolls a
+real contact.
+
+## Reconstruct the journey graph
+
+`steps` is ordered. The durable fields are:
+
+- `step_type`, `status`, `display_text`, and `stats`
+- `trigger_details.tag.tag_name` for tag-entry triggers
+- `delay_time` in seconds for delays
+- `action_details.email.id` for send-email campaign IDs
+- `action_details.email.settings` and `report_summary` for a quick audit
+
+Sum consecutive delay values to describe the customer-facing schedule. Check
+`can_contacts_reenter` and `journey_wide_exit_condition` on the journey itself;
+an active series with no exit condition can keep emailing after a lead converts
+or replies.
+
+## Verify content and rendering
+
+Use `/campaigns/{id}/content` for the actual HTML, not just the subject line.
+Look for:
+
+- placeholder headings, lorem ipsum, and unexpanded merge tags
+- hard-coded prices, dates, warranties, or promotions
+- CTA text that is not wrapped in a link
+- default social links such as generic Mailchimp, Facebook, or X URLs
+- missing image alt text
+
+The campaign object exposes `archive_url` and `long_archive_url`. Open the
+public archive in the browser and take a screenshot to verify the rendered
+email. This is safe: viewing an archive does not send or enroll anyone.
+
+## Interpret reports carefully
+
+Automation samples are often tiny. Use aggregate reports first. Mask recipient
+addresses if `/sent-to` is needed for bounce or merge-field diagnosis.
+
+- `emails_sent` includes recipients who later hard-bounced.
+- A high open or click rate from only two or three delivered contacts is not a
+  stable performance result.
+- Security scanners may click every footer/social link. Compare tracked URLs
+  and `unique_subscriber_clicks` before treating clicks as buyer intent.
+- Check whether merge fields are populated. `Hi *|FNAME|*,` renders poorly when
+  every enrolled member has an empty `FNAME`.
+
+## Read-only safety boundary
+
+Do not call journey trigger, campaign send, test-send, pause/resume, member
+create/update, tag mutation, or delete/archive endpoints during an audit. Do not
+create a test contact. Record the exact GET evidence and request approval before
+making any live change.


### PR DESCRIPTION
## Summary

- document read-only Mailchimp automation-flow discovery endpoints
- show how to reconstruct tag triggers, delays, and email campaign steps
- cover content, archive-render, report, bounce, merge-field, and click-scanner checks
- define a no-send safety boundary for automation audits

## Why

Mailchimp exposes useful journey and step reads that are not obvious from the public API reference. A read-only audit can otherwise drift into dangerous trigger, test-send, or contact-mutation actions. The new domain note provides a bounded workflow that produces live evidence without enrolling or messaging anyone.

## Impact

Documentation only. No runtime behaviour changes.

## Validation

- `git diff --check`
- confirmed the document contains no account IDs, contact data, credentials, or task-specific details


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a read-only Mailchimp automation audit guide that uses GET-only endpoints to inspect journeys and campaigns without enrolling or sending. It covers reconstructing triggers/delays/steps, safe content/report checks, and a no-send safety boundary; no runtime changes.

- **New Features**
  - Documented GET endpoints for journeys, steps, campaigns, reports, and segments.
  - Steps to rebuild the journey graph and timing from step data.
  - Guidance for content verification via campaign content and archive URLs.
  - Do-not-call list of write endpoints to keep audits read-only.

<sup>Written for commit e2cc89c2f824360c15ef8ad2fa673356f1927e41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

