### PR TITLE
reuse one connection instead of chrome re-prompting perms

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,10 @@ description: "Always use browser-harness for any web interaction: automation, sc
 
 Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py`. For setup, install, or connection problems, read https://github.com/browser-use/browser-harness/blob/main/install.md.
 
+## When Not to Use
+
+A basic fetch of public information needs no browser. If a plain HTTP request can read it — a public page, an API, docs — use `curl` or your fetch tool, and leave the browser alone. Use browser-harness when the task needs interaction (click, type, navigate), the user's logged-in session, JS rendering, or a bot-protected page. If a direct fetch fails or returns a shell page, then escalate to the browser.
+
 Domain skills are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.
 
 **If `BH_DOMAIN_SKILLS=1` and the task is site-specific, read every file in the matching `$BH_AGENT_WORKSPACE/domain-skills/<site>/` directory before inventing an approach.**
@@ -154,7 +158,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow.
+- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow. Do not retry in a loop — Chrome pops a fresh dialog for every new connection, and the daemon's single held connection is what makes this a one-time click.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -334,11 +334,14 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
         # Must go through ipc.connect so this works on Windows (TCP loopback) too;
         # raw AF_UNIX here would fail on every warm call and churn the daemon.
-        try:
-            s, token = ipc.connect(name or NAME, timeout=3.0)
-            resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
-            if "result" in resp: return
-        except Exception: pass
+        for last in (False, True):
+            try:
+                s, token = ipc.connect(name or NAME, timeout=3.0)
+                resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
+                if "result" in resp: return
+                break  # daemon answered with an error → CDP link truly dead
+            except Exception:
+                if not last: time.sleep(0.5)
         restart_daemon(name)
 
     import subprocess, sys
@@ -355,12 +358,22 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         )
         if stderr_sink is not subprocess.DEVNULL:
             stderr_sink.close()
-        deadline = time.time() + wait
+        spawned = time.time()
+        deadline = spawned + wait
+        hinted = not local
         while time.time() < deadline:
             if daemon_alive(name): return
             if p.poll() is not None: break
+            if not hinted and time.time() - spawned > 2 and (_log_tail(name) or "").startswith("handshake-wait"):
+                print('browser-harness: Chrome is asking "Allow remote debugging?" — click Allow to continue.', file=sys.stderr)
+                hinted = True
             time.sleep(0.2)
         msg = _log_tail(name) or ""
+        if local and msg.startswith("handshake-wait"):
+            restart_daemon(name)
+            raise RuntimeError(
+                "permission-blocked: Chrome's Allow popup was not clicked in time -- wait for the user to click Allow, then retry."
+            )
         if local and attempt == 0 and _needs_chrome_permission_popup(msg):
             print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
             restart_daemon(name)
@@ -368,6 +381,14 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
             )
         if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
+            from .daemon import remote_debugging_user_enabled
+            if remote_debugging_user_enabled():
+                # chrome://inspect toggle is already on — connection died
+                print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
+                restart_daemon(name)
+                raise RuntimeError(
+                    "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
+                )
             _open_chrome_inspect()
             print('browser-harness: at chrome://inspect/#remote-debugging, tick "Allow remote debugging for this browser instance" and click Allow on the popup that appears', file=sys.stderr)
             restart_daemon(name)

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -339,9 +339,9 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 s, token = ipc.connect(name or NAME, timeout=3.0)
                 resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
                 if "result" in resp: return
-                break  # daemon answered with an error → CDP link truly dead
             except Exception:
-                if not last: time.sleep(0.5)
+                pass
+            if not last: time.sleep(0.5)
         restart_daemon(name)
 
     import subprocess, sys

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -92,10 +92,27 @@ BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") 
 LOCAL_HANDSHAKE_TIMEOUT = 45
 
 
+def _devtools_port_live(base):
+    """True when something is listening on the profile's DevToolsActivePort port.
+
+    A stale file left behind by a closed browser must not count as a running
+    instance — it would route recovery to "click Allow" on a popup that can't
+    exist."""
+    try:
+        port = int((base / "DevToolsActivePort").read_text(encoding="utf-8", errors="replace").splitlines()[0].strip())
+    except (OSError, ValueError, IndexError):
+        return False
+    try:
+        socket.create_connection(("127.0.0.1", port), timeout=0.5).close()
+        return True
+    except OSError:
+        return False
+
+
 def remote_debugging_user_enabled():
     """chrome://inspect's "Allow remote debugging" toggle
 
-    True only when a toggle-on profile also exposes a DevToolsActivePort.
+    True only when a toggle-on profile also has a live DevTools port.
     False if a profile records it off, None when no profile records it."""
     seen = None
     for base in PROFILES:
@@ -104,7 +121,7 @@ def remote_debugging_user_enabled():
             enabled = ((state.get("devtools") or {}).get("remote_debugging") or {}).get("user-enabled")
         except (OSError, ValueError, AttributeError):
             continue
-        if enabled is True and (base / "DevToolsActivePort").exists():
+        if enabled is True and _devtools_port_live(base):
             return True
         if enabled is False:
             seen = False

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -95,8 +95,8 @@ LOCAL_HANDSHAKE_TIMEOUT = 45
 def remote_debugging_user_enabled():
     """chrome://inspect's "Allow remote debugging" toggle
 
-    True if any known profile records it on, False if one records it off, None
-    when no profile records it."""
+    True only when a toggle-on profile also exposes a DevToolsActivePort.
+    False if a profile records it off, None when no profile records it."""
     seen = None
     for base in PROFILES:
         try:
@@ -104,7 +104,7 @@ def remote_debugging_user_enabled():
             enabled = ((state.get("devtools") or {}).get("remote_debugging") or {}).get("user-enabled")
         except (OSError, ValueError, AttributeError):
             continue
-        if enabled is True:
+        if enabled is True and (base / "DevToolsActivePort").exists():
             return True
         if enabled is False:
             seen = False
@@ -239,7 +239,10 @@ class _PatientCDPClient(CDPClient):
         import websockets
         if self.ws is not None:
             raise RuntimeError("Client is already started")
-        self.ws = await websockets.connect(self.url, max_size=self.max_ws_frame_size, open_timeout=LOCAL_HANDSHAKE_TIMEOUT)
+        connect_kwargs = {"max_size": self.max_ws_frame_size, "open_timeout": LOCAL_HANDSHAKE_TIMEOUT}
+        if self.additional_headers:
+            connect_kwargs["additional_headers"] = self.additional_headers
+        self.ws = await websockets.connect(self.url, **connect_kwargs)
         self._message_handler_task = asyncio.create_task(self._handle_messages())
 
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -88,6 +88,27 @@ INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension
 BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
+# Chrome 144+ shows a per-connection popup. Keep popup open enough to click.
+LOCAL_HANDSHAKE_TIMEOUT = 45
+
+
+def remote_debugging_user_enabled():
+    """chrome://inspect's "Allow remote debugging" toggle
+
+    True if any known profile records it on, False if one records it off, None
+    when no profile records it."""
+    seen = None
+    for base in PROFILES:
+        try:
+            state = json.loads((base / "Local State").read_text(encoding="utf-8", errors="replace"))
+            enabled = ((state.get("devtools") or {}).get("remote_debugging") or {}).get("user-enabled")
+        except (OSError, ValueError, AttributeError):
+            continue
+        if enabled is True:
+            return True
+        if enabled is False:
+            seen = False
+    return seen
 
 
 def log(msg):
@@ -185,6 +206,8 @@ def get_ws_url():
                 raise RuntimeError("permission-blocked: Chrome is reachable, but the per-session Allow remote debugging popup has not been accepted")
         except (OSError, KeyError, ValueError):
             continue
+    if remote_debugging_user_enabled() is False:
+        raise RuntimeError('remote debugging is turned off for this browser instance — enable chrome://inspect/#remote-debugging (tick "Allow remote debugging for this browser instance")')
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 
@@ -207,6 +230,17 @@ def stop_remote():
 
 def is_real_page(t):
     return t["type"] == "page" and not t.get("url", "").startswith(INTERNAL)
+
+
+class _PatientCDPClient(CDPClient):
+    """CDPClient with the WS opening handshake stretched to LOCAL_HANDSHAKE_TIMEOUT."""
+
+    async def start(self):
+        import websockets
+        if self.ws is not None:
+            raise RuntimeError("Client is already started")
+        self.ws = await websockets.connect(self.url, max_size=self.max_ws_frame_size, open_timeout=LOCAL_HANDSHAKE_TIMEOUT)
+        self._message_handler_task = asyncio.create_task(self._handle_messages())
 
 
 class Daemon:
@@ -263,7 +297,10 @@ class Daemon:
         self.stop = asyncio.Event()
         url = get_ws_url()
         log(f"connecting to {url}")
-        self.cdp = CDPClient(url)
+        self.cdp = _PatientCDPClient(url) if BROWSER_KIND == "local" else CDPClient(url)
+        if BROWSER_KIND == "local":
+            # Allow while this handshake is still parked on the popup
+            log("handshake-wait: if Chrome shows an 'Allow remote debugging?' popup, click Allow")
         try:
             await self.cdp.start()
         except Exception as e:
@@ -272,6 +309,11 @@ class Daemon:
                     f"CDP WS handshake failed: {e} -- remote browser WebSocket connection failed. "
                     "This can happen when network policy blocks the connection, the WS URL is wrong or expired, or the remote endpoint is down. "
                     "If you use Browser Use cloud, verify auth and get a fresh URL via start_remote_daemon()."
+                )
+            if BROWSER_KIND == "local" and ("timed out" in str(e).lower() or "403" in str(e)) and remote_debugging_user_enabled():
+                raise RuntimeError(
+                    f"permission-blocked: Chrome's 'Allow remote debugging?' popup was not accepted within {LOCAL_HANDSHAKE_TIMEOUT}s"
+                    " -- wait for the user to click Allow, then retry"
                 )
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()


### PR DESCRIPTION
Chrome 144+ shows "Allow remote debugging?" for every new CDP connection
- wait on same connection (dying + retrying adds popups)
- tell the user to click Allow while it's there
- skip the chrome://inspect flow when the toggle is already on
- probe a live daemon twice before restarting it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse a single CDP connection and stretch the local WS handshake so Chrome’s “Allow remote debugging?” popup stays up long enough to click Allow. This cuts repeated prompts, avoids unnecessary restarts, and supports endpoints that require auth headers.

- **Bug Fixes**
  - Extend the WS handshake to 45s (local) and forward auth headers; show a “handshake-wait” hint and reuse the same connection so the popup is a one-time click.
  - Give the daemon health check a second try before restarting to avoid churn and extra popups.
  - Ignore stale `DevToolsActivePort` files; treat profiles as running only when the port is live, and skip opening `chrome://inspect` when the toggle is already enabled.
  - Return clear `permission-blocked` errors when the popup times out or remote debugging is off; update SKILL.md with “When Not to Use” and advice not to retry permission prompts in a loop.

<sup>Written for commit 5726f42d560f73c88bf5f4a3a64624329e322de4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

