### PR TITLE
Bump browser-harness to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.6"
+version = "0.1.7"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release 0.1.7: Chrome Allow-popup handling (patient 45s handshake, connection reuse hardening, stale-port + toggle gating).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `browser-harness` 0.1.7 with improved Chrome allow-popup handling: 45s handshake, hardened connection reuse, stale-port detection, and a toggle gate. Bumps the package version in pyproject.toml for the 0.1.7 release.

<sup>Written for commit 23f7d84545a512b6b4b4abfc3767c15778103e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

