### PR TITLE
docs(domain-skills): slack file downloads

### DIFF
--- a/domain-skills/slack/files.md
+++ b/domain-skills/slack/files.md
@@ -1,0 +1,44 @@
+# Slack: downloading shared files
+
+Fetching files behind a Slack workspace login, given a permalink like
+`https://<ws>.slack.com/files/<USERID>/<FILEID>/<name>`.
+
+## URL structure
+
+- The `FILEID` segment routes; the filename segment is cosmetic. Two permalinks that
+  differ only in the filename (e.g. `…/F123/shot1.png` vs `…/F123/shot2.png`) return the
+  **same** file. Users often hand you "same URL, just change the number" — resolve each
+  real file ID instead.
+- The `USERID` segment is not necessarily the uploader (share links keep the sharer's id),
+  so `files.list?user=<USERID>` can come back empty for the file you're after. Use
+  `search.files?query=<filename>` to resolve real per-file IDs.
+- Raw bytes live at `https://files.slack.com/files-pri/<TEAMID>-<FILEID>/<name>` and need
+  cookie auth.
+
+## Auth without an app token
+
+1. The `d` cookie on `.slack.com` is the session. It's HttpOnly, so in-page JS can't read
+   it — read it over CDP from any workspace tab:
+
+   ```python
+   r = cdp("Network.getCookies", urls=["https://<ws>.slack.com/"])
+   d = next(c["value"] for c in r["cookies"] if c["name"] == "d")
+   ```
+
+2. Fetching the permalink HTML with that cookie (plain `http_get`/curl, no browser needed)
+   yields a page embedding `"api_token":"xoxc-…"` and `team_id = "T…"`. No need to load
+   `app.slack.com` or dig through localStorage (`localConfig_v2` only exists on the
+   `app.slack.com` origin anyway).
+
+3. API calls: POST to `https://<ws>.slack.com/api/<method>` with `token=<xoxc>` as a form
+   field **and** the `d` cookie — xoxc web tokens are only valid together with the cookie.
+   `files.info`, `files.list`, `search.files` all work.
+
+4. Download `url_private` (or the files-pri URL) with just the `d` cookie.
+
+## Traps
+
+- The permalink page in a real browser tab sticks on "Redirecting…" forever (it's waiting
+  to open the desktop app) — don't wait for it; you only need it as an HTML fetch.
+- `files.list` sorts/filters in ways that can silently omit recent files; when a named
+  file must be found, `search.files` is the reliable path.


### PR DESCRIPTION
Adds `domain-skills/slack/files.md`: downloading workspace-shared files given a permalink.

Non-obvious findings this captures:
- The FILEID segment of a permalink routes; the filename segment is cosmetic — "same URL, replace the number" silently returns the same file.
- The permalink HTML (fetched with just the `d` cookie, no browser tab needed) embeds a usable `xoxc` api_token + team_id — much simpler than digging `localConfig_v2` out of the app.slack.com origin.
- The `d` cookie is HttpOnly, so read it via CDP `Network.getCookies`, not in-page JS.
- `files.list` can silently omit recent files; `search.files` is the reliable resolver.
- In a real tab the permalink sticks on "Redirecting…" forever (waiting for the desktop app) — a trap if you wait on it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for downloading Slack workspace-shared files from a permalink using the `d` cookie and the permalink-embedded `xoxc` token. Covers URL routing, reliable file lookup, and common traps.

- **New Features**
  - Added `domain-skills/slack/files.md` with a step-by-step flow.
  - Clarifies only `FILEID` routes; the filename segment is cosmetic.
  - Shows reading HttpOnly `d` via CDP and fetching permalink HTML to extract `xoxc` and `team_id`.
  - Explains API calls need `token=<xoxc>` plus the `d` cookie; download via `url_private`.
  - Recommends `search.files` over `files.list`; avoid waiting on the "Redirecting…" permalink tab.

<sup>Written for commit 61043a153aab5690d9b7a23d8560f43f285a18e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

