### PR TITLE
Narrow skill description to match When Not to Use

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-harness
-description: "Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work."
+description: "Control a real browser via CDP: clicking, typing, navigation, logged-in sessions, JS-rendered or bot-protected pages. Not for plain HTTP fetches of public content - use curl for those."
 ---
 
 # browser-harness

--- a/tests/unit/test_skill.py
+++ b/tests/unit/test_skill.py
@@ -31,5 +31,5 @@ def test_packaged_skill_frontmatter_is_valid_simple_yaml():
 
     assert metadata == {
         "name": "browser-harness",
-        "description": "Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work.",
+        "description": "Control a real browser via CDP: clicking, typing, navigation, logged-in sessions, JS-rendered or bot-protected pages. Not for plain HTTP fetches of public content - use curl for those.",
     }


### PR DESCRIPTION
## What

The `SKILL.md` frontmatter description still reads:

> Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work.

0.1.7 added a **When Not to Use** section that says the opposite for the simple cases - prefer `curl` for a plain HTTP fetch of public content. The description was never updated to match. `git log -L 3,3:SKILL.md` shows it unchanged apart from the browser-use -> browser-harness rename.

## Why it matters

In Claude Code and Codex the frontmatter `description` is the always-loaded field, and it is what decides whether the skill gets invoked at all. The body only loads once the skill fires. So the always-visible text tells agents to always use the browser for any web interaction, while the correction sits in the half that may never be read.

The practical effect is agents opening a browser for tasks the skill itself says should use `curl`.

## Change

One line. Keeps trigger coverage for genuine browser work (interaction, logged-in sessions, JS-rendered or bot-protected pages) and drops the claim over plain fetches.

Related to #554 but independent - that one is daemon connection classification, this is skill metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `SKILL.md`'s description so agents stop assuming `browser-harness` should drive every web interaction. It now reserves browser use for real-browser work (clicking, typing, navigation, logged-in, JS-rendered or bot-protected pages) and points plain public fetches at `curl`, matching the existing When Not to Use section; the description is the always-loaded field, so the old text made agents launch browsers unnecessarily.

<sup>Written for commit 4e519864235692de16b168672158071b2ca58cb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

