### PR TITLE
Add slacal domain skill: finding official forms & documents

### DIFF
--- a/domain-skills/slacal/documents.md
+++ b/domain-skills/slacal/documents.md
@@ -1,0 +1,35 @@
+# SLA-CAL (Surplus Line Association of California) — Finding Official Forms & Documents
+
+Two hosts, and the split is the trap:
+
+- `www.slacal.com` — DNN (DotNetNuke) site. **All document PDFs actually live here** under `/docs/default-source/<category>/<file>.pdf`. Direct `http_get` works, no browser needed.
+- `learningcenter.slacal.com` — React SPA ("SLA LC"). Resource/forms *pages* moved here (old `www.slacal.com/brokers/...` URLs 301 to it), but it serves the SPA shell HTML (`<title>SLA LC</title>`) for ANY unknown path — **including paths ending in `.pdf`, with HTTP 200**. Always check `file`/content-type: if you got HTML back, you got the shell, not the document.
+
+## Getting a form PDF without a browser
+
+1. Guess/confirm the `www.slacal.com` DNN path. Known categories:
+   - `docs/default-source/general-content-documents/filing-forms/` — broker filing forms (D-1, D-2, SL-1, SL-2, diligent-search addendum)
+   - `docs/default-source/general-content-documents/insurer-filing-forms/` — insurer checklists, verifications
+   - `docs/default-source/bulletins/<n>.pdf` — bulletins by number
+2. Filenames carry revision suffixes, e.g. `d1-form-rev-01-01-2020.pdf`, `d2-form-rev-01-01-2020.pdf`. The bare name (`d1-form.pdf`) 404s.
+3. If the live path 404s, enumerate what exists via the Wayback CDX API — it indexes the whole DNN doc tree:
+
+```python
+from helpers import http_get
+rows = http_get(
+    "http://web.archive.org/cdx/search/cdx?url=slacal.com&matchType=domain"
+    "&filter=original:.*\\.pdf.*&collapse=urlkey&limit=2000&fl=timestamp,original,statuscode"
+)
+print([r for r in rows.splitlines() if "filing-forms" in r])
+```
+
+Archived URLs usually still work live on `www.slacal.com` (the DNN docs were never taken down — only the *pages* moved to the learning center). `?sfvrsn=` version params are optional.
+
+Verified example (July 2026): official California D-1 disclosure form:
+`https://www.slacal.com/docs/default-source/general-content-documents/filing-forms/d1-form-rev-01-01-2020.pdf`
+
+## Learning center SPA internals (if you must)
+
+- Config: `https://learningcenter.slacal.com/env.js` → `SERVER_API_URL: https://learningcenter.slacal.com/api`, plus `RAPID_SERVER_URL: https://rapid.slacal.com` (course content).
+- ASP.NET Web API, `/api/{controller}/{action}`. Controllers seen in the bundle: `resources` (faqgroups, notices, bulletins/series, bulletins/byseries/{id}, getsection/{name}, getpagecontent/?url=), `brokerguides`, `courseofferings`, `LcUsers`, `location`.
+- `getpagecontent`/`getsection` reject bare GETs with generic errors ("An error occurred…") — likely needs headers/params the SPA sets. Don't burn time here; the CDX + DNN-path route above is faster for documents.


### PR DESCRIPTION
## What

New domain skill `domain-skills/slacal/documents.md` for the Surplus Line Association of California (slacal.com) — how to fetch official forms (D-1/D-2 disclosures, SL-1/SL-2, bulletins) without a browser.

## Non-obvious findings this captures

- `learningcenter.slacal.com` (React SPA) serves its app shell with **HTTP 200 for any unknown path, including `.pdf` URLs** — a curl "success" that is actually HTML. Check content-type before trusting a download.
- The actual document PDFs never moved: they live on `www.slacal.com` DNN paths (`/docs/default-source/<category>/…`), which still serve directly via plain HTTP.
- Filenames carry revision suffixes (`d1-form-rev-01-01-2020.pdf`); bare names 404.
- The Wayback CDX API enumerates the whole DNN doc tree when you don't know the exact filename — archived URLs still work live.
- Learning center API surface (`/api/{controller}`, controllers from the bundle) documented for completeness, with a warning that `getpagecontent` rejects bare GETs — the CDX route is faster.

Field-tested July 2026 while fetching the California D-1 surplus lines disclosure form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new domain skill that explains how to reliably download official SLA-CAL forms (D-1/D-2, SL-1/SL-2, bulletins) without a browser by using `www.slacal.com` PDFs and avoiding SPA false positives on `learningcenter.slacal.com`.

- **New Features**
  - Added `domain-skills/slacal/documents.md`.
  - Clarifies the two-host setup and why the SPA returns HTML with HTTP 200 for `.pdf` URLs; instructs checking content-type.
  - Lists the DNN document paths and categories on `www.slacal.com` and notes required revision-suffixed filenames.
  - Shows how to enumerate PDFs via the Wayback CDX API; briefly notes the learning center API but recommends the DNN/CDX route for documents.

<sup>Written for commit 23d99c9adc98ff3279ccff0179e5465b5855be53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

