### PR TITLE
detect closed Chrome and launch + reuse tabs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -36,7 +36,9 @@ If the daemon cannot connect, run diagnostics:
 browser-harness --doctor
 ```
 
-If Chrome remote debugging is not enabled, the harness opens:
+If Chrome is not running at all, the harness launches it automatically and retries — no user action needed beyond clicking Allow if a permission popup appears.
+
+If Chrome is running but remote debugging is not enabled, the harness opens:
 
 ```text
 chrome://inspect/#remote-debugging

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -164,6 +164,11 @@ def _needs_chrome_permission_popup(msg):
     return "permission-blocked" in lower
 
 
+def _chrome_not_running(msg):
+    """True when the daemon found no running supported browser"""
+    return "chrome-not-running" in (msg or "").lower()
+
+
 def _is_local_chrome_mode(env=None):
     """True when the daemon discovers a local Chrome instead of a remote CDP WS."""
     env = env or {}
@@ -328,7 +333,8 @@ def run_doctor_fix_snap():
 
 
 def ensure_daemon(wait=60.0, name=None, env=None):
-    """Idempotent. Self-heals stale daemon, cold Chrome, and missing Allow on chrome://inspect."""
+    """Idempotent. Self-heals stale daemon, closed Chrome (launches it), cold
+    Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
@@ -346,7 +352,9 @@ def ensure_daemon(wait=60.0, name=None, env=None):
 
     import subprocess, sys
     local = _is_local_chrome_mode(env)
-    for attempt in (0, 1):
+    launched_browser = False
+    opened_inspect = False
+    for _ in range(3):
         e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
         try:
             stderr_sink = open(ipc.log_path(name or NAME), "ab")
@@ -374,14 +382,29 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             raise RuntimeError(
                 "permission-blocked: Chrome's Allow popup was not clicked in time -- wait for the user to click Allow, then retry."
             )
-        if local and attempt == 0 and _needs_chrome_permission_popup(msg):
+        if local and _needs_chrome_permission_popup(msg):
             print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
             restart_daemon(name)
             raise RuntimeError(
                 "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
             )
-        if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
-            from .daemon import remote_debugging_user_enabled
+        if local and not launched_browser and _chrome_not_running(msg):
+            # Chrome is closed — launch the browser and retry
+            launched_browser = True
+            restart_daemon(name)
+            if not _launch_browser():
+                raise RuntimeError(
+                    "chrome-not-running: no supported browser is running and none could be launched -- ask the user to open Chrome, then retry."
+                )
+            print("browser-harness: Chrome isn't running — launching it. If Chrome shows an \"Allow remote debugging?\" popup, click Allow.", file=sys.stderr)
+            from .daemon import supported_browser_running
+            boot_deadline = time.time() + 15
+            while time.time() < boot_deadline and not supported_browser_running():
+                time.sleep(0.3)
+            continue
+        if local and not opened_inspect and _needs_chrome_remote_debugging_prompt(msg):
+            opened_inspect = True
+            from .daemon import remote_debugging_toggle_profiles, remote_debugging_user_enabled
             if remote_debugging_user_enabled():
                 # chrome://inspect toggle is already on — connection died
                 print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
@@ -389,10 +412,19 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 raise RuntimeError(
                     "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
                 )
-            _open_chrome_inspect()
-            print('browser-harness: at chrome://inspect/#remote-debugging, tick "Allow remote debugging for this browser instance" and click Allow on the popup that appears', file=sys.stderr)
             restart_daemon(name)
-            continue
+            _open_chrome_inspect_once()
+            if remote_debugging_toggle_profiles():
+                # Toggle already ticked from a previous run, but Chrome 144+
+                # wants new Allow for this browser run.
+                todo = 'click Allow on Chrome\'s "Allow remote debugging?" popup (the checkbox is already ticked; if no popup appears, untick and re-tick it)'
+            else:
+                todo = 'tick "Allow remote debugging for this browser instance" and click Allow on the popup'
+            raise RuntimeError(
+                f"remote-debugging-setup: opened chrome://inspect/#remote-debugging in Chrome -- ask the user to {todo}. "
+                "Warn them Chrome shows ONE more Allow popup when the harness connects on the next attempt (per-connection approval; it is expected, not a re-ask). "
+                "Retry after the user confirms; do not retry before."
+            )
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
 
 
@@ -779,6 +811,88 @@ def _chrome_running():
         return False
 
 
+_BROWSER_LAUNCH = (
+    # (profile-dir fragment, macOS app name, POSIX commands, Windows `start` target)
+    ("chrome canary", "Google Chrome Canary", ("google-chrome-canary",), "chrome"),
+    ("chromium", "Chromium", ("chromium", "chromium-browser"), "chromium"),
+    ("chrome", "Google Chrome", ("google-chrome-stable", "google-chrome"), "chrome"),
+    ("edge", "Microsoft Edge", ("microsoft-edge", "microsoft-edge-stable"), "msedge"),
+    ("brave", "Brave Browser", ("brave-browser", "brave"), "brave"),
+    ("arc", "Arc", (), None),
+    ("dia", "Dia", (), None),
+    ("comet", "Comet", (), None),
+)
+_DEFAULT_LAUNCH = (
+    "Google Chrome",
+    ("google-chrome-stable", "google-chrome", "chromium", "chromium-browser", "microsoft-edge"),
+    "chrome",
+)
+
+
+def _browser_launch_spec(base):
+    """(mac app, posix commands, windows target) for the browser w profile dir"""
+    tail = "/".join(p.lower() for p in Path(base).parts[-2:])
+    for frag, mac_app, posix_cmds, win_target in _BROWSER_LAUNCH:
+        if frag in tail:
+            return (mac_app, posix_cmds, win_target)
+    return _DEFAULT_LAUNCH
+
+
+def _profile_directory_args(base):
+    """Relaunch skips Chrome's profile picker"""
+    if not base:
+        return []
+    try:
+        state = json.loads((Path(base) / "Local State").read_text(encoding="utf-8", errors="replace"))
+        last = ((state.get("profile") or {}).get("last_used")) or "Default"
+    except (OSError, ValueError, AttributeError):
+        last = "Default"
+    if not isinstance(last, str) or not (Path(base) / last).is_dir():
+        return []
+    return [f"--profile-directory={last}"]
+
+
+def _launch_browser():
+    """Prefers the browser whose profile already has perm box checked"""
+    import platform, shutil, subprocess
+    from .daemon import PROFILES, remote_debugging_toggle_profiles
+
+    for key in ("BH_CHROME_PATH", "CHROME_PATH"):
+        raw = (os.environ.get(key) or "").strip()
+        if raw and Path(raw).expanduser().is_file():
+            subprocess.Popen(
+                [str(Path(raw).expanduser())],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
+            )
+            return True
+
+    enabled = remote_debugging_toggle_profiles()
+    base = enabled[0] if enabled else next((b for b in PROFILES if (b / "Local State").exists()), None)
+    mac_app, posix_cmds, win_target = _browser_launch_spec(base) if base else _DEFAULT_LAUNCH
+    profile_args = _profile_directory_args(base)
+    try:
+        system = platform.system()
+        if system == "Darwin":
+            cmd = ["open", "-a", mac_app] + (["--args"] + profile_args if profile_args else [])
+            r = subprocess.run(cmd, timeout=10, check=False, capture_output=True)
+            if r.returncode != 0 and mac_app != "Google Chrome":
+                # Different app → its profile dir may not match; launch plain
+                r = subprocess.run(["open", "-a", "Google Chrome"], timeout=10, check=False, capture_output=True)
+            return r.returncode == 0
+        if system == "Windows":
+            # `start <name>` resolves browsers via App Paths without knowing the install dir
+            subprocess.Popen(["cmd", "/c", "start", "", win_target or "chrome"] + profile_args, **ipc.spawn_kwargs())
+            return True
+        for cmd in posix_cmds or _DEFAULT_LAUNCH[1]:
+            w = shutil.which(cmd)
+            if w:
+                subprocess.Popen([w] + profile_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs())
+                return True
+        return False
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
     import platform, subprocess, webbrowser
@@ -796,6 +910,25 @@ def _open_chrome_inspect():
     try:
         webbrowser.open(url, new=2)
     except Exception:
+        pass
+
+
+INSPECT_REOPEN_TTL = 180.0  # seconds open new chrome://inspect tab
+
+
+def _open_chrome_inspect_once():
+    """Open chrome://inspect at most once per INSPECT_REOPEN_TTL across invocations"""
+    marker = paths.config_dir() / "inspect-opened"
+    try:
+        if time.time() - marker.stat().st_mtime < INSPECT_REOPEN_TTL:
+            return
+    except OSError:
+        pass
+    _open_chrome_inspect()
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+    except OSError:
         pass
 
 

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -860,11 +860,16 @@ def _launch_browser():
     for key in ("BH_CHROME_PATH", "CHROME_PATH"):
         raw = (os.environ.get(key) or "").strip()
         if raw and Path(raw).expanduser().is_file():
-            subprocess.Popen(
-                [str(Path(raw).expanduser())],
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
-            )
-            return True
+            try:
+                subprocess.Popen(
+                    [str(Path(raw).expanduser())],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
+                )
+                return True
+            except (OSError, subprocess.SubprocessError):
+                # A path that exists but can't execute (permissions, wrong arch)
+                # must fall through to normal discovery, not abort
+                continue
 
     enabled = remote_debugging_toggle_profiles()
     base = enabled[0] if enabled else next((b for b in PROFILES if (b / "Local State").exists()), None)
@@ -899,18 +904,19 @@ def _open_chrome_inspect():
     url = "chrome://inspect/#remote-debugging"
     if platform.system() == "Darwin":
         try:
-            subprocess.run([
+            r = subprocess.run([
                 "osascript",
                 "-e", 'tell application "Google Chrome" to activate',
                 "-e", f'tell application "Google Chrome" to open location "{url}"',
-            ], timeout=5, check=False)
-            return
+            ], timeout=5, check=False, capture_output=True)
+            if r.returncode == 0:
+                return True
         except Exception:
             pass
     try:
-        webbrowser.open(url, new=2)
+        return bool(webbrowser.open(url, new=2))
     except Exception:
-        pass
+        return False
 
 
 INSPECT_REOPEN_TTL = 180.0  # seconds open new chrome://inspect tab
@@ -918,13 +924,14 @@ INSPECT_REOPEN_TTL = 180.0  # seconds open new chrome://inspect tab
 
 def _open_chrome_inspect_once():
     """Open chrome://inspect at most once per INSPECT_REOPEN_TTL across invocations"""
-    marker = paths.config_dir() / "inspect-opened"
+    marker = paths.inspect_marker()
     try:
         if time.time() - marker.stat().st_mtime < INSPECT_REOPEN_TTL:
             return
     except OSError:
         pass
-    _open_chrome_inspect()
+    if not _open_chrome_inspect():
+        return
     try:
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.touch()

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -325,6 +325,15 @@ def is_inspect_tab(t):
     return t["type"] == "page" and t.get("url", "").startswith("chrome://inspect")
 
 
+def harness_opened_inspect():
+    """True when admin's recovery flow opened a chrome://inspect tab that is
+    still awaiting cleanup (the marker survives until the next connect)."""
+    try:
+        return paths.inspect_marker().exists()
+    except OSError:
+        return False
+
+
 def is_reusable_new_tab_page(t):
     """The browser's own New Tab Page, ex: from a fresh launch"""
     return t["type"] == "page" and t.get("url", "").startswith(
@@ -367,9 +376,9 @@ class Daemon:
             # starts with just the New Tab Page. Reuse it — creating about:blank
             pages = [t for t in targets if is_reusable_new_tab_page(t)]
         take_over = None
-        if not pages:
+        if not pages and harness_opened_inspect():
             # After perms granted, only tab is often chrome://inspect
-            # Attach to it instead of creaing new about:blank
+            # Attach to it instead of creating a new about:blank
             inspect_tabs = [t for t in targets if is_inspect_tab(t)]
             if inspect_tabs:
                 pages = [inspect_tabs[0]]
@@ -397,6 +406,8 @@ class Daemon:
 
     async def _close_inspect_tabs(self, targets):
         """Close chrome://inspect tabs left open by the permission recovery flow"""
+        if not harness_opened_inspect():
+            return
         for t in targets:
             if t["targetId"] != self.target_id and is_inspect_tab(t):
                 try:
@@ -404,6 +415,10 @@ class Daemon:
                     log(f"closed leftover chrome://inspect tab {t['targetId']}")
                 except Exception as e:
                     log(f"close inspect tab {t['targetId']}: {e}")
+        try:
+            paths.inspect_marker().unlink()
+        except OSError:
+            pass
 
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -90,6 +90,9 @@ REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
 # Chrome 144+ shows a per-connection popup. Keep popup open enough to click.
 LOCAL_HANDSHAKE_TIMEOUT = 45
+# How long get_ws_url() keeps waiting for DevToolsActivePort before giving up
+NO_TOGGLE_GRACE = 3
+TOGGLE_BOOT_GRACE = 12
 
 
 def _devtools_port_live(base):
@@ -126,6 +129,51 @@ def remote_debugging_user_enabled():
         if enabled is False:
             seen = False
     return seen
+
+
+def remote_debugging_toggle_profiles():
+    """Profile dirs whose chrome://inspect toggle is recorded on in Local State"""
+    out = []
+    for base in PROFILES:
+        try:
+            state = json.loads((base / "Local State").read_text(encoding="utf-8", errors="replace"))
+            if ((state.get("devtools") or {}).get("remote_debugging") or {}).get("user-enabled") is True:
+                out.append(base)
+        except (OSError, ValueError, AttributeError):
+            continue
+    return out
+
+
+def browser_running_for_profile(base):
+    """True when a running browser instance holds this user-data-dir (POSIX)"""
+    try:
+        target = os.readlink(str(base / "SingletonLock"))
+    except OSError:
+        return False
+    try:
+        pid = int(target.rsplit("-", 1)[-1])
+    except ValueError:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True  # pid exists but belongs to another user
+
+
+def supported_browser_running():
+    """Is any browser whose profile we scan actually running?"""
+    if platform.system() == "Windows":
+        # Chromium on Windows uses a named mutex instead of SingletonLock —
+        import subprocess
+        try:
+            out = subprocess.check_output(["tasklist"], text=True, errors="replace", timeout=5).lower()
+        except Exception:
+            return True  # can't tell — assume running so recovery stays on the popup/toggle path
+        return any(n in out for n in ("chrome.exe", "msedge.exe", "chromium.exe", "brave.exe", "helium.exe"))
+    return any(browser_running_for_profile(base) for base in PROFILES)
 
 
 def log(msg):
@@ -188,6 +236,7 @@ def get_ws_url():
             hint += "; on Windows also check that a firewall/antivirus isn't blocking localhost connections"
         raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- {hint}")
     deadline = time.time() + 30
+    next_liveness_check = 0.0
     while time.time() < deadline:
         for base in PROFILES:
             try:
@@ -213,6 +262,18 @@ def get_ws_url():
                     return f"ws://127.0.0.1:{port}{ws_path}"
             except (OSError, KeyError, ValueError):
                 pass
+        # Closed browser leaves stale DevToolsActivePort files
+        now = time.time()
+        if now >= next_liveness_check:
+            if not supported_browser_running():
+                raise RuntimeError(
+                    "chrome-not-running: no supported Chromium-family browser is running -- start Chrome, then retry"
+                )
+            next_liveness_check = now + 2
+        # The browser is running but the port isn't up; waiting 30s
+        grace = TOGGLE_BOOT_GRACE if remote_debugging_toggle_profiles() else NO_TOGGLE_GRACE
+        if now > deadline - 30 + grace:
+            break
         time.sleep(0.2)
     for probe_port in (9222, 9223):
         try:
@@ -249,6 +310,28 @@ def is_real_page(t):
     return t["type"] == "page" and not t.get("url", "").startswith(INTERNAL)
 
 
+def is_reusable_blank_page(t):
+    """A plain about:blank tab that is safe to attach to and navigate"""
+    url = t.get("url", "")
+    return (
+        t["type"] == "page"
+        and (url == "about:blank" or url.startswith("about:blank#"))
+        and not t.get("title", "").startswith("Starting agent ")
+    )
+
+
+def is_inspect_tab(t):
+    """A chrome://inspect tab — normally the one the permission flow opened"""
+    return t["type"] == "page" and t.get("url", "").startswith("chrome://inspect")
+
+
+def is_reusable_new_tab_page(t):
+    """The browser's own New Tab Page, ex: from a fresh launch"""
+    return t["type"] == "page" and t.get("url", "").startswith(
+        ("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab")
+    )
+
+
 class _PatientCDPClient(CDPClient):
     """CDPClient with the WS opening handshake stretched to LOCAL_HANDSHAKE_TIMEOUT."""
 
@@ -277,7 +360,22 @@ class Daemon:
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         pages = [t for t in targets if is_real_page(t)]
         if not pages:
-            # No real pages - create one instead of attaching to omnibox popup.
+            # Fresh browser (ex: BU cloud) starts w about:blank; reuse it
+            pages = [t for t in targets if is_reusable_blank_page(t)]
+        if not pages:
+            # Freshly launched browser (ex: harness relaunching closed Chrome)
+            # starts with just the New Tab Page. Reuse it — creating about:blank
+            pages = [t for t in targets if is_reusable_new_tab_page(t)]
+        take_over = None
+        if not pages:
+            # After perms granted, only tab is often chrome://inspect
+            # Attach to it instead of creaing new about:blank
+            inspect_tabs = [t for t in targets if is_inspect_tab(t)]
+            if inspect_tabs:
+                pages = [inspect_tabs[0]]
+                take_over = inspect_tabs[0]["targetId"]
+        if not pages:
+            # No usable pages - create one instead of attaching to omnibox popup.
             tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
@@ -286,8 +384,26 @@ class Daemon:
         ))["sessionId"]
         self.target_id = pages[0]["targetId"]
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
+        if take_over:
+            try:
+                await self.cdp.send_raw("Page.navigate", {"url": "about:blank"}, session_id=self.session)
+                log(f"took over inspect tab {take_over} -> about:blank")
+            except Exception as e:
+                log(f"take over inspect tab {take_over}: {e}")
+        if BROWSER_KIND == "local":
+            await self._close_inspect_tabs(targets)
         await self._enable_default_domains(self.session)
         return pages[0]
+
+    async def _close_inspect_tabs(self, targets):
+        """Close chrome://inspect tabs left open by the permission recovery flow"""
+        for t in targets:
+            if t["targetId"] != self.target_id and is_inspect_tab(t):
+                try:
+                    await self.cdp.send_raw("Target.closeTarget", {"targetId": t["targetId"]})
+                    log(f"closed leftover chrome://inspect tab {t['targetId']}")
+                except Exception as e:
+                    log(f"close inspect tab {t['targetId']}: {e}")
 
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -313,7 +313,12 @@ def new_tab(url="about:blank"):
         try:
             cur = current_tab()
             cur_url = cur.get("url") or ""
-            if cur_url in ("", "about:blank") or cur_url.startswith("about:blank#"):
+            # Reuse attached tab when it's blank
+            if (
+                cur_url in ("", "about:blank")
+                or cur_url.startswith("about:blank#")
+                or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
+            ):
                 goto_url(url)
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:

--- a/src/browser_harness/paths.py
+++ b/src/browser_harness/paths.py
@@ -29,6 +29,11 @@ def config_dir() -> Path:
     return ensure_private_dir(Path(raw).expanduser().resolve() if raw else home_dir())
 
 
+def inspect_marker() -> Path:
+    """Marker recording that the harness opened a chrome://inspect tab"""
+    return config_dir() / "inspect-opened"
+
+
 def runtime_dir() -> Path:
     raw = os.environ.get("BH_RUNTIME_DIR")
     return ensure_private_dir(Path(raw).expanduser().resolve() if raw else home_dir() / "runtime")

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -377,7 +377,12 @@ def _run(args):
             and os.environ.get("BU_AUTOSPAWN")
         ):
             start_remote_daemon(NAME)
-        ensure_daemon()
+        try:
+            ensure_daemon()
+        except RuntimeError as e:
+            # Setup/permission errors are instructions for calling agent
+            print(f"browser-harness: {e}", file=sys.stderr)
+            sys.exit(1)
     _install_helper_trace()
     exec(code, globals())
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically launches Chrome when none is running and reuses safe tabs (about:blank/New Tab/inspect) to speed up startup and reduce user prompts. Cleans up only inspect tabs the harness opened.

- **New Features**
  - Detects closed Chromium-family browsers and launches one (macOS/Windows/Linux), preferring profiles with the remote debugging toggle and skipping the profile picker.
  - Opens `chrome://inspect/#remote-debugging` at most once per 3 minutes across runs and surfaces clear, actionable errors; prints instructions and exits non‑zero on setup/permission issues.
  - Guards against stale DevToolsActivePort files by checking browser liveness and using smarter boot grace periods.
  - Attaches to a reusable tab: about:blank, New Tab, or the existing inspect tab (then navigates to about:blank); after connecting, closes leftover inspect tabs only if opened by the harness.
  - Reuses blank/New Tab in `new_tab()`; updated SKILL docs to note automatic launch behavior.

<sup>Written for commit 2e89e133e4d3c1fdb38efbc96c4a3f7857de69dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

