### PR TITLE
Bump browser-harness to 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.7"
+version = "0.1.8"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release 0.1.8.

Since v0.1.7 (#560):
- Detects a closed Chromium-family browser and launches one automatically (macOS/Windows/Linux), preferring profiles with the remote-debugging toggle already set.
- Attaches to a reusable tab (about:blank / New Tab / existing inspect tab) instead of always opening a new one.
- Only closes leftover `chrome://inspect` tabs the harness itself opened.
- Guards against stale DevToolsActivePort files; clearer, actionable setup/permission errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `browser-harness` 0.1.8 to improve startup reliability and session reuse. It now auto-relaunches Chromium browsers and prefers reusing an existing tab for faster workflows.

- **New Features**
  - Auto-launches a closed Chromium browser on macOS/Windows/Linux.
  - Prefers profiles with remote-debugging already enabled.
  - Reuses an existing tab (about:blank/New Tab/inspect) instead of opening a new one.
  - Clearer, actionable setup and permission error messages.

- **Bug Fixes**
  - Only closes `chrome://inspect` tabs opened by the harness.
  - Guards against stale DevToolsActivePort files.

<sup>Written for commit c99966abc9c89ac4685a5c4b73c962bf97d9e98b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

