### PR TITLE
Bump Pillow to 12.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "cdp-use==1.4.5",
     "fetch-use==0.4.0",
-    "pillow==12.2.0",
+    "pillow==12.3.0",
     "websockets==15.0.1",
 ]
 


### PR DESCRIPTION
## Summary

- bump Pillow from 12.2.0 to 12.3.0
- clear CVE-2026-55798, CVE-2026-59198, and CVE-2026-59203
- unblock downstream `browser-use` and `workflow-use` security updates

## Root cause

Browser Harness pins Pillow exactly, so downstream packages cannot select the patched 12.3.0 release through normal wheel metadata.

## Validation

- `uv run --with pytest pytest tests/unit/test_helpers.py` (18 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pillow` to 12.3.0 to patch CVE-2026-55798, CVE-2026-59198, and CVE-2026-59203. This unblocks security updates in `browser-use` and `workflow-use`.

- **Dependencies**
  - Update exact pin: `pillow` 12.2.0 -> 12.3.0.

<sup>Written for commit 331ad6aafa28eb220535b5d748a1a77010484ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

