### PR TITLE
docs: document Stripe account sandbox distinction

### DIFF
--- a/agent-workspace/domain-skills/stripe/account-sandboxes.md
+++ b/agent-workspace/domain-skills/stripe/account-sandboxes.md
@@ -1,0 +1,28 @@
+# Stripe account Test mode and sandboxes
+
+Stripe's new-account onboarding can expose two distinct test environments:
+
+- The account's classic Test mode keeps the main account ID and uses URLs shaped
+  like `https://dashboard.stripe.com/{account_id}/test/...`.
+- Choosing **Go to sandbox** during onboarding can create an additional sandbox
+  with its own account ID and API keys.
+
+Do not assume that the environment opened by the onboarding flow is the main
+account's Test mode. Before creating products, prices, or webhooks:
+
+1. Read the account ID from the URL.
+2. Open `/{main_account_id}/test/apikeys`.
+3. Verify the API key by retrieving `/v1/account` and comparing its `id` with
+   the intended main account ID.
+
+Useful stable routes:
+
+- `/{account_id}/test/apikeys` — Test mode API keys
+- `/{account_id}/test/settings/account` — account display name
+- `/{account_id}/test/settings/payment_methods` — payment method configuration
+- `/{account_id}/test/settings/tax` — Stripe Tax settings
+
+The initial **Business name** onboarding field can replace the display name
+shown in the account switcher. Restore a product-specific display name under
+**Settings → Business → Account details** if the legal name makes sibling
+product accounts indistinguishable.


### PR DESCRIPTION
Documents the non-obvious distinction between a main account’s classic Test mode and the additional sandbox created by new-account onboarding, including safe account-ID verification and stable settings routes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add documentation that clarifies the difference between a main Stripe account’s Test mode and the onboarding-created sandbox, so teams don’t create resources in the wrong account. Includes a quick verification flow using the URL account ID and `/v1/account`, plus stable dashboard routes for API keys and settings.

<sup>Written for commit cd746e95a66d02b8578b8eeffc156f853e1e893c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

