### PR TITLE
skill: Knowify vendor bills (private API, replace semantics, QuickBooks trap)

### DIFF
--- a/domain-skills/knowify/bills.md
+++ b/domain-skills/knowify/bills.md
@@ -1,0 +1,83 @@
+# Knowify — vendor bills (`secure.knowify.com`)
+
+AngularJS SPA. Reads/writes go to `api.knowify.com` over XHR with a `kAuth` bearer token, so
+**prefer the private API over DOM work** — the DOM is only worth driving when you need to learn a
+request shape.
+
+## Discovering a request shape without a capture
+
+The whole API registry plus every call site is in the main bundle — no auth, no browser:
+
+```bash
+curl -s https://secure.knowify.com/ | grep -oE 'main\.[^"]+\.js'   # current hash
+curl -s "https://secure.knowify.com/main.<hash>.js" > main.js
+grep -oE '[A-Za-z0-9_]+:\{[^{}]*verb:"Payables"[^{}]*\}' main.js | sort -u   # endpoints
+grep -oE '.{200}callAPI\("updatePayableItem".{300}' main.js                  # literal body
+```
+
+`verb` is the path prefix, the key is the endpoint name → `api.knowify.com/<verb>/<name>`.
+
+## URL patterns
+
+- `#/bills/manage` — list; `#/bills/manage/{id}` — one bill
+- `#/bills/edit?id={id}` — the edit form (Details + Items)
+- `#/projects/details/plan/{projectId}` — job cost view
+- `#/projects/details/contracts/del/{projectId}` — contract/invoice view
+
+## Selectors that work on the bill edit form
+
+- `input[name="payable-item-description-{rowIndex}"]` — a line's description. It's a
+  `k-typeahead-field`: focusing it fires `ServiceCatalog/Search2` against the current value.
+  Typing a value that matches no catalog item leaves no dropdown, so plain
+  `Input.insertText` after Cmd+A is safe.
+- Modals render inside `<k-modal-target>`. Query within it — a document-wide
+  `input[type=checkbox]` scan misses them.
+
+## Trap: the confirm dialog's checkbox is 0×0
+
+The bill-edit confirm ("Bill Summary") has a **"Send to QuickBooks"** checkbox, `#invoice-qb-sync`
+/ `ng-model="payable.NeedsToBeSynced"`, **checked by default**. The real `<input>` has a zero-size
+bounding box (it's visually replaced by a styled `<label for=…>`), so `getBoundingClientRect()` on
+the input returns 0,0 and clicking there does nothing. Click the label instead:
+
+```python
+r = js("""(() => {
+  const inp = document.querySelector('#invoice-qb-sync');
+  const lbl = document.querySelector(`label[for="${inp.id}"]`);
+  const b = lbl.getBoundingClientRect();
+  return {x: Math.round(b.x + 8), y: Math.round(b.y + b.height/2)};
+})()""")
+click(r["x"], r["y"])
+```
+
+Then assert `js("document.querySelector('#invoice-qb-sync').checked")` is what you intended —
+submitting with it checked pushes the bill to QuickBooks, which is not reversible from here.
+
+## Capturing a save payload
+
+`window.__cap` wrapper around `XMLHttpRequest.prototype.open/send` catches everything; filter to
+`api.knowify.com` because the app also POSTs to rollbar, vitally, and `developers.knowify.com`
+(its own telemetry, which conveniently mirrors each API call's body under `Data`).
+
+## Trap: `updatePayable` is replace-not-update
+
+Saving the edit form POSTs `Payables/updatePayable`, then `Indexing/allocatePayable {Id}`. The
+**old bill id stops existing** and every line-item id changes. `NewId` in the response is
+populated only sometimes — a null `NewId` still means the bill was replaced. Two things do not
+survive on their own: the attached PDF (echo `SupportingDocuments` verbatim) and the generated
+billable (regenerate with `Payables/createBillablesBill {Id}`; `allocatePayable` reports
+"Bill Has Been Indexed" without creating one).
+
+`Payables/updatePayableItem` accepts `{Id, PayableId, ClientId, DepartmentId, ProjectId,
+MilestoneId}` and returns `DidSucceed:true` — but it **silently ignores `Description`**. It is an
+allocation-only endpoint; don't use it to edit text.
+
+## Useful reads
+
+- `Payables/Get {Id}` — one bill incl. `Payable.PayableItems`, `SupportingDocuments`, `Comments`
+- `Payables/searchPayablesIds {Sort, SortAsc, Search}` — id lookup by invoice number
+- `Invoices/GetBillablesForProject {ProjectId, ClientId, StartDate, EndDate, SkipDates:true}` —
+  exactly what the invoicing screen offers. `OriginOfBillable` is `PayableItem` /
+  `ResourceTimeEntry` / `FixedDeliverable` / `PurchaseRequestItem`; `OriginOfBillableId` points at
+  that source row. Already-invoiced billables drop out of this read, so a lower count than you
+  expect on a billed job is normal.


### PR DESCRIPTION
Adds `domain-skills/knowify/bills.md` from a real session driving a vendor-bill edit in Knowify (`secure.knowify.com` — construction accounting; AngularJS SPA over `api.knowify.com`).

What's in it, all verified against the live app rather than inferred:

- **Learn a request shape without a capture or a write** — recipe for pulling the whole API registry *and* its call sites out of the main bundle. `verb` is the path prefix, the key is the endpoint name.
- **Stable selectors** for the bill edit form, plus the fact that modals render inside `<k-modal-target>`, so a document-wide `input[type=checkbox]` scan misses them entirely.
- **A 0×0 checkbox trap.** The "Send to QuickBooks" input is visually replaced by a styled `<label for=…>`, so `getBoundingClientRect()` on the input returns `0,0` and a coordinate click there does nothing. It also defaults to **CHECKED** — submitting without unticking pushes the bill to QuickBooks, which isn't reversible from the browser. Includes the label-click snippet and the assertion to make afterward.
- **`Payables/updatePayable` is replace-not-update.** The old bill id stops existing, every line-item id changes, and `NewId` is populated only sometimes. Two things don't survive on their own: the attached PDF (echo `SupportingDocuments` verbatim) and the generated billable (regenerate with `Payables/createBillablesBill`; `allocatePayable` reports success without creating one).
- **`Payables/updatePayableItem` silently ignores `Description`** while returning `DidSucceed:true` — it's allocation-only. Easy to waste time on.
- **Read endpoints worth starting from**, including the non-obvious detail that already-invoiced billables drop out of `GetBillablesForProject`, so a lower count than expected on a billed job is normal.

No credentials, cookies, or account-specific data — selectors, endpoints, and payload shapes only, per the `domain-skills` guidance. No raw pixel coordinates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `domain-skills/knowify/bills.md`, a focused guide for editing Knowify vendor bills via the private API, with safe selectors and key traps to avoid. Helps prevent accidental QuickBooks sync and clarifies replace semantics in `Payables/updatePayable`.

- **New Features**
  - How to pull the API registry and call sites from the main bundle; map to `api.knowify.com/<verb>/<name>`.
  - Stable edit-form selectors; modals render inside `<k-modal-target>`.
  - QuickBooks trap: the confirm dialog’s checkbox is 0×0; click its label instead. It defaults to checked—assert the state before saving.
  - Save flow: `Payables/updatePayable` replaces the bill (IDs change, `NewId` may be null). Echo `SupportingDocuments` and regenerate the billable via `Payables/createBillablesBill`; `Indexing/allocatePayable` won’t create one.
  - `Payables/updatePayableItem` ignores `Description` (allocation-only).
  - Useful reads to start from: `Payables/Get`, `Payables/searchPayablesIds`, `Invoices/GetBillablesForProject` (already invoiced items drop out).

<sup>Written for commit f173b3da30ffb0b7eb874729bcf9ed110e2b1b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

