### PR TITLE
docs: align install skill name with browser-use frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Try browser-harness in [Browser Use Cloud](https://cloud.browser-use.com/v4?utm_
 Paste into Claude Code or Codex:
 
 ```text
-Install or upgrade browser-harness to the latest stable version with uv using Python 3.12, register the skill from `browser-harness skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
+Install or upgrade browser-harness to the latest stable version with uv using Python 3.12, register the skill body from `browser-harness skill` (skill name is `browser-use`; CLI remains `browser-harness`), and connect it to my browser. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
 ```
 
 The agent will open `chrome://inspect/#remote-debugging`. Tick the checkbox so the agent can connect to your browser:

--- a/install.md
+++ b/install.md
@@ -22,13 +22,15 @@ If `page_info()` prints, stop. Setup is done.
 
 `--python 3.12` prevents uv from selecting old releases that support older Python versions. `--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
 
-For Claude Code or other agents: install `browser-harness`, register a skill named `browser-harness`, use `browser-harness skill` as the body, and use this trigger:
+For Claude Code or other agents: install the `browser-harness` package/CLI, register a skill whose body comes from `browser-harness skill` (YAML frontmatter keeps `name: browser-use` — do not rename it to `browser-harness`), and use this trigger:
 
 ```text
-Always use browser-harness for any web interaction: automation, scraping, testing, or site/app work.
+Always use browser-use for any web interaction: automation, scraping, testing, or site/app work.
 ```
 
-If an old user-installed `browser` or `browser-use` skill is being picked instead, remove that stale skill directory manually. Do not edit bundled/vendor plugin caches.
+Package/CLI = `browser-harness`. Skill identity (frontmatter `name` + trigger) = `browser-use`. Codex may install the file under `skills/browser-harness/`; the skill name is still `browser-use`.
+
+If an old user-installed `browser` skill, or a hand-edited skill still named `browser-harness`, is being picked instead of `browser-use`, remove that stale skill directory manually. Do not remove a correctly installed `browser-use` skill. Do not edit bundled/vendor plugin caches.
 
 ## If Chrome Blocks It
 


### PR DESCRIPTION
## Summary
- Clarify package/CLI (`browser-harness`) vs skill identity (`browser-use` from `SKILL.md` / unit tests)
- Fix install guidance that told agents to register a skill named `browser-harness` and to remove a correct `browser-use` skill
- Align README setup prompt with the same naming split

## Test plan
- [ ] Diff `install.md` / `README.md` against packaged `SKILL.md` frontmatter (`name: browser-use`)
- [ ] Confirm Codex path still writes under `skills/browser-harness/` while body keeps YAML name `browser-use`
- [ ] No code changes — docs only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the naming split between the `browser-harness` CLI/package and the `browser-use` skill to prevent wrong skill registration or accidental removal. Updates install instructions and the README prompt to match the `SKILL.md` frontmatter.

- **Bug Fixes**
  - README: prompt now says the skill body comes from `browser-harness skill`, while the skill name remains `browser-use`.
  - Install guide: explains that files may live under `skills/browser-harness/`, but the YAML frontmatter keeps `name: browser-use`; instructs not to delete a correctly installed `browser-use` skill.

<sup>Written for commit 380cf0f05ff8005b7b0c8a2e69133f0ccb5c07cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

