### PR TITLE
Add google-drive domain skill: download, upload, convert

### DIFF
--- a/domain-skills/google-drive/upload-download-convert.md
+++ b/domain-skills/google-drive/upload-download-convert.md
@@ -1,0 +1,54 @@
+# Google Drive / Slides: download, upload, convert
+
+Field-tested mechanics for moving files in and out of Drive with an authenticated Chrome session.
+
+## Download a Google Doc/Slides/Sheet as Office format
+
+Export URLs: `https://docs.google.com/presentation/d/<id>/export/pptx` (also `/export?format=docx|xlsx` for docs/sheets).
+
+- **Cookie replay does NOT work.** Reading cookies via `Network.getCookies` and replaying them through `urllib` returns the "Sign in - Google Accounts" wall, even with all `.google.com` cookies attached. Google's export endpoint needs more session state than the cookie jar carries.
+- **What works: let Chrome download it.** Set a download directory, then navigate a tab to the export URL:
+
+```python
+cdp("Browser.setDownloadBehavior", behavior="allow", downloadPath=DL_DIR, eventsEnabled=True)
+cdp("Page.navigate", url=export_url)
+# poll DL_DIR until a non-.crdownload file appears and its size stabilizes
+```
+
+## Upload a local file to Drive
+
+Drive has **no persistent `<input type="file">`** in its DOM — it's created on demand, so you can't just query and set it. Use file-chooser interception:
+
+```python
+cdp("Page.setInterceptFileChooserDialog", enabled=True)
+drain_events()
+click_at_xy(...)  # "+ New"
+wait(1.5)
+click_at_xy(...)  # "File upload" menu item
+# poll drain_events() for Page.fileChooserOpened, then:
+cdp("DOM.setFileInputFiles", files=[path], backendNodeId=evt["params"]["backendNodeId"])
+```
+
+An "Uploading 1 item" toast appears bottom-right with per-file progress. The uploaded file lands in My Drive root (`parentId` = the My Drive root id).
+
+- Do the whole sequence (menu click → chooser event → set files) in ONE script invocation. Menus close and the daemon's attached tab can drift between invocations if the user is browsing.
+- If the user is actively using Chrome, re-attach explicitly every script: find your tab via `list_tabs()` by URL substring, `switch_tab(targetId)`, and assert `page_info()["url"]` before any click.
+
+## Convert an uploaded .pptx to a native Google Slides file
+
+Open the uploaded file at `https://docs.google.com/presentation/d/<pptx-file-id>/edit` — Slides opens it in Office-compatibility mode (title shows a `.PPTX` badge, no Extensions menu). Two equivalent converters:
+
+- **"Convert" button in the right rail** (bottom of the Slide/Image/Media/Uploads stack), or
+- File → Save as Google Slides.
+
+Either creates a NEW file (native Slides, `application/vnd.google-apps.presentation`) with the same title minus `.pptx`; the original .pptx stays behind.
+
+**Trap: permissions do not carry over.** Sharing added to the .pptx (explicit user grants) is NOT inherited by the converted Slides file — it starts fresh with just the owner + domain default. Re-share the converted file.
+
+## Renaming a Docs-editor file
+
+Click the title field (top-left), `press_key('a', 4)` (cmd+A), `type_text(new_name)`, `press_key('Enter')`. Verified by the title box updating; no dialog involved.
+
+## GAM note (not browser, but adjacent)
+
+`gam user <email> add drivefile localfile <path> mimetype gpresentation` would upload+convert in one shot, but requires the GAM project to have Drive API service enabled — admin-directory-only GAM setups fail with "Drive API v3 Service/App not enabled". The browser path above is the fallback.


### PR DESCRIPTION
Field-tested mechanics from automating a Slides→PPTX→Slides round-trip:

- Export downloads: cookie replay to export URLs fails (sign-in wall); navigating a tab with `Browser.setDownloadBehavior` works.
- Uploads: Drive has no persistent file input — use `Page.setInterceptFileChooserDialog` + `DOM.setFileInputFiles` on the `fileChooserOpened` event, all in one script invocation.
- PPTX→Slides conversion via the right-rail Convert button / File → Save as Google Slides, and the trap that explicit permissions do not carry over to the converted file.
- Docs-editor rename mechanic + GAM fallback note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Google Drive/Slides domain skill documenting how to download, upload, and convert files with an authenticated Chrome session. Enables reliable automation for Office ↔ Google formats with clear steps and gotchas.

- New Features
  - Download exports by navigating export URLs with `Browser.setDownloadBehavior`; cookie replay does not work.
  - Upload via file-chooser interception using `Page.setInterceptFileChooserDialog` + `DOM.setFileInputFiles` in a single script run.
  - Convert `.pptx` to native Slides via UI; converted file is new and does not inherit permissions (re-share required).
  - Rename via the Docs editor title field; includes a GAM upload+convert note and Drive API enablement caveat.

<sup>Written for commit 306a672f4d6edae2dad791927e2e286b3c9acc3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

