### PR TITLE
Support background tab attachment without stealing focus

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,6 +26,9 @@ PY
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
 - First navigation is `new_tab(url)`, not `goto_url(url)`.
+- To control a tab without bringing its Chrome window or tab forward, use
+  `new_tab(url, activate=False)`, `switch_tab(target, activate=False)`, or
+  `ensure_real_tab(activate=False)`.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -4,7 +4,7 @@
 
 When Chrome opens fresh, the only CDP `type: "page"` targets are `chrome://inspect` and `chrome://omnibox-popup.top-chrome/` (a 1px invisible viewport). If the daemon attaches to the omnibox popup, all subsequent work — including `new_tab()` and `goto_url()` — happens on tabs that exist in CDP but may not be visible in the Chrome UI.
 
-The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` which calls `Target.activateTarget` to bring the tab to front.
+The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` which calls `Target.activateTarget` by default to bring the tab to front.
 
 ## Startup sequence
 
@@ -13,6 +13,11 @@ The daemon's `attach_first_page()` handles this by creating an `about:blank` tab
 3. List open tabs with `list_tabs()` to see what's available
 4. `ensure_real_tab()` attaches to a real page
 5. `switch_tab(target_id)` both attaches AND activates (brings to front)
+
+Pass `activate=False` to `switch_tab()`, `new_tab()`, or `ensure_real_tab()`
+when the harness should attach without changing the user's visible window or
+tab. Background `new_tab()` calls also ask Chrome to create the target in the
+background, avoiding focus before the harness attaches.
 
 ```python
 if not daemon_alive():

--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -7,12 +7,21 @@ Use **CDP for control**, **UI automation for user-visible order**.
 ```python
 tabs = list_tabs()                    # includes chrome:// pages too
 real_tabs = list_tabs(include_chrome=False)
-tid = new_tab("https://example.com")  # create + attach
-switch_tab(tid)                       # attach harness to tab
-cdp("Target.activateTarget", targetId=tid)  # show it in Chrome
+tid = new_tab("https://example.com")  # create + attach + show
+switch_tab(tid)                       # attach + show an existing tab
 print(current_tab())
 print(page_info())
 ```
+
+To leave the user's visible Chrome window and tab unchanged:
+
+```python
+tid = new_tab("https://example.com", activate=False)
+switch_tab(real_tabs[0], activate=False)  # attach to an existing tab instead
+```
+
+The harness remains attached to the background target, so its inspection,
+navigation, screenshots, and input helpers continue to address that tab.
 
 What CDP is good at:
 - attach to a tab
@@ -61,8 +70,10 @@ Typical tools:
 
 ## Rules that held up in practice
 
-- `switch_tab()` is **not enough** if the user expects Chrome to visibly change.
-- `Target.activateTarget` is the CDP-side "show this tab".
+- `switch_tab()` activates the target by default. Pass `activate=False` to
+  attach without changing the visible window or tab.
+- `new_tab(..., activate=False)` creates the target with CDP's `background`
+  option and attaches without calling `Target.activateTarget`.
 - `list_tabs()` includes `chrome://newtab/` by default; ask for `include_chrome=False` when you want only real pages.
 - `chrome://omnibox-popup.top-chrome/` can appear as a fake page target; ignore it for user-facing tab lists.
 - If a page has `w=0 h=0`, you may be attached to the wrong target or a non-window surface.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -291,7 +291,7 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
-def switch_tab(target):
+def switch_tab(target, activate=True):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
     target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
@@ -299,17 +299,18 @@ def switch_tab(target):
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    if activate:
+        cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
     return sid
 
-def new_tab(url="about:blank"):
+def new_tab(url="about:blank", activate=True):
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    if url != "about:blank":
+    if activate and url != "about:blank":
         try:
             cur = current_tab()
             cur_url = cur.get("url") or ""
@@ -323,8 +324,11 @@ def new_tab(url="about:blank"):
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
-    switch_tab(tid)
+    create_args = {"url": "about:blank"}
+    if not activate:
+        create_args["background"] = True
+    tid = cdp("Target.createTarget", **create_args)["targetId"]
+    switch_tab(tid, activate=activate)
     if url != "about:blank":
         goto_url(url)
     return tid
@@ -338,7 +342,7 @@ def close_tab(target=None):
     cdp("Target.closeTarget", targetId=target_id)
 
 
-def ensure_real_tab():
+def ensure_real_tab(activate=True):
     """Switch to a real user tab if current is chrome:// / internal / stale."""
     tabs = list_tabs(include_chrome=False)
     if not tabs:
@@ -349,7 +353,7 @@ def ensure_real_tab():
             return cur
     except Exception:
         pass
-    switch_tab(tabs[0]["targetId"])
+    switch_tab(tabs[0]["targetId"], activate=activate)
     return tabs[0]
 
 def iframe_target(url_substr):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -77,6 +77,75 @@ def test_page_info_raises_clear_error_on_js_exception():
             helpers.page_info()
 
 
+# --- tabs ---
+
+def _tab_cdp(calls):
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-1"}
+        if method == "Target.createTarget":
+            return {"targetId": "target-1"}
+        return {}
+
+    return fake_cdp
+
+
+def test_switch_tab_activates_by_default():
+    calls = []
+
+    with patch("browser_harness.helpers.cdp", side_effect=_tab_cdp(calls)), \
+         patch("browser_harness.helpers._send"):
+        helpers.switch_tab("target-1")
+
+    assert ("Target.activateTarget", {"targetId": "target-1"}) in calls
+    assert ("Target.attachToTarget", {"targetId": "target-1", "flatten": True}) in calls
+
+
+def test_switch_tab_can_attach_without_activating():
+    calls = []
+
+    with patch("browser_harness.helpers.cdp", side_effect=_tab_cdp(calls)), \
+         patch("browser_harness.helpers._send") as send:
+        helpers.switch_tab("target-1", activate=False)
+
+    assert not any(method == "Target.activateTarget" for method, _ in calls)
+    assert ("Target.attachToTarget", {"targetId": "target-1", "flatten": True}) in calls
+    send.assert_called_once_with({
+        "meta": "set_session",
+        "session_id": "session-1",
+        "target_id": "target-1",
+    })
+
+
+def test_new_tab_can_create_and_attach_in_background():
+    calls = []
+
+    with patch("browser_harness.helpers.cdp", side_effect=_tab_cdp(calls)), \
+         patch("browser_harness.helpers.current_tab") as current, \
+         patch("browser_harness.helpers.switch_tab") as switch, \
+         patch("browser_harness.helpers.goto_url") as goto:
+        target_id = helpers.new_tab("https://example.com", activate=False)
+
+    assert target_id == "target-1"
+    assert calls == [("Target.createTarget", {"url": "about:blank", "background": True})]
+    current.assert_not_called()
+    switch.assert_called_once_with("target-1", activate=False)
+    goto.assert_called_once_with("https://example.com")
+
+
+def test_ensure_real_tab_can_attach_without_activating():
+    tab = {"targetId": "target-1", "url": "https://example.com"}
+
+    with patch("browser_harness.helpers.list_tabs", return_value=[tab]), \
+         patch("browser_harness.helpers.current_tab", side_effect=RuntimeError("stale")), \
+         patch("browser_harness.helpers.switch_tab") as switch:
+        result = helpers.ensure_real_tab(activate=False)
+
+    assert result == tab
+    switch.assert_called_once_with("target-1", activate=False)
+
+
 # --- fill_input ---
 
 def test_fill_input_focuses_types_and_fires_events():


### PR DESCRIPTION
## Summary

- add an `activate=False` mode to `switch_tab`, `new_tab`, and `ensure_real_tab`
- create non-activating new targets with CDP's `background` option and skip `Target.activateTarget`
- preserve the existing foreground behavior by default and document both workflows

## Testing

- `uv run --with pytest pytest` — 118 passed
- visible Chrome smoke test: created and navigated a background tab, dispatched a click into it, and verified the frontmost macOS process stayed unchanged while both the background and sentinel targets remained controllable


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add background tab support so the harness can create or attach to tabs without stealing focus. Adds an `activate=False` option while keeping current foreground behavior by default.

- **New Features**
  - `switch_tab(target, activate=False)` attaches without calling `Target.activateTarget`.
  - `new_tab(url, activate=False)` uses `Target.createTarget` with `background=True` and attaches without focus.
  - `ensure_real_tab(activate=False)` attaches to a real tab without activating.
  - Docs updated to show both flows; unit tests added to cover defaults and background mode.

<sup>Written for commit 98d33bb7f678a46aee831648a281543b6abe0fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

