### PR TITLE
docs(screenshots): document the 5s CDP ceiling and the full=True stall

### DIFF
--- a/interaction-skills/screenshots.md
+++ b/interaction-skills/screenshots.md
@@ -15,3 +15,23 @@ capture_screenshot("/tmp/shot.png", max_dim=1800)
 The downscale only happens when the image actually exceeds `max_dim`, so it's safe to leave on for every shot.
 
 Use full-page screenshots (`full=True`) only when you need to see content below the fold — they are much larger and slower than viewport-only.
+
+## `full=True` never returns when the window is hidden
+
+`full=True` sets CDP's `captureBeyondViewport`, which needs the compositor to produce a fresh frame covering the whole scrollable area. A minimized or fully occluded window never produces one, so the call does not come back — measured past two minutes on Windows 11 / Chrome 150, with the socket timeout raised to 90s to rule the client out.
+
+Viewport-only capture is unaffected: it still returns in about two seconds on that same hidden window. And once the window is visible, the full-page capture of the same page finishes in well under a second — so this is a stall, not slowness.
+
+Raise the window before a full-page shot, or stay on viewport captures and scroll between them.
+
+## Every CDP call has a five-second ceiling
+
+`_send()` opens its socket with `timeout=5.0`, so *any* call needing longer than that fails. This is not screenshot-specific — a `js()` expression that blocks for three seconds returns normally, while the same expression blocked for seven fails at exactly 5.0s. Given a longer timeout, that seven-second call succeeds.
+
+It surfaces as a bare traceback ending in `_ipc.py`:
+
+```text
+TimeoutError: timed out
+```
+
+That names the IPC layer rather than the call you made, so it reads like a dropped connection or a dead tab. It is neither — it means "that call needed more than five seconds." Both the daemon and the tab are still healthy afterwards, and the next call works.


### PR DESCRIPTION
Two distinct failure modes that both surface as the same unexplained `TimeoutError`, so they're easy to mistake for a dropped connection. Both are documented in `interaction-skills/screenshots.md`; no code changes.

### 1. Every CDP call has a hard five-second ceiling

`_send()` in `helpers.py` opens its socket with `timeout=5.0`, so any call needing longer than that fails. Not screenshot-specific:

| call | result |
|---|---|
| `js()` blocked 3s | OK in 3.0s |
| `js()` blocked 7s | `TimeoutError` at exactly 5.0s |
| same 7s call, socket timeout raised to 30s | OK in 7.0s |

The traceback ends in `_ipc.py` rather than naming the call that was made, which reads like a dead tab. It isn't — the daemon and tab are both fine, and the next call works.

### 2. `full=True` never returns when the window is hidden

`full=True` sets `captureBeyondViewport`, which needs a fresh composited frame for the whole scrollable area. A minimized or fully occluded window never produces one:

| window state | capture | result |
|---|---|---|
| minimized | viewport | OK in 1.8s |
| minimized | `full=True` | still hanging past 2min, socket timeout raised to 90s |
| visible | `full=True` | OK in 0.4s |

So it's a stall, not slowness — and it's invisible to anyone testing with the window on screen.

Measured on Windows 11 / Chrome 150 (Canary), harness at v0.1.8.

### Note for maintainers

The 5s value is hard-coded and there's no way to raise it from a script without reaching past `helpers._send` into `_ipc` directly. If you'd take a patch making it configurable — an env var, or a per-call `timeout=` on `cdp()` — happy to follow up with one. I kept this PR docs-only since that's a behavioral change worth deciding separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented two screenshot timeouts/stalls: a hard 5s ceiling on all CDP calls due to `_send()` socket `timeout=5.0`, and `full=True` never returning when the window is minimized or fully hidden.
Adds guidance to raise the window or use viewport captures, and clarifies the `TimeoutError` from `_ipc.py` isn’t a dropped connection.

<sup>Written for commit 147dd6a9b529cc14f1d2dcd1ffb28df29f13431e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

