### PR TITLE
domain-skills: google voice - messaging (existing-thread sends, deterministic thread URLs)

### DIFF
--- a/agent-workspace/domain-skills/google-voice/messaging.md
+++ b/agent-workspace/domain-skills/google-voice/messaging.md
@@ -1,0 +1,63 @@
+# Google Voice - reading threads and sending in EXISTING threads
+
+Verified live 2026-08-05 (send + screenshot proof) and 2026-08-03 (new-recipient failure).
+
+## The one rule that decides automatability
+
+- **Existing thread (any prior message with that number): sending WORKS.** The send
+  button enables once text is in the box.
+- **New recipient (no thread yet): sending does NOT work.** Send stays
+  `disabled=true` no matter what you type. Two materially different approaches
+  failed on 2026-08-03. Escalate to manual, do not retry variations.
+
+So check for a thread first; it also tells you which lane you are in.
+
+## Go straight to a thread by phone number
+
+The thread URL is deterministic. `itemId` is `t.` + the E.164 number, URL-encoded:
+
+```text
+https://voice.google.com/u/0/messages?itemId=t.%2B15551230100
+```
+
+No scroll hunt needed when you know the number. Verify with `location.href` and the
+header text ("Messages with <label>") after load; give it ~8-10s, GV is slow.
+
+## Thread list (only needed when you do not know the number)
+
+- Container: `cdk-virtual-scroll-viewport`. Rows: `GV-THREAD-LIST-ITEM` /
+  `GV-MESSAGE-THREAD-LIST-ITEM` inside `<li>`.
+- The list is VIRTUALIZED: only ~12 rows exist in DOM at once. Loop
+  `v.scrollTop += 450-500` via `js()` and re-query each step. JS scroll only,
+  never `Input.dispatchMouseEvent` wheel (blocks forever on background tabs).
+- Thread label = whatever Google Contacts calls the number, NOT the business name.
+  Two 2026-08-03 sends landed under unrelated stale contact labels from the
+  account's own address book. Match by number when possible.
+
+## Sending in an existing thread (working recipe)
+
+1. Open the thread by itemId URL (above), wait, verify header.
+2. Compose box: the VISIBLE `<textarea>` (aria-label "Type a message"). Click its
+   center coordinates to focus, confirm `document.activeElement.tagName === 'TEXTAREA'`.
+3. `cdp("Input.insertText", text=MSG)` into the focused box. Then verify
+   `document.activeElement.value === MSG` EXACTLY before sending.
+4. Click `button[aria-label="Send message"]` via element `.click()` (check
+   `disabled` first; enabled means existing-thread lane).
+5. Verify with `screenshot()`: the new bubble in the conversation pane AND the
+   compose box back to placeholder. DOM text reads are unreliable here (below).
+
+## Traps
+
+- **A second, HIDDEN `<textarea>` holds a ~2.4KB token blob.** "Some textarea has
+  content" does NOT mean the compose box is unsent. Scope reads to the visible
+  textarea or `activeElement`.
+- **`body.innerText` mixes both panes.** "Latest messages" appears in the thread
+  LIST pane too, so a marker-based slice can return the list, not the
+  conversation. Scope to the conversation pane or trust the screenshot.
+- **Fresh bubbles may not appear in smallest-div text heuristics** right after
+  send. The screenshot is the ground truth; the sent bubble renders within ~5s.
+- Outbound messages read as "You: ..." / "Message from you, ..." in innerText;
+  anything else on a thread's latest line is inbound. That is the whole
+  reply-detection signal, with one trap: GV stamps 1-6 day-old threads with a
+  bare weekday abbreviation ("Mon"/"Tue"), which parses as a fake inbound reply
+  unless filtered.


### PR DESCRIPTION
Adds a Google Voice messaging domain skill, verified live 2026-08-05 with a real send.

What it documents:
- The rule that decides automatability: sending in an EXISTING thread works normally, while new-recipient compose is not automatable (the send button stays disabled because synthetic input never creates the recipient chip; two input approaches failed).
- Deterministic thread URLs: itemId is t. plus the E.164 number, so a known number goes straight to its thread with no virtualized-list scroll hunt.
- Thread list mechanics: cdk-virtual-scroll-viewport with GV-THREAD-LIST-ITEM rows, ~12 in DOM at once, JS scroll only (Input mouseWheel blocks on background tabs).
- A working compose recipe: focus the visible textarea, Input.insertText, exact value check, click the aria-label Send message button, verify by screenshot.
- Traps: a hidden second textarea holding a token blob that must not be read as compose state, both panes sharing innerText markers, fresh bubbles missing from DOM text heuristics, contact labels not matching business names, and the bare-weekday timestamp that parses as a fake inbound reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents reading threads and sending in existing Google Voice threads, with deterministic thread URLs and a reliable send flow. Confirms new-recipient compose is not automatable.

- **New Features**
  - Defines the rule: sending works in existing threads; new-recipient compose stays disabled.
  - Documents deterministic thread URLs (`itemId` = `t.` + E.164) to open threads directly.
  - Provides a working send flow: focus visible textarea, insert text, verify value, click "Send message," confirm by screenshot.
  - Notes GV specifics: virtualized thread list with JS scroll-only, hidden second textarea, mixed-pane innerText pitfalls, delayed bubble render, contact label mismatches, outbound "You:" detection signal, and weekday timestamp false positives.

<sup>Written for commit 48b000c214d256ba927b391f3c8e2354d91ccd69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

