### PR TITLE
domain-skills/figma: read file comments via the internal web API

### DIFF
--- a/domain-skills/figma/comments.md
+++ b/domain-skills/figma/comments.md
@@ -1,0 +1,64 @@
+# Figma — reading file comments
+
+Figma comments are invisible to the Plugin API — plugins cannot read them at
+all. The official REST endpoint (`api.figma.com/v1/files/:key/comments`) needs a
+personal access token and is metered. But the web app's own internal API serves
+the full comment set with nothing but the session cookies already in the
+browser.
+
+## The endpoint
+
+```
+GET https://www.figma.com/api/file/<FILE_KEY>/comments
+```
+
+Same-origin from any `www.figma.com` page, so call it with `js()` from
+wherever you already are:
+
+```python
+r = js("""
+const xhr = new XMLHttpRequest();
+xhr.open("GET", "/api/file/<FILE_KEY>/comments", false);
+xhr.send();
+const d = JSON.parse(xhr.responseText);
+const byId = {}; d.meta.forEach(c => byId[c.id] = c);
+return JSON.stringify(d.meta
+  .filter(c => !c.is_deleted)
+  .sort((a,b) => b.created_at.localeCompare(a.created_at))
+  .slice(0, 15)
+  .map(c => ({
+    at: c.created_at, who: c.user.handle, msg: c.message,
+    reply_to: c.parent_id ? (byId[c.parent_id]?.message ?? null) : null,
+    resolved: !!c.resolved_at
+  })), null, 1)
+""")
+```
+
+The file key is the middle segment of any share URL:
+`figma.com/design/<FILE_KEY>/<slug>`.
+
+## Response shape
+
+`{ meta: [...] }` — one flat array, every comment in the file (threads
+included). Useful fields per comment:
+
+- `message` — plain text; `message_meta` is the structured form
+- `user.handle` / `user.img_url` — author display name
+- `parent_id` — non-null on replies; join against `id` to rebuild threads
+- `created_at`, `resolved_at`, `is_deleted`
+- `client_meta` — the pin: node id + offset when anchored to a node
+- `thumbnail_url` — pre-rendered crop around the pin (`commentx`/`commenty`
+  query params carry the pin position)
+
+## Traps
+
+- `figma.com/design/<key>` URLs auto-launch the **desktop app** and leave the
+  tab on an interstitial ("Opened ... in Figma app" / "Open here instead").
+  No need to click through — the interstitial is on `www.figma.com`, so the
+  comments XHR works right there without ever loading the heavy editor.
+- `/api/comments?file_key=<key>` does **not** exist (404). The file-scoped path
+  above is the real one.
+- Don't wrap your expression in your own IIFE with an inner `return` — the
+  `js()` helper wraps anything containing `return ` in its own function, and a
+  self-wrapped IIFE gets double-wrapped into an expression whose outer wrapper
+  returns nothing. Write a bare top-level `return` and let the helper do it.


### PR DESCRIPTION
Figma comments are invisible to the Plugin API and metered behind a PAT on the REST API — but `www.figma.com/api/file/<key>/comments` serves the full threaded comment set with nothing but the session cookies already in the browser.

This documents:
- the endpoint and a working `js()` snippet (synchronous XHR, thread rebuild via `parent_id`)
- the response shape worth knowing (`message`, `user.handle`, `client_meta` pin, `thumbnail_url`)
- the desktop-app interstitial trap: `figma.com/design/<key>` auto-launches the app, but the leftover tab is same-origin so the XHR works without clicking "Open here instead"
- the `/api/comments?file_key=` 404 decoy
- the `js()` double-wrap trap (self-wrapped IIFE + inner `return` → helper wraps again → `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to read Figma file comments via the internal web API using existing session cookies. Adds `domain-skills/figma/comments.md` with the `https://www.figma.com/api/file/<FILE_KEY>/comments` endpoint, a working `js()` snippet, key response fields, and pitfalls (desktop-app interstitial, 404 decoy, `js()` double-wrap).

<sup>Written for commit 3657ddbc9854d76046ab41cf1c308f74624fe519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

