### PR TITLE
Add sharepoint domain skill: authenticated file downloads

### DIFF
--- a/domain-skills/sharepoint/download.md
+++ b/domain-skills/sharepoint/download.md
@@ -1,0 +1,37 @@
+# SharePoint / OneDrive file downloads
+
+Downloading actual file bytes from `*.sharepoint.com` document libraries.
+
+## What works
+
+Open a tab on the tenant origin first, then fetch in page context with cookies:
+
+```python
+import json, base64
+from urllib.parse import quote
+
+new_tab("https://<tenant>.sharepoint.com/sites/<Site>")
+wait_for_load()
+
+url = "https://<tenant>.sharepoint.com/sites/<Site>/Shared Documents/<path>/<file>.pdf"
+code = """(async () => {
+  const r = await fetch(%s, {credentials: 'include'});
+  if (!r.ok) return 'ERR:' + r.status;
+  const bytes = new Uint8Array(await r.arrayBuffer());
+  let bin = '';
+  for (let i = 0; i < bytes.length; i += 0x8000)
+    bin += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000));
+  return btoa(bin);
+})()""" % json.dumps(quote(url, safe=":/"))
+data = base64.b64decode(js(code))
+```
+
+- The direct file `webUrl` under `/Shared Documents/` returns the binary when authenticated — no need for `?download=1` or the `download.aspx` route.
+- `quote(url, safe=":/")` the URL: library paths contain spaces.
+- Works for multi-MB files; base64 marshals fine through `js()`. Verify with the magic bytes (`%PDF-`, `PK`, ...).
+- Personal OneDrive (`<tenant>-my.sharepoint.com`) is a different origin — open a tab there before fetching its files.
+
+## Traps
+
+- `http_get()` fails: SharePoint needs session cookies, which pure HTTP doesn't carry.
+- The Microsoft Graph / ms365 MCP `read_resource` on a `file:///` URI returns *extracted text*, not bytes, and its search results carry `downloadUrl: null`. Don't burn time there if you need the real file.


### PR DESCRIPTION
Field-tested pattern for pulling real file bytes out of SharePoint/OneDrive document libraries: open a tab on the tenant origin, page-context fetch with credentials, base64 back through js(). Documents the traps (http_get has no cookies; Graph/ms365 MCP read_resource returns extracted text, never bytes; personal OneDrive is a separate origin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SharePoint/OneDrive domain skill for authenticated file downloads. Documents a tested way to fetch real binary bytes from document libraries using an in-page, cookie-carrying request.

- **New Features**
  - Guide added at `domain-skills/sharepoint/download.md` with a step-by-step snippet: open the tenant tab, `fetch(..., { credentials: 'include' })`, marshal via `js()`, decode to bytes.
  - Covers quoting URLs with spaces, verifying magic bytes, and handling multi‑MB files.
  - Notes personal OneDrive’s separate origin (`<tenant>-my.sharepoint.com`) and pitfalls: `http_get()` has no cookies; Graph/ms365 MCP `read_resource` returns extracted text, not bytes.

<sup>Written for commit dc508b860523161a4625707101f7e9702d27e76f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

