### PR TITLE
Add BH_NO_FOCUS so tab operations don't raise the browser window

### DIFF
--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -14,6 +14,13 @@ print(current_tab())
 print(page_info())
 ```
 
+With `BH_NO_FOCUS=1`, `new_tab()` creates tabs in the background and `switch_tab()`
+skips `Target.activateTarget` — nothing raises the browser window, so a run never steals
+focus from the terminal (on macOS activating a target activates the whole application).
+The harness still attaches to and drives the tab; it just isn't the visibly-selected one,
+so the explicit `cdp("Target.activateTarget", ...)` above is how you show a tab on
+purpose. Pass `switch_tab(tid, activate=True)` to force it per call.
+
 What CDP is good at:
 - attach to a tab
 - open a tab

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -385,7 +385,12 @@ class Daemon:
                 take_over = inspect_tabs[0]["targetId"]
         if not pages:
             # No usable pages - create one instead of attaching to omnibox popup.
-            tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+            # background under BH_NO_FOCUS so the bootstrap tab doesn't raise the
+            # window (mirrors helpers._no_focus(); the daemon can't import helpers).
+            tid = (await self.cdp.send_raw("Target.createTarget", {
+                "url": "about:blank",
+                "background": os.environ.get("BH_NO_FOCUS") == "1",
+            }))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
         self.session = (await self.cdp.send_raw(

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -255,6 +255,19 @@ def capture_screenshot(path=None, full=False, max_dim=None):
 
 
 # --- tabs ---
+def _no_focus():
+    """BH_NO_FOCUS=1: never let a tab operation raise the browser window.
+
+    Opening or switching tabs normally calls Target.activateTarget, which on
+    macOS activates the whole application -- so every new_tab() steals keyboard
+    focus from the terminal driving the run. With this set, tabs are created in
+    the background and activation is skipped; the harness still attaches to and
+    drives the right tab, it just isn't the visibly-selected one. Use
+    cdp("Target.activateTarget", targetId=tid) to show a tab on purpose.
+    """
+    return os.environ.get("BH_NO_FOCUS") == "1"
+
+
 def _is_agent_startup_placeholder(title, url):
     url = str(url or "")
     return str(title or "").startswith("Starting agent ") and (
@@ -291,7 +304,7 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
-def switch_tab(target):
+def switch_tab(target, activate=None):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
     target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
@@ -299,7 +312,12 @@ def switch_tab(target):
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    # Attaching is what actually drives the tab; activating only makes it the
+    # visible one -- and raises the window with it. See _no_focus().
+    if activate is None:
+        activate = not _no_focus()
+    if activate:
+        cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
@@ -323,7 +341,7 @@ def new_tab(url="about:blank"):
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
+    tid = cdp("Target.createTarget", url="about:blank", background=_no_focus())["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)


### PR DESCRIPTION
## Problem

`Target.activateTarget` activates the whole application on macOS, not just the window. `switch_tab()` calls it unconditionally and `new_tab()` calls `switch_tab()`, so **every tab the harness opens steals keyboard focus** from the terminal driving the run. For long agent runs on a desktop that makes the machine unusable — you get yanked out of whatever you were typing every few seconds.

## Change

Opt-in `BH_NO_FOCUS=1`:

- `new_tab()` passes `background=True` to `Target.createTarget`
- `switch_tab()` skips `Target.activateTarget`
- the daemon's bootstrap `Target.createTarget` is backgrounded too

The harness still attaches to and drives the right tab — activation only controls which tab is *visibly* selected. `switch_tab(tid, activate=True)` and an explicit `cdp("Target.activateTarget", targetId=tid)` remain the way to show a tab on purpose; `interaction-skills/tabs.md` is updated to say so.

**Default behaviour is unchanged** when the variable is unset.

## Notes

Pairs well with launching Chrome via `open -g` on macOS, plus `--disable-backgrounding-occluded-windows --disable-renderer-backgrounding --disable-background-timer-throttling` — without those an occluded window stops producing frames and throttles timers.

## Verification

macOS 26.5, Chrome 151, dedicated automation profile:

- three `new_tab()` calls plus a `switch_tab()` with `BH_NO_FOCUS=1` — frontmost app never changed; with `BH_NO_FOCUS=0` it changed to Chrome as before
- `capture_screenshot()` on a never-activated tab renders the page correctly (not blank)
- `setInterval(…, 10)` on a never-activated tab: 300 ticks in 3s, i.e. unthrottled
- same tab sequence A/B'd with the variable set and unset produced identical results
- `pytest tests/unit` — 97 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-in BH_NO_FOCUS=1 mode to stop tab operations from raising the Chrome window, so long runs don’t steal focus from the terminal on macOS. Tabs open in the background and activation is skipped; default behavior is unchanged.

- **New Features**
  - `new_tab()` uses `Target.createTarget` with `background=True` when BH_NO_FOCUS=1.
  - `switch_tab(target, activate=None)` skips `Target.activateTarget` by default when BH_NO_FOCUS=1; use `switch_tab(tid, activate=True)` or `cdp("Target.activateTarget", ...)` to show a tab.
  - Daemon bootstrap tab creation passes `background` under BH_NO_FOCUS.
  - Updated docs in interaction-skills/tabs.md.

<sup>Written for commit 9f50d2e560059eb0cea32cc28ee3fad562a01c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

