### PR TITLE
helpers: reject scroll(direction, amount) with a message that names the fix

### DIFF
--- a/interaction-skills/scrolling.md
+++ b/interaction-skills/scrolling.md
@@ -1,3 +1,98 @@
 # Scrolling
 
 Separate page scroll, nested containers, virtualized lists, and dropdown menus, and identify which element is actually consuming wheel events before scrolling.
+
+## The signature is (x, y, dy, dx): position first, movement second
+
+```python
+scroll(640, 400, dy=1400)    # down 1400px, wheel positioned at x=640 y=400
+scroll(640, 400, dy=-1400)   # up
+```
+
+`x` and `y` say *where the pointer is*, not which way to go. That matters because
+the element under the pointer is the one that receives the wheel event, which is
+how you aim at a specific pane (see nested containers below).
+
+This is not the `scroll(direction, amount)` convention most browser tools use,
+and reaching for that convention out of habit is the easy mistake:
+
+```python
+scroll("down", 1400)   # wrong
+```
+
+That binds `x="down"`, `y=1400`, and leaves `dy` at its **default of -300**, so
+the intent (down 1400) becomes up 300. There are two errors there and the second
+one survives fixing the first: someone who sees the failure, guesses that the
+numbers are wrong, and writes `scroll(0, 1400)` still scrolls up 300.
+
+CDP does reject the string, but the message points at the wrong thing:
+
+```
+Failed to deserialize params.x - BINDINGS: double value expected at position 26
+```
+
+That names a byte offset in the serialized payload and says nothing about `dy`.
+`scroll()` now raises `TypeError` on a non-numeric `x` or `y` and names the
+correct call instead.
+
+## Debugging a scroll that did not move
+
+Read the position back rather than trusting the call. A wheel event can
+legitimately do nothing: already at the end, the page not laid out yet, or some
+other element consuming the wheel.
+
+```python
+before = page_info()["sy"]
+scroll(640, 400, dy=1400)
+print(before, "->", page_info()["sy"])
+```
+
+## The window did not move but the page clearly scrolls
+
+The page is scrolling an inner container. Position the wheel over that container
+rather than over the page background:
+
+```python
+box = js("""(()=>{const e=document.querySelector('SELECTOR');
+  const r=e.getBoundingClientRect();
+  return JSON.stringify({x:r.left+r.width/2, y:r.top+r.height/2});})()""")
+import json; c = json.loads(box)
+scroll(c["x"], c["y"], dy=1400)
+```
+
+If the container still does not take the wheel, drive it directly and skip the
+event entirely:
+
+```python
+js("document.querySelector('SELECTOR').scrollTop += 1400")
+```
+
+## Virtualized feeds drop what you scrolled past
+
+Infinite feeds (social timelines, long search results, big tables) unmount rows
+once they leave the viewport. A single extraction after the scroll loop returns
+only what is near the viewport at that moment, not everything you scrolled
+through, and it looks like a short page rather than a bug.
+
+Collect **inside** the loop, at every step, and de-duplicate afterwards.
+
+```python
+seen, rows = set(), []
+for _ in range(8):
+    for r in js("...extract currently-rendered rows..."):
+        if r not in seen:
+            seen.add(r); rows.append(r)
+    scroll(640, 400, dy=1400)
+    wait_for_network_idle()
+```
+
+This applies to links as much as to text: `a[href]` on a virtualized feed
+returns only the currently-rendered subset, so harvesting permalinks needs the
+same per-step collection as harvesting content.
+
+Two more things that bite here:
+
+- **Some sites restore your previous scroll position on load.** Force
+  `js("window.scrollTo(0,0)")` before the loop so step one starts at the top.
+- **Lazy content needs a beat to arrive.** `wait_for_network_idle()` between
+  steps beats a fixed sleep, and both beat scrolling straight to the bottom.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -235,6 +235,19 @@ def press_key(key, modifiers=0):
     cdp("Input.dispatchKeyEvent", type="keyUp", **base)
 
 def scroll(x, y, dy=-300, dx=0):
+    # (x, y) is a viewport POSITION and the movement is dy/dx. That is not the
+    # scroll(direction, amount) convention most browser tools use, so the wrong
+    # call is easy to make: scroll("down", 1400) binds x="down", y=1400 and
+    # leaves dy at its default of -300, turning "down 1400" into up 300.
+    # CDP does reject the string, but as "Failed to deserialize params.x -
+    # BINDINGS: double value expected at position 26", which names a byte
+    # offset rather than the mistake and says nothing about dy having defaulted.
+    if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+        raise TypeError(
+            "scroll(x, y, dy=-300, dx=0) takes a viewport position first, not a "
+            "direction. To scroll down 1400px from mid-viewport: "
+            "scroll(640, 400, dy=1400). Negative dy scrolls up."
+        )
     cdp("Input.dispatchMouseEvent", type="mouseWheel", x=x, y=y, deltaX=dx, deltaY=dy)
 
 


### PR DESCRIPTION
## The problem

`scroll()` is `(x, y, dy, dx)`: a viewport position first, then the movement. Most browser tools use `scroll(direction, amount)`, so the wrong call is an easy one to reach for out of habit:

```python
scroll("down", 1400)
```

That binds `x="down"`, `y=1400`, and leaves `dy` at its **default of -300**, so the intent (down 1400) becomes up 300.

There are two errors there, and the second one survives fixing the first. Someone who hits the failure, assumes the numbers are wrong, and writes `scroll(0, 1400)` still scrolls up 300.

CDP does reject the string today, but the message points somewhere else:

```
Failed to deserialize params.x - BINDINGS: double value expected at position 26
```

That names a byte offset in the serialized payload rather than the mistake, and says nothing about `dy` having defaulted.

## The change

`scroll()` raises `TypeError` on a non-numeric `x` or `y`, naming the correct call:

```
scroll(x, y, dy=-300, dx=0) takes a viewport position first, not a direction.
To scroll down 1400px from mid-viewport: scroll(640, 400, dy=1400).
Negative dy scrolls up.
```

Valid calls are untouched, including the `-300` default. Verified: numeric calls still reach `Input.dispatchMouseEvent` with the same params, `scroll(640, 400)` still sends `deltaY=-300`, and both `scroll("down", 1400)` and `scroll(0, "x")` now raise.

## Docs

`interaction-skills/scrolling.md` was a one-line stub. It now covers:

- the argument order, and why `x`/`y` is a position (it decides which element receives the wheel, which is how you aim at a pane)
- this trap
- reading the position back to debug a scroll that did nothing
- aiming the wheel at a nested container, or driving `scrollTop` directly when it will not take the event
- virtualized feeds: collect inside the loop, because a single extraction afterwards returns only the last screen and looks like a short page rather than a bug

## Notes

Found while writing a feed-scraping loop. Happy to drop the docs commit if you would rather keep `interaction-skills/` stubs as they are, or to make the guard a warning instead of a raise if `TypeError` is too strict for a helper this low-level.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an argument guard to `scroll(x, y, dy, dx)` to catch mistaken `scroll("direction", amount)` calls and show a clear fix. Expanded scrolling docs cover argument order, debugging no-op scrolls, nested containers, and virtualized feeds.

- **Bug Fixes**
  - `scroll()` now raises `TypeError` when `x` or `y` is non-numeric, with a message that shows the correct call (e.g., `scroll(640, 400, dy=1400)`).
  - Keeps existing behavior for valid calls; `dy` default of `-300` and CDP params are unchanged.
  - Replaces the confusing CDP error with an actionable message.

- **Migration**
  - Replace calls like `scroll("down", 1400)` with `scroll(x, y, dy=1400)` using a viewport position for `x`/`y`.

<sup>Written for commit 73edfd1f0cfd5f7bce8d5055ffbf53bec2bb47a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

