### PR TITLE
Add domain-skills/epson: Linux driver downloads

### DIFF
--- a/domain-skills/epson/downloads.md
+++ b/domain-skills/epson/downloads.md
@@ -1,0 +1,128 @@
+# Epson — Linux Driver Downloads
+
+Epson's driver hosts are **geo-fenced, not bot-fenced**. This is the single most
+expensive thing to rediscover: driving a real browser at them does **not** help,
+so don't reach for the harness first. Get the metadata from a third-party mirror
+(below), and have a human on a US route fetch the binary.
+
+## The block
+
+Verified August 2026 from a Canadian IP, with both `curl` and a real (headless)
+Chromium — identical result, which is what proves it is geography and not
+fingerprinting:
+
+| Host | Result |
+|---|---|
+| `download-center.epson.com` | HTTP 403, Akamai "Access Denied" |
+| `download.ebz.epson.net` | HTTP 403, Akamai "Access Denied" |
+| `support.epson.net` | HTTP 403, Akamai "Access Denied" |
+| `epson.ca` (and other regional sites) | loads normally |
+
+Those first three are Epson **America**. Regional sites are served fine — so a
+403 here means "wrong country", not "you look like a robot".
+
+Two traps in the error itself:
+
+- The denial body echoes the URL back as `http://…` even for an HTTPS request.
+  That is Akamai's template, not a protocol downgrade. Don't chase it.
+- It returns 403 (not 451 or a redirect), which reads like a WAF/bot rule and
+  baits you into UA spoofing, referer headers, and browser automation. None of
+  it works.
+
+To confirm a block is geographic rather than bot-driven, fetch the same path
+twice — once with `http_get`, once through a real browser context. Same status
+from both ⇒ geography. Stop escalating.
+
+## Regional sites don't expose driver files
+
+`epson.ca` (pattern: `/Support/Printers/All-In-Ones/ET-Series/Epson-<MODEL>/s/<SKU>`)
+does carry a Linux section, and it is a dead end for automation:
+
+- OS chooser is `select#review-filter`; setting `.value` + firing `change` is not
+  enough, a sibling **GO** button must be clicked.
+- It then navigates to `?review-filter=Linux` and renders a "Linux Drivers"
+  heading.
+- Every link in that section is an `href="…#"` accordion toggle. Expanding them
+  yields **no** file URLs — the downloads themselves still live on the blocked
+  America hosts.
+
+Budget zero time here.
+
+## Where the real metadata lives
+
+A Gentoo overlay mirrors everything you need *except* the binary:
+`gitlab.com/at.gentoo.repo/epson-inkjet-printer-escpr2` (GitLab is not blocked).
+
+```python
+from helpers import http_get
+BASE = "https://gitlab.com/at.gentoo.repo/epson-inkjet-printer-escpr2/-/raw/master"
+
+# 1. Is this model supported at all?  (282 entries as of 1.2.39)
+models = http_get(f"{BASE}/SUPPORTED-PRINTERS")
+assert "Epson ET-4950 Series" in models
+
+# 2. Available versions + checksums to verify a download you didn't make yourself
+manifest = http_get(f"{BASE}/net-print/epson-inkjet-printer-escpr2-bin/Manifest")
+# DIST epson-inkjet-printer-escpr2-1.2.39-1.x86_64.rpm 5014785 BLAKE2B … SHA512 …
+```
+
+List the tree via the API (note the URL-encoded project path):
+
+```
+https://gitlab.com/api/v4/projects/at.gentoo.repo%2Fepson-inkjet-printer-escpr2/repository/tree?recursive=true&per_page=100
+```
+
+### The canonical download URL
+
+Each ebuild carries a per-version `DL_UUID`:
+
+```
+https://download-center.epson.com/f/module/${DL_UUID}/epson-inkjet-printer-escpr2-${VER}-1.x86_64.rpm
+```
+
+`DL_UUID` changes with every release, so read it from that version's ebuild —
+never reuse one. For 1.2.39 it is `89853441-b79f-4d67-a3b5-83eca1254b9f`.
+
+Epson publishes a Debian build of the same version too, which the overlay does
+not track: `epson-inkjet-printer-escpr2_${VER}-1_amd64.deb`. The Manifest's
+SHA512 covers the **rpm only** — it will not match the deb. Verify a deb by its
+control metadata instead (`Maintainer: Seiko Epson Corporation`) plus the
+expected payload under `/opt/epson-inkjet-printer-escpr2/`.
+
+## escpr vs escpr2 — check before you download
+
+Two different drivers, and the distro one is old:
+
+- `printer-driver-escpr` — in Debian/Ubuntu repos (1.8.7). Covers older models
+  only. **No ET-4950.**
+- `epson-inkjet-printer-escpr2` — Epson's own, not in any distro repo. Covers
+  current models.
+
+Enumerate what v1 actually supports without installing it:
+
+```bash
+apt-get download printer-driver-escpr        # no root needed
+dpkg-deb -x printer-driver-escpr_*.deb escpr/
+escpr/usr/lib/cups/driver/escpr list | grep -oiE "ET-[0-9]+" | sort -u
+```
+
+## After you have it: PPD vocabulary
+
+escpr2 PPDs do not use IPP/driverless names, which breaks any code matching on
+`PhotographicSemiGloss` / `cupsPrintQuality` / `ColorModel`:
+
+| Intent | driverless PPD | escpr2 PPD |
+|---|---|---|
+| borderless size | `5x7.Borderless` | `T2L` (`T` prefix = borderless) |
+| semi-gloss photo | `MediaType=PhotographicSemiGloss` | `MediaType=PSGLOS_HIGH` |
+| high quality | `cupsPrintQuality=High` | folded into the `MediaType` choice |
+| colour | `ColorModel=RGB` | `Ink=COLOR` |
+
+Borderless page sizes are `T`-prefixed throughout (`T2L`, `TLetter`,
+`T4X6FULL`, `TPostcard`). Match on intent, not keywords.
+
+Also worth knowing: in **both** PPD families the borderless `ImageableArea`
+equals `PaperDimension` exactly — no over-spray is declared anywhere. escpr2
+performs the borderless expansion inside the `epson-escpr2` filter when it emits
+ESC/P-R, so the CUPS raster still measures exactly the sheet. You cannot verify
+expansion by reading the PPD or the raster; only a print shows it.


### PR DESCRIPTION
Epson's driver hosts return Akamai `403 Access Denied` to non-US IPs:

| Host | Result |
|---|---|
| `download-center.epson.com` | 403 |
| `download.ebz.epson.net` | 403 |
| `support.epson.net` | 403 |
| `epson.ca` (regional sites) | loads fine |

The failure mode reads exactly like bot detection — a 403 with an Akamai reference number — so the natural move is to escalate into browser automation. That is the trap: a real Chromium gets blocked identically, because the block is **geographic**. Regional sites serve fine, which is what gives it away.

This skill documents:

- **How to tell geo-blocking from bot-blocking in one check** — fetch the same path with `http_get` and through a real browser context; same status from both means stop escalating.
- **Two traps in the error itself** — the denial body echoes `http://` even for HTTPS requests (Akamai template, not a protocol downgrade), and the 403 status baits UA spoofing and referer headers that cannot work.
- **Why the regional sites are a dead end** — `epson.ca` has a Linux section, but the OS chooser needs a GO click and every link in it is an `href="…#"` accordion that never yields a file URL.
- **Where the metadata actually lives** — a Gentoo overlay on GitLab (not blocked) carries the supported-model list, versions, SHA512s, and the per-version download UUID that forms the canonical URL.
- **escpr vs escpr2** — the Debian/Ubuntu `printer-driver-escpr` package is v1 and covers older models only; includes a no-root way to enumerate what it supports before downloading.
- **escpr2 PPD vocabulary** — borderless sizes are `T`-prefixed (`T2L`, `TLetter`), quality is folded into `MediaType` (`PSGLOS_HIGH`), and colour is `Ink=COLOR`, so nothing matching on the IPP/driverless option names will work.

Found while getting an ET-4950 to print true borderless on Ubuntu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Epson Linux driver downloads guide that explains the US-only Akamai 403 block, where to get safe metadata, and how to choose/configure the right driver. This unblocks non‑US setups and avoids wasting time on browser automation.

- **New Features**
  - Added `domain-skills/epson/downloads.md` with a clear flow for obtaining Epson Linux drivers.
  - One-check method to differentiate geo-blocking from bot-blocking (same 403 via `http_get` and real browser).
  - Notes that regional sites don’t expose file URLs and aren’t automatable for downloads.
  - Uses a Gentoo overlay on GitLab to get supported models, versions, SHA512s, and per-version `DL_UUID` for the canonical URL.
  - Explains `escpr` vs `escpr2`, how to list `escpr` support without root, and key escpr2 PPD options (borderless `T*`, `MediaType=PSGLOS_HIGH`, `Ink=COLOR`).

<sup>Written for commit e8e94a3c33da4e86dba5604575021ad1c82f8775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

