### PR TITLE
Add Mighty Networks (mn.co) domain skill: reading community feeds

### DIFF
--- a/domain-skills/mighty-networks/reading-feeds.md
+++ b/domain-skills/mighty-networks/reading-feeds.md
@@ -1,0 +1,37 @@
+# Mighty Networks (*.mn.co) — reading community feeds
+
+Applies to any Mighty Networks community on `<community>.mn.co` (or a custom domain running Mighty).
+
+## No usable API
+
+- The feed is server-rendered and hydrates without JSON XHR — `performance.getEntriesByType('resource')` shows no data fetches after load.
+- Guessing REST paths fails: `/api/web/v1|v2/...`, `/api/v2/...`, `/api/mobile/v2/...` all return 404 JSON. Scrape the DOM.
+
+## URL patterns
+
+- `/feed` — the logged-in member's personal feed (aggregates followed spaces).
+- `/spaces/<id>/feed` — a space's feed. Spaces have three types and the server redirects to the real one:
+  - discussion space → stays on `/feed` (has `li.feed-item` cards)
+  - chat space → redirects to `/spaces/<id>/chat` (message list, no feed items)
+  - static page space → redirects to `/spaces/<id>/page` (no posts at all)
+  A space returning zero `li.feed-item` is not necessarily empty — check `location.href` for `/chat` or `/page`.
+- `/posts/<id>` — post permalink; `/posts/<id>/comments` — its comments.
+- Not logged in → redirect to `/landing`. Detect this instead of scraping a sign-in page.
+
+## Stable selectors (feed)
+
+Each post card is `li.feed-item`:
+
+- `.feed-attribution-container` — author name + space + post age ("2w ago" = when the post was **created**)
+- `.feed-item-story` — activity line ("X reacted to this 1w ago") = why it's ranked here; null if no recent activity
+- `.feed-item-post-description` — body snippet (also `.feed-item-post` for the title link text)
+- `a[href*="/posts/"]` — permalink
+- `a[href$="/comments"]` — comments link
+
+Default feed sort is **last activity**, so post age (attribution) and activity age (story) differ — use attribution for "how old is this post".
+
+Sidebar space list: `a[href*="/spaces/"]` (dedupe — links repeat inside feed cards).
+
+## Chat spaces
+
+The chat view loads near the bottom but the newest messages can still be below the fold — scroll down (`scroll(x, y, dy=800)` a few times) before concluding what the latest message is. Date separators ("Fri, Jul 24") are plain text rows between messages.


### PR DESCRIPTION
Field-tested notes from scanning a Mighty Networks community read-only:

- No usable JSON API (server-rendered; common /api/* guesses 404) — DOM scraping is the path
- URL patterns incl. the three space types (discussion/chat/page) and their redirects, plus the /landing login-wall redirect
- Stable feed selectors (li.feed-item and children), and the post-age vs activity-age distinction under the default last-activity sort
- Chat spaces: newest messages can sit below the fold; scroll before concluding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a domain skill guide for reading Mighty Networks community feeds on `*.mn.co`. It explains how to extract posts via DOM scraping and handle space types, redirects, and chat quirks.

- New Features
  - Documents the lack of a usable JSON API and the need to scrape the server-rendered DOM.
  - Maps key URLs: `/feed`, `/spaces/<id>/{feed|chat|page}`, `/posts/<id>`, `/posts/<id>/comments`, and `/landing` for login-wall redirects.
  - Lists stable selectors: `li.feed-item`, attribution vs activity timestamps, post and comments links, and sidebar space links (with dedupe).
  - Notes chat specifics: newest messages may sit below the fold; scroll to capture latest; date separators are plain text rows.

<sup>Written for commit a2688d13de0a619fc473432959b48c80993d3607. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

