### PR TITLE
fix(daemon): pin stale-session recovery to the original target

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -95,6 +95,7 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Fall back to raw HTML via `js(...)` only when the AX tree lacks the element (canvas, exotic widgets); screenshot when layout or imagery matters.
 - After navigation, call `wait_for_load()`.
 - If the current tab is stale or internal, call `ensure_real_tab()`.
+- Stale sessions re-attach to the SAME tab only. If that tab is gone, calls fail with an error instead of silently attaching to whatever tab is frontmost — dispatching a replayed click into an unrelated tab (possibly a different app the user switched to) is worse than failing. Re-anchor explicitly with `list_tabs()` + `switch_tab()`.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -573,9 +573,27 @@ class Daemon:
         except Exception as e:
             msg = str(e)
             if "Session with given id not found" in msg and sid == self.session and sid:
-                log(f"stale session {sid}, re-attaching")
-                if await self.attach_first_page():
+                # Re-attach ONLY to the target we were pinned to. Falling over to
+                # attach_first_page() here grabs whatever tab is frontmost and
+                # replays the pending command into it — if the user moved to a
+                # different window mid-script, that replays clicks/keys into an
+                # unrelated app (observed: a click meant for a PBX admin page
+                # landed in a production EHR tab). Same-target re-attach keeps
+                # the replay safe; a vanished target must fail loudly instead.
+                try:
+                    self.session = (await self.cdp.send_raw(
+                        "Target.attachToTarget", {"targetId": self.target_id, "flatten": True}
+                    ))["sessionId"]
+                    await self._enable_default_domains(self.session)
+                    log(f"stale session, re-attached to same target {self.target_id}")
                     return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
+                except Exception as e2:
+                    log(f"stale session and target {self.target_id} unavailable: {e2}")
+                    return {"error": (
+                        f"stale session and original target {self.target_id} is gone: {e2}. "
+                        "Not attaching to another tab automatically — re-anchor explicitly "
+                        "with list_tabs() + switch_tab(), or ensure_real_tab()."
+                    )}
             return {"error": msg}
 
 


### PR DESCRIPTION
When a CDP session goes stale mid-script, the daemon currently re-attaches via `attach_first_page()` and replays the pending command into whatever tab is frontmost. If the user switched windows while a script was running (or sleeping), the replayed input lands in an unrelated tab — in our case a click meant for a PBX admin page was dispatched into a production EHR calendar. The command replay makes this worse than a plain misfire: the daemon actively re-targets user input at a tab the script never selected.

This PR pins recovery to the original target:

- On `Session with given id not found`, re-attach to `self.target_id` (the tab the session was pinned to) and replay there — same tab, fresh session, safe.
- If that target no longer exists, return a loud error instructing the caller to re-anchor explicitly (`list_tabs()` + `switch_tab()`, or `ensure_real_tab()`) instead of silently adopting another tab.
- SKILL.md updated to document the behavior.

Field-tested locally (reinstalled the tool from source and exercised list_tabs/page_info/navigation against a 40-tab Chrome).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents replaying commands into the wrong tab after a stale CDP session by reattaching only to the original target. If that tab is gone, the daemon now fails loudly instead of attaching to the frontmost tab.

- **Bug Fixes**
  - On `Session with given id not found`, reattach to the saved `target_id` and replay there.
  - If the original target is missing, return an error instead of attaching elsewhere. Documented in `SKILL.md`.

- **Migration**
  - When you see the new stale-session error, re-anchor with `list_tabs()` + `switch_tab()`, or call `ensure_real_tab()`.

<sup>Written for commit c288748854514efbac1063308f30160b6fbc951e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

