### PR TITLE
docs: add GA4 key-event audit workflow

### DIFF
--- a/domain-skills/google-analytics/key-event-audit.md
+++ b/domain-skills/google-analytics/key-event-audit.md
@@ -1,0 +1,61 @@
+# Google Analytics 4 key-event audit
+
+Use the current GA4 Admin state and a short Data API report together when
+checking whether reported "key events" are genuine business outcomes.
+
+## Open the authoritative Admin view
+
+The stable property route is:
+
+```text
+https://analytics.google.com/analytics/web/#/a{account_id}p{property_id}/admin/events/hub
+```
+
+Including both the account and property IDs matters. Property-only admin URLs
+can redirect to Analytics Home instead of the requested settings page.
+
+The Events hub lists the events currently marked as key events and whether each
+has received stream data in the last 28 days. In the DOM, the Admin card links
+are anchors such as `a.admin-events`; report-card links such as "View events"
+may be buttons without an `href`, so click the matching element rather than
+trying to copy a URL from it.
+
+## Do not equate key events with completed conversions
+
+The Data API metric `keyEvents`, segmented by `eventName`, can contain counts
+for an event that was marked as a key event earlier in the requested period but
+is no longer marked in Admin. A 28- or 30-day report can therefore disagree
+with the current Events hub without either surface being broken.
+
+For a current-state audit:
+
+1. Record the key-event list from `/admin/events/hub`.
+2. Query a short recent range (for example, the last seven complete days) with
+   `eventName`, `eventCount`, and `keyEvents`.
+3. Treat starts, previews, page views, and funnel steps as diagnostic events,
+   not completed leads, unless the business explicitly defines them otherwise.
+4. Cross-check any GA4 event imported into Google Ads. In Google Ads, inspect
+   `conversion_action.primary_for_goal`,
+   `conversion_action.include_in_conversions_metric`, and
+   `conversion_action.counting_type`, plus the campaign bidding strategy.
+
+This catches the risky combination where a campaign uses Maximize Conversions
+while an intermediate funnel event is a primary conversion. The UI may show
+strong conversion volume even though no final form submission, purchase, or
+qualified offline outcome was recorded.
+
+## Useful read-only Data API request
+
+Call `properties/{property_id}:runReport` with:
+
+```json
+{
+  "dateRanges": [{"startDate": "7daysAgo", "endDate": "yesterday"}],
+  "dimensions": [{"name": "eventName"}],
+  "metrics": [{"name": "eventCount"}, {"name": "keyEvents"}],
+  "orderBys": [{"metric": {"metricName": "eventCount"}, "desc": true}]
+}
+```
+
+Use aggregate output only, and never print service-account keys or access
+tokens while testing access.

--- a/domain-skills/google-business-profile/basic-api-access.md
+++ b/domain-skills/google-business-profile/basic-api-access.md
@@ -1,0 +1,33 @@
+# Google Business Profile Basic API Access workflow
+
+## Prerequisites
+
+The Cloud-side API toggle alone is not enough. Before applying, confirm:
+
+- the signed-in Google identity is an owner or manager of the Business Profile;
+- the selected profile is verified and has been active for at least 60 days;
+- the business has a public website;
+- you have the numeric Google Cloud project number, not only the project ID.
+
+If the Business Profile Performance API quota page shows zero requests per minute, the project still needs Basic API Access approval.
+
+## Application path
+
+Open the official support workflow:
+
+`https://support.google.com/business/workflow/16726127`
+
+The current flow is:
+
+1. Confirm the signed-in owner/manager identity.
+2. Select the verified Business Profile from the table. The row uses a custom radio control; clicking the visible row may not select it, but clicking the nested `input.scSharedMaterialradionative-control` does.
+3. Enter the numeric Cloud project number and public company website.
+4. Describe how the form was found and the first-party reason for access.
+5. Continue to submit the allowlist request.
+
+The completion page returns a support case ID and an estimated review window. Save that non-secret case ID in the project runbook so future runs do not submit a duplicate application.
+
+## Important boundary
+
+Approval grants quota to the project; it does not replace user OAuth. Business Profile APIs require user authorization (normally the `business.manage` scope) for the Google identity that manages the listing. Do not try to use a service account as a substitute for the profile owner/manager.
+

--- a/domain-skills/google-merchant-center/service-account-api-access.md
+++ b/domain-skills/google-merchant-center/service-account-api-access.md
@@ -1,0 +1,59 @@
+# Merchant Center service-account API access
+
+## What is non-obvious
+
+Enabling the Merchant API in Google Cloud and adding the service account as a Merchant Center user are both necessary, but the first API call can still fail with `401` until the Cloud project is registered to the Merchant Center account.
+
+## Reliable setup sequence
+
+1. Enable `merchantapi.googleapis.com` in the intended Google Cloud project.
+2. In Merchant Center, open **Settings → People and access** and add the service-account email.
+3. Give it the product roles needed by the use case. Reporting requires **Performance and insights**; account/product operations may need **Standard** or **Admin**.
+4. Authenticate as that service account with the `https://www.googleapis.com/auth/content` scope.
+5. Register the Cloud project once:
+
+```http
+POST https://merchantapi.googleapis.com/accounts/v1/accounts/{ACCOUNT_ID}/developerRegistration:registerGcp
+Content-Type: application/json
+
+{"developerEmail":"owner-or-developer@example.com"}
+```
+
+6. Allow several minutes for registration to propagate, then retry the read canary:
+
+```http
+GET https://merchantapi.googleapis.com/accounts/v1/accounts/{ACCOUNT_ID}
+```
+
+## Useful read canaries
+
+Processed products and their item-level issues:
+
+```http
+GET https://merchantapi.googleapis.com/products/v1/accounts/{ACCOUNT_ID}/products?pageSize=1000
+```
+
+Aggregated product eligibility and issue counts:
+
+```http
+GET https://merchantapi.googleapis.com/issueresolution/v1/accounts/{ACCOUNT_ID}/aggregateProductStatuses?pageSize=100
+```
+
+Product performance uses the Reports sub-API and MCQL:
+
+```http
+POST https://merchantapi.googleapis.com/reports/v1/accounts/{ACCOUNT_ID}/reports:search
+Content-Type: application/json
+
+{
+  "query": "SELECT impressions, clicks, click_through_rate FROM product_performance_view WHERE date DURING LAST_30_DAYS"
+}
+```
+
+## Operational cautions
+
+- The API may intermittently return `500`/`502`/`503`; retry bounded read calls with short backoff.
+- A successful account read does not prove product or reporting roles. Test the exact API family you intend to use.
+- Do not print service-account keys or access tokens in logs or screenshots.
+- Treat product writes, feed changes, shipping/return settings, and destination changes as production mutations; verify the exact account and product IDs first.
+


### PR DESCRIPTION
Adds a credential-free GA4 domain skill for auditing key-event quality. Documents the stable Admin Events route, the historical keyEvents/current Admin-state mismatch, and a read-only GA4 plus Google Ads cross-check that catches intermediate funnel events used as primary conversions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three domain-skill guides: a GA4 key‑event audit and access workflows for Google Business Profile and Merchant Center. These help prevent false conversion claims and reduce API setup failures.

- GA4 key‑event audit: use the stable Admin Events hub route with both account and property IDs; explain the `keyEvents` vs current Admin-state mismatch; run a short 7‑day `runReport` by `eventName` with `eventCount` and `keyEvents`; cross‑check Google Ads (`conversion_action.*` and bidding strategy); keep aggregate only and never expose tokens.
- Google Business Profile Basic API Access: list prerequisites (owner/manager, verified ≥60 days, public website, numeric project number); link to the official support workflow; note the table selection quirk; save the case ID; approval grants project quota only—user OAuth with `business.manage` is still required (service accounts won’t substitute).
- Merchant Center service‑account API access: enable `merchantapi.googleapis.com`, add the service account as a user with needed roles, authenticate with the content scope, then register the Cloud project via `developerRegistration:registerGcp`; include read canaries for accounts/products/reports; retry transient 5xx and avoid logging secrets; treat writes as production mutations.

<sup>Written for commit 92b145da8c1636ca52be262fbcc5ee9e71d53025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

