### PR TITLE
fix: open remote debugging in the running Chromium browser

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -814,8 +814,13 @@ def _chrome_running():
 _BROWSER_LAUNCH = (
     # (profile-dir fragment, macOS app name, POSIX commands, Windows `start` target)
     ("chrome canary", "Google Chrome Canary", ("google-chrome-canary",), "chrome"),
+    ("chrome beta", "Google Chrome Beta", ("google-chrome-beta",), "chrome"),
+    ("chrome dev", "Google Chrome Dev", ("google-chrome-unstable",), "chrome"),
     ("chromium", "Chromium", ("chromium", "chromium-browser"), "chromium"),
     ("chrome", "Google Chrome", ("google-chrome-stable", "google-chrome"), "chrome"),
+    ("edge beta", "Microsoft Edge Beta", ("microsoft-edge-beta",), "msedge"),
+    ("edge dev", "Microsoft Edge Dev", ("microsoft-edge-dev",), "msedge"),
+    ("edge canary", "Microsoft Edge Canary", ("microsoft-edge-canary",), "msedge"),
     ("edge", "Microsoft Edge", ("microsoft-edge", "microsoft-edge-stable"), "msedge"),
     ("brave", "Brave Browser", ("brave-browser", "brave"), "brave"),
     ("arc", "Arc", (), None),
@@ -903,13 +908,14 @@ def _open_chrome_inspect():
     import platform, shutil, subprocess, webbrowser
     if platform.system() == "Darwin":
         try:
-            running = subprocess.check_output(
+            process_output = subprocess.check_output(
                 ["ps", "-A", "-o", "comm="], text=True, errors="replace", timeout=5,
-            ).lower()
+            )
+            running = {Path(line.strip()).name.lower() for line in process_output.splitlines() if line.strip()}
         except Exception:
-            running = ""
+            running = set()
 
-        apps = [(mac_app, "edge" if frag == "edge" else "chrome") for frag, mac_app, _, _ in _BROWSER_LAUNCH]
+        apps = [(mac_app, "edge" if frag.startswith("edge") else "chrome") for frag, mac_app, _, _ in _BROWSER_LAUNCH]
         apps.sort(key=lambda spec: (spec[0].lower() not in running, spec[0] == "Google Chrome"))
         for app, scheme in apps:
             if not shutil.which("open"):

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -900,21 +900,39 @@ def _launch_browser():
 
 def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
-    import platform, subprocess, webbrowser
-    url = "chrome://inspect/#remote-debugging"
+    import platform, shutil, subprocess, webbrowser
     if platform.system() == "Darwin":
         try:
-            r = subprocess.run([
-                "osascript",
-                "-e", 'tell application "Google Chrome" to activate',
-                "-e", f'tell application "Google Chrome" to open location "{url}"',
-            ], timeout=5, check=False, capture_output=True)
-            if r.returncode == 0:
-                return True
+            running = subprocess.check_output(
+                ["ps", "-A", "-o", "comm="], text=True, errors="replace", timeout=5,
+            ).lower()
         except Exception:
-            pass
+            running = ""
+
+        apps = [(mac_app, "edge" if frag == "edge" else "chrome") for frag, mac_app, _, _ in _BROWSER_LAUNCH]
+        apps.sort(key=lambda spec: (spec[0].lower() not in running, spec[0] == "Google Chrome"))
+        for app, scheme in apps:
+            if not shutil.which("open"):
+                break
+            try:
+                installed = subprocess.run(
+                    ["open", "-Ra", app], timeout=5, check=False, capture_output=True,
+                )
+                if installed.returncode != 0:
+                    continue
+                opened = subprocess.run(
+                    ["open", "-a", app, f"{scheme}://inspect/#remote-debugging"],
+                    timeout=5,
+                    check=False,
+                    capture_output=True,
+                )
+                if opened.returncode == 0:
+                    return True
+            except (OSError, subprocess.SubprocessError):
+                continue
+        return False
     try:
-        return bool(webbrowser.open(url, new=2))
+        return bool(webbrowser.open("chrome://inspect/#remote-debugging", new=2))
     except Exception:
         return False
 

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -803,10 +803,11 @@ def _chrome_running():
         if system == "Windows":
             out = subprocess.check_output(["tasklist"], text=True, errors="replace", timeout=5)
             names = ("chrome.exe", "msedge.exe", "helium.exe")
-        else:
-            out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, errors="replace", timeout=5)
-            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium")
-        return any(n.lower() in out.lower() for n in names)
+            return any(n.lower() in out.lower() for n in names)
+        out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, errors="replace", timeout=5)
+        running = {Path(line.strip()).name.lower() for line in out.splitlines() if line.strip()}
+        names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium")
+        return any(n.lower() in running for n in names)
     except Exception:
         return False
 
@@ -903,6 +904,42 @@ def _launch_browser():
         return False
 
 
+def _mac_app_installed(app):
+    """Check whether a macOS app is installed, without revealing it in Finder.
+
+    `open -Ra` also reveals the app in Finder as a side effect, popping a
+    Finder window to the front for every browser probed. Check well-known
+    install locations first, then fall back to Spotlight metadata; neither
+    has that side effect.
+
+    Trade-off: the `mdfind` fallback depends on Spotlight indexing, so an
+    app on a non-indexed volume, with indexing disabled, or installed just
+    before this runs, can produce a false negative. Accepted limitation -
+    Spotlight and Launch Services are different subsystems, and there is no
+    clean fix without reintroducing the `open -Ra` Finder-reveal side effect
+    this function exists to avoid.
+    """
+    name = f"{app}.app"
+    bases = [Path("/Applications")]
+    try:
+        bases.append(Path.home() / "Applications")
+    except RuntimeError:
+        pass  # HOME unresolvable (e.g. sandboxed/CI) - skip the per-user check, don't crash the probe loop
+    for base in bases:
+        try:
+            if (base / name).exists():
+                return True
+        except OSError:
+            continue  # e.g. PermissionError on a base dir - skip it, don't crash the probe loop
+    try:
+        result = subprocess.run(
+            ["mdfind", "-name", name], timeout=5, check=False, capture_output=True, text=True,
+        )
+        return bool(result.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
     import platform, shutil, subprocess, webbrowser
@@ -920,12 +957,9 @@ def _open_chrome_inspect():
         for app, scheme in apps:
             if not shutil.which("open"):
                 break
+            if not _mac_app_installed(app):
+                continue
             try:
-                installed = subprocess.run(
-                    ["open", "-Ra", app], timeout=5, check=False, capture_output=True,
-                )
-                if installed.returncode != 0:
-                    continue
                 opened = subprocess.run(
                     ["open", "-a", app, f"{scheme}://inspect/#remote-debugging"],
                     timeout=5,

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -48,6 +48,52 @@ def test_stale_websocket_does_not_open_chrome_inspect():
     assert not admin._needs_chrome_remote_debugging_prompt(msg)
 
 
+def test_open_chrome_inspect_uses_running_edge_on_macos(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *args, **kwargs: (
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\n"
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge\n"
+        ),
+    )
+    monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+
+    class Result:
+        returncode = 0
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert admin._open_chrome_inspect()
+    assert calls == [
+        ["open", "-Ra", "Microsoft Edge"],
+        ["open", "-a", "Microsoft Edge", "edge://inspect/#remote-debugging"],
+    ]
+
+
+def test_open_chrome_inspect_does_not_fall_back_to_safari_on_macos(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("subprocess.check_output", lambda *args, **kwargs: "Safari\n")
+    monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+
+    class Result:
+        returncode = 1
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Result())
+    monkeypatch.setattr(
+        "webbrowser.open",
+        lambda *args, **kwargs: pytest.fail("macOS must not send chrome:// URLs to the default browser"),
+    )
+
+    assert not admin._open_chrome_inspect()
+
+
 def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
     monkeypatch.setattr(admin.ipc, "BH_RUNTIME_DIR", None)  # shared-tmpdir mode

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -60,6 +60,7 @@ def test_open_chrome_inspect_uses_running_edge_on_macos(monkeypatch):
         ),
     )
     monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+    monkeypatch.setattr(admin, "_mac_app_installed", lambda app: True)
 
     class Result:
         returncode = 0
@@ -72,7 +73,6 @@ def test_open_chrome_inspect_uses_running_edge_on_macos(monkeypatch):
 
     assert admin._open_chrome_inspect()
     assert calls == [
-        ["open", "-Ra", "Microsoft Edge"],
         ["open", "-a", "Microsoft Edge", "edge://inspect/#remote-debugging"],
     ]
 
@@ -89,6 +89,7 @@ def test_open_chrome_inspect_does_not_substring_match_process_names(monkeypatch)
         ),
     )
     monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+    monkeypatch.setattr(admin, "_mac_app_installed", lambda app: True)
 
     class Result:
         returncode = 0
@@ -100,21 +101,24 @@ def test_open_chrome_inspect_does_not_substring_match_process_names(monkeypatch)
     monkeypatch.setattr("subprocess.run", fake_run)
 
     assert admin._open_chrome_inspect()
-    assert calls[:2] == [
-        ["open", "-Ra", "Dia"],
+    assert calls[:1] == [
         ["open", "-a", "Dia", "chrome://inspect/#remote-debugging"],
     ]
 
 
-def test_open_chrome_inspect_supports_running_edge_beta_on_macos(monkeypatch):
+def test_open_chrome_inspect_uses_running_brave_on_macos(monkeypatch):
     calls = []
 
     monkeypatch.setattr("platform.system", lambda: "Darwin")
     monkeypatch.setattr(
         "subprocess.check_output",
-        lambda *args, **kwargs: "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta\n",
+        lambda *args, **kwargs: (
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\n"
+            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser\n"
+        ),
     )
     monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+    monkeypatch.setattr(admin, "_mac_app_installed", lambda app: True)
 
     class Result:
         returncode = 0
@@ -127,7 +131,32 @@ def test_open_chrome_inspect_supports_running_edge_beta_on_macos(monkeypatch):
 
     assert admin._open_chrome_inspect()
     assert calls == [
-        ["open", "-Ra", "Microsoft Edge Beta"],
+        ["open", "-a", "Brave Browser", "chrome://inspect/#remote-debugging"],
+    ]
+
+
+def test_open_chrome_inspect_supports_running_edge_beta_on_macos(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *args, **kwargs: "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta\n",
+    )
+    monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+    monkeypatch.setattr(admin, "_mac_app_installed", lambda app: True)
+
+    class Result:
+        returncode = 0
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert admin._open_chrome_inspect()
+    assert calls == [
         ["open", "-a", "Microsoft Edge Beta", "edge://inspect/#remote-debugging"],
     ]
 
@@ -136,17 +165,98 @@ def test_open_chrome_inspect_does_not_fall_back_to_safari_on_macos(monkeypatch):
     monkeypatch.setattr("platform.system", lambda: "Darwin")
     monkeypatch.setattr("subprocess.check_output", lambda *args, **kwargs: "Safari\n")
     monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
-
-    class Result:
-        returncode = 1
-
-    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Result())
+    monkeypatch.setattr(admin, "_mac_app_installed", lambda app: False)
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: pytest.fail("must not shell out once no supported browser is installed"),
+    )
     monkeypatch.setattr(
         "webbrowser.open",
         lambda *args, **kwargs: pytest.fail("macOS must not send chrome:// URLs to the default browser"),
     )
 
     assert not admin._open_chrome_inspect()
+
+
+def test_mac_app_installed_finds_app_in_home_applications_without_shelling_out(monkeypatch, tmp_path):
+    (tmp_path / "Applications").mkdir()
+    (tmp_path / "Applications" / "Zzz Fake Browser For Tests.app").mkdir()
+    monkeypatch.setattr(admin.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: pytest.fail("must not shell out when the app is found on disk"),
+    )
+
+    assert admin._mac_app_installed("Zzz Fake Browser For Tests")
+
+
+def test_mac_app_installed_falls_back_to_mdfind(monkeypatch, tmp_path):
+    monkeypatch.setattr(admin.Path, "home", lambda: tmp_path)
+
+    class Result:
+        stdout = "/Volumes/External/Zzz Fake Browser For Tests.app\n"
+
+    def fake_run(args, **kwargs):
+        assert args == ["mdfind", "-name", "Zzz Fake Browser For Tests.app"]
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert admin._mac_app_installed("Zzz Fake Browser For Tests")
+
+
+def test_mac_app_installed_returns_false_when_not_found_anywhere(monkeypatch, tmp_path):
+    monkeypatch.setattr(admin.Path, "home", lambda: tmp_path)
+
+    class Result:
+        stdout = ""
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Result())
+
+    assert not admin._mac_app_installed("Zzz Fake Browser For Tests")
+
+
+def test_mac_app_installed_survives_unresolvable_home_directory(monkeypatch):
+    def raise_no_home():
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(admin.Path, "home", raise_no_home)
+
+    class Result:
+        stdout = "/Applications/Zzz Fake Browser For Tests.app\n"
+
+    def fake_run(args, **kwargs):
+        assert args == ["mdfind", "-name", "Zzz Fake Browser For Tests.app"]
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    # Path.home() raising must not propagate - it should degrade to the
+    # mdfind fallback instead of crashing the whole browser probe loop.
+    assert admin._mac_app_installed("Zzz Fake Browser For Tests")
+
+
+def test_mac_app_installed_survives_permission_error_on_exists(monkeypatch, tmp_path):
+    monkeypatch.setattr(admin.Path, "home", lambda: tmp_path)
+
+    def raise_permission_error(self):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(admin.Path, "exists", raise_permission_error)
+
+    class Result:
+        stdout = "/Applications/Zzz Fake Browser For Tests.app\n"
+
+    def fake_run(args, **kwargs):
+        assert args == ["mdfind", "-name", "Zzz Fake Browser For Tests.app"]
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    # A base dir's .exists() raising PermissionError must not propagate - it
+    # should skip that base and degrade to the mdfind fallback instead of
+    # crashing the whole browser probe loop.
+    assert admin._mac_app_installed("Zzz Fake Browser For Tests")
 
 
 def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):
@@ -533,7 +643,6 @@ def test_restart_daemon_does_not_signal_when_daemon_unreachable(monkeypatch, tmp
 def test_restart_daemon_signals_pid_returned_by_identify_not_pid_file(monkeypatch, tmp_path):
     """The PID we signal must come from the live daemon's self-report, never
     from the pid file. If a stale pid file disagrees, the live daemon's PID wins."""
-    import signal
 
     pid_path = tmp_path / "default.pid"
     pid_path.write_text("99999")  # bogus stale value — must be ignored
@@ -754,7 +863,8 @@ def test_restart_daemon_skips_sigterm_when_start_time_changed_during_wait(monkey
 def test_process_start_time_returns_stable_fingerprint_for_self():
     """The start-time of the current process should be readable on Linux,
     macOS, and Windows, and stable across two reads."""
-    import os as _os, sys
+    import os as _os
+    import sys
     if sys.platform.startswith("linux") or sys.platform == "darwin" or sys.platform == "win32":
         pid = _os.getpid()
         first = admin._process_start_time(pid)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -77,6 +77,61 @@ def test_open_chrome_inspect_uses_running_edge_on_macos(monkeypatch):
     ]
 
 
+def test_open_chrome_inspect_does_not_substring_match_process_names(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *args, **kwargs: (
+            "/usr/libexec/searchpartyd\n"
+            "/Applications/Dia.app/Contents/MacOS/Dia\n"
+        ),
+    )
+    monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+
+    class Result:
+        returncode = 0
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert admin._open_chrome_inspect()
+    assert calls[:2] == [
+        ["open", "-Ra", "Dia"],
+        ["open", "-a", "Dia", "chrome://inspect/#remote-debugging"],
+    ]
+
+
+def test_open_chrome_inspect_supports_running_edge_beta_on_macos(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *args, **kwargs: "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta\n",
+    )
+    monkeypatch.setattr("shutil.which", lambda command: "/usr/bin/open" if command == "open" else None)
+
+    class Result:
+        returncode = 0
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert admin._open_chrome_inspect()
+    assert calls == [
+        ["open", "-Ra", "Microsoft Edge Beta"],
+        ["open", "-a", "Microsoft Edge Beta", "edge://inspect/#remote-debugging"],
+    ]
+
+
 def test_open_chrome_inspect_does_not_fall_back_to_safari_on_macos(monkeypatch):
     monkeypatch.setattr("platform.system", lambda: "Darwin")
     monkeypatch.setattr("subprocess.check_output", lambda *args, **kwargs: "Safari\n")


### PR DESCRIPTION
Closes #425 (macOS browser-selection recovery path).

## Problem

`_open_chrome_inspect()` hardcodes Google Chrome through AppleScript. If that launch fails, it calls Python's generic `webbrowser.open()` with a `chrome://inspect` URL. On macOS that fallback can dispatch the unsupported URL to Safari, even when Microsoft Edge is the running Chromium browser.

That recovery is unusable—Safari cannot provide the Chromium CDP inspector—and it surprises the user by opening the wrong browser.

## Fix

- Reuse the existing `_BROWSER_LAUNCH` registry rather than adding another browser list.
- On macOS, prefer a running supported non-Chrome Chromium browser.
- Use `edge://inspect/#remote-debugging` for Edge and `chrome://...` for the other supported browsers.
- Use macOS `open` rather than AppleScript, avoiding Automation/TCC prompts.
- Probe candidate app installations with `open -Ra`.
- Fail closed when no supported Chromium browser can be opened; never send `chrome://` to Safari through the generic default-browser handler.
- Preserve the existing generic `webbrowser` behavior off macOS.

This supersedes the current-main portion of #471, which identified the hardcoded-browser problem and added the key running-browser/Edge-scheme behavior. That PR is currently conflicting with `main`; this version also covers the newer Safari fallback and reuses the browser registry now present on `main`. Credit to @ahmadalzaro1 for the original approach in #471.

## Tests

Red against `upstream/main`:

- `test_open_chrome_inspect_uses_running_edge_on_macos` fails because Chrome is hardcoded.
- `test_open_chrome_inspect_does_not_fall_back_to_safari_on_macos` fails because `webbrowser.open()` is called.

Green on this branch:

- `.venv/bin/pytest -q tests/unit/test_admin.py -k open_chrome_inspect` — 3 passed
- `.venv/bin/pytest -q tests/unit/test_admin.py` — 41 passed
- `.venv/bin/pytest -q` — 116 passed
- `git diff --check` — passed

Tested on macOS 26.4.1 with browser-harness 0.1.8 / browser-use 0.13.7 and Microsoft Edge installed and running.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open remote debugging in the active Chromium browser on macOS and never in Safari. Previously we AppleScript-launched Google Chrome and fell back to the default browser; now we detect a running supported Chromium app by exact process name and launch it with open, or fail closed. Also switch `_chrome_running` to exact process-name matching to avoid false positives.

- Select from `_BROWSER_LAUNCH` on macOS; prefer a running supported Chromium app (de-prioritize Chrome when Edge is running), else any installed candidate.
- Use `open` to launch `edge://inspect/#remote-debugging` for Edge channels and `chrome://inspect/#remote-debugging` otherwise; remove AppleScript and its TCC prompts.
- Detect installations without revealing Finder windows: check /Applications and ~/Applications, then fall back to Spotlight via `mdfind`.
- On macOS, never call `webbrowser.open`; return False if no supported Chromium is available. Preserve `webbrowser` behavior on other platforms.
- Add Chrome Beta/Dev and Edge Beta/Dev/Canary support; expand tests for exact process matching, Edge/Brave preference, Safari fallback blocking, and `_mac_app_installed` fallbacks.

<sup>Written for commit 68a222dc2258deb623319a969199bb92c44f92a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

