### PR TITLE
Add MCP server wrapper over browser-harness helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ PY
 
 Normal agent-facing docs should keep using `browser-harness`; the `./browser-harness` launcher is only for local repo testing.
 
+## MCP server
+
+`mcp_server.py` exposes the browser control helpers as MCP tools over stdio,
+so any MCP client (Claude Code, Devin, Cursor, etc.) can drive the browser
+without writing a second CDP layer. See [docs/MCP.md](docs/MCP.md) for setup and
+client configuration.
+
 ## Contributing
 
 PRs and improvements welcome. The best way to help: **contribute a new domain skill** under [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for a site or task you use often (LinkedIn outreach, ordering on Amazon, filing expenses, etc.). Each skill teaches the agent the selectors, flows, and edge cases it would otherwise have to rediscover.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,100 @@
+# Browser Harness MCP Server
+
+The MCP server in `mcp_server.py` exposes `browser_harness.helpers` as MCP tools.
+It reuses the existing helper layer — no second CDP implementation and no changes
+inside `src/browser_harness/`.
+
+## Start
+
+From the repo root:
+
+```bash
+uv run python -m mcp_server
+```
+
+The server speaks MCP stdio and connects to the same local Chrome CDP endpoint
+(9222/9223) used by `browser-harness`. The daemon auto-starts on the first tool
+call.
+
+## Tools
+
+All helpers from `browser_harness.helpers` are exposed with a `browser_` prefix:
+
+- `browser_new_tab`
+- `browser_goto`
+- `browser_page_info`
+- `browser_click`
+- `browser_type`
+- `browser_fill`
+- `browser_press`
+- `browser_scroll`
+- `browser_screenshot`
+- `browser_list_tabs`
+- `browser_current_tab`
+- `browser_switch_tab`
+- `browser_close_tab`
+- `browser_ensure_real_tab`
+- `browser_wait`
+- `browser_wait_for_load`
+- `browser_wait_for_element`
+- `browser_js`
+- `browser_cdp`
+- `browser_upload_file`
+- `browser_http_get`
+- `browser_start_recording`
+- `browser_stop_recording`
+
+Every tool returns JSON text. On error the response is `{"error": "..."}` and the
+server process keeps running.
+
+## Example flow
+
+1. `browser_new_tab(url="https://example.com")`
+2. `browser_wait_for_load()`
+3. `browser_screenshot()` → returns `path`, `width`, `height`, `size_bytes`
+4. `browser_page_info()` → returns `url`, `title`, viewport/scroll/page size
+
+## Client configuration
+
+Replace `<path-to-repo>` with your checkout path.
+
+### Claude Code
+
+```bash
+claude mcp add browser-harness \
+  uv --directory <path-to-repo> run python -m mcp_server
+```
+
+### Devin
+
+```bash
+devin mcp add -s project browser-harness -- \
+  uv --directory <path-to-repo> run python -m mcp_server
+```
+
+### Cursor / OpenClaw / other MCP clients
+
+```json
+{
+  "mcpServers": {
+    "browser-harness": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "<path-to-repo>",
+        "run",
+        "python",
+        "-m",
+        "mcp_server"
+      ]
+    }
+  }
+}
+```
+
+### MCP Inspector
+
+```bash
+npx @modelcontextprotocol/inspector \
+  uv --directory <path-to-repo> run python -m mcp_server
+```

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,252 @@
+# MIT License
+# Copyright (c) 2026 Browser Use
+# See LICENSE for details.
+"""MCP server exposing browser-harness helpers over stdio.
+
+Run:
+    uv run python -m mcp_server
+
+The server starts on stdio and exposes one MCP tool per browser-harness
+helper. Each tool ensures the daemon is running, calls the existing helper,
+and returns JSON text. Errors are caught and returned as {"error": ...}.
+"""
+import functools
+import json
+import math
+import os
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+from mcp.server import MCPServer
+
+from browser_harness.admin import ensure_daemon
+from browser_harness.helpers import (
+    capture_screenshot,
+    click_at_xy,
+    close_tab,
+    cdp,
+    current_tab,
+    ensure_real_tab,
+    fill_input,
+    goto_url,
+    http_get,
+    js,
+    list_tabs,
+    new_tab,
+    page_info,
+    press_key,
+    scroll,
+    start_recording,
+    stop_recording,
+    switch_tab,
+    type_text,
+    upload_file,
+    wait,
+    wait_for_element,
+    wait_for_load,
+)
+
+SERVER = MCPServer("browser-harness")
+
+
+def _json_default(value: Any) -> Any:
+    """Fallback JSON encoder for values that json.dumps cannot serialize."""
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return None
+    if isinstance(value, (set, frozenset)):
+        return list(value)
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, Path):
+        return str(value)
+    return str(value)
+
+
+def _dump(value: Any) -> str:
+    """Serialize a value to JSON text, never raising for unserializable data."""
+    return json.dumps(value, ensure_ascii=False, allow_nan=False, default=_json_default)
+
+
+def _tool(fn):
+    """Wrap a helper so it is exposed as an MCP tool and returns JSON text.
+
+    Ensures the daemon is up, runs the helper, catches exceptions, and always
+    returns a JSON string. Tool name and description are taken from the
+    wrapped function so the schema matches the parameter annotations.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        ensure_daemon()
+        try:
+            return _dump(fn(*args, **kwargs))
+        except Exception as exc:
+            return _dump({"error": str(exc)})
+
+    return SERVER.tool(name=fn.__name__, description=fn.__doc__ or "")(wrapper)
+
+
+@_tool
+def browser_new_tab(url: str = "about:blank"):
+    """Open a new browser tab. Returns the new tab's targetId."""
+    return {"targetId": new_tab(url)}
+
+
+@_tool
+def browser_goto(url: str):
+    """Navigate the current tab to `url`. Returns the navigation result."""
+    return goto_url(url)
+
+
+@_tool
+def browser_page_info():
+    """Return current tab metadata: url, title, viewport and scroll sizes."""
+    return page_info()
+
+
+@_tool
+def browser_click(x: int, y: int, button: str = "left", clicks: int = 1):
+    """Click at screen coordinates (x, y). `button` is 'left'/'right'/'middle'."""
+    click_at_xy(x, y, button=button, clicks=clicks)
+    return {"ok": True}
+
+
+@_tool
+def browser_type(text: str):
+    """Insert text into the focused element."""
+    type_text(text)
+    return {"ok": True}
+
+
+@_tool
+def browser_fill(selector: str, text: str, clear_first: bool = True):
+    """Fill an input matched by `selector` with `text`."""
+    fill_input(selector, text, clear_first=clear_first)
+    return {"ok": True}
+
+
+@_tool
+def browser_press(key: str, modifiers: int = 0):
+    """Press a key. `modifiers` is a bitfield: 1=Alt, 2=Ctrl, 4=Meta, 8=Shift."""
+    press_key(key, modifiers=modifiers)
+    return {"ok": True}
+
+
+@_tool
+def browser_scroll(x: int, y: int, dy: int = -300, dx: int = 0):
+    """Scroll the wheel at (x, y) by `dy` vertical / `dx` horizontal pixels."""
+    scroll(x, y, dy=dy, dx=dx)
+    return {"ok": True}
+
+
+@_tool
+def browser_screenshot(
+    path: str | None = None, full: bool = False, max_dim: int | None = None
+):
+    """Capture a PNG screenshot. If `path` is omitted, a temp file is used.
+    Set `max_dim` to downscale results larger than that dimension."""
+    path = capture_screenshot(path=path, full=full, max_dim=max_dim)
+    width, height = Image.open(path).size
+    size = os.path.getsize(path)
+    return {"path": path, "width": width, "height": height, "size_bytes": size}
+
+
+@_tool
+def browser_list_tabs():
+    """List open page tabs."""
+    return list_tabs()
+
+
+@_tool
+def browser_current_tab():
+    """Return the active tab's targetId, url and title."""
+    return current_tab()
+
+
+@_tool
+def browser_switch_tab(target: str):
+    """Switch to tab by `targetId` or URL substring. Returns the sessionId."""
+    return {"sessionId": switch_tab(target)}
+
+
+@_tool
+def browser_close_tab(target: str | None = None):
+    """Close a tab. Without `target`, closes the active tab."""
+    close_tab(target)
+    return {"ok": True}
+
+
+@_tool
+def browser_ensure_real_tab():
+    """Switch to a real (non-internal) tab if the current one is chrome:// or stale."""
+    return ensure_real_tab()
+
+
+@_tool
+def browser_wait(seconds: float = 1.0):
+    """Wait for `seconds`."""
+    wait(seconds)
+    return {"ok": True}
+
+
+@_tool
+def browser_wait_for_load(timeout: float = 15.0):
+    """Wait until the current tab's readyState is 'complete'."""
+    return {"ok": wait_for_load(timeout=timeout)}
+
+
+@_tool
+def browser_wait_for_element(
+    selector: str, timeout: float = 10.0, visible: bool = False
+):
+    """Wait for an element matching `selector` to appear. Set `visible=True` to
+    also require it to be rendered."""
+    return {"ok": wait_for_element(selector, timeout=timeout, visible=visible)}
+
+
+@_tool
+def browser_js(expression: str, target_id: str | None = None):
+    """Evaluate a JavaScript expression in the current tab (or an iframe `target_id`)."""
+    return js(expression, target_id=target_id)
+
+
+@_tool
+def browser_cdp(method: str, params: dict = {}):
+    """Call a raw Chrome DevTools Protocol method. `params` are passed as kwargs."""
+    return cdp(method, **(params or {}))
+
+
+@_tool
+def browser_upload_file(selector: str, path: str):
+    """Set files on a file input matched by `selector`. `path` is the local file."""
+    upload_file(selector, path)
+    return {"ok": True}
+
+
+@_tool
+def browser_http_get(url: str, timeout: float = 20.0):
+    """HTTP GET `url` (browser-less). Returns the response body."""
+    return {"text": http_get(url, timeout=timeout)}
+
+
+@_tool
+def browser_start_recording(name: str | None = None, title: str | None = None):
+    """Start recording actions to a local directory."""
+    return {"recording_dir": start_recording(name=name, title=title)}
+
+
+@_tool
+def browser_stop_recording():
+    """Stop the active recording and return its directory."""
+    return {"recording_dir": stop_recording()}
+
+
+if __name__ == "__main__":
+    SERVER.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "cdp-use==1.4.5",
     "fetch-use==0.4.0",
+    "mcp>=2.0.0,<3",
     "pillow==12.2.0",
     "websockets==15.0.1",
 ]


### PR DESCRIPTION
## Summary

Adds a stdio MCP server that exposes the existing `browser_harness.helpers` as MCP tools, so any MCP client (Claude Code, Devin, Cursor, etc.) can drive the browser without a second CDP implementation.

- New `mcp_server.py` at the repo root; 23 `browser_*` tools mapped 1:1 to helpers.
- Each tool calls `ensure_daemon()` and returns JSON text; helper exceptions are caught and returned as `{"error": "..."}`.
- Adds `mcp>=2.0.0,<3` to `pyproject.toml`.
- Adds `docs/MCP.md` with start commands and client config examples, plus a short `README.md` section.
- No changes to `src/browser_harness/`.

## Test plan

- [x] `uv add mcp` / `uv run python -m mcp_server` starts the stdio server without error.
- [x] `tools/list` returns 23 tools with the expected names.
- [x] Real flow `browser_new_tab` → `browser_wait_for_load` → `browser_screenshot` → `browser_page_info` succeeds against example.com.
- [x] Invalid selector (`browser_fill` on missing element) returns `{"error": ...}` and the server stays alive.
- [x] Existing CLI unaffected: `browser-harness --version` and `pytest tests/unit/test_run.py tests/unit/test_helpers.py -q` pass (35 passed).
- [x] Server listed and reachable from Devin via the configured `.devin/mcp_config.json`.

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stdio MCP server that exposes `browser_harness.helpers` as `browser_*` tools so MCP clients can drive the harness without a second CDP. Previous access was CLI/Python-only; now tools return JSON, normalize NaN/Infinity, and redirect helper stdout to stderr to keep the MCP protocol clean.

**Review notes**
- New `mcp_server.py` registers 23 tools mapped 1:1 to helpers. Each ensures the daemon inside a try block and returns `{"error": "..."}` on failure without exiting.
- JSON responses use `_dump`/`_json_default`; non-finite floats become `null` before `json.dumps`.
- `browser_http_get` accepts optional `headers` and forwards them to `http_get`.
- Docs added in `docs/MCP.md` with start command: `uv run --extra mcp python -m mcp_server`; README references client setup.
- Moves `mcp>=2.0.0,<3` to optional extra `mcp` in `pyproject.toml`. No changes under `src/browser_harness/`.

**Rollout**
- No migration for existing CLI or tests. To use MCP, run `uv run --extra mcp python -m mcp_server` and configure clients per `docs/MCP.md`.

<sup>Written for commit 5e205248473fdd1fe2f328a05dbc84936fc6153d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

