### PR TITLE
fix: fail closed when named daemon loses endpoint

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -82,6 +82,12 @@ print(page_info())
 PY
 ```
 
+The live named daemon holds the remote endpoint, so the example reuses it with
+only `BU_NAME`. Non-default names are managed/isolated daemons and never fall
+back to local Chrome. If one disappears, call `start_remote_daemon("r7k2")`
+again or provide `BU_CDP_WS`/`BU_CDP_URL`; a `BU_NAME`-only respawn fails
+closed. The unset/default daemon is the only daemon that discovers local Chrome.
+
 When the task is done and a cloud browser is still running, ask directly: "Should I close this browser now?" If yes, run `stop_remote_daemon(name)`. Remote daemons bill until they stop or time out.
 
 Do not start a remote daemon and then keep using the default daemon. Use the same name for `BU_NAME`.

--- a/install.md
+++ b/install.md
@@ -75,6 +75,12 @@ print(page_info())
 PY
 ```
 
+The named daemon holds its remote endpoint while it is alive. Non-default
+`BU_NAME` values are managed/isolated and never fall back to local Chrome; if a
+named daemon must be recreated, call `start_remote_daemon(name)` again or pass
+`BU_CDP_WS`/`BU_CDP_URL`. Invoking with only `BU_NAME` fails closed. The
+unset/default daemon is the local Chrome discovery path.
+
 ## If Still Broken
 
 ```bash

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -169,9 +169,11 @@ def _chrome_not_running(msg):
     return "chrome-not-running" in (msg or "").lower()
 
 
-def _is_local_chrome_mode(env=None):
-    """True when the daemon discovers a local Chrome instead of a remote CDP WS."""
+def _is_local_chrome_mode(env=None, name=None):
+    """True when the default daemon discovers local Chrome."""
     env = env or {}
+    if (name or env.get("BU_NAME") or os.environ.get("BU_NAME") or NAME) != "default":
+        return False
     return not (
         env.get("BU_CDP_WS")
         or env.get("BU_CDP_URL")
@@ -351,11 +353,11 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         restart_daemon(name)
 
     import subprocess, sys
-    local = _is_local_chrome_mode(env)
+    local = _is_local_chrome_mode(env, name)
     launched_browser = False
     opened_inspect = False
     for _ in range(3):
-        e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
+        e = {**os.environ, **(env or {}), **({"BU_NAME": name} if name else {})}
         try:
             stderr_sink = open(ipc.log_path(name or NAME), "ab")
         except OSError:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -235,6 +235,10 @@ def get_ws_url():
         if platform.system() == "Windows":
             hint += "; on Windows also check that a firewall/antivirus isn't blocking localhost connections"
         raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- {hint}")
+    if NAME != "default":
+        raise RuntimeError(
+            f"BU_NAME={NAME!r} requires BU_CDP_WS or BU_CDP_URL; refusing local Chrome discovery"
+        )
     deadline = time.time() + 30
     next_liveness_check = 0.0
     while time.time() < deadline:

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -371,6 +371,7 @@ def _run(args):
     if not cloud_admin:
         if (
             not daemon_alive()
+            and NAME == "default"
             and not _local_chrome_listening()
             and not _explicit_cdp_configured()
             and _cloud_auth_configured()

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from browser_harness import admin
+from browser_harness import admin, daemon
 
 
 class FakeSocket:
@@ -28,6 +28,92 @@ def test_local_chrome_mode_is_false_when_process_env_provides_remote_cdp(monkeyp
     monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/1")
 
     assert not admin._is_local_chrome_mode()
+
+
+def test_named_daemon_without_endpoint_is_not_local_chrome_mode(monkeypatch):
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+
+    assert not admin._is_local_chrome_mode(name="managed")
+
+
+def test_named_daemon_failure_does_not_trigger_local_recovery(monkeypatch, tmp_path):
+    class _ExitedProcess:
+        def poll(self):
+            return 1
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin, "_log_tail", lambda name: "chrome-not-running: strict named daemon failure")
+    monkeypatch.setattr(admin.ipc, "log_path", lambda name: tmp_path / "managed.log")
+    monkeypatch.setattr(admin.subprocess, "Popen", lambda *args, **kwargs: _ExitedProcess())
+    monkeypatch.setattr(admin, "_launch_browser", lambda: (_ for _ in ()).throw(AssertionError("local Chrome launch attempted")))
+    monkeypatch.setattr(admin, "_open_chrome_inspect_once", lambda: (_ for _ in ()).throw(AssertionError("chrome://inspect recovery attempted")))
+
+    with pytest.raises(RuntimeError, match="chrome-not-running"):
+        admin.ensure_daemon(name="managed", wait=0)
+
+
+def test_named_daemon_respawn_without_endpoint_remains_strict(monkeypatch, tmp_path):
+    spawned_envs = []
+
+    class _Process:
+        def poll(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        spawned_envs.append(kwargs["env"])
+        return _Process()
+
+    monkeypatch.setattr(admin.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(admin.ipc, "log_path", lambda name: tmp_path / f"{name}.log")
+    monkeypatch.setattr(admin, "restart_daemon", lambda name: None)
+    monkeypatch.setattr(admin, "_log_tail", lambda name: "BU_NAME='managed' requires BU_CDP_WS or BU_CDP_URL")
+
+    alive = iter([False, True, False])
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: next(alive))
+    admin.ensure_daemon(name="managed", env={"BU_CDP_WS": "ws://cloud.example"}, wait=1)
+
+    with pytest.raises(RuntimeError, match="requires BU_CDP_WS or BU_CDP_URL"):
+        admin.ensure_daemon(name="managed", wait=0)
+
+    assert spawned_envs[0]["BU_CDP_WS"] == "ws://cloud.example"
+    assert spawned_envs[1].get("BU_CDP_WS") is None
+    assert spawned_envs[1].get("BU_CDP_URL") is None
+
+    monkeypatch.setattr(daemon, "NAME", spawned_envs[1]["BU_NAME"])
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+
+    class _NoProfiles:
+        def __iter__(self):
+            raise AssertionError("respawned named daemon must not scan local profiles")
+
+    monkeypatch.setattr(daemon, "PROFILES", _NoProfiles())
+
+    with pytest.raises(RuntimeError, match="requires BU_CDP_WS or BU_CDP_URL"):
+        daemon.get_ws_url()
+
+
+def test_requested_daemon_name_wins_over_child_environment(monkeypatch, tmp_path):
+    spawned_envs = []
+
+    class _ExitedProcess:
+        def poll(self):
+            return 1
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin, "_log_tail", lambda name: "BU_NAME='managed' requires BU_CDP_WS or BU_CDP_URL")
+    monkeypatch.setattr(admin.ipc, "log_path", lambda name: tmp_path / "managed.log")
+    monkeypatch.setattr(
+        admin.subprocess,
+        "Popen",
+        lambda *args, **kwargs: spawned_envs.append(kwargs["env"]) or _ExitedProcess(),
+    )
+
+    with pytest.raises(RuntimeError, match="requires BU_CDP_WS or BU_CDP_URL"):
+        admin.ensure_daemon(name="managed", env={"BU_NAME": "default"}, wait=0)
+
+    assert spawned_envs[0]["BU_NAME"] == "managed"
 
 
 def test_handshake_timeout_needs_chrome_remote_debugging_prompt():

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from browser_harness import daemon
 
 
@@ -19,6 +21,75 @@ def _fresh_daemon():
     d = daemon.Daemon()
     d.cdp = _FakeCDP()
     return d
+
+
+class _JsonResponse:
+    def __init__(self, body):
+        self.body = body
+
+    def read(self):
+        return self.body
+
+
+def test_named_daemon_requires_explicit_endpoint_before_local_discovery(monkeypatch):
+    monkeypatch.setattr(daemon, "NAME", "managed")
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+
+    class _NoProfiles:
+        def __iter__(self):
+            raise AssertionError("named daemons must not scan local profiles")
+
+    def fail_urlopen(*args, **kwargs):
+        raise AssertionError("named daemons must not probe local CDP ports")
+
+    monkeypatch.setattr(daemon, "PROFILES", _NoProfiles())
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fail_urlopen)
+
+    with pytest.raises(RuntimeError, match="requires BU_CDP_WS or BU_CDP_URL"):
+        daemon.get_ws_url()
+
+
+def test_named_daemon_with_cdp_ws_keeps_explicit_endpoint(monkeypatch):
+    monkeypatch.setattr(daemon, "NAME", "managed")
+    monkeypatch.setenv("BU_CDP_WS", "ws://dedicated.example/devtools/browser/1")
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+
+    assert daemon.get_ws_url() == "ws://dedicated.example/devtools/browser/1"
+
+
+def test_named_daemon_with_cdp_url_keeps_explicit_endpoint(monkeypatch):
+    monkeypatch.setattr(daemon, "NAME", "managed")
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:9333")
+    calls = []
+
+    def fake_urlopen(url, timeout):
+        calls.append((url, timeout))
+        return _JsonResponse(b'{"webSocketDebuggerUrl":"ws://dedicated.example/devtools/browser/2"}')
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
+
+    assert daemon.get_ws_url() == "ws://dedicated.example/devtools/browser/2"
+    assert calls == [("http://127.0.0.1:9333/json/version", 5)]
+
+
+def test_default_daemon_without_endpoint_keeps_local_profile_discovery(monkeypatch, tmp_path):
+    monkeypatch.setattr(daemon, "NAME", "default")
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    (tmp_path / "DevToolsActivePort").write_text("9222\n/devtools/browser/default")
+    calls = []
+
+    def fake_urlopen(url, timeout):
+        calls.append((url, timeout))
+        return _JsonResponse(b'{"webSocketDebuggerUrl":"ws://local.example/devtools/browser/1"}')
+
+    monkeypatch.setattr(daemon, "PROFILES", [tmp_path])
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
+
+    assert daemon.get_ws_url() == "ws://local.example/devtools/browser/1"
+    assert calls == [("http://127.0.0.1:9222/json/version", 1)]
 
 
 def test_set_session_enables_all_four_default_domains_on_new_session():

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -72,6 +72,24 @@ def test_cloud_bootstrap_on_headless_server(monkeypatch):
     mock_start.assert_called_once()
 
 
+def test_named_daemon_does_not_probe_local_chrome_before_strict_ensure(monkeypatch):
+    monkeypatch.setattr(run, "NAME", "managed")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", side_effect=AssertionError("named daemon probed local CDP ports")), \
+         patch("browser_harness.run._cloud_auth_configured", side_effect=AssertionError("named daemon attempted cloud bootstrap")), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.ensure_daemon") as mock_ensure, \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+
+    mock_start.assert_not_called()
+    mock_ensure.assert_called_once()
+
+
 def test_explicit_bu_cdp_url_blocks_cloud_bootstrap(monkeypatch):
     """BU_CDP_URL is documented to override local Chrome discovery (install.md:58-59),
     so it must also block cloud auto-bootstrap. Otherwise start_remote_daemon would


### PR DESCRIPTION
## Summary

Fixes #479.

A start_remote_daemon(name) child starts with BU_NAME plus BU_CDP_WS and BU_BROWSER_ID. The documented later invocation carries only BU_NAME. If the daemon has died, ensure_daemon() respawns it without the endpoint, the child is classified as local, and get_ws_url() can scan default Chrome profiles and probe ports 9222/9223. admin.py can then launch local Chrome or open chrome://inspect, allowing a managed daemon to attach to the user's daily browser.

## Change

- Only the default daemon may discover local Chrome.
- Non-default named daemons fail before PROFILES or 9222/9223 discovery when BU_CDP_WS and BU_CDP_URL are absent.
- Named daemon recovery is non-local, so admin.py never launches Chrome or opens chrome://inspect for this failure.
- The requested daemon name wins over any conflicting child environment value.
- Explicit BU_CDP_WS and BU_CDP_URL behavior is unchanged.
- Documentation now states the named-daemon respawn contract.

This uses the existing BU_NAME semantics: the initial multi-daemon history describes named daemons as independent remote daemons, while the default daemon remains the local Chrome path. No new flag, supervisor, browser manager, or persistence layer is introduced.

## Regression coverage

- Named daemon without an endpoint fails before profile discovery and port probes.
- Named daemon failure cannot trigger Chrome launch or chrome://inspect recovery.
- Named BU_CDP_WS and BU_CDP_URL paths remain intact.
- Default daemon local profile discovery remains intact.
- A simulated endpoint-bearing start followed by a BU_NAME-only respawn fails closed.
- Named CLI invocations do not probe local ports or cloud-bootstrap before strict ensure.

## Validation

- Focused tests: 72 passed; 2 pre-existing Windows symlink privilege failures (WinError 1314).
- Full suite: 120 passed; the same 2 symlink failures plus the pre-existing packaged-skill symlink failure on this Windows checkout.
- python -m compileall -q src tests: passed.
- git diff --check: passed.
- ./browser-harness --version: 0.1.8.
- End-to-end ./browser-harness named smoke: expected exit 1 with the explicit fail-closed error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Named (non-default) daemons now fail closed if respawned without an explicit CDP endpoint, instead of falling back to local Chrome discovery. This prevents managed daemons from attaching to a user’s local browser and clarifies the default daemon as the only local-discovery path.

- Only the default daemon may discover/probe local Chrome. `get_ws_url()` now raises for `BU_NAME != "default"` when `BU_CDP_WS`/`BU_CDP_URL` are absent; `_is_local_chrome_mode()` enforces this.
- Named daemon recovery is non-local. `ensure_daemon()` no longer launches Chrome or opens `chrome://inspect` for named daemon failures and now ensures the requested `name` overrides any child `BU_NAME`.
- Cloud bootstrap is default-only. `run._run()` skips local probes and cloud bootstrap for named daemons before strict ensure.
- Docs clarify the respawn contract; tests cover strict named behavior and default-path regressions.

**Migration**
- For named daemons, always pass `BU_CDP_WS` or `BU_CDP_URL`, or call `start_remote_daemon(name)` to recreate the endpoint; `BU_NAME`-only invocations now fail with an explicit error.
- No changes for the default daemon or when `BU_CDP_WS`/`BU_CDP_URL` are set.

<sup>Written for commit 4c16f16e739aaa67239f295b9699e0b04efcfe2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

