### PR TITLE
Keep agent tab switching in the background

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -79,6 +79,11 @@ browser-harness <<'PY'
 start_remote_daemon("r7k2")
 PY
 
+# Keep the cloud session fully backgrounded; this prints liveUrl without opening it locally.
+browser-harness <<'PY'
+start_remote_daemon("r7k2", openLiveUrl=False)
+PY
+
 BU_NAME=r7k2 browser-harness <<'PY'
 new_tab("https://example.com")
 print(page_info())

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,6 +26,9 @@ PY
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
 - First navigation is `new_tab(url)`, not `goto_url(url)`.
+- `new_tab()` and `switch_tab()` attach and move the horse marker without
+  changing Chrome's visible tab; call `activate_tab(target)` only when the
+  user explicitly wants Chrome brought forward.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -4,7 +4,7 @@
 
 When Chrome opens fresh, the only CDP `type: "page"` targets are `chrome://inspect` and `chrome://omnibox-popup.top-chrome/` (a 1px invisible viewport). If the daemon attaches to the omnibox popup, all subsequent work — including `new_tab()` and `goto_url()` — happens on tabs that exist in CDP but may not be visible in the Chrome UI.
 
-The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` which calls `Target.activateTarget` to bring the tab to front.
+The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` to attach to the real tab; call `activate_tab()` only when Chrome must visibly show it.
 
 ## Startup sequence
 
@@ -12,7 +12,7 @@ The daemon's `attach_first_page()` handles this by creating an `about:blank` tab
 2. If stale sockets exist but daemon is dead, clean them up
 3. List open tabs with `list_tabs()` to see what's available
 4. `ensure_real_tab()` attaches to a real page
-5. `switch_tab(target_id)` both attaches AND activates (brings to front)
+5. `switch_tab(target_id)` attaches without changing the visible Chrome tab; use `activate_tab(target_id)` for an explicit visible switch
 
 ```python
 if not daemon_alive():
@@ -31,12 +31,15 @@ tab = ensure_real_tab()
 
 ## Bringing Chrome to front
 
-If Chrome is behind other windows or on another desktop:
+If Chrome is behind other windows or on another desktop and the user explicitly wants it shown:
 
 ```python
 import subprocess
 subprocess.run(["osascript", "-e", 'tell application "Google Chrome" to activate'])
 ```
+
+For normal agent work, do not activate Chrome: `switch_tab()` attaches to the
+target and moves the horse marker while leaving the user's foreground app alone.
 
 ## Navigating
 

--- a/interaction-skills/profile-sync.md
+++ b/interaction-skills/profile-sync.md
@@ -27,6 +27,7 @@ sync_local_profile(profile_name, browser=None,
 # (the existing one if cloud_profile_id was passed, else the newly-created one).
 
 start_remote_daemon("work", profileName="my-work")   # name→id resolved client-side
+start_remote_daemon("work", profileName="my-work", openLiveUrl=False)  # keep local browser untouched
 start_remote_daemon("work", profileId="<uuid>")      # or pass UUID directly
 
 stop_remote_daemon("work")                           # shut the daemon and PATCH the cloud browser to stop — billing ends

--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -7,9 +7,9 @@ Use **CDP for control**, **UI automation for user-visible order**.
 ```python
 tabs = list_tabs()                    # includes chrome:// pages too
 real_tabs = list_tabs(include_chrome=False)
-tid = new_tab("https://example.com")  # create + attach
-switch_tab(tid)                       # attach harness to tab
-cdp("Target.activateTarget", targetId=tid)  # show it in Chrome
+tid = new_tab("https://example.com")  # create + attach, keep Chrome in background
+switch_tab(tid)                       # attach harness, move the horse marker
+activate_tab(tid)                     # optional: explicitly show it in Chrome
 print(current_tab())
 print(page_info())
 ```
@@ -61,7 +61,8 @@ Typical tools:
 
 ## Rules that held up in practice
 
-- `switch_tab()` is **not enough** if the user expects Chrome to visibly change.
+- `switch_tab()` intentionally does **not** change Chrome's visible tab.
+- `activate_tab()` is the explicit opt-in when the user expects Chrome to visibly change.
 - `Target.activateTarget` is the CDP-side "show this tab".
 - `list_tabs()` includes `chrome://newtab/` by default; ask for `include_chrome=False` when you want only real pages.
 - `chrome://omnibox-popup.top-chrome/` can appear as a fake page target; ignore it for user-facing tab lists.

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -610,7 +610,7 @@ def _resolve_profile_name(profile_name):
     return matches[0]["id"]
 
 
-def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
+def start_remote_daemon(name="remote", profileName=None, openLiveUrl=True, **create_kwargs):
     """Provision a Browser Use cloud browser and start a daemon attached to it.
 
     kwargs forwarded to `POST /browsers` (camelCase):
@@ -620,9 +620,12 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
       timeout          — minutes, 1..240.
       customProxy      — {host, port, username, password, ignoreCertErrors}.
       browserScreenWidth / browserScreenHeight, allowResizing, enableRecording.
+      openLiveUrl      — open the cloud live viewer locally (default True). Set
+                         False to keep the local browser completely untouched.
 
     Returns the full browser dict including `liveUrl`. Prints the liveUrl and
-    auto-opens it locally when a GUI is detected, so the user can watch along."""
+    auto-opens it locally when `openLiveUrl=True` and a GUI is detected, so the
+    user can watch along."""
     if daemon_alive(name):
         raise RuntimeError(f"daemon {name!r} already alive -- restart_daemon({name!r}) first")
     if profileName:
@@ -638,7 +641,10 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
     except BaseException:
         _stop_cloud_browser(browser.get("id"))
         raise
-    _show_live_url(browser.get("liveUrl"))
+    if openLiveUrl:
+        _show_live_url(browser.get("liveUrl"))
+    elif browser.get("liveUrl"):
+        print(browser["liveUrl"])
     return browser
 
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -291,7 +291,24 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
-def switch_tab(target):
+def activate_tab(target):
+    """Make a target the visible Chrome tab.
+
+    This is intentionally separate from switch_tab(): attaching the agent to a
+    target does not require taking Chrome or the user's current application to
+    the foreground.
+    """
+    target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
+    cdp("Target.activateTarget", targetId=target_id)
+    return target_id
+
+def switch_tab(target, activate=False):
+    """Attach the agent to a target without changing Chrome's visible tab.
+
+    Pass activate=True when a caller explicitly needs Chrome to show the tab.
+    The horse marker still moves to the attached target so the user can find it
+    and switch to it manually.
+    """
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
     target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
@@ -299,7 +316,8 @@ def switch_tab(target):
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    if activate:
+        activate_tab(target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -376,7 +376,7 @@ def _run(args):
             and _cloud_auth_configured()
             and os.environ.get("BU_AUTOSPAWN")
         ):
-            start_remote_daemon(NAME)
+            start_remote_daemon(NAME, openLiveUrl=False)
         try:
             ensure_daemon()
         except RuntimeError as e:

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -401,6 +401,21 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     ]
 
 
+def test_start_remote_daemon_can_keep_live_viewer_closed(monkeypatch, capsys):
+    browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin, "_browser_use", lambda *args: browser)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
+    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: None)
+    show_calls = []
+    monkeypatch.setattr(admin, "_show_live_url", lambda url: show_calls.append(url))
+
+    assert admin.start_remote_daemon(openLiveUrl=False) == browser
+    assert show_calls == []
+    assert capsys.readouterr().out.strip() == "https://live.example"
+
+
 # --- restart_daemon: PID-reuse safety ---
 
 def test_restart_daemon_does_not_signal_when_daemon_unreachable(monkeypatch, tmp_path):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -350,3 +350,37 @@ def test_wait_for_network_idle_filters_events_to_active_session():
         "session filter, the background rWS/lF pair would have updated "
         "last_activity and prevented the idle window from elapsing."
     )
+
+
+def test_switch_tab_keeps_chrome_in_background_by_default(monkeypatch):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-new"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    assert helpers.switch_tab("target-new") == "session-new"
+    assert not any(method == "Target.activateTarget" for method, _ in calls)
+
+
+def test_switch_tab_can_explicitly_activate_chrome(monkeypatch):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-new"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    assert helpers.switch_tab("target-new", activate=True) == "session-new"
+    assert any(method == "Target.activateTarget" for method, _ in calls)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -69,7 +69,7 @@ def test_cloud_bootstrap_on_headless_server(monkeypatch):
          patch("browser_harness.run.ensure_daemon"), \
          patch("browser_harness.run.print_update_banner"):
         run.main()
-    mock_start.assert_called_once()
+    mock_start.assert_called_once_with("default", openLiveUrl=False)
 
 
 def test_explicit_bu_cdp_url_blocks_cloud_bootstrap(monkeypatch):


### PR DESCRIPTION
## Summary

- Keep `switch_tab()`, `new_tab()`, and `ensure_real_tab()` background-only by default.
- Add `activate_tab()` and `switch_tab(..., activate=True)` for explicit visible switching.
- Add `start_remote_daemon(..., openLiveUrl=False)` for cloud sessions that must not open or foreground a local browser.
- Document the focus behavior and add regression coverage.

## Motivation

On macOS, CDP `Target.activateTarget` changes Chrome's selected tab and reactivates the owning Chrome window. Chrome/macOS may restore that window's frame near the top of the screen. `Target.attachToTarget`, session setup, and the horse marker work without activating Chrome, so users can switch to the marked tab manually.

Cloud sessions avoid local Chrome entirely; the only local focus path was the optional `liveUrl` viewer opened by `webbrowser.open()`.

## Validation

- `uv run --with pytest pytest -q` — 117 passed
- Manual macOS probe: `Target.activateTarget` foregrounded Chrome; attach/evaluate did not.