### PR TITLE
Stop the tab marker from reaching what the agent reads

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -162,7 +162,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
 - Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow. Do not retry in a loop — Chrome pops a fresh dialog for every new connection, and the daemon's single held connection is what makes this a one-time click.
 - Omnibox popups are not real work tabs.
-- A headed browser gets a `🐴 ` prefix on the driven tab's title, so the user can see which tab is yours. `page_info()`, `current_tab()` and `list_tabs()` return the page's own title, without it; raw reads like `js("document.title")` still see it.
+- A headed browser gets a `🐴 ` prefix on the driven tab's title, so the user can see which tab is yours. `page_info()`, `current_tab()` and `list_tabs()` return the page's own title, without it; raw reads like `js("document.title")` still see it. Headless browsers are never marked; `BH_TAB_MARKER=0` or `=1` forces the choice when detection gets it wrong.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.
 - Ask before leaving cloud browsers running; stop them with `stop_remote_daemon(name)` or `PATCH /browsers/{id} {"action":"stop"}`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -162,6 +162,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
 - Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow. Do not retry in a loop — Chrome pops a fresh dialog for every new connection, and the daemon's single held connection is what makes this a one-time click.
 - Omnibox popups are not real work tabs.
+- A headed browser gets a `🐴 ` prefix on the driven tab's title, so the user can see which tab is yours. `page_info()`, `current_tab()` and `list_tabs()` return the page's own title, without it; raw reads like `js("document.title")` still see it.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.
 - Ask before leaving cloud browsers running; stop them with `stop_remote_daemon(name)` or `PATCH /browsers/{id} {"action":"stop"}`.

--- a/agent-workspace/domain-skills/aa/checkout.md
+++ b/agent-workspace/domain-skills/aa/checkout.md
@@ -149,7 +149,6 @@ For the PAN / CVV specifically, prefer the harness's `type_text()` (CDP keystrok
 - **`gender` values are single letters** (`M`, `F`, `U`, `X`), not `MALE`/`FEMALE`. The a11y label shows "MaleFemaleUnspecifiedUndisclosed" concatenated, which is misleading.
 - **Formcontrolname `firstName` exists twice in the DOM** — once on the passenger modal (`<adc-text-input id="firstName">`) and once on the checkout payment form (`<input id="firstNameInput">`). Target by the specific id to avoid collisions.
 - **Viewport emulation resets across `Emulation.setDeviceMetricsOverride` boundaries** after navigation. Re-apply `setDeviceMetricsOverride` if the later page's `page_info().w` jumps back up.
-- **Tab title is prefixed with the harness's `🟢 ` marker** on each real page, so `page_info().title` will start with that emoji — don't treat it as site content.
 
 ## Waits
 

--- a/agent-workspace/domain-skills/ctrip/hotels.md
+++ b/agent-workspace/domain-skills/ctrip/hotels.md
@@ -161,8 +161,7 @@ https://hotels.ctrip.com/hotel/<hotelId>.html?checkin=YYYY-MM-DD&checkout=YYYY-M
 ```
 
 Works pre-login. Server normalizes to `/hotels/detail/?...` but the data is
-identical. Title format: `🟢 <hotelName>预订价格,联系电话位置地址【携程酒店】`
-(the 🟢 prefix is from `browser-harness`, not ctrip).
+identical. Title format: `<hotelName>预订价格,联系电话位置地址【携程酒店】`.
 
 Detail page renders multiple room-rate rows with the same `¥orig ¥current`
 shape as the list. Look for `<button>` or `<a>` whose text is exactly `预订`

--- a/agent-workspace/domain-skills/wehotel/hotels.md
+++ b/agent-workspace/domain-skills/wehotel/hotels.md
@@ -180,7 +180,7 @@ return rows.map(row => {
 }).filter(r => r.price > 0);
 ```
 
-Title pattern: stays `🟢 锦江酒店WeHotel官网` (the harness 🟢 prefix). The
+Title pattern: stays `锦江酒店WeHotel官网`. The
 hotel name is in the page body, not the title — extract via the page header,
 which uses generic `[class*=name]` or `[class*=title]` selectors.
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -363,6 +363,9 @@ class Daemon:
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
+        # No window means nobody is watching the tab: the marker would have no
+        # reader and could only pollute the titles the agent reads.
+        self.headless = False
 
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
@@ -550,15 +553,18 @@ class Daemon:
             tasks.append(self._enable_default_domains(self.session))
             await asyncio.gather(*tasks)
             # 🐴 tab-marker title prefix is purely cosmetic — fire-and-forget so
-            # it doesn't add to the synchronous IPC budget.
-            asyncio.create_task(_silent(asyncio.wait_for(
-                self.cdp.send_raw(
-                    "Runtime.evaluate",
-                    {"expression": "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"},
-                    session_id=self.session,
-                ),
-                timeout=2,
-            )))
+            # it doesn't add to the synchronous IPC budget. Skipped headless:
+            # no window, no one to read it, and it would only leak into the
+            # titles the agent reads.
+            if not self.headless:
+                asyncio.create_task(_silent(asyncio.wait_for(
+                    self.cdp.send_raw(
+                        "Runtime.evaluate",
+                        {"expression": "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"},
+                        session_id=self.session,
+                    ),
+                    timeout=2,
+                )))
             return {"session_id": self.session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from . import _ipc as ipc
 from . import auth
 from . import paths
+from . import tab_marker
 from cdp_use.client import CDPClient
 
 
@@ -472,17 +473,33 @@ class Daemon:
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
-        mark_js = "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"
         async def tap(method, params, session_id=None):
             self.events.append({"method": method, "params": params, "session_id": session_id})
-            if method == "Page.javascriptDialogOpening":
-                self.dialog = params
-            elif method == "Page.javascriptDialogClosed":
-                self.dialog = None
-            elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-                asyncio.create_task(_silent(asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session), timeout=2)))
+            self.on_cdp_event(method, params)
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
+
+    def on_cdp_event(self, method, params):
+        """Side effects of a browser event, off the request path."""
+        if method == "Page.javascriptDialogOpening":
+            self.dialog = params
+        elif method == "Page.javascriptDialogClosed":
+            self.dialog = None
+        elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
+            self.mark_tab_soon(self.session)
+
+    def mark_tab_soon(self, session_id):
+        """Show the 🐴 marker on the driven tab, without blocking the caller.
+
+        Purely cosmetic, so never on the synchronous path: awaiting it cost
+        ~4s per navigation (#136). Skipped headless: no window, no one to
+        read it, and it would only leak into the titles the agent reads."""
+        if self.headless or not session_id:
+            return
+        asyncio.create_task(_silent(asyncio.wait_for(
+            self.cdp.send_raw("Runtime.evaluate", {"expression": tab_marker.MARK_JS}, session_id=session_id),
+            timeout=2,
+        )))
 
     async def handle(self, req):
         # Token guard for Windows TCP loopback: any local process can otherwise
@@ -552,19 +569,7 @@ class Daemon:
                 tasks.append(disable_old())
             tasks.append(self._enable_default_domains(self.session))
             await asyncio.gather(*tasks)
-            # 🐴 tab-marker title prefix is purely cosmetic — fire-and-forget so
-            # it doesn't add to the synchronous IPC budget. Skipped headless:
-            # no window, no one to read it, and it would only leak into the
-            # titles the agent reads.
-            if not self.headless:
-                asyncio.create_task(_silent(asyncio.wait_for(
-                    self.cdp.send_raw(
-                        "Runtime.evaluate",
-                        {"expression": "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"},
-                        session_id=self.session,
-                    ),
-                    timeout=2,
-                )))
+            self.mark_tab_soon(self.session)
             return {"session_id": self.session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -372,7 +372,12 @@ class Daemon:
         """Chrome reports itself as HeadlessChrome when it runs without a window.
 
         Undetermined counts as headless: the marker is cosmetic, the titles it
-        pollutes are not, so a browser that will not say costs us a horse."""
+        pollutes are not, so a browser that will not say costs us a horse.
+        BH_TAB_MARKER=0/1 settles it when the caller knows better."""
+        override = os.environ.get("BH_TAB_MARKER")
+        if override == "0":
+            self.headless = True
+            return
         try:
             ua = (await self.cdp.send_raw("Browser.getVersion")).get("userAgent", "")
         except Exception as e:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -368,6 +368,15 @@ class Daemon:
         # reader and could only pollute the titles the agent reads.
         self.headless = False
 
+    async def detect_headless(self):
+        """Chrome reports itself as HeadlessChrome when it runs without a window."""
+        try:
+            ua = (await self.cdp.send_raw("Browser.getVersion")).get("userAgent", "")
+        except Exception as e:
+            log(f"headless detection: {e}")
+            return
+        self.headless = "HeadlessChrome" in ua
+
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
@@ -471,6 +480,7 @@ class Daemon:
                     " -- wait for the user to click Allow, then retry"
                 )
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
+        await self.detect_headless()
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -365,7 +365,8 @@ class Daemon:
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
         # No window means nobody is watching the tab: the marker would have no
-        # reader and could only pollute the titles the agent reads.
+        # reader and could only pollute the titles the agent reads. Detection
+        # decides, unless the caller says so through BH_TAB_MARKER.
         self.headless = False
 
     async def detect_headless(self):
@@ -375,8 +376,8 @@ class Daemon:
         pollutes are not, so a browser that will not say costs us a horse.
         BH_TAB_MARKER=0/1 settles it when the caller knows better."""
         override = os.environ.get("BH_TAB_MARKER")
-        if override == "0":
-            self.headless = True
+        if override in ("0", "1"):
+            self.headless = override == "0"
             return
         try:
             ua = (await self.cdp.send_raw("Browser.getVersion")).get("userAgent", "")

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -551,7 +551,7 @@ class Daemon:
             if is_real_page(info):
                 page = {
                     "targetId": info.get("targetId"),
-                    "title": info.get("title") or "(untitled)",
+                    "title": tab_marker.strip_title(info.get("title")) or "(untitled)",
                     "url": info.get("url") or "",
                 }
             return {"target_id": self.target_id, "session_id": self.session, "page": page}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -511,6 +511,15 @@ class Daemon:
             timeout=2,
         )))
 
+    def unmark_tab_soon(self, session_id):
+        """Give the tab we are leaving its own title back."""
+        if self.headless or not session_id:
+            return
+        asyncio.create_task(_silent(asyncio.wait_for(
+            self.cdp.send_raw("Runtime.evaluate", {"expression": tab_marker.UNMARK_JS}, session_id=session_id),
+            timeout=2,
+        )))
+
     async def handle(self, req):
         # Token guard for Windows TCP loopback: any local process can otherwise
         # connect and issue CDP commands. expected_token() is None on POSIX so
@@ -579,6 +588,8 @@ class Daemon:
                 tasks.append(disable_old())
             tasks.append(self._enable_default_domains(self.session))
             await asyncio.gather(*tasks)
+            if old_session and old_session != self.session:
+                self.unmark_tab_soon(old_session)
             self.mark_tab_soon(self.session)
             return {"session_id": self.session}
         if meta == "pending_dialog": return {"dialog": self.dialog}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -369,11 +369,19 @@ class Daemon:
         self.headless = False
 
     async def detect_headless(self):
-        """Chrome reports itself as HeadlessChrome when it runs without a window."""
+        """Chrome reports itself as HeadlessChrome when it runs without a window.
+
+        Undetermined counts as headless: the marker is cosmetic, the titles it
+        pollutes are not, so a browser that will not say costs us a horse."""
         try:
             ua = (await self.cdp.send_raw("Browser.getVersion")).get("userAgent", "")
         except Exception as e:
             log(f"headless detection: {e}")
+            self.headless = True
+            return
+        if not ua:
+            log("headless detection: browser reported no user agent")
+            self.headless = True
             return
         self.headless = "HeadlessChrome" in ua
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -317,7 +317,7 @@ def is_reusable_blank_page(t):
     return (
         t["type"] == "page"
         and (url == "about:blank" or url.startswith("about:blank#"))
-        and not t.get("title", "").startswith("Starting agent ")
+        and not tab_marker.strip_title(t.get("title")).startswith("Starting agent ")
     )
 
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -289,23 +289,15 @@ def current_tab():
         "title": strip_title(r["title"]),
     }
 
-def _mark_tab():
-    """Prepend horse emoji to tab title so the user can see which tab the agent controls."""
-    try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
-    except Exception: pass
-
 def switch_tab(target):
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
     target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
-    # Unmark old tab. Horse emoji is a surrogate pair in JS UTF-16 strings (2 code units),
-    # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
-    try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
-    except Exception: pass
     cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
+    # set_session moves the 🐴 marker to this tab: the daemon owns it, being
+    # the side that knows whether the browser has a window at all.
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
-    _mark_tab()
     return sid
 
 def new_tab(url="about:blank"):

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -269,12 +269,13 @@ def list_tabs(include_chrome=True):
     for t in cdp("Target.getTargets")["targetInfos"]:
         if t["type"] != "page": continue
         url = t.get("url", "")
+        title = strip_title(t.get("title"))
         if _is_agent_startup_placeholder(t.get("title", ""), url): continue
         if not include_chrome and url.startswith(INTERNAL): continue
         out.append({
             "targetId": t["targetId"],
             "target_id": t["targetId"],
-            "title": t.get("title", ""),
+            "title": title,
             "url": url,
         })
     return out
@@ -285,7 +286,7 @@ def current_tab():
         "targetId": r["targetId"],
         "target_id": r["targetId"],
         "url": r["url"],
-        "title": r["title"],
+        "title": strip_title(r["title"]),
     }
 
 def _mark_tab():

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from . import _ipc as ipc
 from . import paths
+from .tab_marker import strip_title
 
 
 CORE_DIR = Path(__file__).resolve().parent
@@ -144,7 +145,8 @@ def page_info():
     if dialog:
         return {"dialog": dialog}
     expression = "JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})"
-    return json.loads(_runtime_evaluate(expression))
+    info = json.loads(_runtime_evaluate(expression))
+    return {**info, "title": strip_title(info.get("title"))}
 
 # --- input ---
 _debug_click_counter = 0

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -270,7 +270,7 @@ def list_tabs(include_chrome=True):
         if t["type"] != "page": continue
         url = t.get("url", "")
         title = strip_title(t.get("title"))
-        if _is_agent_startup_placeholder(t.get("title", ""), url): continue
+        if _is_agent_startup_placeholder(title, url): continue
         if not include_chrome and url.startswith(INTERNAL): continue
         out.append({
             "targetId": t["targetId"],

--- a/src/browser_harness/recorder.py
+++ b/src/browser_harness/recorder.py
@@ -24,6 +24,7 @@ import base64, json, os, re, time
 from pathlib import Path
 
 from . import paths
+from . import tab_marker
 
 # Helpers that change what's on screen. Read-only helpers (js, page_info,
 # capture_screenshot, ...) don't get frames — they'd bloat recordings of
@@ -265,7 +266,12 @@ def _capture(d, helper, args=(), kwargs=None, duration=None):
     if duration is not None:
         event["duration"] = duration
     try:
-        event.update(helpers.js(_CTX_JS) or {})
+        ctx = helpers.js(_CTX_JS) or {}
+        # The 🐴 marker is the harness's, not the page's, and this trace ends
+        # up in recording-summary.json, which an agent reads.
+        if "title" in ctx:
+            ctx["title"] = tab_marker.strip_title(ctx["title"])
+        event.update(ctx)
     except Exception:
         pass
     event.update(_details(helper, args, kwargs or {}, event))

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -2,7 +2,7 @@ import os, sys, time, urllib.request
 from io import StringIO
 
 # Windows default stdout/stderr encoding is cp1252
-# which can't encode the 🐴 marker helpers prepend to tab titles (or anything
+# which can't encode the 🐴 marker the daemon prepends to tab titles (or anything
 # else outside the locale charset). Force UTF-8 so `print(page_info())` and
 # tracebacks carrying page titles don't UnicodeEncodeError on Windows. #124(4).
 for _stream in (sys.stdout, sys.stderr):

--- a/src/browser_harness/tab_marker.py
+++ b/src/browser_harness/tab_marker.py
@@ -8,6 +8,13 @@ not recognise is exactly the leak this module exists to prevent.
 
 MARKER = "\U0001F434 "
 
+
+def strip_title(title):
+    """The page's own title: our prefix removed, anything else left alone."""
+    title = title or ""
+    return title[len(MARKER):] if title.startswith(MARKER) else title
+
+
 MARK_JS = (
     "(function(){var M='" + MARKER + "';"
     "if(!document.title.startsWith(M))document.title=M+document.title})()"

--- a/src/browser_harness/tab_marker.py
+++ b/src/browser_harness/tab_marker.py
@@ -19,3 +19,8 @@ MARK_JS = (
     "(function(){var M='" + MARKER + "';"
     "if(!document.title.startsWith(M))document.title=M+document.title})()"
 )
+
+UNMARK_JS = (
+    "(function(){var M='" + MARKER + "';"
+    "if(document.title.startsWith(M))document.title=document.title.slice(M.length)})()"
+)

--- a/src/browser_harness/tab_marker.py
+++ b/src/browser_harness/tab_marker.py
@@ -1,0 +1,14 @@
+"""The 🐴 prefix the harness puts on the tab it drives.
+
+It exists for the user watching the browser, so it lives in document.title —
+the one channel the page also writes to. The programs below are derived from
+MARKER rather than spelling it again: a marker the JS writes but Python does
+not recognise is exactly the leak this module exists to prevent.
+"""
+
+MARKER = "\U0001F434 "
+
+MARK_JS = (
+    "(function(){var M='" + MARKER + "';"
+    "if(!document.title.startsWith(M))document.title=M+document.title})()"
+)

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -6,8 +6,10 @@ leaked into every title the agent read, and agents repeatedly mistook it
 for a property of the site under test.
 """
 import asyncio
+import json
+from unittest.mock import patch
 
-from browser_harness import daemon, tab_marker
+from browser_harness import daemon, helpers, tab_marker
 
 MARKER = "\U0001F434 "
 
@@ -164,3 +166,27 @@ def test_a_headed_browser_session_still_marks_the_tab(monkeypatch):
     assert tab_marker.MARK_JS in _title_writes(d), (
         f"headed session lost the marker: {_title_writes(d)}"
     )
+
+
+# --- what the agent reads ---
+
+def _page_info_with_title(title):
+    payload = json.dumps({
+        "url": "https://example.com/", "title": title,
+        "w": 1, "h": 1, "sx": 0, "sy": 0, "pw": 1, "ph": 1,
+    })
+    with patch("browser_harness.helpers._send", return_value={}), \
+         patch("browser_harness.helpers.cdp", return_value={"result": {"type": "string", "value": payload}}):
+        return helpers.page_info()["title"]
+
+
+def test_page_info_returns_the_page_title_without_the_marker():
+    """The marker says how the agent reached the tab, not what the page is.
+    Reading it back as a page property has led agents to false findings."""
+    assert _page_info_with_title(MARKER + "Community Events | example.test") == "Community Events | example.test"
+
+
+def test_page_info_keeps_a_horse_the_page_itself_put_there():
+    """Only a leading marker-plus-space is ours. Anything else is the page's."""
+    assert _page_info_with_title("Horses \U0001F434 for sale") == "Horses \U0001F434 for sale"
+    assert _page_info_with_title("\U0001F434Emoji-first title") == "\U0001F434Emoji-first title"

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -261,3 +261,21 @@ def test_switching_away_leaves_the_previous_tab_clean():
         f"old tab was never unmarked: {_writes_on(d, 's1')}"
     )
     assert tab_marker.MARK_JS in _writes_on(d, "s2"), "the new tab must be the marked one"
+
+
+def test_switch_tab_does_not_mark_titles_from_the_client_side():
+    """The daemon decides whether a tab gets marked — it is the side that
+    knows whether the browser has a window. A helper writing the prefix
+    itself puts it back on a headless tab."""
+    cdp_calls = []
+
+    def fake_cdp(method, **kwargs):
+        cdp_calls.append((method, kwargs))
+        return {"sessionId": "s2", "targetId": "t2"}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers._send", return_value={}):
+        helpers.switch_tab("t2")
+
+    title_writes = [kw.get("expression", "") for m, kw in cdp_calls if m == "Runtime.evaluate"]
+    assert not title_writes, f"switch_tab wrote to document.title itself: {title_writes}"

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -59,3 +59,20 @@ def test_headless_session_never_marks_the_tab():
     assert not [e for e in _title_writes(d) if "title" in e], (
         f"headless session wrote to document.title: {_title_writes(d)}"
     )
+
+
+def test_headless_session_never_marks_on_page_load():
+    """The load-event marking path is separate from the session one, and fires
+    on every navigation — it must respect headless too."""
+    d = _daemon(headless=True)
+    d.session = "session-1"
+
+    async def go():
+        d.on_cdp_event("Page.loadEventFired", {})
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending, return_exceptions=True)
+    asyncio.run(go())
+
+    assert not [e for e in _title_writes(d) if "title" in e], (
+        f"headless session wrote to document.title on load: {_title_writes(d)}"
+    )

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -279,3 +279,29 @@ def test_switch_tab_does_not_mark_titles_from_the_client_side():
 
     title_writes = [kw.get("expression", "") for m, kw in cdp_calls if m == "Runtime.evaluate"]
     assert not title_writes, f"switch_tab wrote to document.title itself: {title_writes}"
+
+
+def test_the_marked_startup_placeholder_is_not_reused_as_a_blank_page(monkeypatch):
+    """The daemon reuses a fresh about:blank tab, but never the placeholder it
+    opened for the session — a tab it recognises by title, and marks."""
+    class _Targets(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            await super().send_raw(method, params, session_id)
+            if method == "Target.getTargets":
+                return {"targetInfos": [{"targetId": "t1", "type": "page", "url": "about:blank",
+                                         "title": MARKER + "Starting agent session"}]}
+            if method == "Target.createTarget":
+                return {"targetId": "fresh"}
+            if method == "Target.attachToTarget":
+                return {"sessionId": "s1"}
+            return {}
+
+    monkeypatch.setattr(daemon, "harness_opened_inspect", lambda: False)
+    d = daemon.Daemon()
+    d.cdp = _Targets()
+
+    attached = asyncio.run(d.attach_first_page())
+
+    assert attached["targetId"] == "fresh", (
+        f"the daemon took over its own startup placeholder: {attached}"
+    )

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -190,3 +190,22 @@ def test_page_info_keeps_a_horse_the_page_itself_put_there():
     """Only a leading marker-plus-space is ours. Anything else is the page's."""
     assert _page_info_with_title("Horses \U0001F434 for sale") == "Horses \U0001F434 for sale"
     assert _page_info_with_title("\U0001F434Emoji-first title") == "\U0001F434Emoji-first title"
+
+
+def test_current_tab_returns_the_title_without_the_marker():
+    """current_tab() reads the title from the CDP target, a second channel the
+    marker leaks through."""
+    reply = {"targetId": "t1", "url": "https://example.com/", "title": MARKER + "Dashboard"}
+    with patch("browser_harness.helpers._send", return_value=reply):
+        assert helpers.current_tab()["title"] == "Dashboard"
+
+
+def test_list_tabs_returns_titles_without_the_marker():
+    """One tab in the list is the driven one; it must not look different from
+    the others to the agent."""
+    targets = {"targetInfos": [
+        {"targetId": "t1", "type": "page", "url": "https://a.test/", "title": MARKER + "Driven tab"},
+        {"targetId": "t2", "type": "page", "url": "https://b.test/", "title": "Other tab"},
+    ]}
+    with patch("browser_harness.helpers.cdp", return_value=targets):
+        assert [t["title"] for t in helpers.list_tabs()] == ["Driven tab", "Other tab"]

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -1,0 +1,61 @@
+"""The 🐴 tab marker: visible to the human, invisible to the agent.
+
+The marker exists so the user can see which tab the agent drives. It is
+written into document.title — the same channel the page writes to — so it
+leaked into every title the agent read, and agents repeatedly mistook it
+for a property of the site under test.
+"""
+import asyncio
+
+from browser_harness import daemon
+
+MARKER = "\U0001F434 "
+
+
+class _FakeCDP:
+    """Records send_raw calls."""
+
+    def __init__(self):
+        self.calls = []  # list of (method, params, session_id)
+
+    async def send_raw(self, method, params=None, session_id=None):
+        self.calls.append((method, params, session_id))
+        return {}
+
+
+def _daemon(headless):
+    d = daemon.Daemon()
+    d.cdp = _FakeCDP()
+    d.headless = headless
+    return d
+
+
+def _handle(d, req):
+    """Run an IPC request and let its fire-and-forget tasks finish."""
+    async def go():
+        result = await d.handle(req)
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        return result
+    return asyncio.run(go())
+
+
+def _title_writes(d):
+    return [
+        (params or {}).get("expression", "")
+        for (method, params, _sid) in d.cdp.calls
+        if method == "Runtime.evaluate"
+    ]
+
+
+def test_headless_session_never_marks_the_tab():
+    """No window, nobody watching: the marker can only pollute what the agent
+    reads. So a headless session must not touch document.title at all."""
+    d = _daemon(headless=True)
+
+    _handle(d, {"meta": "set_session", "session_id": "session-2", "target_id": "target-2"})
+
+    assert not [e for e in _title_writes(d) if "title" in e], (
+        f"headless session wrote to document.title: {_title_writes(d)}"
+    )

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -237,3 +237,27 @@ def test_a_marked_startup_placeholder_tab_stays_out_of_list_tabs():
     ]}
     with patch("browser_harness.helpers.cdp", return_value=targets):
         assert [t["targetId"] for t in helpers.list_tabs()] == ["t2"]
+
+
+# --- one marked tab at a time ---
+
+def _writes_on(d, session_id):
+    return [
+        (params or {}).get("expression", "")
+        for (method, params, sid) in d.cdp.calls
+        if method == "Runtime.evaluate" and sid == session_id
+    ]
+
+
+def test_switching_away_leaves_the_previous_tab_clean():
+    """Exactly one tab is the driven one. The tab left behind gets its own
+    title back — trailing space included — while the new one gets marked."""
+    d = _daemon(headless=False)
+    _handle(d, {"meta": "set_session", "session_id": "s1", "target_id": "t1"})
+
+    _handle(d, {"meta": "set_session", "session_id": "s2", "target_id": "t2"})
+
+    assert tab_marker.UNMARK_JS in _writes_on(d, "s1"), (
+        f"old tab was never unmarked: {_writes_on(d, 's1')}"
+    )
+    assert tab_marker.MARK_JS in _writes_on(d, "s2"), "the new tab must be the marked one"

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -7,7 +7,7 @@ for a property of the site under test.
 """
 import asyncio
 
-from browser_harness import daemon
+from browser_harness import daemon, tab_marker
 
 MARKER = "\U0001F434 "
 
@@ -75,4 +75,92 @@ def test_headless_session_never_marks_on_page_load():
 
     assert not [e for e in _title_writes(d) if "title" in e], (
         f"headless session wrote to document.title on load: {_title_writes(d)}"
+    )
+
+
+class _VersionCDP(_FakeCDP):
+    def __init__(self, user_agent):
+        super().__init__()
+        self.user_agent = user_agent
+
+    async def send_raw(self, method, params=None, session_id=None):
+        await super().send_raw(method, params, session_id)
+        if method == "Browser.getVersion":
+            return {"userAgent": self.user_agent}
+        return {}
+
+
+def test_headless_is_detected_from_the_browser_user_agent():
+    """Chrome announces itself as HeadlessChrome when it runs without a window."""
+    d = daemon.Daemon()
+    d.cdp = _VersionCDP("Mozilla/5.0 (Macintosh) HeadlessChrome/151.0.0.0 Safari/537.36")
+
+    asyncio.run(d.detect_headless())
+
+    assert d.headless is True
+
+
+def test_headed_browser_is_not_reported_as_headless():
+    d = daemon.Daemon()
+    d.cdp = _VersionCDP("Mozilla/5.0 (Macintosh) Chrome/151.0.0.0 Safari/537.36")
+
+    asyncio.run(d.detect_headless())
+
+    assert d.headless is False
+
+
+class _FakeBrowser(_FakeCDP):
+    """Stands in for a live CDP connection, headless or headed."""
+
+    def __init__(self, user_agent):
+        super().__init__()
+        self.user_agent = user_agent
+        self._event_registry = type("R", (), {"handle_event": None})()
+
+    async def start(self):
+        pass
+
+    async def send_raw(self, method, params=None, session_id=None):
+        await super().send_raw(method, params, session_id)
+        if method == "Browser.getVersion":
+            return {"userAgent": self.user_agent}
+        if method == "Target.getTargets":
+            return {"targetInfos": [{"targetId": "t1", "type": "page", "url": "https://example.com/"}]}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "s1"}
+        return {}
+
+
+def _started_daemon(monkeypatch, user_agent):
+    browser = _FakeBrowser(user_agent)
+    monkeypatch.setattr(daemon, "get_ws_url", lambda: "ws://fake")
+    monkeypatch.setattr(daemon, "CDPClient", lambda url: browser)
+    monkeypatch.setattr(daemon, "_PatientCDPClient", lambda url: browser)
+    d = daemon.Daemon()
+    asyncio.run(d.start())
+    return d
+
+
+def test_a_headless_browser_session_marks_nothing_end_to_end(monkeypatch):
+    """From connection to tab switch: a daemon that connected to a headless
+    browser never writes the marker, without anyone setting a flag by hand."""
+    d = _started_daemon(monkeypatch, "Mozilla/5.0 HeadlessChrome/151.0.0.0 Safari/537.36")
+
+    _handle(d, {"meta": "set_session", "session_id": "s2", "target_id": "t2"})
+    _handle(d, {"meta": "ping"})
+
+    assert not [e for e in _title_writes(d) if "title" in e], (
+        f"headless browser got its titles rewritten: {_title_writes(d)}"
+    )
+
+
+def test_a_headed_browser_session_still_marks_the_tab(monkeypatch):
+    """The marker is what tells the user which tab the agent drives — it must
+    survive the headless work."""
+    d = _started_daemon(monkeypatch, "Mozilla/5.0 Chrome/151.0.0.0 Safari/537.36")
+
+    _handle(d, {"meta": "set_session", "session_id": "s2", "target_id": "t2"})
+
+    assert tab_marker.MARK_JS in _title_writes(d), (
+        f"headed session lost the marker: {_title_writes(d)}"
     )

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -209,3 +209,20 @@ def test_list_tabs_returns_titles_without_the_marker():
     ]}
     with patch("browser_harness.helpers.cdp", return_value=targets):
         assert [t["title"] for t in helpers.list_tabs()] == ["Driven tab", "Other tab"]
+
+
+def test_connection_status_reports_the_page_title_without_the_marker():
+    """`browser-harness status` prints this title, and agents read it back."""
+    d = _daemon(headless=False)
+    d.target_id = "t1"
+
+    class _Info(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            await super().send_raw(method, params, session_id)
+            if method == "Target.getTargetInfo":
+                return {"targetInfo": {"targetId": "t1", "type": "page",
+                                       "url": "https://example.com/", "title": MARKER + "Dashboard"}}
+            return {}
+
+    d.cdp = _Info()
+    assert _handle(d, {"meta": "connection_status"})["page"]["title"] == "Dashboard"

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -305,3 +305,25 @@ def test_the_marked_startup_placeholder_is_not_reused_as_a_blank_page(monkeypatc
     assert attached["targetId"] == "fresh", (
         f"the daemon took over its own startup placeholder: {attached}"
     )
+
+
+def test_a_recorded_event_carries_the_page_title_without_the_marker(tmp_path, monkeypatch):
+    """events.jsonl is copied into recording-summary.json, which make-video
+    hands straight to an agent — a fourth way the marker reached one."""
+    from browser_harness import recorder
+
+    monkeypatch.setattr(recorder, "_SETTLE_SECONDS", 0)
+    monkeypatch.setattr(recorder, "recording_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(recorder, "_is_auto_recording", lambda d: False)
+    monkeypatch.setattr(recorder, "_auto_is_stale", lambda d: False)
+
+    def boom(*a, **kw):
+        raise RuntimeError("no browser in this test")
+
+    with patch("browser_harness.helpers.js", return_value={"url": "https://example.com/",
+                                                           "title": MARKER + "Dashboard"}), \
+         patch("browser_harness.helpers.cdp", side_effect=boom):
+        recorder.observe("click_at_xy", (1, 2), {})
+
+    events = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text().splitlines()]
+    assert [e["title"] for e in events] == ["Dashboard"], f"recorded titles: {events}"

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -226,3 +226,14 @@ def test_connection_status_reports_the_page_title_without_the_marker():
 
     d.cdp = _Info()
     assert _handle(d, {"meta": "connection_status"})["page"]["title"] == "Dashboard"
+
+
+def test_a_marked_startup_placeholder_tab_stays_out_of_list_tabs():
+    """The placeholder the harness opens at startup is filtered by title —
+    a filter the marker used to defeat on the very tab the agent drives."""
+    targets = {"targetInfos": [
+        {"targetId": "t1", "type": "page", "url": "about:blank", "title": MARKER + "Starting agent session"},
+        {"targetId": "t2", "type": "page", "url": "https://b.test/", "title": "Other tab"},
+    ]}
+    with patch("browser_harness.helpers.cdp", return_value=targets):
+        assert [t["targetId"] for t in helpers.list_tabs()] == ["t2"]

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -111,6 +111,49 @@ def test_headed_browser_is_not_reported_as_headless():
     assert d.headless is False
 
 
+class _BrokenVersionCDP(_FakeCDP):
+    async def send_raw(self, method, params=None, session_id=None):
+        await super().send_raw(method, params, session_id)
+        if method == "Browser.getVersion":
+            raise RuntimeError("CDP went away")
+        return {}
+
+
+def test_a_browser_that_reports_no_user_agent_does_not_mark():
+    """A reply without a user agent determines nothing either — same safe side."""
+    d = daemon.Daemon()
+    d.cdp = _FakeCDP()  # Browser.getVersion answers {}
+
+    async def go():
+        await d.detect_headless()
+        d.mark_tab_soon("s1")
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending, return_exceptions=True)
+    asyncio.run(go())
+
+    assert not [e for e in _title_writes(d) if "title" in e], (
+        f"a browser with no user agent still got marked: {_title_writes(d)}"
+    )
+
+
+def test_a_session_that_cannot_detect_the_mode_does_not_mark():
+    """Marking is cosmetic; polluting a headless title is a bug. When the
+    browser will not say which mode it runs in, take the safe side."""
+    d = daemon.Daemon()
+    d.cdp = _BrokenVersionCDP()
+
+    async def go():
+        await d.detect_headless()
+        d.mark_tab_soon("s1")
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending, return_exceptions=True)
+    asyncio.run(go())
+
+    assert not [e for e in _title_writes(d) if "title" in e], (
+        f"undetectable mode still marked the tab: {_title_writes(d)}"
+    )
+
+
 class _FakeBrowser(_FakeCDP):
     """Stands in for a live CDP connection, headless or headed."""
 

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -154,6 +154,25 @@ def test_a_session_that_cannot_detect_the_mode_does_not_mark():
     )
 
 
+def test_bh_tab_marker_0_never_marks(monkeypatch):
+    """Detection reads a string the project does not control. Whoever launched
+    the browser can settle the question instead."""
+    monkeypatch.setenv("BH_TAB_MARKER", "0")
+    d = daemon.Daemon()
+    d.cdp = _VersionCDP("Mozilla/5.0 (Macintosh) Chrome/151.0.0.0 Safari/537.36")
+
+    async def go():
+        await d.detect_headless()
+        d.mark_tab_soon("s1")
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending, return_exceptions=True)
+    asyncio.run(go())
+
+    assert not [e for e in _title_writes(d) if "title" in e], (
+        f"BH_TAB_MARKER=0 still marked a headed browser: {_title_writes(d)}"
+    )
+
+
 class _FakeBrowser(_FakeCDP):
     """Stands in for a live CDP connection, headless or headed."""
 

--- a/tests/unit/test_tab_marker.py
+++ b/tests/unit/test_tab_marker.py
@@ -9,9 +9,17 @@ import asyncio
 import json
 from unittest.mock import patch
 
+import pytest
+
 from browser_harness import daemon, helpers, tab_marker
 
 MARKER = "\U0001F434 "
+
+
+@pytest.fixture(autouse=True)
+def _no_marker_override(monkeypatch):
+    """Every test states its own mode; a developer's shell must not decide."""
+    monkeypatch.delenv("BH_TAB_MARKER", raising=False)
 
 
 class _FakeCDP:
@@ -170,6 +178,25 @@ def test_bh_tab_marker_0_never_marks(monkeypatch):
 
     assert not [e for e in _title_writes(d) if "title" in e], (
         f"BH_TAB_MARKER=0 still marked a headed browser: {_title_writes(d)}"
+    )
+
+
+def test_bh_tab_marker_1_always_marks(monkeypatch):
+    """The other direction: a browser reporting HeadlessChrome that a human is
+    in fact watching still gets its horse."""
+    monkeypatch.setenv("BH_TAB_MARKER", "1")
+    d = daemon.Daemon()
+    d.cdp = _VersionCDP("Mozilla/5.0 (Macintosh) HeadlessChrome/151.0.0.0 Safari/537.36")
+
+    async def go():
+        await d.detect_headless()
+        d.mark_tab_soon("s1")
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending, return_exceptions=True)
+    asyncio.run(go())
+
+    assert tab_marker.MARK_JS in _title_writes(d), (
+        f"BH_TAB_MARKER=1 did not mark: {_title_writes(d)}"
     )
 
 


### PR DESCRIPTION
The 🐴 tab marker is written into `document.title` — the same channel the page writes to — and nothing removes it before an agent reads it back. So the marker, which describes the harness, reaches the agent as if it described the site.

## Why this is worse than noise

The marker is not consistently present. Whether a title carries it is decided by a race between the harness and the page:

| Situation | Result |
|---|---|
| Page whose title is settled at load (plain SSR) | harness writes last → **marked** |
| Page that sets its title client-side after load (SPA, React hydration) | page writes last → **clean forever** |
| Tab reached by `switch_tab()` once already settled | harness writes last → **marked, whatever the page** |

Same URL, two access paths, opposite results:

```
after direct navigation, settled          clean   'Peru travel guide | Example'
after switch_tab() back onto that tab     MARKED  '🐴 Peru travel guide | Example'
```

The marker says nothing about the page — it says how the agent got there. That is exactly what makes it read as data: it correlates with real technical properties (render mode, load speed) without being one.

## This has already misled agents, in this repo

Six `domain-skills` files mention the marker. Four document the trap correctly. Two took it for a property of the site and built on it:

- `agent-workspace/domain-skills/vercel/vercel.md:135` — *"Page title prefix is a status signal — 🟢 Vercel = all systems nominal"*
- `agent-workspace/domain-skills/atlas/overview.md:70` — *"The app sets a green-dot emoji prefix on titles… Useful for `wait_for` conditions"*

Both are pre-existing and untouched here. The same question was raised from outside the project in [NousResearch/hermes-agent#85430](https://github.com/NousResearch/hermes-agent/issues/85430): *"It can be mistaken for actual website content during QA, so a documented explanation — or a less content-like marker / separate metadata field — would help prevent false findings."*

## What this changes

**No marker at all when the browser is headless.** With no window there is no one to read it, so it can only pollute. Detected from `Browser.getVersion`'s user agent at connection time.

**Every title a helper hands back is stripped** — `page_info()`, `current_tab()`, `list_tabs()`, `connection_status()`, and the title the recorder traces into `recording-summary.json`. Only a leading marker-plus-space is removed; `"Horses 🐴 for sale"` and `"🐴Emoji-first"` survive untouched.

Marking moves from `switch_tab()` into the daemon, which is what knows whether the browser has a window. The fire-and-forget marking on load events is preserved unchanged — awaiting it costs ~4 s per navigation (#136).

`SKILL.md` gains the warning that was missing: the marker exists, helper-returned titles are stripped of it, and `js("document.title")` therefore disagrees with `page_info()["title"]` in a headed session. Three domain-skill files that quoted the old marked titles are corrected.

## The follow-up, and why it comes second

The marker still vanishes when a page rewrites its own title after load — most modern sites, since an SPA or a hydrating framework sets its title after the load event fires. That is a separate bug and the fix is ready: [misterbridge/browser-harness-fork#1](https://github.com/misterbridge/browser-harness-fork/pull/1), six commits on top of this branch, opened there rather than here so its diff shows those six alone. It moves here once this lands.

The order is not a convenience. Making the marker persistent *without* the stripping in this PR would turn an intermittent leak into a permanent one: today the marker often disappears on its own, so some reads come back clean by accident; re-applied on every title write, it would reach every single read.

## Verified

- `pytest tests -q` → 130 passed.
- Live, headless Chrome 151: 0 of 25 title reads carried the marker, against 15 of 24 before the change — and the raw in-page `document.title` is never marked, confirming the skip fires rather than the stripping merely hiding it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the 🐴 tab marker from reaching agent-visible titles while keeping it visible to users in headed sessions. Previously the harness wrote the marker into document.title and helpers returned it; now headless sessions never mark, and helper/recorded titles strip a leading "🐴 " prefix.

- Detect headless via Browser.getVersion once at connect; if undetermined, treat as headless. `BH_TAB_MARKER=0/1` forces off/on.
- Strip a leading "🐴 " from titles returned by page_info(), current_tab(), list_tabs(), connection_status(), and from recorder context.
- Move marking to the daemon and unmark the previous tab on session switch; client-side helpers no longer write to document.title.
- Match blank-page and startup-placeholder filters on stripped titles to avoid reusing the placeholder.
- Add `tab_marker` module with shared marker/JS and unit tests; update SKILL.md and domain skills.

**Migration notes**
- Remove waits/assertions that depend on a title prefix (e.g., 🟢/🐴); helpers no longer return it.
- To read the literal page title in headed runs, use js("document.title"); it can differ from page_info()["title"].

<sup>Written for commit 6f5e184e2370961a8e58501b7d81b1e46bd88079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


