### PR TITLE
docs: add Capterra listing audit workflow

### DIFF
--- a/domain-skills/capterra/audit.md
+++ b/domain-skills/capterra/audit.md
@@ -1,0 +1,86 @@
+# Capterra Public Listing Audit
+
+Field-tested against https://www.capterra.com on 2026-08-14.
+
+## Access pattern
+
+Capterra may return a Cloudflare block to curl, headless browsers, or separate browser clients while loading normally in an established visible Chrome profile on the same machine. Treat this as client-specific access behavior, not proof that the site or listing is unavailable. Do not bypass a CAPTCHA or security challenge; switch to an already-authorized established browser profile when available.
+
+```python
+tid = new_tab("https://www.capterra.com/search/?query=Exact%20Product%20Name")
+wait_for_load(30)
+wait(3)  # listing cards continue rendering after the load event
+print(page_info())
+```
+
+## Find the canonical product page
+
+Search results expose ordinary product links. Match exact visible product text before opening because broad names can return many near-matches.
+
+```python
+results = js("""
+Array.from(document.querySelectorAll('a[href*="/p/"]'))
+  .map(a => ({text:(a.innerText||'').trim(), href:a.href}))
+  .filter(x => x.text)
+""")
+```
+
+Product URLs follow:
+
+```text
+https://www.capterra.com/p/<numeric-id>/<product-slug>/
+```
+
+After opening a result, read the canonical URL from `link[rel="canonical"]`; do not guess the numeric ID.
+
+## Audit a live listing
+
+Capture both visible text and structured page state:
+
+```python
+meta = js("""
+({
+  title: document.title,
+  description: document.querySelector('meta[name=description]')?.content,
+  canonical: document.querySelector('link[rel=canonical]')?.href,
+  ogTitle: document.querySelector('meta[property="og:title"]')?.content,
+  ogDescription: document.querySelector('meta[property="og:description"]')?.content
+})
+""")
+
+jsonld = js("""
+Array.from(document.querySelectorAll('script[type="application/ld+json"]'))
+  .map(s => s.textContent)
+""")
+
+links = js("""
+Array.from(document.querySelectorAll('a[href]'))
+  .map(a => ({text:(a.innerText||a.getAttribute('aria-label')||'').trim(), href:a.href, rel:a.rel}))
+""")
+
+images = js("""
+Array.from(document.images)
+  .map(i => ({alt:i.alt, src:i.currentSrc||i.src, width:i.naturalWidth, height:i.naturalHeight}))
+""")
+```
+
+Also take a full-page screenshot. The visual presentation distinguishes selected options from unavailable ones; a plain `innerText` dump can list both without preserving check/X state.
+
+Audit at least:
+
+- product and vendor branding;
+- category, short description, and long description;
+- pricing and plan features;
+- selected category features;
+- support, training, deployment, and typical-user choices;
+- logo plus screenshot count/captions;
+- canonical public URL;
+- buyer-facing Website or Visit Website link.
+
+## Backlink trap
+
+A product-site URL can appear only inside Capterra's `Manage this product listing` / claim URL query parameters. That is not a buyer-facing backlink to the product site. Count a backlink only when an actual visible buyer CTA or anchor resolves to the product domain. Inspect both anchors and buttons; do not infer a backlink from raw HTML string occurrence alone.
+
+## Verification rule
+
+A publication email or vendor-dashboard status proves publication, but not the quality or backlink value of the live page. Before asking support for a correction, open the public listing and compare the current visible state to the intended request. If branding is already correct, narrow the request to the remaining issue instead of sending a stale broad correction.


### PR DESCRIPTION
## Summary
- document established-Chrome fallback for client-specific Cloudflare blocks
- add canonical product discovery and live-listing audit extraction patterns
- distinguish buyer-facing backlinks from product URLs embedded only in claim parameters

## Verification
- field-tested against Capterra public search and product listing pages on 2026-08-14
- documentation-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a documentation page for auditing Capterra public listings to standardize access, canonical page discovery, live-page capture, and backlink validation. This prevents false negatives from Cloudflare client blocks and avoids counting claim-only URLs as backlinks.

- Handle Cloudflare client-specific blocks by using an established visible Chrome profile; do not bypass CAPTCHA.
- Discover the canonical product page via exact-result text match and rel=canonical; do not guess numeric IDs.
- Audit the live listing by capturing meta, JSON-LD, links, images, and a full-page screenshot; verify branding, descriptions, pricing/features, support/training/deployment, screenshots, canonical URL, and the buyer-facing Website link.
- Count a backlink only when a visible CTA or anchor resolves to the product domain; ignore product-site URLs found only in claim parameters.
- Documentation-only change; field-tested against public search and product pages on 2026-08-14.

<sup>Written for commit f33b86725eaa1279b708962c66e3aeab92774764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

