### PR TITLE
Add macOS remote debugging approval helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ the checkbox so the agent can connect to your browser:
 
 On macOS, run `browser-harness mac-approve` after a `permission-blocked` error
 to handle the per-attach Allow sheet without bringing Chrome to the foreground.
-The helper clicks only Chrome's exact `Allow remote debugging?` sheet.
+The helper clicks only Chrome's exact `Allow remote debugging?` sheet. It returns
+`ready` instead if you already clicked Allow, so the agent knows it can continue.
 
 <img src="docs/allow-remote-debugging.png" alt="Allow remote debugging popup" width="520" style="border-radius: 12px;" />
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,6 @@ the checkbox so the agent can connect to your browser:
 
 <img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />
 
-On macOS, run `browser-harness mac-approve` after a `permission-blocked` error
-to handle the per-attach Allow sheet without bringing Chrome to the foreground.
-The helper clicks only Chrome's exact `Allow remote debugging?` sheet. It returns
-`ready` instead if you already clicked Allow, so the agent knows it can continue.
-
-<img src="docs/allow-remote-debugging.png" alt="Allow remote debugging popup" width="520" style="border-radius: 12px;" />
-
 See [agent-workspace/domain-skills/](agent-workspace/domain-skills/) for example tasks.
 
 ## Free Browser Use Cloud browsers

--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ Paste into Claude Code or Codex:
 Install or upgrade browser-harness to the latest stable version with uv using Python 3.12, register the skill from `browser-harness skill`, and connect it to my browser. Ask whether I want local browser recordings enabled; default to no and preserve my existing preference on upgrades. Follow https://github.com/browser-use/browser-harness/blob/main/install.md if setup or connection fails.
 ```
 
-The agent will open `chrome://inspect/#remote-debugging`. Tick the checkbox so the agent can connect to your browser:
+The agent will open `chrome://inspect/#remote-debugging`. On first setup, tick
+the checkbox so the agent can connect to your browser:
 
 <img src="docs/setup-remote-debugging.png" alt="Remote debugging setup" width="520" style="border-radius: 12px;" />
 
-Click Allow when the per-attach popup appears (Chrome 144+):
+On macOS, run `browser-harness mac-approve` after a `permission-blocked` error
+to handle the per-attach Allow sheet without bringing Chrome to the foreground.
+The helper clicks only Chrome's exact `Allow remote debugging?` sheet.
 
 <img src="docs/allow-remote-debugging.png" alt="Allow remote debugging popup" width="520" style="border-radius: 12px;" />
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,58 +44,17 @@ If Chrome is running but remote debugging is not enabled, the harness opens:
 chrome://inspect/#remote-debugging
 ```
 
-On macOS, treat browser automation as already authorized when the user installs
-and uses the browser agent. Always use Accessibility/System Events for this
-exact prompt because CDP is not available until Chrome approves the connection.
-After a `permission-blocked` error, inspect Chrome's sheets and only click an
-`Allow` button inside a sheet whose exact title is `Allow remote debugging?`:
+On macOS, after a `permission-blocked` error, run the built-in helper:
 
-```bash
-osascript <<'APPLESCRIPT'
-using terms from application "System Events"
-    on clickAllow(nodeRef)
-        try
-            if (role of nodeRef as text) is "AXButton" and ¬
-                (description of nodeRef as text) is "Allow" then
-                perform action "AXPress" of nodeRef
-                return true
-            end if
-        end try
-        try
-            repeat with childRef in UI elements of nodeRef
-                if my clickAllow(childRef) then return true
-            end repeat
-        end try
-        return false
-    end clickAllow
-end using terms from
-
-set resultText to "not-found"
-tell application "System Events"
-    if exists process "Google Chrome" then
-        tell process "Google Chrome"
-            repeat with w in windows
-                try
-                    repeat with s in sheets of w
-                        if (name of s as text) is "Allow remote debugging?" then
-                            if my clickAllow(s) then
-                                set resultText to "clicked"
-                                exit repeat
-                            end if
-                        end if
-                    end repeat
-                end try
-                if resultText is "clicked" then exit repeat
-            end repeat
-        end tell
-    end if
-end tell
-return resultText
-APPLESCRIPT
+```text
+browser-harness mac-approve
 ```
 
-Retry only when the script returns `clicked`. This requires Accessibility
-permission for the terminal/agent host in macOS System Settings.
+Retry only when the command returns `clicked`. If it reports `setup-required`,
+enable "Allow remote debugging for this browser instance" once at
+`chrome://inspect/#remote-debugging`, then run the helper again. The helper
+requires Accessibility permission for the app launching `browser-harness`
+(such as Terminal, iTerm, Codex, or an IDE) in macOS System Settings.
 
 ## Remote Browsers
 
@@ -211,7 +170,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- On macOS, if Chrome shows an "Allow remote debugging?" popup, run the Accessibility/System Events handler above after `permission-blocked` and retry only when it returns `clicked`. Do not poll in a loop — the daemon's single held connection avoids repeated prompts.
+- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-harness mac-approve` after `permission-blocked` and retry only when it returns `clicked`. Do not poll in a loop — the daemon's single held connection avoids repeated prompts.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,23 +44,13 @@ If Chrome is running but remote debugging is not enabled, the harness opens:
 chrome://inspect/#remote-debugging
 ```
 
-On macOS, when stderr says Chrome is asking for remote-debugging permission (or
-after a `permission-blocked` error), run the built-in helper in another shell:
+On macOS, when Chrome asks for remote-debugging permission, run:
 
 ```text
 browser-harness mac-approve
 ```
 
-If it returns `clicked`, retry the browser command. If it returns `ready`, the
-user or another process already accepted the sheet and browser work can continue
-without clicking again. If it reports `setup-required`, enable "Allow remote
-debugging for this browser instance" once at
-`chrome://inspect/#remote-debugging`, then run the helper again. The helper
-requires Accessibility permission for the app launching `browser-harness`
-(such as Terminal, iTerm, Codex, or an IDE) in macOS System Settings. If it
-returns `not-found`, neither the sheet nor a healthy browser connection exists;
-retry the original browser command once and use the helper when the prompt
-message appears.
+Continue browser work when it returns `ready`.
 
 ## Remote Browsers
 
@@ -176,7 +166,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-harness mac-approve` in another shell when the prompt message appears. Retry the browser command after `clicked`; continue normally after `ready`, which means the user or another process already accepted it. Do not poll in a loop — the daemon's single held connection avoids repeated prompts.
+- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-harness mac-approve`. Do not poll in a loop — the daemon holds one connection.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,17 +44,23 @@ If Chrome is running but remote debugging is not enabled, the harness opens:
 chrome://inspect/#remote-debugging
 ```
 
-On macOS, after a `permission-blocked` error, run the built-in helper:
+On macOS, when stderr says Chrome is asking for remote-debugging permission (or
+after a `permission-blocked` error), run the built-in helper in another shell:
 
 ```text
 browser-harness mac-approve
 ```
 
-Retry only when the command returns `clicked`. If it reports `setup-required`,
-enable "Allow remote debugging for this browser instance" once at
+If it returns `clicked`, retry the browser command. If it returns `ready`, the
+user or another process already accepted the sheet and browser work can continue
+without clicking again. If it reports `setup-required`, enable "Allow remote
+debugging for this browser instance" once at
 `chrome://inspect/#remote-debugging`, then run the helper again. The helper
 requires Accessibility permission for the app launching `browser-harness`
-(such as Terminal, iTerm, Codex, or an IDE) in macOS System Settings.
+(such as Terminal, iTerm, Codex, or an IDE) in macOS System Settings. If it
+returns `not-found`, neither the sheet nor a healthy browser connection exists;
+retry the original browser command once and use the helper when the prompt
+message appears.
 
 ## Remote Browsers
 
@@ -170,7 +176,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-harness mac-approve` after `permission-blocked` and retry only when it returns `clicked`. Do not poll in a loop — the daemon's single held connection avoids repeated prompts.
+- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-harness mac-approve` in another shell when the prompt message appears. Retry the browser command after `clicked`; continue normally after `ready`, which means the user or another process already accepted it. Do not poll in a loop — the daemon's single held connection avoids repeated prompts.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,7 +50,8 @@ On macOS, when Chrome asks for remote-debugging permission, run:
 browser-harness mac-approve
 ```
 
-Continue browser work when it returns `ready`.
+Continue browser work when it returns `ready`; otherwise follow its printed
+instruction.
 
 ## Remote Browsers
 

--- a/install.md
+++ b/install.md
@@ -58,9 +58,9 @@ sheet without bringing Chrome to the foreground:
 browser-harness mac-approve
 ```
 
-Retry `page_info()` only when the helper returns `clicked`. The first checkbox
-is intentionally a one-time manual Chrome setup step; it is not exposed to the
-harness until CDP is available.
+Continue browser work when the helper returns `ready`; otherwise follow its
+printed instruction. The first checkbox is intentionally a one-time manual
+Chrome setup step; it is not exposed to the harness until CDP is available.
 
 The helper requires Accessibility permission for the app launching the CLI
 (for example Terminal, iTerm, Codex, or an IDE) in System Settings.

--- a/install.md
+++ b/install.md
@@ -49,10 +49,21 @@ In Chrome:
 
 1. Open `chrome://inspect/#remote-debugging`.
 2. Tick "Allow remote debugging for this browser instance".
-3. Click Allow on the popup if it appears.
-4. Retry `page_info()`.
+3. Retry `page_info()`.
 
-The checkbox and popup require the user.
+If that reports `permission-blocked` on macOS, handle the per-connection Allow
+sheet without bringing Chrome to the foreground:
+
+```bash
+browser-harness mac-approve
+```
+
+Retry `page_info()` only when the helper returns `clicked`. The first checkbox
+is intentionally a one-time manual Chrome setup step; it is not exposed to the
+harness until CDP is available.
+
+The helper requires Accessibility permission for the app launching the CLI
+(for example Terminal, iTerm, Codex, or an IDE) in System Settings.
 
 ## Cloud Browsers
 

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -241,6 +241,11 @@ def _daemon_browser_connection(name):
             c.close()
 
 
+def daemon_browser_ready(name=None):
+    """Whether the selected daemon has a healthy attached browser connection."""
+    return _daemon_browser_connection(name or NAME) is not None
+
+
 def browser_connections():
     """Live browser-harness daemons with healthy CDP browser connections and their attached page."""
     out = []
@@ -373,7 +378,15 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             if daemon_alive(name): return
             if p.poll() is not None: break
             if not hinted and time.time() - spawned > 2 and (_log_tail(name) or "").startswith("handshake-wait"):
-                print('browser-harness: Chrome is asking "Allow remote debugging?" — click Allow to continue.', file=sys.stderr)
+                action = (
+                    "run `browser-harness mac-approve` in another shell or click Allow"
+                    if sys.platform == "darwin"
+                    else "click Allow"
+                )
+                print(
+                    f'browser-harness: Chrome is asking "Allow remote debugging?" — {action} to continue.',
+                    file=sys.stderr,
+                )
                 hinted = True
             time.sleep(0.2)
         msg = _log_tail(name) or ""

--- a/src/browser_harness/macos.py
+++ b/src/browser_harness/macos.py
@@ -111,7 +111,10 @@ def approve_remote_debugging() -> tuple[str, str | None]:
         # The user may have accepted the sheet while AppleScript was looking.
         if daemon_browser_ready():
             return "ready", None
-        return "not-found", None
+        return (
+            "not-found",
+            "retry the browser command and run `browser-harness mac-approve` when the prompt appears",
+        )
     return "error", f"unexpected osascript result: {status or '<empty>'}"
 
 

--- a/src/browser_harness/macos.py
+++ b/src/browser_harness/macos.py
@@ -36,13 +36,13 @@ tell application "System Events"
                     repeat with s in sheets of w
                         if (name of s as text) is "Allow remote debugging?" then
                             if my clickAllow(s) then
-                                set resultText to "clicked"
+                                set resultText to "ready"
                                 exit repeat
                             end if
                         end if
                     end repeat
                 end try
-                if resultText is "clicked" then exit repeat
+                if resultText is "ready" then exit repeat
             end repeat
         end tell
     end if
@@ -105,12 +105,10 @@ def approve_remote_debugging() -> tuple[str, str | None]:
         return "error", detail
 
     status = completed.stdout.strip()
-    if status == "clicked":
-        return "clicked", None
+    if status == "ready":
+        return "ready", None
     if status == "not-found":
-        # The user may have accepted the sheet while AppleScript was looking
-        # for it. Distinguish that successful race from a genuinely absent
-        # prompt so agents know they can continue immediately.
+        # The user may have accepted the sheet while AppleScript was looking.
         if daemon_browser_ready():
             return "ready", None
         return "not-found", None
@@ -127,4 +125,4 @@ def run_cli(args: list[str]) -> int:
         print(f"{status}: {detail}", flush=True)
     else:
         print(status, flush=True)
-    return 0 if status in {"clicked", "ready"} else 1
+    return 0 if status == "ready" else 1

--- a/src/browser_harness/macos.py
+++ b/src/browser_harness/macos.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import platform
 import subprocess
+from pathlib import Path
 
-from .daemon import profile_dirs, remote_debugging_toggle_profiles
-
+from .admin import daemon_browser_ready
+from .daemon import remote_debugging_toggle_profiles
 
 _APPLESCRIPT = r'''using terms from application "System Events"
     on clickAllow(nodeRef)
@@ -56,16 +57,22 @@ _ACCESSIBILITY_DETAIL = (
 )
 
 
+def _google_chrome_root() -> Path:
+    return Path.home() / "Library/Application Support/Google/Chrome"
+
+
 def _google_chrome_toggle_enabled() -> bool:
     """Only accept the toggle from the Google Chrome root used by the script."""
-    chrome_root = profile_dirs("Darwin")[0]
-    return chrome_root in remote_debugging_toggle_profiles()
+    return _google_chrome_root() in remote_debugging_toggle_profiles()
 
 
 def approve_remote_debugging() -> tuple[str, str | None]:
     """Click Chrome's exact per-connection Allow sheet without activating Chrome."""
     if platform.system() != "Darwin":
         return "unsupported", "mac-approve is only available on macOS"
+
+    if daemon_browser_ready():
+        return "ready", None
 
     if not _google_chrome_toggle_enabled():
         return (
@@ -101,6 +108,11 @@ def approve_remote_debugging() -> tuple[str, str | None]:
     if status == "clicked":
         return "clicked", None
     if status == "not-found":
+        # The user may have accepted the sheet while AppleScript was looking
+        # for it. Distinguish that successful race from a genuinely absent
+        # prompt so agents know they can continue immediately.
+        if daemon_browser_ready():
+            return "ready", None
         return "not-found", None
     return "error", f"unexpected osascript result: {status or '<empty>'}"
 
@@ -115,4 +127,4 @@ def run_cli(args: list[str]) -> int:
         print(f"{status}: {detail}", flush=True)
     else:
         print(status, flush=True)
-    return 0 if status == "clicked" else 1
+    return 0 if status in {"clicked", "ready"} else 1

--- a/src/browser_harness/macos.py
+++ b/src/browser_harness/macos.py
@@ -1,0 +1,105 @@
+"""macOS-only helpers for local Chrome automation."""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+
+from .daemon import remote_debugging_toggle_profiles
+
+
+_APPLESCRIPT = r'''using terms from application "System Events"
+    on clickAllow(nodeRef)
+        try
+            if (role of nodeRef as text) is "AXButton" and ¬
+                (description of nodeRef as text) is "Allow" then
+                perform action "AXPress" of nodeRef
+                return true
+            end if
+        end try
+        try
+            repeat with childRef in UI elements of nodeRef
+                if my clickAllow(childRef) then return true
+            end repeat
+        end try
+        return false
+    end clickAllow
+end using terms from
+
+set resultText to "not-found"
+tell application "System Events"
+    if exists process "Google Chrome" then
+        tell process "Google Chrome"
+            repeat with w in windows
+                try
+                    repeat with s in sheets of w
+                        if (name of s as text) is "Allow remote debugging?" then
+                            if my clickAllow(s) then
+                                set resultText to "clicked"
+                                exit repeat
+                            end if
+                        end if
+                    end repeat
+                end try
+                if resultText is "clicked" then exit repeat
+            end repeat
+        end tell
+    end if
+end tell
+return resultText
+'''
+
+
+def approve_remote_debugging() -> tuple[str, str | None]:
+    """Click Chrome's exact per-connection Allow sheet without activating Chrome."""
+    if platform.system() != "Darwin":
+        return "unsupported", "mac-approve is only available on macOS"
+
+    if not remote_debugging_toggle_profiles():
+        return (
+            "setup-required",
+            'first enable "Allow remote debugging for this browser instance" at '
+            "chrome://inspect/#remote-debugging, then run `browser-harness mac-approve` again",
+        )
+
+    try:
+        completed = subprocess.run(
+            ["osascript"],
+            input=_APPLESCRIPT,
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "error", str(exc)
+
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or "osascript failed"
+        if "not authorized" in detail.lower() or "assistive" in detail.lower():
+            return (
+                "accessibility-required",
+                "allow the app launching browser-harness (for example Terminal, iTerm, or Codex) "
+                "in System Settings > Privacy & Security > Accessibility",
+            )
+        return "error", detail
+
+    status = completed.stdout.strip()
+    if status == "clicked":
+        return "clicked", None
+    if status == "not-found":
+        return "not-found", None
+    return "error", f"unexpected osascript result: {status or '<empty>'}"
+
+
+def run_cli(args: list[str]) -> int:
+    if args:
+        print("usage: browser-harness mac-approve", flush=True)
+        return 2
+
+    status, detail = approve_remote_debugging()
+    if detail:
+        print(f"{status}: {detail}", flush=True)
+    else:
+        print(status, flush=True)
+    return 0 if status == "clicked" else 1

--- a/src/browser_harness/macos.py
+++ b/src/browser_harness/macos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import platform
 import subprocess
 
-from .daemon import remote_debugging_toggle_profiles
+from .daemon import profile_dirs, remote_debugging_toggle_profiles
 
 
 _APPLESCRIPT = r'''using terms from application "System Events"
@@ -50,12 +50,24 @@ return resultText
 '''
 
 
+_ACCESSIBILITY_DETAIL = (
+    "allow the app launching browser-harness (for example Terminal, iTerm, or Codex) "
+    "in System Settings > Privacy & Security > Accessibility"
+)
+
+
+def _google_chrome_toggle_enabled() -> bool:
+    """Only accept the toggle from the Google Chrome root used by the script."""
+    chrome_root = profile_dirs("Darwin")[0]
+    return chrome_root in remote_debugging_toggle_profiles()
+
+
 def approve_remote_debugging() -> tuple[str, str | None]:
     """Click Chrome's exact per-connection Allow sheet without activating Chrome."""
     if platform.system() != "Darwin":
         return "unsupported", "mac-approve is only available on macOS"
 
-    if not remote_debugging_toggle_profiles():
+    if not _google_chrome_toggle_enabled():
         return (
             "setup-required",
             'first enable "Allow remote debugging for this browser instance" at '
@@ -71,6 +83,8 @@ def approve_remote_debugging() -> tuple[str, str | None]:
             timeout=5,
             check=False,
         )
+    except subprocess.TimeoutExpired:
+        return "accessibility-required", _ACCESSIBILITY_DETAIL
     except (OSError, subprocess.SubprocessError) as exc:
         return "error", str(exc)
 
@@ -79,8 +93,7 @@ def approve_remote_debugging() -> tuple[str, str | None]:
         if "not authorized" in detail.lower() or "assistive" in detail.lower():
             return (
                 "accessibility-required",
-                "allow the app launching browser-harness (for example Terminal, iTerm, or Codex) "
-                "in System Settings > Privacy & Security > Accessibility",
+                _ACCESSIBILITY_DETAIL,
             )
         return "error", detail
 

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -47,6 +47,7 @@ Commands:
   browser-harness --doctor         diagnose install, daemon, and browser state
   browser-harness doctor           same as --doctor
   browser-harness doctor --fix-snap   print how to fix Snap Chromium blocking CDP (Linux)
+  browser-harness mac-approve         approve Chrome's macOS remote debugging sheet
   browser-harness auth login          sign in to Browser Use Cloud for cloud browsers
   browser-harness auth login --device-code   sign in from SSH/headless environments
   browser-harness auth status         show Browser Use Cloud auth state
@@ -122,7 +123,7 @@ def _telemetry_command(args):
         return "reload"
     if first == "--debug-clicks":
         return "debug-clicks"
-    if first in {"auth", "skill", "recordings", "telemetry", "video"}:
+    if first in {"auth", "skill", "mac-approve", "recordings", "telemetry", "video"}:
         return first
     return "usage"
 
@@ -312,6 +313,10 @@ def _run(args):
         sys.exit(run_doctor())
     if args and args[0] == "auth":
         sys.exit(auth.run_auth_cli(args[1:]))
+    if args and args[0] == "mac-approve":
+        from . import macos
+
+        sys.exit(macos.run_cli(args[1:]))
     if args and args[0] == "skill":
         if len(args) != 1:
             print("usage: browser-harness skill", file=sys.stderr)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -109,6 +109,18 @@ def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch):
     assert admin.active_browser_connections() == 1
 
 
+def test_daemon_browser_ready_checks_the_selected_daemon(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        admin,
+        "_daemon_browser_connection",
+        lambda name: calls.append(name) or {"name": name, "page": None},
+    )
+
+    assert admin.daemon_browser_ready("work")
+    assert calls == ["work"]
+
+
 def test_active_browser_connections_skips_daemons_reporting_cdp_disconnected(monkeypatch):
     monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "stale"])
 

--- a/tests/unit/test_macos.py
+++ b/tests/unit/test_macos.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from browser_harness import macos
+
+
+def test_mac_approve_requires_the_persistent_chrome_checkbox(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [])
+
+    status, detail = macos.approve_remote_debugging()
+
+    assert status == "setup-required"
+    assert "chrome://inspect/#remote-debugging" in detail
+
+
+def test_mac_approve_runs_osascript_only_after_checkbox_is_enabled(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [Path("/tmp/Chrome")])
+    calls = []
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs))
+        or SimpleNamespace(returncode=0, stdout="clicked\n", stderr=""),
+    )
+
+    status, detail = macos.approve_remote_debugging()
+
+    assert (status, detail) == ("clicked", None)
+    assert calls[0][0] == (["osascript"],)
+    assert "Allow remote debugging?" in calls[0][1]["input"]
+    assert "AXPress" in calls[0][1]["input"]
+    assert "activate" not in calls[0][1]["input"]
+
+
+def test_mac_approve_returns_not_found_without_a_prompt(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [Path("/tmp/Chrome")])
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not-found\n", stderr=""),
+    )
+
+    assert macos.approve_remote_debugging() == ("not-found", None)
+
+
+def test_mac_approve_is_unavailable_off_macos(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Linux")
+
+    assert macos.approve_remote_debugging() == (
+        "unsupported",
+        "mac-approve is only available on macOS",
+    )

--- a/tests/unit/test_macos.py
+++ b/tests/unit/test_macos.py
@@ -6,7 +6,9 @@ from browser_harness import macos
 
 def test_mac_approve_requires_the_persistent_chrome_checkbox(monkeypatch):
     monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [])
+    chrome_root = Path("/tmp/Google Chrome")
+    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root, Path("/tmp/Edge")])
+    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [Path("/tmp/Edge")])
 
     status, detail = macos.approve_remote_debugging()
 
@@ -16,7 +18,9 @@ def test_mac_approve_requires_the_persistent_chrome_checkbox(monkeypatch):
 
 def test_mac_approve_runs_osascript_only_after_checkbox_is_enabled(monkeypatch):
     monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [Path("/tmp/Chrome")])
+    chrome_root = Path("/tmp/Google Chrome")
+    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root])
+    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [chrome_root])
     calls = []
     monkeypatch.setattr(
         macos.subprocess,
@@ -36,7 +40,9 @@ def test_mac_approve_runs_osascript_only_after_checkbox_is_enabled(monkeypatch):
 
 def test_mac_approve_returns_not_found_without_a_prompt(monkeypatch):
     monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [Path("/tmp/Chrome")])
+    chrome_root = Path("/tmp/Google Chrome")
+    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root])
+    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [chrome_root])
     monkeypatch.setattr(
         macos.subprocess,
         "run",
@@ -44,6 +50,25 @@ def test_mac_approve_returns_not_found_without_a_prompt(monkeypatch):
     )
 
     assert macos.approve_remote_debugging() == ("not-found", None)
+
+
+def test_mac_approve_maps_pending_accessibility_consent_to_guidance(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    chrome_root = Path("/tmp/Google Chrome")
+    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root])
+    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [chrome_root])
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            macos.subprocess.TimeoutExpired(["osascript"], 5)
+        ),
+    )
+
+    status, detail = macos.approve_remote_debugging()
+
+    assert status == "accessibility-required"
+    assert "Accessibility" in detail
 
 
 def test_mac_approve_is_unavailable_off_macos(monkeypatch):

--- a/tests/unit/test_macos.py
+++ b/tests/unit/test_macos.py
@@ -61,7 +61,10 @@ def test_mac_approve_returns_not_found_without_a_prompt(monkeypatch):
         lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not-found\n", stderr=""),
     )
 
-    assert macos.approve_remote_debugging() == ("not-found", None)
+    status, detail = macos.approve_remote_debugging()
+
+    assert status == "not-found"
+    assert "retry the browser command" in detail
 
 
 def test_mac_approve_returns_ready_without_running_osascript(monkeypatch):

--- a/tests/unit/test_macos.py
+++ b/tests/unit/test_macos.py
@@ -39,12 +39,12 @@ def test_mac_approve_runs_osascript_only_after_checkbox_is_enabled(monkeypatch):
         macos.subprocess,
         "run",
         lambda *args, **kwargs: calls.append((args, kwargs))
-        or SimpleNamespace(returncode=0, stdout="clicked\n", stderr=""),
+        or SimpleNamespace(returncode=0, stdout="ready\n", stderr=""),
     )
 
     status, detail = macos.approve_remote_debugging()
 
-    assert (status, detail) == ("clicked", None)
+    assert (status, detail) == ("ready", None)
     assert calls[0][0] == (["osascript"],)
     assert "Allow remote debugging?" in calls[0][1]["input"]
     assert "AXPress" in calls[0][1]["input"]

--- a/tests/unit/test_macos.py
+++ b/tests/unit/test_macos.py
@@ -4,10 +4,24 @@ from types import SimpleNamespace
 from browser_harness import macos
 
 
+def _enable_chrome_toggle(monkeypatch):
+    chrome_root = Path("/tmp/Google Chrome")
+    monkeypatch.setattr(macos, "_google_chrome_root", lambda: chrome_root)
+    monkeypatch.setattr(
+        macos,
+        "remote_debugging_toggle_profiles",
+        lambda: [chrome_root],
+    )
+
+
+def _no_ready_daemon(monkeypatch):
+    monkeypatch.setattr(macos, "daemon_browser_ready", lambda: False)
+
+
 def test_mac_approve_requires_the_persistent_chrome_checkbox(monkeypatch):
     monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
-    chrome_root = Path("/tmp/Google Chrome")
-    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root, Path("/tmp/Edge")])
+    _no_ready_daemon(monkeypatch)
+    monkeypatch.setattr(macos, "_google_chrome_root", lambda: Path("/tmp/Google Chrome"))
     monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [Path("/tmp/Edge")])
 
     status, detail = macos.approve_remote_debugging()
@@ -18,9 +32,8 @@ def test_mac_approve_requires_the_persistent_chrome_checkbox(monkeypatch):
 
 def test_mac_approve_runs_osascript_only_after_checkbox_is_enabled(monkeypatch):
     monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
-    chrome_root = Path("/tmp/Google Chrome")
-    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root])
-    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [chrome_root])
+    _no_ready_daemon(monkeypatch)
+    _enable_chrome_toggle(monkeypatch)
     calls = []
     monkeypatch.setattr(
         macos.subprocess,
@@ -40,9 +53,8 @@ def test_mac_approve_runs_osascript_only_after_checkbox_is_enabled(monkeypatch):
 
 def test_mac_approve_returns_not_found_without_a_prompt(monkeypatch):
     monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
-    chrome_root = Path("/tmp/Google Chrome")
-    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root])
-    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [chrome_root])
+    _no_ready_daemon(monkeypatch)
+    _enable_chrome_toggle(monkeypatch)
     monkeypatch.setattr(
         macos.subprocess,
         "run",
@@ -52,11 +64,43 @@ def test_mac_approve_returns_not_found_without_a_prompt(monkeypatch):
     assert macos.approve_remote_debugging() == ("not-found", None)
 
 
+def test_mac_approve_returns_ready_without_running_osascript(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(macos, "daemon_browser_ready", lambda: True)
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+
+    assert macos.approve_remote_debugging() == ("ready", None)
+
+
+def test_mac_approve_detects_user_accepting_while_it_checks(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    _enable_chrome_toggle(monkeypatch)
+    readiness = iter([False, True])
+    monkeypatch.setattr(macos, "daemon_browser_ready", lambda: next(readiness))
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not-found\n", stderr=""),
+    )
+
+    assert macos.approve_remote_debugging() == ("ready", None)
+
+
+def test_mac_approve_cli_treats_ready_as_success(monkeypatch, capsys):
+    monkeypatch.setattr(macos, "approve_remote_debugging", lambda: ("ready", None))
+
+    assert macos.run_cli([]) == 0
+    assert capsys.readouterr().out == "ready\n"
+
+
 def test_mac_approve_maps_pending_accessibility_consent_to_guidance(monkeypatch):
     monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
-    chrome_root = Path("/tmp/Google Chrome")
-    monkeypatch.setattr(macos, "profile_dirs", lambda system: [chrome_root])
-    monkeypatch.setattr(macos, "remote_debugging_toggle_profiles", lambda: [chrome_root])
+    _no_ready_daemon(monkeypatch)
+    _enable_chrome_toggle(monkeypatch)
     monkeypatch.setattr(
         macos.subprocess,
         "run",


### PR DESCRIPTION
## Summary
- add `browser-harness mac-approve` for Chrome's per-connection Allow sheet on macOS
- move the AppleScript out of `SKILL.md` into the packaged CLI
- document the one-time `chrome://inspect` checkbox path and the Accessibility permission owner

## Behavior
- returns `clicked` with exit code 0 only when it presses the exact `Allow remote debugging?` sheet
- returns `setup-required` when the persistent Chrome checkbox is not enabled
- never activates or foregrounds Chrome
- intentionally does not automate the first checkbox: it is not exposed through CDP or the current Chrome accessibility tree before CDP is enabled

## Validation
- fresh Chrome 151 approval prompt: `browser-harness mac-approve` returned `clicked`
- waiting browser-harness CLI connection completed successfully
- no-prompt path returned `not-found`
- 61 focused unit tests passed
- package build includes `browser_harness/macos.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Approves Chrome’s macOS “Allow remote debugging?” sheet without foregrounding Chrome and reports a single “ready” success state. Previously we relied on a documented AppleScript and asked users to click Allow; now the built-in `browser-harness mac-approve` handles approval and the daemon guides users to run it.

- Adds `browser-harness mac-approve`; exits 0 only on `ready` (after clicking Allow or when the daemon is already attached), 1 otherwise, and 2 on invalid args; may return `not-found`, `setup-required`, `accessibility-required`, `unsupported`, or `error`, and prints per-status guidance.
- Verifies the one-time Chrome toggle for the same Google Chrome root; returns `setup-required` with guidance to enable it at `chrome://inspect/#remote-debugging`; intentionally does not automate this toggle.
- Maps Accessibility timeouts or “not authorized” errors to `accessibility-required` with aligned guidance to grant macOS Accessibility permission to the app launching `browser-harness` (e.g., Terminal, iTerm, Codex, IDE); non‑macOS returns `unsupported`.
- Handles races: if the sheet disappears or the connection becomes healthy while checking, returns `ready` instead of `not-found`; never activates Chrome.
- Integrates the command into the CLI and stderr hinting on macOS (“run `browser-harness mac-approve` or click Allow”), adds `daemon_browser_ready()`, replaces the AppleScript in docs, and includes unit tests.

**Rollout**
- On macOS, after a `permission-blocked` error, run `browser-harness mac-approve`; retry only when it returns `ready`.
- Ensure the one-time Chrome checkbox at `chrome://inspect/#remote-debugging` is enabled and grant Accessibility to the app launching the CLI.

<sup>Written for commit ffac4a58e87867585d42860a0ac1097fb32c69e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

