### PR TITLE
Remove agent cloud signup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Stealth, sub-agents, or headless deployment.<br>
 **Browser Use Cloud free tier: 3 concurrent browsers, proxies, captcha solving, and more. No card required.**
 
 - Grab a key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key)
-- Or let the agent sign up itself via [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt) (setup flow + challenge context included).
 
 ## Architecture (~1k lines across 4 core files)
 


### PR DESCRIPTION
Removes the agent self-signup sentence from the README cloud section.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the agent self-signup link from the Cloud section of the README to set accurate expectations. Previously we documented two signup paths (manual API key and agent self-signup via docs link); now only manual API key is listed.

- Docs-only change in `README.md`; no product or API impact.
- No migration or rollout steps.

<sup>Written for commit 0c3b586f53595c89bb41b023a4a50024e1314dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

