### PR TITLE
daemon: keep named automation in reusable background tabs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,6 +26,10 @@ PY
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
 - First navigation is `new_tab(url)`, not `goto_url(url)`.
+- `new_tab()` and `switch_tab()` attach and move the horse marker without
+  changing Chrome's visible tab. Screenshots and normal CDP input work in the
+  background; call `activate_tab(target)` only when the user explicitly asks
+  or a page demonstrably pauses rendering while hidden.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -4,7 +4,7 @@
 
 When Chrome opens fresh, the only CDP `type: "page"` targets are `chrome://inspect` and `chrome://omnibox-popup.top-chrome/` (a 1px invisible viewport). If the daemon attaches to the omnibox popup, all subsequent work — including `new_tab()` and `goto_url()` — happens on tabs that exist in CDP but may not be visible in the Chrome UI.
 
-The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` which calls `Target.activateTarget` to bring the tab to front.
+The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` to attach to the real tab; call `activate_tab()` only when Chrome must visibly show it.
 
 ## Startup sequence
 
@@ -12,7 +12,7 @@ The daemon's `attach_first_page()` handles this by creating an `about:blank` tab
 2. If stale sockets exist but daemon is dead, clean them up
 3. List open tabs with `list_tabs()` to see what's available
 4. `ensure_real_tab()` attaches to a real page
-5. `switch_tab(target_id)` both attaches AND activates (brings to front)
+5. `switch_tab(target_id)` attaches without changing the visible Chrome tab; use `activate_tab(target_id)` for an explicit visible switch
 
 ```python
 if not daemon_alive():
@@ -31,16 +31,20 @@ tab = ensure_real_tab()
 
 ## Bringing Chrome to front
 
-If Chrome is behind other windows or on another desktop:
+If Chrome is behind other windows or on another desktop and the user explicitly wants it shown:
 
 ```python
 import subprocess
 subprocess.run(["osascript", "-e", 'tell application "Google Chrome" to activate'])
 ```
 
+For normal agent work, do not activate Chrome. Screenshots and CDP input work
+on the attached background tab; activate only for a page that demonstrably
+pauses visibility-dependent rendering while hidden.
+
 ## Navigating
 
-Prefer navigating an existing tab over `new_tab()`. Tabs created via CDP's `Target.createTarget` are visible but may open behind the active tab.
+Prefer navigating an existing tab over `new_tab()`. Harness-created tabs open in the background.
 
 ```python
 tab = ensure_real_tab()

--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -7,9 +7,9 @@ Use **CDP for control**, **UI automation for user-visible order**.
 ```python
 tabs = list_tabs()                    # includes chrome:// pages too
 real_tabs = list_tabs(include_chrome=False)
-tid = new_tab("https://example.com")  # create + attach
-switch_tab(tid)                       # attach harness to tab
-cdp("Target.activateTarget", targetId=tid)  # show it in Chrome
+tid = new_tab("https://example.com")  # create + attach in the background
+switch_tab(tid)                       # attach harness, move the horse marker
+activate_tab(tid)                     # optional: explicitly show it in Chrome
 print(current_tab())
 print(page_info())
 ```
@@ -61,7 +61,9 @@ Typical tools:
 
 ## Rules that held up in practice
 
-- `switch_tab()` is **not enough** if the user expects Chrome to visibly change.
+- `switch_tab()` intentionally does **not** change Chrome's visible tab.
+- Static screenshots and normal CDP input work on the attached background tab.
+- `activate_tab()` is the explicit opt-in for visibility-dependent rendering or a user-requested visible switch.
 - `Target.activateTarget` is the CDP-side "show this tab".
 - `list_tabs()` includes `chrome://newtab/` by default; ask for `include_chrome=False` when you want only real pages.
 - `chrome://omnibox-popup.top-chrome/` can appear as a fake page target; ignore it for user-facing tab lists.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -367,7 +367,7 @@ class Daemon:
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
 
-    async def attach_first_page(self):
+    async def attach_first_page(self, replaces_session=None):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         # Named daemons (BU_NAME != "default") share one browser with other
@@ -402,6 +402,7 @@ class Daemon:
             self.session = (await self.cdp.send_raw(
                 "Target.attachToTarget", {"targetId": tid, "flatten": True}
             ))["sessionId"]
+            self._record_session_replacement(replaces_session, self.session)
             self.target_id = tid
             log(f"attached {tid} ({page.get('url','')[:80]}) session={self.session}")
             await self._enable_default_domains(self.session)
@@ -433,6 +434,7 @@ class Daemon:
         self.session = (await self.cdp.send_raw(
             "Target.attachToTarget", {"targetId": pages[0]["targetId"], "flatten": True}
         ))["sessionId"]
+        self._record_session_replacement(replaces_session, self.session)
         self.target_id = pages[0]["targetId"]
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
         if take_over:
@@ -635,10 +637,9 @@ class Daemon:
                 replacement_session = self._session_replacements.get(sid)
                 if replacement_session is None and sid == self.session:
                     log(f"stale session {sid}, re-attaching")
-                    if not await self.attach_first_page():
+                    if not await self.attach_first_page(replaces_session=sid):
                         return {"error": msg}
-                    replacement_session = self.session
-                    self._record_session_replacement(sid, replacement_session)
+                    replacement_session = self._session_replacements.get(sid)
                 # Retry only on a session known to replace this exact stale
                 # session. self.session may instead have changed because the
                 # user deliberately switched tabs while this request waited.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -391,7 +391,9 @@ class Daemon:
                     pages_by_id = {t["targetId"]: t for t in refreshed if t["type"] == "page"}
                     page = pages_by_id.get(self.target_id) or pages_by_id.get(self.dedicated_target_id)
                     if page is None:
-                        tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+                        tid = (await self.cdp.send_raw(
+                            "Target.createTarget", {"url": "about:blank", "background": True}
+                        ))["targetId"]
                         self.dedicated_target_id = tid
                         log(f"named daemon {NAME}: created dedicated tab ({tid})")
                         page = {"targetId": tid, "url": "about:blank", "type": "page"}
@@ -422,7 +424,9 @@ class Daemon:
                 take_over = inspect_tabs[0]["targetId"]
         if not pages:
             # No usable pages - create one instead of attaching to omnibox popup.
-            tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+            tid = (await self.cdp.send_raw(
+                "Target.createTarget", {"url": "about:blank", "background": True}
+            ))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
         self.session = (await self.cdp.send_raw(
@@ -609,10 +613,24 @@ class Daemon:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
             msg = str(e)
-            if "Session with given id not found" in msg and sid == self.session and sid:
-                log(f"stale session {sid}, re-attaching")
-                if await self.attach_first_page():
-                    return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
+            if "Session with given id not found" in msg and sid:
+                # Explicit session callers asked for that exact session; do not
+                # silently redirect them to the daemon's current tab.
+                if req.get("session_id"):
+                    return {"error": msg}
+                if sid == self.session:
+                    log(f"stale session {sid}, re-attaching")
+                    if not await self.attach_first_page():
+                        return {"error": msg}
+                # Another in-flight request may already have recovered while
+                # this request was waiting for its stale-session response.
+                if self.session and sid != self.session:
+                    try:
+                        return {"result": await self.cdp.send_raw(
+                            method, params, session_id=self.session
+                        )}
+                    except Exception as retry_error:
+                        return {"error": str(retry_error)}
             return {"error": msg}
 
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -362,12 +362,13 @@ class Daemon:
         self.target_id = None
         self.dedicated_target_id = None
         self._dedicated_target_lock = asyncio.Lock()
+        self._session_state_lock = asyncio.Lock()
         self._session_replacements = {}
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
 
-    async def attach_first_page(self, replaces_session=None):
+    async def attach_first_page(self, replaces_session=None, enable_domains=True):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         # Named daemons (BU_NAME != "default") share one browser with other
@@ -405,7 +406,8 @@ class Daemon:
             self._record_session_replacement(replaces_session, self.session)
             self.target_id = tid
             log(f"attached {tid} ({page.get('url','')[:80]}) session={self.session}")
-            await self._enable_default_domains(self.session)
+            if enable_domains:
+                await self._enable_default_domains(self.session)
             return page
 
         pages = [t for t in targets if is_real_page(t)]
@@ -445,7 +447,8 @@ class Daemon:
                 log(f"take over inspect tab {take_over}: {e}")
         if BROWSER_KIND == "local":
             await self._close_inspect_tabs(targets)
-        await self._enable_default_domains(self.session)
+        if enable_domains:
+            await self._enable_default_domains(self.session)
         return pages[0]
 
     async def _close_inspect_tabs(self, targets):
@@ -583,9 +586,11 @@ class Daemon:
                 }
             return {"target_id": self.target_id, "session_id": self.session, "page": page}
         if meta == "set_session":
-            old_session = self.session
-            self.session = req.get("session_id")
-            self.target_id = req.get("target_id") or self.target_id
+            async with self._session_state_lock:
+                old_session = self.session
+                self.session = req.get("session_id")
+                self.target_id = req.get("target_id") or self.target_id
+                new_session = self.session
             # Run the old-session Network.disable (defense in depth — keeps
             # background-tab traffic out of the global event buffer; the
             # consumer-side filter in wait_for_network_idle is the actual
@@ -595,7 +600,7 @@ class Daemon:
             # even on a remote daemon — sequentially these would have stacked
             # to ~22s worst case.
             tasks = []
-            if old_session and old_session != self.session:
+            if old_session and old_session != new_session:
                 async def disable_old():
                     try:
                         await asyncio.wait_for(
@@ -604,7 +609,7 @@ class Daemon:
                         )
                     except Exception: pass
                 tasks.append(disable_old())
-            tasks.append(self._enable_default_domains(self.session))
+            tasks.append(self._enable_default_domains(new_session))
             await asyncio.gather(*tasks)
             # 🐴 tab-marker title prefix is purely cosmetic — fire-and-forget so
             # it doesn't add to the synchronous IPC budget.
@@ -612,11 +617,11 @@ class Daemon:
                 self.cdp.send_raw(
                     "Runtime.evaluate",
                     {"expression": "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"},
-                    session_id=self.session,
+                    session_id=new_session,
                 ),
                 timeout=2,
             )))
-            return {"session_id": self.session}
+            return {"session_id": new_session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":    self.stop.set(); return {"ok": True}
 
@@ -634,12 +639,19 @@ class Daemon:
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):
                     return {"error": msg}
-                replacement_session = self._session_replacements.get(sid)
-                if replacement_session is None and sid == self.session:
-                    log(f"stale session {sid}, re-attaching")
-                    if not await self.attach_first_page(replaces_session=sid):
-                        return {"error": msg}
+                recovered_here = False
+                async with self._session_state_lock:
                     replacement_session = self._session_replacements.get(sid)
+                    if replacement_session is None and sid == self.session:
+                        log(f"stale session {sid}, re-attaching")
+                        if not await self.attach_first_page(
+                            replaces_session=sid, enable_domains=False
+                        ):
+                            return {"error": msg}
+                        replacement_session = self._session_replacements.get(sid)
+                        recovered_here = replacement_session is not None
+                if recovered_here:
+                    await self._enable_default_domains(replacement_session)
                 # Retry only on a session known to replace this exact stale
                 # session. self.session may instead have changed because the
                 # user deliberately switched tabs while this request waited.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -361,12 +361,18 @@ class Daemon:
         self.session = None
         self.target_id = None
         self.owned_target_id = None  # target created by this named daemon
+        self._attach_lock = asyncio.Lock()
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
+        async with self._attach_lock:
+            return await self._attach_first_page_unlocked()
+
+    async def _attach_first_page_unlocked(self):
+        """Attach while the caller holds _attach_lock."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         # Named daemons (BU_NAME != "default") share one browser with other
         # daemons — attaching to the first page makes parallel daemons fight
@@ -458,30 +464,34 @@ class Daemon:
         except OSError:
             pass
 
-    async def _close_owned_target(self):
+    async def _close_owned_target(self, attempts=1):
         """Best-effort close of the tab created by this named daemon.
 
         `target_id` follows the user's current tab after switch_tab/new_tab,
         so it cannot be used for ownership cleanup. Keep the owned target ID
-        separately and retain it when close fails so a later retry does not
-        create another orphan tab.
+        separately. Failed closes retain the ID so this method can retry
+        without ever targeting the user's currently selected tab.
         """
         tid = self.owned_target_id
         if not tid or not self.cdp:
             return True
-        try:
-            await asyncio.wait_for(
-                self.cdp.send_raw("Target.closeTarget", {"targetId": tid}),
-                timeout=2,
-            )
-            log(f"closed owned tab {tid}")
-            self.owned_target_id = None
-            if self.target_id == tid:
-                self.target_id = None
-            return True
-        except Exception as e:
-            log(f"close owned tab {tid}: {e}")
-            return False
+        attempts = max(1, attempts)
+        for attempt in range(1, attempts + 1):
+            try:
+                await asyncio.wait_for(
+                    self.cdp.send_raw("Target.closeTarget", {"targetId": tid}),
+                    timeout=2,
+                )
+                log(f"closed owned tab {tid}")
+                self.owned_target_id = None
+                if self.target_id == tid:
+                    self.target_id = None
+                return True
+            except Exception as e:
+                log(f"close owned tab {tid} (attempt {attempt}/{attempts}): {e}")
+                if attempt < attempts:
+                    await asyncio.sleep(0.1)
+        return False
 
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.
@@ -635,10 +645,23 @@ class Daemon:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
             msg = str(e)
-            if "Session with given id not found" in msg and sid == self.session and sid:
-                log(f"stale session {sid}, re-attaching")
-                if await self.attach_first_page():
-                    return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
+            if "Session with given id not found" in msg and sid:
+                # IPC handlers run concurrently. Only one request may replace a
+                # stale session; later requests reuse that replacement instead
+                # of closing it and creating another dedicated tab.
+                async with self._attach_lock:
+                    explicit_session = req.get("session_id")
+                    if sid == self.session:
+                        log(f"stale session {sid}, re-attaching")
+                        if not await self._attach_first_page_unlocked():
+                            return {"error": msg}
+                    elif explicit_session:
+                        return {"error": msg}
+                    if self.session:
+                        try:
+                            return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
+                        except Exception as retry_error:
+                            return {"error": str(retry_error)}
             return {"error": msg}
 
 
@@ -684,7 +707,7 @@ async def main():
         # Startup can fail after Target.createTarget has succeeded, and the
         # selected tab can change during a normal run. Always clean up by the
         # separately tracked owned target ID.
-        await d._close_owned_target()
+        await d._close_owned_target(attempts=3)
 
 
 def already_running():

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -361,6 +361,7 @@ class Daemon:
         self.session = None
         self.target_id = None
         self.dedicated_target_id = None
+        self._dedicated_target_lock = asyncio.Lock()
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
@@ -383,10 +384,17 @@ class Daemon:
             # Reattach to the current tab first, then the daemon's dedicated tab.
             page = pages_by_id.get(self.target_id) or pages_by_id.get(self.dedicated_target_id)
             if page is None:
-                tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
-                self.dedicated_target_id = tid
-                log(f"named daemon {NAME}: created dedicated tab ({tid})")
-                page = {"targetId": tid, "url": "about:blank", "type": "page"}
+                # Two stale IPC requests can recover concurrently. Recheck
+                # inside a narrow lock so they share one replacement tab.
+                async with self._dedicated_target_lock:
+                    refreshed = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+                    pages_by_id = {t["targetId"]: t for t in refreshed if t["type"] == "page"}
+                    page = pages_by_id.get(self.target_id) or pages_by_id.get(self.dedicated_target_id)
+                    if page is None:
+                        tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+                        self.dedicated_target_id = tid
+                        log(f"named daemon {NAME}: created dedicated tab ({tid})")
+                        page = {"targetId": tid, "url": "about:blank", "type": "page"}
             tid = page["targetId"]
             self.session = (await self.cdp.send_raw(
                 "Target.attachToTarget", {"targetId": tid, "flatten": True}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -360,6 +360,7 @@ class Daemon:
         self.cdp = None
         self.session = None
         self.target_id = None
+        self.owned_target_id = None  # target created by this named daemon
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
@@ -367,6 +368,43 @@ class Daemon:
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+        # Named daemons (BU_NAME != "default") share one browser with other
+        # daemons — attaching to the first page makes parallel daemons fight
+        # over a single tab (navigations clobber each other). Give each named
+        # daemon its own dedicated tab instead. REMOTE_ID (cloud) browsers are
+        # already exclusive to this daemon, so first-page attach stays.
+        if NAME != "default" and not REMOTE_ID:
+            # The permission recovery flow can leave chrome://inspect open.
+            # Clean it up before returning from this early path as well.
+            if BROWSER_KIND == "local":
+                await self._close_inspect_tabs(targets)
+            if self.owned_target_id and not await self._close_owned_target():
+                raise RuntimeError(
+                    f"cannot close previously owned tab {self.owned_target_id}; refusing to create another"
+                )
+
+            tid = None
+            try:
+                tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
+                # Record ownership immediately: attach or domain setup can fail
+                # after Target.createTarget has already made a real tab.
+                self.owned_target_id = tid
+                log(f"named daemon {NAME}: created dedicated tab ({tid})")
+                page = {"targetId": tid, "url": "about:blank", "type": "page"}
+                self.session = (await self.cdp.send_raw(
+                    "Target.attachToTarget", {"targetId": tid, "flatten": True}
+                ))["sessionId"]
+                self.target_id = tid
+                log(f"attached {tid} (about:blank) session={self.session}")
+                await self._enable_default_domains(self.session)
+                return page
+            except Exception:
+                await self._close_owned_target()
+                self.session = None
+                if self.target_id == tid:
+                    self.target_id = None
+                raise
+
         pages = [t for t in targets if is_real_page(t)]
         if not pages:
             # Fresh browser (ex: BU cloud) starts w about:blank; reuse it
@@ -419,6 +457,31 @@ class Daemon:
             paths.inspect_marker().unlink()
         except OSError:
             pass
+
+    async def _close_owned_target(self):
+        """Best-effort close of the tab created by this named daemon.
+
+        `target_id` follows the user's current tab after switch_tab/new_tab,
+        so it cannot be used for ownership cleanup. Keep the owned target ID
+        separately and retain it when close fails so a later retry does not
+        create another orphan tab.
+        """
+        tid = self.owned_target_id
+        if not tid or not self.cdp:
+            return True
+        try:
+            await asyncio.wait_for(
+                self.cdp.send_raw("Target.closeTarget", {"targetId": tid}),
+                timeout=2,
+            )
+            log(f"closed owned tab {tid}")
+            self.owned_target_id = None
+            if self.target_id == tid:
+                self.target_id = None
+            return True
+        except Exception as e:
+            log(f"close owned tab {tid}: {e}")
+            return False
 
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.
@@ -614,8 +677,14 @@ async def serve(d):
 
 async def main():
     d = Daemon()
-    await d.start()
-    await serve(d)
+    try:
+        await d.start()
+        await serve(d)
+    finally:
+        # Startup can fail after Target.createTarget has succeeded, and the
+        # selected tab can change during a normal run. Always clean up by the
+        # separately tracked owned target ID.
+        await d._close_owned_target()
 
 
 def already_running():

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -362,6 +362,7 @@ class Daemon:
         self.target_id = None
         self.dedicated_target_id = None
         self._dedicated_target_lock = asyncio.Lock()
+        self._session_replacements = {}
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
@@ -484,6 +485,19 @@ class Daemon:
             except Exception as e:
                 log(f"enable {d} on {session_id}: {e}")
         await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
+
+    def _record_session_replacement(self, stale_session, replacement_session):
+        """Remember which recovered session still controls the same tab."""
+        if not stale_session or not replacement_session or stale_session == replacement_session:
+            return
+        # Preserve chains so requests delayed across multiple recoveries still
+        # land on their original tab, never whichever tab is current now.
+        for source, replacement in list(self._session_replacements.items()):
+            if replacement == stale_session:
+                self._session_replacements[source] = replacement_session
+        self._session_replacements[stale_session] = replacement_session
+        while len(self._session_replacements) > 32:
+            self._session_replacements.pop(next(iter(self._session_replacements)))
 
     async def start(self):
         self.stop = asyncio.Event()
@@ -618,16 +632,20 @@ class Daemon:
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):
                     return {"error": msg}
-                if sid == self.session:
+                replacement_session = self._session_replacements.get(sid)
+                if replacement_session is None and sid == self.session:
                     log(f"stale session {sid}, re-attaching")
                     if not await self.attach_first_page():
                         return {"error": msg}
-                # Another in-flight request may already have recovered while
-                # this request was waiting for its stale-session response.
-                if self.session and sid != self.session:
+                    replacement_session = self.session
+                    self._record_session_replacement(sid, replacement_session)
+                # Retry only on a session known to replace this exact stale
+                # session. self.session may instead have changed because the
+                # user deliberately switched tabs while this request waited.
+                if replacement_session:
                     try:
                         return {"result": await self.cdp.send_raw(
-                            method, params, session_id=self.session
+                            method, params, session_id=replacement_session
                         )}
                     except Exception as retry_error:
                         return {"error": str(retry_error)}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -360,19 +360,13 @@ class Daemon:
         self.cdp = None
         self.session = None
         self.target_id = None
-        self.owned_target_id = None  # target created by this named daemon
-        self._attach_lock = asyncio.Lock()
+        self.dedicated_target_id = None
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
-        async with self._attach_lock:
-            return await self._attach_first_page_unlocked()
-
-    async def _attach_first_page_unlocked(self):
-        """Attach while the caller holds _attach_lock."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         # Named daemons (BU_NAME != "default") share one browser with other
         # daemons — attaching to the first page makes parallel daemons fight
@@ -384,32 +378,23 @@ class Daemon:
             # Clean it up before returning from this early path as well.
             if BROWSER_KIND == "local":
                 await self._close_inspect_tabs(targets)
-            if self.owned_target_id and not await self._close_owned_target():
-                raise RuntimeError(
-                    f"cannot close previously owned tab {self.owned_target_id}; refusing to create another"
-                )
-
-            tid = None
-            try:
+            pages_by_id = {t["targetId"]: t for t in targets if t["type"] == "page"}
+            # A stale CDP session does not necessarily mean its tab disappeared.
+            # Reattach to the current tab first, then the daemon's dedicated tab.
+            page = pages_by_id.get(self.target_id) or pages_by_id.get(self.dedicated_target_id)
+            if page is None:
                 tid = (await self.cdp.send_raw("Target.createTarget", {"url": "about:blank"}))["targetId"]
-                # Record ownership immediately: attach or domain setup can fail
-                # after Target.createTarget has already made a real tab.
-                self.owned_target_id = tid
+                self.dedicated_target_id = tid
                 log(f"named daemon {NAME}: created dedicated tab ({tid})")
                 page = {"targetId": tid, "url": "about:blank", "type": "page"}
-                self.session = (await self.cdp.send_raw(
-                    "Target.attachToTarget", {"targetId": tid, "flatten": True}
-                ))["sessionId"]
-                self.target_id = tid
-                log(f"attached {tid} (about:blank) session={self.session}")
-                await self._enable_default_domains(self.session)
-                return page
-            except Exception:
-                await self._close_owned_target()
-                self.session = None
-                if self.target_id == tid:
-                    self.target_id = None
-                raise
+            tid = page["targetId"]
+            self.session = (await self.cdp.send_raw(
+                "Target.attachToTarget", {"targetId": tid, "flatten": True}
+            ))["sessionId"]
+            self.target_id = tid
+            log(f"attached {tid} ({page.get('url','')[:80]}) session={self.session}")
+            await self._enable_default_domains(self.session)
+            return page
 
         pages = [t for t in targets if is_real_page(t)]
         if not pages:
@@ -463,35 +448,6 @@ class Daemon:
             paths.inspect_marker().unlink()
         except OSError:
             pass
-
-    async def _close_owned_target(self, attempts=1):
-        """Best-effort close of the tab created by this named daemon.
-
-        `target_id` follows the user's current tab after switch_tab/new_tab,
-        so it cannot be used for ownership cleanup. Keep the owned target ID
-        separately. Failed closes retain the ID so this method can retry
-        without ever targeting the user's currently selected tab.
-        """
-        tid = self.owned_target_id
-        if not tid or not self.cdp:
-            return True
-        attempts = max(1, attempts)
-        for attempt in range(1, attempts + 1):
-            try:
-                await asyncio.wait_for(
-                    self.cdp.send_raw("Target.closeTarget", {"targetId": tid}),
-                    timeout=2,
-                )
-                log(f"closed owned tab {tid}")
-                self.owned_target_id = None
-                if self.target_id == tid:
-                    self.target_id = None
-                return True
-            except Exception as e:
-                log(f"close owned tab {tid} (attempt {attempt}/{attempts}): {e}")
-                if attempt < attempts:
-                    await asyncio.sleep(0.1)
-        return False
 
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.
@@ -645,23 +601,10 @@ class Daemon:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
             msg = str(e)
-            if "Session with given id not found" in msg and sid:
-                # IPC handlers run concurrently. Only one request may replace a
-                # stale session; later requests reuse that replacement instead
-                # of closing it and creating another dedicated tab.
-                async with self._attach_lock:
-                    explicit_session = req.get("session_id")
-                    if sid == self.session:
-                        log(f"stale session {sid}, re-attaching")
-                        if not await self._attach_first_page_unlocked():
-                            return {"error": msg}
-                    elif explicit_session:
-                        return {"error": msg}
-                    if self.session:
-                        try:
-                            return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
-                        except Exception as retry_error:
-                            return {"error": str(retry_error)}
+            if "Session with given id not found" in msg and sid == self.session and sid:
+                log(f"stale session {sid}, re-attaching")
+                if await self.attach_first_page():
+                    return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
             return {"error": msg}
 
 
@@ -700,14 +643,8 @@ async def serve(d):
 
 async def main():
     d = Daemon()
-    try:
-        await d.start()
-        await serve(d)
-    finally:
-        # Startup can fail after Target.createTarget has succeeded, and the
-        # selected tab can change during a normal run. Always clean up by the
-        # separately tracked owned target ID.
-        await d._close_owned_target(attempts=3)
+    await d.start()
+    await serve(d)
 
 
 def already_running():

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -291,15 +291,35 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
-def switch_tab(target):
+def _target_id(target):
+    """Accept a raw target id or a tab dict returned by the helpers."""
+    return (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
+
+def activate_tab(target):
+    """Make a target the visible Chrome tab.
+
+    This is intentionally separate from switch_tab(): attaching the agent to a
+    target does not require taking over the user's visible Chrome tab.
+    """
+    target_id = _target_id(target)
+    cdp("Target.activateTarget", targetId=target_id)
+    return target_id
+
+def switch_tab(target, activate=False):
+    """Attach the agent without changing Chrome's visible tab by default.
+
+    Pass activate=True only when Chrome must visibly show the target. The horse
+    marker still moves to the attached target so the user can find it.
+    """
     # Accept either a raw targetId string or the dict returned by current_tab() / list_tabs(),
     # so `switch_tab(current_tab())` works without a manual ["targetId"] dance.
-    target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
+    target_id = _target_id(target)
     # Unmark old tab. Horse emoji is a surrogate pair in JS UTF-16 strings (2 code units),
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    if activate:
+        activate_tab(target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()
@@ -323,7 +343,7 @@ def new_tab(url="about:blank"):
                 return cur.get("targetId") or cur.get("target_id")
         except Exception:
             pass
-    tid = cdp("Target.createTarget", url="about:blank")["targetId"]
+    tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)
@@ -332,7 +352,7 @@ def new_tab(url="about:blank"):
 def close_tab(target=None):
     """Close a tab. If `target` is omitted, closes the currently attached tab.
     Accepts a raw targetId string or a dict from list_tabs()/current_tab()."""
-    target_id = (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
+    target_id = _target_id(target)
     if target_id is None:
         target_id = current_tab()["targetId"]
     cdp("Target.closeTarget", targetId=target_id)

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -562,8 +562,8 @@ def test_shutdown_leaves_dedicated_tab_open(monkeypatch):
     assert d.target_id == "user-selected-tab"
 
 
-def test_delayed_implicit_stale_request_retries_current_session():
-    """A slow stale response follows recovery completed by another request."""
+def test_delayed_implicit_stale_request_retries_its_recovered_session():
+    """A slow stale response follows recovery for its original session."""
     class _DelayedStaleCDP(_FakeCDP):
         def __init__(self):
             super().__init__()
@@ -603,6 +603,9 @@ def test_delayed_implicit_stale_request_retries_current_session():
         fast = await d.handle({
             "method": "Runtime.evaluate", "params": {"expression": "fast"}
         })
+        # A later tab switch must not redirect the delayed request. Its stale
+        # session maps to the replacement that still controls its original tab.
+        d.session = "user-selected-session"
         d.cdp.release_slow.set()
         return d, recoveries, fast, await slow
 
@@ -617,6 +620,62 @@ def test_delayed_implicit_stale_request_retries_current_session():
         if method == "Runtime.evaluate" and sid == "replacement-session"
     ]
     assert retries == [("fast", "replacement-session"), ("slow", "replacement-session")]
+
+
+def test_stale_request_is_not_replayed_after_unrelated_tab_switch():
+    """set_session must never redirect an older request onto the new tab."""
+    class _SwitchRaceCDP(_FakeCDP):
+        def __init__(self):
+            super().__init__()
+            self.request_started = None
+            self.release_request = None
+
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if (
+                method == "Runtime.evaluate"
+                and params.get("expression") == "old-tab-action"
+                and session_id == "old-session"
+            ):
+                self.request_started.set()
+                await self.release_request.wait()
+                raise RuntimeError("Session with given id not found")
+            return {}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _SwitchRaceCDP()
+        d.cdp.request_started = asyncio.Event()
+        d.cdp.release_request = asyncio.Event()
+        d.session = "old-session"
+        d.target_id = "old-tab"
+
+        request = asyncio.create_task(d.handle({
+            "method": "Runtime.evaluate",
+            "params": {"expression": "old-tab-action"},
+        }))
+        await d.cdp.request_started.wait()
+        await d.handle({
+            "meta": "set_session",
+            "session_id": "new-session",
+            "target_id": "new-tab",
+        })
+        d.cdp.release_request.set()
+        result = await request
+        await asyncio.sleep(0)  # let the cosmetic marker task finish
+        return d, result
+
+    d, result = asyncio.run(run())
+
+    assert result == {"error": "Session with given id not found"}
+    redirected = [
+        (params, sid)
+        for method, params, sid in d.cdp.calls
+        if method == "Runtime.evaluate"
+        and params.get("expression") == "old-tab-action"
+        and sid == "new-session"
+    ]
+    assert redirected == []
 
 
 def test_explicit_stale_session_is_not_redirected():

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -315,7 +315,9 @@ class _AttachCDP(_FakeCDP):
             return {"targetInfos": self.targets}
         if method == "Target.createTarget":
             self.created += 1
-            return {"targetId": f"created-{self.created}"}
+            tid = f"created-{self.created}"
+            self.targets.append({"targetId": tid, "url": "about:blank", "type": "page"})
+            return {"targetId": tid}
         if method == "Target.attachToTarget":
             return {"sessionId": f"session-for-{params['targetId']}"}
         if method == "Target.closeTarget":
@@ -336,7 +338,7 @@ def test_named_daemon_creates_dedicated_tab(monkeypatch):
 
     assert page["targetId"] == "created-1"
     assert d.target_id == "created-1"
-    assert d.owned_target_id == "created-1"
+    assert d.dedicated_target_id == "created-1"
     assert d.session == "session-for-created-1"
     attach_calls = [p for (m, p, _s) in d.cdp.calls if m == "Target.attachToTarget"]
     assert attach_calls == [{"targetId": "created-1", "flatten": True}]
@@ -355,7 +357,7 @@ def test_default_daemon_still_attaches_first_page(monkeypatch):
     page = asyncio.run(d.attach_first_page())
 
     assert page["targetId"] == "user-tab"
-    assert d.owned_target_id is None
+    assert d.dedicated_target_id is None
     assert d.cdp.created == 0
 
 
@@ -371,12 +373,12 @@ def test_named_remote_daemon_keeps_first_page_attach(monkeypatch):
     page = asyncio.run(d.attach_first_page())
 
     assert page["targetId"] == "cloud-blank"
-    assert d.owned_target_id is None
+    assert d.dedicated_target_id is None
     assert d.cdp.created == 0
 
 
-def test_named_reattach_closes_previous_owned_tab_before_creating_another(monkeypatch):
-    """A stale-session retry must not leak the old dedicated tab."""
+def test_named_reattach_reuses_dedicated_tab(monkeypatch):
+    """A stale CDP session should not replace a tab that still exists."""
     monkeypatch.setattr(daemon, "NAME", "worker-a")
     monkeypatch.setattr(daemon, "REMOTE_ID", None)
     monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
@@ -384,77 +386,80 @@ def test_named_reattach_closes_previous_owned_tab_before_creating_another(monkey
     d.cdp = _AttachCDP()
 
     asyncio.run(d.attach_first_page())
-    d.target_id = "user-selected-tab"
     asyncio.run(d.attach_first_page())
 
-    assert d.cdp.closed == ["created-1"]
-    assert d.target_id == "created-2"
-    assert d.owned_target_id == "created-2"
-
-
-def test_concurrent_stale_requests_share_one_reattached_tab(monkeypatch):
-    """Concurrent stale-session recovery must create only one replacement tab."""
-    class _ConcurrentStaleCDP(_AttachCDP):
-        def __init__(self):
-            super().__init__()
-            self.release_stale = None
-            self.stale_calls = 0
-            self.retry_sessions = []
-
-        async def send_raw(self, method, params=None, session_id=None):
-            if method == "Runtime.evaluate":
-                self.calls.append((method, params, session_id))
-                if session_id == "stale-session":
-                    self.stale_calls += 1
-                    if self.stale_calls == 2:
-                        self.release_stale.set()
-                    await self.release_stale.wait()
-                    raise RuntimeError("Session with given id not found")
-                self.retry_sessions.append(session_id)
-                return {"session": session_id}
-            return await super().send_raw(method, params, session_id)
-
-    async def run():
-        monkeypatch.setattr(daemon, "NAME", "worker-a")
-        monkeypatch.setattr(daemon, "REMOTE_ID", None)
-        monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
-        d = daemon.Daemon()
-        d.cdp = _ConcurrentStaleCDP()
-        d.cdp.release_stale = asyncio.Event()
-        d.session = "stale-session"
-        d.target_id = "old-owned-tab"
-        d.owned_target_id = "old-owned-tab"
-        request = {"method": "Runtime.evaluate", "params": {"expression": "1"}}
-        results = await asyncio.gather(d.handle(request), d.handle(request))
-        return d, results
-
-    d, results = asyncio.run(run())
-
     assert d.cdp.created == 1
-    assert d.cdp.closed == ["old-owned-tab"]
-    assert d.owned_target_id == "created-1"
-    assert d.cdp.retry_sessions == ["session-for-created-1", "session-for-created-1"]
-    assert results == [
-        {"result": {"session": "session-for-created-1"}},
-        {"result": {"session": "session-for-created-1"}},
-    ]
+    assert d.cdp.closed == []
+    assert d.target_id == "created-1"
+    assert d.dedicated_target_id == "created-1"
 
 
-def test_named_attach_failure_closes_created_tab(monkeypatch):
-    """If attach fails after Target.createTarget, the new tab is cleaned up."""
+def test_named_reattach_keeps_selected_tab_when_it_still_exists(monkeypatch):
+    """A deliberate switch_tab remains the active tab after session recovery."""
     monkeypatch.setattr(daemon, "NAME", "worker-a")
     monkeypatch.setattr(daemon, "REMOTE_ID", None)
     monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
     d = daemon.Daemon()
-    d.cdp = _AttachCDP(fail_method="Target.attachToTarget")
+    d.cdp = _AttachCDP()
+
+    asyncio.run(d.attach_first_page())
+    d.cdp.targets.append({"targetId": "selected-tab", "url": "https://example.com", "type": "page"})
+    d.target_id = "selected-tab"
+    asyncio.run(d.attach_first_page())
+
+    assert d.cdp.created == 1
+    assert d.cdp.closed == []
+    assert d.target_id == "selected-tab"
+    assert d.dedicated_target_id == "created-1"
+    assert d.session == "session-for-selected-tab"
+
+
+def test_named_reattach_creates_replacement_only_when_tab_is_gone(monkeypatch):
+    """If the user closes the dedicated tab, the daemon creates one replacement."""
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+
+    asyncio.run(d.attach_first_page())
+    d.cdp.targets = [t for t in d.cdp.targets if t["targetId"] != "created-1"]
+    asyncio.run(d.attach_first_page())
+
+    assert d.cdp.created == 2
+    assert d.cdp.closed == []
+    assert d.target_id == "created-2"
+    assert d.dedicated_target_id == "created-2"
+
+
+def test_named_attach_failure_reuses_created_tab_on_retry(monkeypatch):
+    """A transient attach failure leaves the tab available for the next retry."""
+    class _FailOnceAttachCDP(_AttachCDP):
+        def __init__(self):
+            super().__init__()
+            self.fail_attach = True
+
+        async def send_raw(self, method, params=None, session_id=None):
+            if method == "Target.attachToTarget" and self.fail_attach:
+                self.calls.append((method, params, session_id))
+                self.fail_attach = False
+                raise RuntimeError("simulated Target.attachToTarget failure")
+            return await super().send_raw(method, params, session_id)
+
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d = daemon.Daemon()
+    d.cdp = _FailOnceAttachCDP()
 
     with pytest.raises(RuntimeError, match="Target.attachToTarget"):
         asyncio.run(d.attach_first_page())
+    page = asyncio.run(d.attach_first_page())
 
-    assert d.cdp.closed == ["created-1"]
-    assert d.owned_target_id is None
-    assert d.session is None
-    assert d.target_id is None
+    assert page["targetId"] == "created-1"
+    assert d.cdp.created == 1
+    assert d.cdp.closed == []
+    assert d.dedicated_target_id == "created-1"
 
 
 def test_named_local_attach_cleans_inspect_tabs_before_return(monkeypatch):
@@ -474,50 +479,24 @@ def test_named_local_attach_cleans_inspect_tabs_before_return(monkeypatch):
     assert d.cdp.closed == ["inspect-tab"]
 
 
-def test_owned_cleanup_uses_owned_target_after_tab_switch():
-    """Shutdown must close the daemon tab, not the user's selected tab."""
+def test_main_leaves_dedicated_tab_open(monkeypatch):
+    """Stopping the daemon never closes a working or user tab."""
     d = daemon.Daemon()
     d.cdp = _AttachCDP()
-    d.owned_target_id = "daemon-owned-tab"
-    d.target_id = "user-selected-tab"
 
-    asyncio.run(d._close_owned_target())
+    async def start():
+        d.dedicated_target_id = "daemon-tab"
+        d.target_id = "user-selected-tab"
 
-    assert d.cdp.closed == ["daemon-owned-tab"]
-    assert d.owned_target_id is None
-    assert d.target_id == "user-selected-tab"
+    async def done(_daemon):
+        return None
 
-
-def test_main_retries_owned_tab_cleanup_when_startup_fails(monkeypatch):
-    """Shutdown retries transient close timeouts before exiting."""
-    class _FlakyCloseCDP(_AttachCDP):
-        def __init__(self):
-            super().__init__()
-            self.close_attempts = 0
-
-        async def send_raw(self, method, params=None, session_id=None):
-            if method == "Target.closeTarget":
-                self.calls.append((method, params, session_id))
-                self.close_attempts += 1
-                if self.close_attempts < 3:
-                    raise TimeoutError("simulated close timeout")
-                self.closed.append(params["targetId"])
-                return {}
-            return await super().send_raw(method, params, session_id)
-
-    d = daemon.Daemon()
-    d.cdp = _FlakyCloseCDP()
-
-    async def failed_start():
-        d.owned_target_id = "created-before-startup-failure"
-        raise RuntimeError("simulated startup failure")
-
-    d.start = failed_start
+    d.start = start
     monkeypatch.setattr(daemon, "Daemon", lambda: d)
+    monkeypatch.setattr(daemon, "serve", done)
 
-    with pytest.raises(RuntimeError, match="startup failure"):
-        asyncio.run(daemon.main())
+    asyncio.run(daemon.main())
 
-    assert d.cdp.close_attempts == 3
-    assert d.cdp.closed == ["created-before-startup-failure"]
-    assert d.owned_target_id is None
+    assert d.cdp.closed == []
+    assert d.dedicated_target_id == "daemon-tab"
+    assert d.target_id == "user-selected-tab"

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -432,6 +432,44 @@ def test_named_reattach_creates_replacement_only_when_tab_is_gone(monkeypatch):
     assert d.dedicated_target_id == "created-2"
 
 
+def test_concurrent_named_reattach_creates_one_replacement(monkeypatch):
+    """Concurrent recovery after a user closes the tab shares one replacement."""
+    class _ConcurrentAttachCDP(_AttachCDP):
+        def __init__(self):
+            super().__init__()
+            self.get_calls = 0
+            self.first_gets_done = asyncio.Event()
+
+        async def send_raw(self, method, params=None, session_id=None):
+            if method == "Target.getTargets":
+                self.calls.append((method, params, session_id))
+                snapshot = list(self.targets)
+                self.get_calls += 1
+                if self.get_calls <= 2:
+                    if self.get_calls == 2:
+                        self.first_gets_done.set()
+                    await self.first_gets_done.wait()
+                return {"targetInfos": snapshot}
+            return await super().send_raw(method, params, session_id)
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _ConcurrentAttachCDP()
+        pages = await asyncio.gather(d.attach_first_page(), d.attach_first_page())
+        return d, pages
+
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d, pages = asyncio.run(run())
+
+    assert [page["targetId"] for page in pages] == ["created-1", "created-1"]
+    assert d.cdp.created == 1
+    assert d.cdp.closed == []
+    assert d.target_id == "created-1"
+    assert d.dedicated_target_id == "created-1"
+
+
 def test_named_attach_failure_reuses_created_tab_on_retry(monkeypatch):
     """A transient attach failure leaves the tab available for the next retry."""
     class _FailOnceAttachCDP(_AttachCDP):

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -627,13 +627,13 @@ def test_delayed_stale_request_follows_recovery_during_domain_enable(monkeypatch
     assert d._session_replacements == {"stale-session": "replacement-session"}
 
 
-def test_stale_request_is_not_replayed_after_unrelated_tab_switch():
-    """set_session must never redirect an older request onto the new tab."""
+def test_tab_switch_waits_for_recovery_and_keeps_old_action_on_old_tab(monkeypatch):
+    """A switch during target discovery cannot redirect the recovered action."""
     class _SwitchRaceCDP(_FakeCDP):
         def __init__(self):
             super().__init__()
-            self.request_started = None
-            self.release_request = None
+            self.discovery_started = None
+            self.release_discovery = None
 
         async def send_raw(self, method, params=None, session_id=None):
             self.calls.append((method, params, session_id))
@@ -642,16 +642,28 @@ def test_stale_request_is_not_replayed_after_unrelated_tab_switch():
                 and params.get("expression") == "old-tab-action"
                 and session_id == "old-session"
             ):
-                self.request_started.set()
-                await self.release_request.wait()
                 raise RuntimeError("Session with given id not found")
+            if method == "Target.getTargets":
+                self.discovery_started.set()
+                await self.release_discovery.wait()
+                return {"targetInfos": [
+                    {"targetId": "old-tab", "url": "https://example.com", "type": "page"}
+                ]}
+            if method == "Target.attachToTarget":
+                return {"sessionId": "recovered-old-session"}
+            if (
+                method == "Runtime.evaluate"
+                and params.get("expression") == "old-tab-action"
+                and session_id == "recovered-old-session"
+            ):
+                return {"value": "old-tab-action"}
             return {}
 
     async def run():
         d = daemon.Daemon()
         d.cdp = _SwitchRaceCDP()
-        d.cdp.request_started = asyncio.Event()
-        d.cdp.release_request = asyncio.Event()
+        d.cdp.discovery_started = asyncio.Event()
+        d.cdp.release_discovery = asyncio.Event()
         d.session = "old-session"
         d.target_id = "old-tab"
 
@@ -659,20 +671,27 @@ def test_stale_request_is_not_replayed_after_unrelated_tab_switch():
             "method": "Runtime.evaluate",
             "params": {"expression": "old-tab-action"},
         }))
-        await d.cdp.request_started.wait()
-        await d.handle({
+        await d.cdp.discovery_started.wait()
+        switch = asyncio.create_task(d.handle({
             "meta": "set_session",
             "session_id": "new-session",
             "target_id": "new-tab",
-        })
-        d.cdp.release_request.set()
-        result = await request
+        }))
+        await asyncio.sleep(0)  # let set_session wait on the recovery lock
+        d.cdp.release_discovery.set()
+        result, switch_result = await asyncio.gather(request, switch)
         await asyncio.sleep(0)  # let the cosmetic marker task finish
-        return d, result
+        return d, result, switch_result
 
-    d, result = asyncio.run(run())
+    monkeypatch.setattr(daemon, "NAME", "default")
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d, result, switch_result = asyncio.run(run())
 
-    assert result == {"error": "Session with given id not found"}
+    assert result == {"result": {"value": "old-tab-action"}}
+    assert switch_result == {"session_id": "new-session"}
+    assert d.session == "new-session"
+    assert d.target_id == "new-tab"
+    assert d._session_replacements == {"old-session": "recovered-old-session"}
     redirected = [
         (params, sid)
         for method, params, sid in d.cdp.calls

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -342,6 +342,8 @@ def test_named_daemon_creates_dedicated_tab(monkeypatch):
     assert d.session == "session-for-created-1"
     attach_calls = [p for (m, p, _s) in d.cdp.calls if m == "Target.attachToTarget"]
     assert attach_calls == [{"targetId": "created-1", "flatten": True}]
+    create_calls = [p for (m, p, _s) in d.cdp.calls if m == "Target.createTarget"]
+    assert create_calls == [{"url": "about:blank", "background": True}]
     enabled = {m for (m, _p, s) in d.cdp.calls if s == d.session and m.endswith(".enable")}
     assert enabled == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
 
@@ -359,6 +361,21 @@ def test_default_daemon_still_attaches_first_page(monkeypatch):
     assert page["targetId"] == "user-tab"
     assert d.dedicated_target_id is None
     assert d.cdp.created == 0
+
+
+def test_default_daemon_creates_missing_page_in_background(monkeypatch):
+    """Fallback tabs must not steal the user's foreground Chrome tab."""
+    monkeypatch.setattr(daemon, "NAME", "default")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+
+    page = asyncio.run(d.attach_first_page())
+
+    assert page["targetId"] == "created-1"
+    create_calls = [p for (m, p, _s) in d.cdp.calls if m == "Target.createTarget"]
+    assert create_calls == [{"url": "about:blank", "background": True}]
 
 
 def test_named_remote_daemon_keeps_first_page_attach(monkeypatch):
@@ -517,24 +534,109 @@ def test_named_local_attach_cleans_inspect_tabs_before_return(monkeypatch):
     assert d.cdp.closed == ["inspect-tab"]
 
 
-def test_main_leaves_dedicated_tab_open(monkeypatch):
-    """Stopping the daemon never closes a working or user tab."""
+def test_shutdown_leaves_dedicated_tab_open(monkeypatch):
+    """The real serve shutdown path never closes a working or user tab."""
     d = daemon.Daemon()
     d.cdp = _AttachCDP()
 
     async def start():
         d.dedicated_target_id = "daemon-tab"
         d.target_id = "user-selected-tab"
+        d.stop = asyncio.Event()
+        d.stop.set()
 
-    async def done(_daemon):
-        return None
+    async def wait_forever(*_args):
+        await asyncio.Event().wait()
 
     d.start = start
     monkeypatch.setattr(daemon, "Daemon", lambda: d)
-    monkeypatch.setattr(daemon, "serve", done)
+    monkeypatch.setattr(daemon.ipc, "serve", wait_forever)
+    monkeypatch.setattr(daemon.ipc, "sock_addr", lambda _name: "test-socket")
+    monkeypatch.setattr(daemon.ipc, "cleanup_endpoint", lambda _name: None)
+    monkeypatch.setattr(daemon, "log", lambda _message: None)
 
     asyncio.run(daemon.main())
 
     assert d.cdp.closed == []
     assert d.dedicated_target_id == "daemon-tab"
     assert d.target_id == "user-selected-tab"
+
+
+def test_delayed_implicit_stale_request_retries_current_session():
+    """A slow stale response follows recovery completed by another request."""
+    class _DelayedStaleCDP(_FakeCDP):
+        def __init__(self):
+            super().__init__()
+            self.slow_started = None
+            self.release_slow = None
+
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Runtime.evaluate" and session_id == "stale-session":
+                if params["expression"] == "slow":
+                    self.slow_started.set()
+                    await self.release_slow.wait()
+                raise RuntimeError("Session with given id not found")
+            if method == "Runtime.evaluate" and session_id == "replacement-session":
+                return {"value": params["expression"]}
+            return {}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _DelayedStaleCDP()
+        d.cdp.slow_started = asyncio.Event()
+        d.cdp.release_slow = asyncio.Event()
+        d.session = "stale-session"
+        recoveries = 0
+
+        async def recover():
+            nonlocal recoveries
+            recoveries += 1
+            d.session = "replacement-session"
+            return {"targetId": "same-tab"}
+
+        d.attach_first_page = recover
+        slow = asyncio.create_task(d.handle({
+            "method": "Runtime.evaluate", "params": {"expression": "slow"}
+        }))
+        await d.cdp.slow_started.wait()
+        fast = await d.handle({
+            "method": "Runtime.evaluate", "params": {"expression": "fast"}
+        })
+        d.cdp.release_slow.set()
+        return d, recoveries, fast, await slow
+
+    d, recoveries, fast, slow = asyncio.run(run())
+
+    assert recoveries == 1
+    assert fast == {"result": {"value": "fast"}}
+    assert slow == {"result": {"value": "slow"}}
+    retries = [
+        (params["expression"], sid)
+        for method, params, sid in d.cdp.calls
+        if method == "Runtime.evaluate" and sid == "replacement-session"
+    ]
+    assert retries == [("fast", "replacement-session"), ("slow", "replacement-session")]
+
+
+def test_explicit_stale_session_is_not_redirected():
+    """Explicit session requests retain their exact-session semantics."""
+    class _AlwaysStaleCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            raise RuntimeError("Session with given id not found")
+
+    d = daemon.Daemon()
+    d.cdp = _AlwaysStaleCDP()
+    d.session = "current-session"
+
+    result = asyncio.run(d.handle({
+        "method": "Runtime.evaluate",
+        "params": {"expression": "1"},
+        "session_id": "explicit-stale-session",
+    }))
+
+    assert result == {"error": "Session with given id not found"}
+    assert d.cdp.calls == [
+        ("Runtime.evaluate", {"expression": "1"}, "explicit-stale-session")
+    ]

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -392,6 +392,54 @@ def test_named_reattach_closes_previous_owned_tab_before_creating_another(monkey
     assert d.owned_target_id == "created-2"
 
 
+def test_concurrent_stale_requests_share_one_reattached_tab(monkeypatch):
+    """Concurrent stale-session recovery must create only one replacement tab."""
+    class _ConcurrentStaleCDP(_AttachCDP):
+        def __init__(self):
+            super().__init__()
+            self.release_stale = None
+            self.stale_calls = 0
+            self.retry_sessions = []
+
+        async def send_raw(self, method, params=None, session_id=None):
+            if method == "Runtime.evaluate":
+                self.calls.append((method, params, session_id))
+                if session_id == "stale-session":
+                    self.stale_calls += 1
+                    if self.stale_calls == 2:
+                        self.release_stale.set()
+                    await self.release_stale.wait()
+                    raise RuntimeError("Session with given id not found")
+                self.retry_sessions.append(session_id)
+                return {"session": session_id}
+            return await super().send_raw(method, params, session_id)
+
+    async def run():
+        monkeypatch.setattr(daemon, "NAME", "worker-a")
+        monkeypatch.setattr(daemon, "REMOTE_ID", None)
+        monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+        d = daemon.Daemon()
+        d.cdp = _ConcurrentStaleCDP()
+        d.cdp.release_stale = asyncio.Event()
+        d.session = "stale-session"
+        d.target_id = "old-owned-tab"
+        d.owned_target_id = "old-owned-tab"
+        request = {"method": "Runtime.evaluate", "params": {"expression": "1"}}
+        results = await asyncio.gather(d.handle(request), d.handle(request))
+        return d, results
+
+    d, results = asyncio.run(run())
+
+    assert d.cdp.created == 1
+    assert d.cdp.closed == ["old-owned-tab"]
+    assert d.owned_target_id == "created-1"
+    assert d.cdp.retry_sessions == ["session-for-created-1", "session-for-created-1"]
+    assert results == [
+        {"result": {"session": "session-for-created-1"}},
+        {"result": {"session": "session-for-created-1"}},
+    ]
+
+
 def test_named_attach_failure_closes_created_tab(monkeypatch):
     """If attach fails after Target.createTarget, the new tab is cleaned up."""
     monkeypatch.setattr(daemon, "NAME", "worker-a")
@@ -440,10 +488,25 @@ def test_owned_cleanup_uses_owned_target_after_tab_switch():
     assert d.target_id == "user-selected-tab"
 
 
-def test_main_cleans_owned_tab_when_startup_fails(monkeypatch):
-    """The shutdown finally block must also cover failures during start()."""
+def test_main_retries_owned_tab_cleanup_when_startup_fails(monkeypatch):
+    """Shutdown retries transient close timeouts before exiting."""
+    class _FlakyCloseCDP(_AttachCDP):
+        def __init__(self):
+            super().__init__()
+            self.close_attempts = 0
+
+        async def send_raw(self, method, params=None, session_id=None):
+            if method == "Target.closeTarget":
+                self.calls.append((method, params, session_id))
+                self.close_attempts += 1
+                if self.close_attempts < 3:
+                    raise TimeoutError("simulated close timeout")
+                self.closed.append(params["targetId"])
+                return {}
+            return await super().send_raw(method, params, session_id)
+
     d = daemon.Daemon()
-    d.cdp = _AttachCDP()
+    d.cdp = _FlakyCloseCDP()
 
     async def failed_start():
         d.owned_target_id = "created-before-startup-failure"
@@ -455,4 +518,6 @@ def test_main_cleans_owned_tab_when_startup_fails(monkeypatch):
     with pytest.raises(RuntimeError, match="startup failure"):
         asyncio.run(daemon.main())
 
+    assert d.cdp.close_attempts == 3
     assert d.cdp.closed == ["created-before-startup-failure"]
+    assert d.owned_target_id is None

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from browser_harness import daemon
 
 
@@ -293,3 +295,164 @@ def test_current_tab_meta_returns_not_attached_when_no_target_id():
     assert result == {"error": "not_attached"}
     # No CDP call should have been issued.
     assert d.cdp.calls == []
+
+
+class _AttachCDP(_FakeCDP):
+    """FakeCDP with realistic responses for the attach flow."""
+
+    def __init__(self, targets=None, fail_method=None):
+        super().__init__()
+        self.targets = targets or []
+        self.created = 0
+        self.closed = []
+        self.fail_method = fail_method
+
+    async def send_raw(self, method, params=None, session_id=None):
+        self.calls.append((method, params, session_id))
+        if method == self.fail_method:
+            raise RuntimeError(f"simulated {method} failure")
+        if method == "Target.getTargets":
+            return {"targetInfos": self.targets}
+        if method == "Target.createTarget":
+            self.created += 1
+            return {"targetId": f"created-{self.created}"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-for-{params['targetId']}"}
+        if method == "Target.closeTarget":
+            self.closed.append(params["targetId"])
+        return {}
+
+
+def test_named_daemon_creates_dedicated_tab(monkeypatch):
+    """Named local/CDP daemons must not fight over the first existing tab."""
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    existing = [{"targetId": "someone-elses-tab", "url": "https://example.com/", "type": "page"}]
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP(existing)
+
+    page = asyncio.run(d.attach_first_page())
+
+    assert page["targetId"] == "created-1"
+    assert d.target_id == "created-1"
+    assert d.owned_target_id == "created-1"
+    assert d.session == "session-for-created-1"
+    attach_calls = [p for (m, p, _s) in d.cdp.calls if m == "Target.attachToTarget"]
+    assert attach_calls == [{"targetId": "created-1", "flatten": True}]
+    enabled = {m for (m, _p, s) in d.cdp.calls if s == d.session and m.endswith(".enable")}
+    assert enabled == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
+
+
+def test_default_daemon_still_attaches_first_page(monkeypatch):
+    """The default daemon keeps reusing the user's first real page."""
+    monkeypatch.setattr(daemon, "NAME", "default")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    existing = [{"targetId": "user-tab", "url": "https://example.com/", "type": "page"}]
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP(existing)
+
+    page = asyncio.run(d.attach_first_page())
+
+    assert page["targetId"] == "user-tab"
+    assert d.owned_target_id is None
+    assert d.cdp.created == 0
+
+
+def test_named_remote_daemon_keeps_first_page_attach(monkeypatch):
+    """A cloud browser is exclusive, so a named cloud daemon needs no extra tab."""
+    monkeypatch.setattr(daemon, "NAME", "r7k2")
+    monkeypatch.setattr(daemon, "REMOTE_ID", "remote-browser-id")
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cloud")
+    existing = [{"targetId": "cloud-blank", "url": "about:blank", "type": "page"}]
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP(existing)
+
+    page = asyncio.run(d.attach_first_page())
+
+    assert page["targetId"] == "cloud-blank"
+    assert d.owned_target_id is None
+    assert d.cdp.created == 0
+
+
+def test_named_reattach_closes_previous_owned_tab_before_creating_another(monkeypatch):
+    """A stale-session retry must not leak the old dedicated tab."""
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+
+    asyncio.run(d.attach_first_page())
+    d.target_id = "user-selected-tab"
+    asyncio.run(d.attach_first_page())
+
+    assert d.cdp.closed == ["created-1"]
+    assert d.target_id == "created-2"
+    assert d.owned_target_id == "created-2"
+
+
+def test_named_attach_failure_closes_created_tab(monkeypatch):
+    """If attach fails after Target.createTarget, the new tab is cleaned up."""
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP(fail_method="Target.attachToTarget")
+
+    with pytest.raises(RuntimeError, match="Target.attachToTarget"):
+        asyncio.run(d.attach_first_page())
+
+    assert d.cdp.closed == ["created-1"]
+    assert d.owned_target_id is None
+    assert d.session is None
+    assert d.target_id is None
+
+
+def test_named_local_attach_cleans_inspect_tabs_before_return(monkeypatch):
+    """The named-daemon early path must retain local inspect-tab cleanup."""
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "local")
+    monkeypatch.setattr(daemon, "harness_opened_inspect", lambda: True)
+    inspect = {"targetId": "inspect-tab", "url": "chrome://inspect/#remote-debugging", "type": "page"}
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP([inspect])
+
+    asyncio.run(d.attach_first_page())
+
+    methods = [method for method, _params, _session in d.cdp.calls]
+    assert methods.index("Target.closeTarget") < methods.index("Target.createTarget")
+    assert d.cdp.closed == ["inspect-tab"]
+
+
+def test_owned_cleanup_uses_owned_target_after_tab_switch():
+    """Shutdown must close the daemon tab, not the user's selected tab."""
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+    d.owned_target_id = "daemon-owned-tab"
+    d.target_id = "user-selected-tab"
+
+    asyncio.run(d._close_owned_target())
+
+    assert d.cdp.closed == ["daemon-owned-tab"]
+    assert d.owned_target_id is None
+    assert d.target_id == "user-selected-tab"
+
+
+def test_main_cleans_owned_tab_when_startup_fails(monkeypatch):
+    """The shutdown finally block must also cover failures during start()."""
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+
+    async def failed_start():
+        d.owned_target_id = "created-before-startup-failure"
+        raise RuntimeError("simulated startup failure")
+
+    d.start = failed_start
+    monkeypatch.setattr(daemon, "Daemon", lambda: d)
+
+    with pytest.raises(RuntimeError, match="startup failure"):
+        asyncio.run(daemon.main())
+
+    assert d.cdp.closed == ["created-before-startup-failure"]

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -562,13 +562,15 @@ def test_shutdown_leaves_dedicated_tab_open(monkeypatch):
     assert d.target_id == "user-selected-tab"
 
 
-def test_delayed_implicit_stale_request_retries_its_recovered_session():
-    """A slow stale response follows recovery for its original session."""
-    class _DelayedStaleCDP(_FakeCDP):
+def test_delayed_stale_request_follows_recovery_during_domain_enable(monkeypatch):
+    """Publish the replacement before post-attach domain setup can yield."""
+    class _RecoveryWindowCDP(_FakeCDP):
         def __init__(self):
             super().__init__()
             self.slow_started = None
             self.release_slow = None
+            self.enable_started = None
+            self.release_enables = None
 
         async def send_raw(self, method, params=None, session_id=None):
             self.calls.append((method, params, session_id))
@@ -577,49 +579,52 @@ def test_delayed_implicit_stale_request_retries_its_recovered_session():
                     self.slow_started.set()
                     await self.release_slow.wait()
                 raise RuntimeError("Session with given id not found")
+            if method == "Target.getTargets":
+                return {"targetInfos": [
+                    {"targetId": "same-tab", "url": "https://example.com", "type": "page"}
+                ]}
+            if method == "Target.attachToTarget":
+                return {"sessionId": "replacement-session"}
+            if method.endswith(".enable") and session_id == "replacement-session":
+                self.enable_started.set()
+                await self.release_enables.wait()
+                return {}
             if method == "Runtime.evaluate" and session_id == "replacement-session":
                 return {"value": params["expression"]}
             return {}
 
     async def run():
         d = daemon.Daemon()
-        d.cdp = _DelayedStaleCDP()
+        d.cdp = _RecoveryWindowCDP()
         d.cdp.slow_started = asyncio.Event()
         d.cdp.release_slow = asyncio.Event()
+        d.cdp.enable_started = asyncio.Event()
+        d.cdp.release_enables = asyncio.Event()
         d.session = "stale-session"
-        recoveries = 0
+        d.target_id = "same-tab"
 
-        async def recover():
-            nonlocal recoveries
-            recoveries += 1
-            d.session = "replacement-session"
-            return {"targetId": "same-tab"}
-
-        d.attach_first_page = recover
         slow = asyncio.create_task(d.handle({
             "method": "Runtime.evaluate", "params": {"expression": "slow"}
         }))
         await d.cdp.slow_started.wait()
-        fast = await d.handle({
+        fast = asyncio.create_task(d.handle({
             "method": "Runtime.evaluate", "params": {"expression": "fast"}
-        })
-        # A later tab switch must not redirect the delayed request. Its stale
-        # session maps to the replacement that still controls its original tab.
-        d.session = "user-selected-session"
+        }))
+        await d.cdp.enable_started.wait()
+        # Recovery has attached but is still blocked enabling domains. The
+        # delayed request must already be able to find the replacement.
         d.cdp.release_slow.set()
-        return d, recoveries, fast, await slow
+        slow_result = await slow
+        d.cdp.release_enables.set()
+        return d, await fast, slow_result
 
-    d, recoveries, fast, slow = asyncio.run(run())
+    monkeypatch.setattr(daemon, "NAME", "default")
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    d, fast, slow = asyncio.run(run())
 
-    assert recoveries == 1
     assert fast == {"result": {"value": "fast"}}
     assert slow == {"result": {"value": "slow"}}
-    retries = [
-        (params["expression"], sid)
-        for method, params, sid in d.cdp.calls
-        if method == "Runtime.evaluate" and sid == "replacement-session"
-    ]
-    assert retries == [("fast", "replacement-session"), ("slow", "replacement-session")]
+    assert d._session_replacements == {"stale-session": "replacement-session"}
 
 
 def test_stale_request_is_not_replayed_after_unrelated_tab_switch():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -350,3 +350,57 @@ def test_wait_for_network_idle_filters_events_to_active_session():
         "session filter, the background rWS/lF pair would have updated "
         "last_activity and prevented the idle window from elapsing."
     )
+
+
+def test_switch_tab_keeps_visible_tab_unchanged_by_default(monkeypatch):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-new"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    assert helpers.switch_tab({"target_id": "target-new"}) == "session-new"
+    assert not any(method == "Target.activateTarget" for method, _ in calls)
+
+
+def test_switch_tab_can_explicitly_activate_visible_tab(monkeypatch):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-new"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    assert helpers.switch_tab("target-new", activate=True) == "session-new"
+    assert ("Target.activateTarget", {"targetId": "target-new"}) in calls
+
+
+def test_new_tab_creates_and_attaches_in_background(monkeypatch):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "target-new"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-new"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    assert helpers.new_tab() == "target-new"
+    assert ("Target.createTarget", {"url": "about:blank", "background": True}) in calls
+    assert not any(method == "Target.activateTarget" for method, _ in calls)


### PR DESCRIPTION
Follow-up to #616.

Named local/CDP daemons now get a dedicated tab so parallel names do not navigate the same page. The lifecycle stays intentionally simple:

- First attach: create one dedicated background tab.
- Stale session: reattach to the current selected tab if it still exists, otherwise the dedicated tab.
- If the user closed both: create one background replacement. Concurrent recovery shares that replacement and delayed requests retry on the recovered session.
- Daemon shutdown or disconnect: leave every working/user tab open.

Normal helper behavior is background-first too:

- `new_tab()` creates a background target.
- `switch_tab(target)` attaches and moves the horse marker without changing Chrome's visible tab.
- `switch_tab(target, activate=True)` or `activate_tab(target)` is the explicit opt-in for a visible switch.
- Static screenshots and normal CDP input work while the tab is hidden. Activation remains available only for a user-requested visible switch or a page that demonstrably pauses visibility-dependent rendering.

This change does not automatically close normal browser tabs. Users and agents can still close a tab explicitly with `close_tab()`.

Default daemons and named Browser Use Cloud daemons keep their existing first-page attach behavior. The existing cleanup for a harness-opened `chrome://inspect` permission tab also remains.

Verification:

- `uv run --with pytest pytest -q` — 140 passed
- `git diff --check` — passed
- Live macOS Chrome — a `document.hidden === true` background tab accepted typing and a coordinate click, captured a 3456×1730 PNG, and did not change the foreground application.
- Review race reproduction — when one request recovered the stale session first, the delayed request retried successfully on the replacement session; explicit stale-session requests still return their error.
- Shutdown regression — the real serve stop path leaves both the dedicated and user-selected tabs open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps named local daemons on a dedicated reusable background tab and stops changing the user’s visible tab. Previously we attached to the first page and `switch_tab()` activated it; now `switch_tab()` attaches without activating, stale-session recovery is scoped and serialized with tab switches, and recovered sessions publish before domain enable so delayed requests hit the right tab.

- Named local daemons create one background `about:blank` tab; default and named remote daemons still attach to the first real page.
- Reattach prefers the current selected tab, then the dedicated tab; if both are closed, one background replacement is created and shared by concurrent recoveries; attach/setup failures leave the created tab for retry.
- Recovery: implicit stale requests reattach and retry only on the specific recovered session; explicit `session_id` requests return an error; we publish the replacement before domain setup and preserve chains; tab switches wait for in-flight recovery so recovered actions are not redirected.
- Helpers: `new_tab()` creates background targets; `switch_tab(target)` attaches and moves the horse marker; `activate_tab(target)` opts into a visible switch; screenshots and normal CDP input work while hidden; shutdown leaves working and user tabs open.
- Migration: Call `activate_tab(target)` or `switch_tab(..., activate=True)` when a visible tab switch is required.

<sup>Written for commit f4c6ca2463830b228d374fb14a8abf32ade46cec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

