### PR TITLE
docs: add agents.aiki.as route map

### DIFF
--- a/domain-skills/agents-aiki-as/overview.md
+++ b/domain-skills/agents-aiki-as/overview.md
@@ -1,0 +1,15 @@
+# agents.aiki.as
+
+## Public widget gallery
+
+- `https://agents.aiki.as/` opens the Beauty widget test gallery.
+- Select an agent with `?agent=<slug>` and a widget with `?variant=spotlight|classic`.
+- Supported public agent slugs are `beauty-technology`, `dermapen`, `genosys`, `innoaesthetics`, `melineskin`, and `noonaesthetics`.
+- The selected links have `aria-current="true"`; all selectors are `.picker a` links, so direct URL navigation is more stable than coordinate clicking.
+- The widget host is `[data-aiki-widget]`; its UI is inside an open shadow root.
+
+## Routes and waits
+
+- `/studio` is the internal Agent Studio shell. Its data calls prompt for an admin key and send it as `X-Admin-Key`; never put that key in a URL.
+- The public hostname is behind a strict Cloudflare Tunnel path allowlist. A route can work against the origin yet return tunnel-level `404` in production until its exact path is added to the allowlist.
+- `wait_for_load()` only covers page load. Wait about 500 ms after opening or closing a widget before taking a screenshot because the panel uses opacity, transform, and blur transitions.


### PR DESCRIPTION
Documents the public widget gallery URL/query pattern, stable selectors, shadow-root boundary, Studio auth behavior, and the Cloudflare path-allowlist trap. Contains no credentials or user-specific state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `agents.aiki.as` public widget gallery routes, stable selectors, Studio auth behavior, and Cloudflare Tunnel allowlist so tests and ops avoid flaky navigation, tunnel 404s, and credential leaks.

- Prefer direct URL navigation: use `?agent=<slug>` and `?variant=spotlight|classic`; widget host is `[data-aiki-widget]` with an open shadow root.
- Accessing `/studio` requires `X-Admin-Key`; never put admin keys in URLs.
- Add any new public route to the Cloudflare Tunnel path allowlist to prevent tunnel-level 404s.
- `wait_for_load()` does not cover widget transitions; wait ~500 ms after open/close before screenshots.

<sup>Written for commit afa0b6612ccc8e8235832db8e4f215dedbaaa4be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

