### PR TITLE
Don't let an unreadable profile dir abort CDP discovery

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -199,7 +199,10 @@ def _ws_from_devtools_active_port(http_url: str) -> str | None:
     for base in PROFILES:
         try:
             active = (base / "DevToolsActivePort").read_text(encoding="utf-8", errors="replace").splitlines()
-        except (FileNotFoundError, NotADirectoryError):
+        # PermissionError: macOS TCC guards ~/Library/Application Support/Google/Chrome,
+        # so a terminal without Full Disk Access gets EPERM here. Skip the profile and
+        # keep looking rather than killing discovery outright.
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
             continue
         port = active[0].strip() if active else ""
         ws_path = active[1].strip() if len(active) > 1 else ""
@@ -241,7 +244,9 @@ def get_ws_url():
         for base in PROFILES:
             try:
                 active = (base / "DevToolsActivePort").read_text(encoding="utf-8", errors="replace").splitlines()
-            except (FileNotFoundError, NotADirectoryError):
+            # PermissionError: see _ws_from_devtools_active_port — an FDA-less terminal
+            # gets EPERM from TCC. Skipping lets the 9222/9223 probe below still run.
+            except (FileNotFoundError, NotADirectoryError, PermissionError):
                 continue
             port = active[0].strip() if active else ""
             ws_path = active[1].strip() if len(active) > 1 else ""

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from browser_harness import daemon
 
 
@@ -293,3 +295,44 @@ def test_current_tab_meta_returns_not_attached_when_no_target_id():
     assert result == {"error": "not_attached"}
     # No CDP call should have been issued.
     assert d.cdp.calls == []
+
+
+class _DeniedProfile:
+    """A profile dir whose DevToolsActivePort read is refused by the OS.
+
+    macOS TCC guards ~/Library/Application Support/Google/Chrome, so a terminal
+    without Full Disk Access gets EPERM -- not ENOENT -- when reading the file.
+    """
+
+    def __truediv__(self, _name):
+        return self
+
+    def read_text(self, *_args, **_kwargs):
+        raise PermissionError(1, "Operation not permitted")
+
+    def __str__(self):
+        return "<denied-profile>"
+
+
+def test_ws_from_devtools_active_port_skips_profiles_it_cannot_read(monkeypatch):
+    monkeypatch.setattr(daemon, "PROFILES", [_DeniedProfile()])
+
+    # Must return None (no match) rather than propagating PermissionError.
+    assert daemon._ws_from_devtools_active_port("http://127.0.0.1:9222") is None
+
+
+def test_get_ws_url_reports_chrome_not_running_when_profiles_are_unreadable(monkeypatch):
+    """An unreadable profile must not abort discovery.
+
+    Before this was handled, a PermissionError escaped get_ws_url() as a fatal
+    traceback, so the daemon never reached its own fallbacks or the actionable
+    "start Chrome" error below.
+    """
+    # An explicit endpoint short-circuits discovery, so clear both overrides.
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(daemon, "PROFILES", [_DeniedProfile()])
+    monkeypatch.setattr(daemon, "supported_browser_running", lambda: False)
+
+    with pytest.raises(RuntimeError, match="chrome-not-running"):
+        daemon.get_ws_url()


### PR DESCRIPTION
On macOS, `~/Library/Application Support/Google/Chrome` is TCC-protected. A terminal without Full Disk Access gets `PermissionError` (EPERM) reading `DevToolsActivePort` — not `FileNotFoundError`.

Both read sites skip a profile on `FileNotFoundError, NotADirectoryError` only, so EPERM escaped as a fatal traceback:

```
browser-harness: fatal: [Errno 1] Operation not permitted:
  /Users/<user>/Library/Application Support/Google/Chrome/DevToolsActivePort
```

The daemon died before reaching any of its own fallbacks — the 9222/9223 probe, the `remote_debugging_user_enabled()` hint, and the final "enable chrome://inspect" error. A user with a perfectly reachable browser on another port just saw a raw errno.

### Change

Add `PermissionError` to both `except` tuples, so an unreadable profile is skipped like a missing one and discovery continues. No behavior change when the read succeeds.

### Tests

Two regression tests in `tests/unit/test_daemon.py`, using a profile stub whose `read_text` raises `PermissionError`. Both fail on `main` with `PermissionError` and pass with the fix. They clear `BU_CDP_WS`/`BU_CDP_URL` so they do not depend on the ambient environment.

Repro without the patch, on any macOS terminal lacking Full Disk Access:

```python
from pathlib import Path
Path("~/Library/Application Support/Google/Chrome/DevToolsActivePort").expanduser().read_text()
# PermissionError: [Errno 1] Operation not permitted
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips unreadable Chrome profile directories during CDP discovery so macOS TCC no longer aborts the daemon. Previously, reading `DevToolsActivePort` could raise `PermissionError` and stop discovery; now we treat it like a missing profile and continue. No change when the read succeeds.

- Handle `PermissionError` in both `_ws_from_devtools_active_port` and `get_ws_url`, alongside `FileNotFoundError` and `NotADirectoryError`.
- Preserves fallbacks: 9222/9223 probe, `remote_debugging_user_enabled()` hint, and the final "chrome-not-running" error instead of a raw errno.
- Adds two regression tests that stub a profile raising `PermissionError`; they clear `BU_CDP_WS`/`BU_CDP_URL` to avoid environment coupling.
- No config or migration changes; improves resilience for macOS terminals without Full Disk Access.

<sup>Written for commit 055384b7b31cea9c587f1544fd37e8a9d3f7b005. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

