### PR TITLE
Make tab activation opt-in via BH_ACTIVATE

### DIFF
--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -4,7 +4,13 @@
 
 When Chrome opens fresh, the only CDP `type: "page"` targets are `chrome://inspect` and `chrome://omnibox-popup.top-chrome/` (a 1px invisible viewport). If the daemon attaches to the omnibox popup, all subsequent work — including `new_tab()` and `goto_url()` — happens on tabs that exist in CDP but may not be visible in the Chrome UI.
 
-The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` which calls `Target.activateTarget` to bring the tab to front.
+The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` to attach to the right tab.
+
+## Focus / tab activation
+
+`switch_tab()` (and `new_tab()`, which calls it) no longer raises the tab to the foreground by default — `Target.activateTarget` stole the user's window/tab focus mid-work while an agent ran in parallel. CDP drives the attached background tab fine, so this is purely cosmetic for the human watching along. The horse-emoji (\U0001F434) title prefix still marks which tab the agent controls.
+
+Caveat: Chrome throttles/pauses compositing on fully hidden tabs, so `capture_screenshot()` of an occluded tab can occasionally come back blank or stale. If you need reliable screenshots of a tab, set `BH_ACTIVATE=1` to restore foregrounding on `switch_tab()`.
 
 ## Startup sequence
 

--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -9,7 +9,7 @@ tabs = list_tabs()                    # includes chrome:// pages too
 real_tabs = list_tabs(include_chrome=False)
 tid = new_tab("https://example.com")  # create + attach
 switch_tab(tid)                       # attach harness to tab
-cdp("Target.activateTarget", targetId=tid)  # show it in Chrome
+cdp("Target.activateTarget", targetId=tid)  # show it in Chrome (steals focus; switch_tab no longer does this by default — see connection.md)
 print(current_tab())
 print(page_info())
 ```

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -299,7 +299,13 @@ def switch_tab(target):
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
     try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
     except Exception: pass
-    cdp("Target.activateTarget", targetId=target_id)
+    # Target.activateTarget raises the tab to the foreground in the user's real
+    # Chrome, stealing window/tab focus mid-work. It's only a "let the human watch"
+    # nicety — CDP drives the attached tab fine in the background. Off by default;
+    # set BH_ACTIVATE=1 to opt back in. The horse-emoji title marker still tells
+    # you which tab the agent controls without grabbing focus.
+    if os.environ.get("BH_ACTIVATE") == "1":
+        cdp("Target.activateTarget", targetId=target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
     _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
     _mark_tab()

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -350,3 +350,39 @@ def test_wait_for_network_idle_filters_events_to_active_session():
         "session filter, the background rWS/lF pair would have updated "
         "last_activity and prevented the idle window from elapsing."
     )
+
+
+def _switch_tab_methods(monkeypatch):
+    """Run switch_tab against a stubbed transport, returning the CDP methods called."""
+    methods = []
+
+    def fake_send(req):
+        method = req.get("method")
+        if method:
+            methods.append(method)
+        if method == "Target.attachToTarget":
+            return {"result": {"sessionId": "sid-1"}}
+        return {"result": {}}
+
+    monkeypatch.setattr(helpers, "_send", fake_send)
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+    helpers.switch_tab("TARGET-1")
+    return methods
+
+
+def test_switch_tab_does_not_steal_focus_by_default(monkeypatch):
+    monkeypatch.delenv("BH_ACTIVATE", raising=False)
+
+    assert "Target.activateTarget" not in _switch_tab_methods(monkeypatch)
+
+
+def test_switch_tab_activates_when_bh_activate_is_set(monkeypatch):
+    monkeypatch.setenv("BH_ACTIVATE", "1")
+
+    assert "Target.activateTarget" in _switch_tab_methods(monkeypatch)
+
+
+def test_switch_tab_still_attaches_when_activation_is_off(monkeypatch):
+    monkeypatch.delenv("BH_ACTIVATE", raising=False)
+
+    assert "Target.attachToTarget" in _switch_tab_methods(monkeypatch)


### PR DESCRIPTION
`switch_tab()` calls `Target.activateTarget` on every attach, and `new_tab()` routes through it. In a real Chrome that raises the tab to the foreground, so an agent working while the user is at the keyboard yanks window and tab focus away mid-task — repeatedly, and worst with several agents running in parallel against their own `BU_NAME` daemons.

Activation is only a "let the human watch along" nicety. CDP drives an attached background tab fine, and the 🐴 title prefix already marks which tab the agent controls without touching focus.

### Change

Gate the `activateTarget` call behind `BH_ACTIVATE=1`. Attach behavior is unchanged; only the foregrounding side effect becomes opt-in.

### Tradeoff

Chrome throttles compositing on fully hidden tabs, so `capture_screenshot()` of an occluded tab can come back stale or blank. `interaction-skills/connection.md` documents `BH_ACTIVATE=1` as the fix, and `tabs.md` notes that the raw `Target.activateTarget` call still foregrounds on demand.

I understand if you would rather have this default the other way, or as a keyword arg instead of an env var — happy to flip it. The env var was chosen so it applies to every helper call in a session without touching call sites.

### Tests

Three tests in `tests/unit/test_helpers.py` covering default-off, opt-in-on, and "still attaches when activation is off". The default-off test fails on `main` and passes with the gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tab activation opt-in to stop stealing user focus. Previously `switch_tab()` (and `new_tab()`) always called `Target.activateTarget`; now they only foreground when `BH_ACTIVATE=1`. Attach behavior is unchanged.

- Hidden/occluded tabs may yield stale or blank `capture_screenshot()` results; set `BH_ACTIVATE=1` or call `cdp("Target.activateTarget", targetId=...)` when you need reliable foreground screenshots.
- Docs updated in `interaction-skills/connection.md` and `interaction-skills/tabs.md`; unit tests added for default-off, opt-in-on, and attach-only paths.

<sup>Written for commit c5dc005ed2d699622ceb8d2c61bd5b071bb90286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

