### PR TITLE
Bump browser-harness to 0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.8"
+version = "0.1.9"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release browser-harness 0.1.9 after #618.

Verification:
- `uv run --with pytest pytest -q` — 140 passed
- `uv build` — sdist and wheel built
- `git diff --check` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `browser-harness` 0.1.9 by bumping the package version from 0.1.8 to 0.1.9. This prepares the package for publishing; no code behavior changes in this diff.

**Rollout**
- Tag v0.1.9 and publish to PyPI.
- Update internal pins to `browser-harness==0.1.9` where needed.

**Verification**
- 140 tests passed; sdist and wheel built; whitespace check clean.

<sup>Written for commit bbb0177ce7d6019c67dc371f6a0b0225d9bf0f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

