### PR TITLE
feat: harden orchestrator-owned browser daemons

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -166,6 +166,9 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 
 - Coordinate clicks default. CDP mouse events pass through iframes/shadow/cross-origin at the compositor level.
 - Keep the connection model simple: use the default daemon, `BU_NAME`, `BU_CDP_URL`, `BU_CDP_WS`, or `start_remote_daemon(...)`.
+- Trusted orchestrators that already provisioned an exact named daemon can set
+  `BH_REQUIRE_EXISTING_DAEMON=1`. Each CLI call then health-checks and reuses
+  that daemon or fails closed; it never auto-starts or discovers another Chrome.
 - Core helpers stay short. Put task-specific helper additions in `$BH_AGENT_WORKSPACE/agent_helpers.py`.
 
 ## Gotchas

--- a/SKILL.md
+++ b/SKILL.md
@@ -169,6 +169,8 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - Trusted orchestrators that already provisioned an exact named daemon can set
   `BH_REQUIRE_EXISTING_DAEMON=1`. Each CLI call then health-checks and reuses
   that daemon or fails closed; it never auto-starts or discovers another Chrome.
+- Trusted orchestrators can set `BH_OPEN_LIVE_URL=0` while provisioning a Cloud
+  daemon to keep its interactive live-view URL from being printed or opened.
 - Core helpers stay short. Put task-specific helper additions in `$BH_AGENT_WORKSPACE/agent_helpers.py`.
 
 ## Gotchas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.9"
+version = "0.1.10"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -50,6 +50,7 @@ def _tmp_stem(name):  # "bu" when BH_TMP_DIR isolates us, else "bu-<NAME>"
 
 def log_path(name):   return _TMP / f"{_tmp_stem(name)}.log"
 def pid_path(name):   return _RUNTIME / f"{_runtime_stem(name)}.pid"
+def remote_id_path(name): return _RUNTIME / f"{_runtime_stem(name)}.remote-id"
 def port_path(name):  return _RUNTIME / f"{_runtime_stem(name)}.port"  # Windows-only: holds {"port","token"} JSON
 def _sock_path(name): return _RUNTIME / f"{_runtime_stem(name)}.sock"
 

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -441,6 +441,28 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
 
 
+def require_existing_daemon(name=None):
+    """Require a healthy existing daemon without spawning or reconnecting.
+
+    Trusted orchestrators use this after they provision a scoped CDP transport.
+    Failing closed prevents a later CLI call from silently discovering a
+    different local Chrome when that orchestrator-owned daemon dies.
+    """
+    daemon_name = name or NAME
+    if not daemon_alive(daemon_name):
+        raise RuntimeError(f"required daemon {daemon_name!r} is not running")
+    try:
+        s, token = ipc.connect(daemon_name, timeout=3.0)
+        try:
+            resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
+        finally:
+            s.close()
+    except Exception as exc:
+        raise RuntimeError(f"required daemon {daemon_name!r} is unhealthy: {exc}") from exc
+    if not isinstance(resp, dict) or "result" not in resp:
+        raise RuntimeError(f"required daemon {daemon_name!r} failed its CDP health check")
+
+
 def stop_remote_daemon(name="remote"):
     """Stop a remote daemon and its backing Browser Use cloud browser.
 
@@ -452,10 +474,10 @@ def stop_remote_daemon(name="remote"):
     # restarts anything on its own; a follow-up `browser-harness`
     # call would auto-spawn a fresh one via ensure_daemon(). That
     # "run-it-again-to-restart" workflow is why it was named that way.
-    restart_daemon(name)
+    restart_daemon(name, require_clean=True)
 
 
-def restart_daemon(name=None):
+def restart_daemon(name=None, require_clean=False):
     """Best-effort daemon shutdown + socket/pid cleanup.
 
     Name is historical: callers typically follow this with another
@@ -492,12 +514,20 @@ def restart_daemon(name=None):
     daemon_start = _process_start_time(daemon_pid)
 
     if daemon_alive:
+        c = None
         try:
-            c, token = ipc.connect(name, timeout=5.0)
-            ipc.request(c, token, {"meta": "shutdown"})
-            c.close()
+            c, token = ipc.connect(name, timeout=50.0 if require_clean else 5.0)
+            response = ipc.request(c, token, {"meta": "shutdown"})
+            if require_clean and isinstance(response, dict) and response.get("error"):
+                raise RuntimeError(response["error"])
         except Exception:
-            pass
+            if require_clean:
+                raise
+        finally:
+            if c is not None:
+                close = getattr(c, "close", None)
+                if close:
+                    close()
 
     if daemon_pid is not None:
         for _ in range(75):
@@ -544,13 +574,21 @@ def _browser_use(path, method, body=None):
     return json.loads(urllib.request.urlopen(req, timeout=60).read() or b"{}")
 
 
-def _stop_cloud_browser(browser_id):
+def _stop_cloud_browser(browser_id, strict=False):
     if not browser_id:
-        return
-    try:
-        _browser_use(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
-    except BaseException:
-        pass
+        return True
+    last_error = None
+    for attempt in range(3):
+        try:
+            _browser_use(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
+            return True
+        except BaseException as exc:
+            last_error = exc
+            if attempt < 2:
+                time.sleep(0.5 * (attempt + 1))
+    if strict:
+        raise RuntimeError(f"failed to stop remote browser {browser_id}: {last_error}")
+    return False
 
 
 def _cdp_ws_from_url(cdp_url):
@@ -648,8 +686,14 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
             name=name,
             env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
         )
-    except BaseException:
-        _stop_cloud_browser(browser.get("id"))
+    except BaseException as start_error:
+        try:
+            _stop_cloud_browser(browser.get("id"), strict=True)
+        except BaseException as cleanup_error:
+            raise BaseExceptionGroup(
+                "remote daemon startup and cloud browser cleanup both failed",
+                [start_error, cleanup_error],
+            )
         raise
     _show_live_url(browser.get("liveUrl"))
     return browser

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -512,16 +512,33 @@ def stop_remote_daemon(name="remote"):
     # restarts anything on its own; a follow-up `browser-harness`
     # call would auto-spawn a fresh one via ensure_daemon(). That
     # "run-it-again-to-restart" workflow is why it was named that way.
-    browser_id = _read_remote_browser_id(name)
     if daemon_alive(name):
-        restart_daemon(name, require_clean=True)
-    elif browser_id:
+        try:
+            restart_daemon(name, require_clean=True)
+        except Exception as daemon_error:
+            # The daemon can die after the health probe or during the shutdown
+            # response. Recover through the durable cloud id instead of treating
+            # a missing/EOF response as proof that billing stopped.
+            browser_id = _read_remote_browser_id(name)
+            if not browser_id:
+                raise
+            try:
+                _stop_cloud_browser(browser_id, strict=True)
+                restart_daemon(name)
+            except Exception as fallback_error:
+                raise ExceptionGroup(
+                    "daemon shutdown and direct cloud browser cleanup both failed",
+                    [daemon_error, fallback_error],
+                )
+        _clear_remote_browser_id(name)
+        return
+
+    browser_id = _read_remote_browser_id(name)
+    if browser_id:
         # The daemon may have crashed or been SIGKILLed. Its environment is
         # gone, so use the private runtime state to stop the exact cloud browser.
         _stop_cloud_browser(browser_id, strict=True)
-        restart_daemon(name)
-    else:
-        restart_daemon(name, require_clean=True)
+    restart_daemon(name)
     _clear_remote_browser_id(name)
 
 
@@ -552,6 +569,8 @@ def restart_daemon(name=None, require_clean=False):
     #     while the process stayed alive.
     daemon_pid = ipc.identify(name, timeout=5.0)
     daemon_alive = daemon_pid is not None or ipc.ping(name, timeout=1.0)
+    if require_clean and not daemon_alive:
+        raise RuntimeError(f"daemon {name!r} is unavailable for required clean shutdown")
     # Snapshot the daemon's process start-time as a secondary identity check.
     # The IPC socket can disappear before the process exits (e.g. the shutdown
     # path tears down the socket and then waits on a slow remote `stop` PATCH),
@@ -566,8 +585,9 @@ def restart_daemon(name=None, require_clean=False):
         try:
             c, token = ipc.connect(name, timeout=50.0 if require_clean else 5.0)
             response = ipc.request(c, token, {"meta": "shutdown"})
-            if require_clean and isinstance(response, dict) and response.get("error"):
-                raise RuntimeError(response["error"])
+            if require_clean and (not isinstance(response, dict) or response.get("ok") is not True):
+                error = response.get("error") if isinstance(response, dict) else None
+                raise RuntimeError(error or f"daemon {name!r} did not confirm clean shutdown")
         except Exception:
             if require_clean:
                 raise

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -848,6 +848,12 @@ def _show_live_url(url):
         print(f"(couldn't auto-open: {e} — share the liveUrl with the user)", file=sys.stderr)
 
 
+def _should_show_remote_live_view():
+    """Whether Cloud provisioning should print and open its interactive live view."""
+    raw = os.environ.get("BH_OPEN_LIVE_URL")
+    return raw is None or raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
 def list_cloud_profiles():
     """List cloud profiles under the current API key.
 
@@ -903,7 +909,8 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
     auto-opens it locally when a GUI is detected, so the user can watch along."""
     with _remote_daemon_lifecycle_lock(name):
         browser = _start_remote_daemon_locked(name, profileName=profileName, **create_kwargs)
-    _show_live_url(browser.get("liveUrl"))
+    if _should_show_remote_live_view():
+        _show_live_url(browser.get("liveUrl"))
     return browser
 
 

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -380,7 +380,7 @@ def _ensure_daemon_locked(wait=60.0, name=None, env=None):
             # both daemon and direct Cloud stop fail, leave it alive.
             _stop_remote_daemon_locked(daemon_name)
         else:
-            restart_daemon(daemon_name)
+            _restart_daemon_locked(daemon_name)
 
     import subprocess, sys
     local = _is_local_chrome_mode(env)
@@ -418,20 +418,20 @@ def _ensure_daemon_locked(wait=60.0, name=None, env=None):
             time.sleep(0.2)
         msg = _log_tail(name) or ""
         if local and msg.startswith("handshake-wait"):
-            restart_daemon(name)
+            _restart_daemon_locked(name)
             raise RuntimeError(
                 "permission-blocked: Chrome's Allow popup was not clicked in time -- wait for the user to click Allow, then retry."
             )
         if local and _needs_chrome_permission_popup(msg):
             print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
-            restart_daemon(name)
+            _restart_daemon_locked(name)
             raise RuntimeError(
                 "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
             )
         if local and not launched_browser and _chrome_not_running(msg):
             # Chrome is closed — launch the browser and retry
             launched_browser = True
-            restart_daemon(name)
+            _restart_daemon_locked(name)
             if not _launch_browser():
                 raise RuntimeError(
                     "chrome-not-running: no supported browser is running and none could be launched -- ask the user to open Chrome, then retry."
@@ -448,11 +448,11 @@ def _ensure_daemon_locked(wait=60.0, name=None, env=None):
             if remote_debugging_user_enabled():
                 # chrome://inspect toggle is already on — connection died
                 print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
-                restart_daemon(name)
+                _restart_daemon_locked(name)
                 raise RuntimeError(
                     "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
                 )
-            restart_daemon(name)
+            _restart_daemon_locked(name)
             _open_chrome_inspect_once()
             if remote_debugging_toggle_profiles():
                 # Toggle already ticked from a previous run, but Chrome 144+
@@ -656,7 +656,7 @@ def _stop_remote_daemon_locked(name):
             and daemon_browser_id == persisted_browser_id
         )
         try:
-            restart_daemon(name, require_clean=True)
+            _restart_daemon_locked(name, require_clean=True)
         except Exception as daemon_error:
             # The daemon can die after the health probe or during the shutdown
             # response. Recover through the durable cloud id instead of treating
@@ -671,7 +671,7 @@ def _stop_remote_daemon_locked(name):
             try:
                 for browser_id in cleanup_ids:
                     _stop_cloud_browser(browser_id, strict=True)
-                restart_daemon(name)
+                _restart_daemon_locked(name)
             except Exception as fallback_error:
                 raise ExceptionGroup(
                     "daemon shutdown and fallback cloud-browser recovery both failed",
@@ -691,11 +691,18 @@ def _stop_remote_daemon_locked(name):
         # The daemon may have crashed or been SIGKILLed. Its environment is
         # gone, so use the private runtime state to stop the exact cloud browser.
         _stop_cloud_browser(browser_id, strict=True)
-    restart_daemon(name)
+    _restart_daemon_locked(name)
     _clear_remote_browser_id(name)
 
 
 def restart_daemon(name=None, require_clean=False):
+    """Stop one daemon while serialized with provisioning and recovery."""
+    daemon_name = name or NAME
+    with _remote_daemon_lifecycle_lock(daemon_name):
+        return _restart_daemon_locked(daemon_name, require_clean=require_clean)
+
+
+def _restart_daemon_locked(name, require_clean=False):
     """Best-effort daemon shutdown + socket/pid cleanup.
 
     Name is historical: callers typically follow this with another
@@ -709,7 +716,6 @@ def restart_daemon(name=None, require_clean=False):
     """
     import signal
 
-    name = name or NAME
     pid_path = str(ipc.pid_path(name))
 
     # Two pieces of information are tracked separately:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -469,6 +469,7 @@ def _persist_remote_browser_id(name, browser_id):
         raise RuntimeError("Browser Use Cloud returned an invalid browser id")
     state_path = ipc.remote_id_path(name)
     pending_path = state_path.with_name(state_path.name + ".pending")
+    pending_durable = False
     try:
         fd = os.open(pending_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as state_file:
@@ -477,13 +478,18 @@ def _persist_remote_browser_id(name, browser_id):
             os.fsync(state_file.fileno())
         if sys.platform != "win32":
             os.chmod(pending_path, 0o600)
+        _fsync_directory(state_path.parent)
+        pending_durable = True
         os.replace(pending_path, state_path)
         _fsync_directory(state_path.parent)
-    finally:
-        try:
-            pending_path.unlink()
-        except FileNotFoundError:
-            pass
+    except BaseException:
+        if not pending_durable:
+            try:
+                pending_path.unlink()
+                _fsync_directory(state_path.parent)
+            except FileNotFoundError:
+                pass
+        raise
 
 
 def _encode_remote_browser_id(browser_id):

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -477,6 +477,7 @@ def _persist_remote_browser_id(name, browser_id):
         if sys.platform != "win32":
             os.chmod(pending_path, 0o600)
         os.replace(pending_path, state_path)
+        _fsync_directory(state_path.parent)
     finally:
         try:
             pending_path.unlink()
@@ -485,20 +486,48 @@ def _persist_remote_browser_id(name, browser_id):
 
 
 def _read_remote_browser_id(name):
+    state_path = ipc.remote_id_path(name)
     try:
-        browser_id = ipc.remote_id_path(name).read_text(encoding="utf-8").strip()
-    except (FileNotFoundError, OSError):
-        return None
+        browser_id = state_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        pending_path = state_path.with_name(state_path.name + ".pending")
+        try:
+            browser_id = pending_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return None
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
+            raise RuntimeError(f"invalid pending remote browser recovery state for daemon {name!r}")
+        os.replace(pending_path, state_path)
+        _fsync_directory(state_path.parent)
+        return browser_id
     if not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
         raise RuntimeError(f"invalid remote browser recovery state for daemon {name!r}")
     return browser_id
 
 
 def _clear_remote_browser_id(name):
+    state_path = ipc.remote_id_path(name)
+    removed = False
+    for candidate in (state_path, state_path.with_name(state_path.name + ".pending")):
+        try:
+            candidate.unlink()
+            removed = True
+        except FileNotFoundError:
+            pass
+    if removed:
+        _fsync_directory(state_path.parent)
+
+
+def _fsync_directory(directory):
+    """Persist a recovery-state rename/unlink across a host crash on POSIX."""
+    if sys.platform == "win32":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    fd = os.open(directory, flags)
     try:
-        ipc.remote_id_path(name).unlink()
-    except FileNotFoundError:
-        pass
+        os.fsync(fd)
+    finally:
+        os.close(fd)
 
 
 def stop_remote_daemon(name="remote"):

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import re
@@ -471,7 +472,7 @@ def _persist_remote_browser_id(name, browser_id):
     try:
         fd = os.open(pending_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as state_file:
-            state_file.write(browser_id + "\n")
+            state_file.write(_encode_remote_browser_id(browser_id))
             state_file.flush()
             os.fsync(state_file.fileno())
         if sys.platform != "win32":
@@ -485,24 +486,44 @@ def _persist_remote_browser_id(name, browser_id):
             pass
 
 
+def _encode_remote_browser_id(browser_id):
+    if not isinstance(browser_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
+        raise RuntimeError("Browser Use Cloud returned an invalid browser id")
+    digest = hashlib.sha256(f"browser-harness-remote-id-v1\0{browser_id}".encode()).hexdigest()
+    return json.dumps(
+        {"browser_id": browser_id, "sha256": digest, "version": 1},
+        separators=(",", ":"),
+        sort_keys=True,
+    ) + "\n"
+
+
+def _decode_remote_browser_id(raw, *, name, pending):
+    label = "pending remote browser recovery state" if pending else "remote browser recovery state"
+    try:
+        record = json.loads(raw)
+        browser_id = record["browser_id"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        raise RuntimeError(f"invalid {label} for daemon {name!r}") from None
+    if raw != _encode_remote_browser_id(browser_id):
+        raise RuntimeError(f"invalid {label} for daemon {name!r}")
+    return browser_id
+
+
 def _read_remote_browser_id(name):
     state_path = ipc.remote_id_path(name)
     try:
-        browser_id = state_path.read_text(encoding="utf-8").strip()
+        raw = state_path.read_text(encoding="utf-8")
     except FileNotFoundError:
         pending_path = state_path.with_name(state_path.name + ".pending")
         try:
-            browser_id = pending_path.read_text(encoding="utf-8").strip()
+            raw = pending_path.read_text(encoding="utf-8")
         except FileNotFoundError:
             return None
-        if not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
-            raise RuntimeError(f"invalid pending remote browser recovery state for daemon {name!r}")
+        browser_id = _decode_remote_browser_id(raw, name=name, pending=True)
         os.replace(pending_path, state_path)
         _fsync_directory(state_path.parent)
         return browser_id
-    if not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
-        raise RuntimeError(f"invalid remote browser recovery state for daemon {name!r}")
-    return browser_id
+    return _decode_remote_browser_id(raw, name=name, pending=False)
 
 
 def _clear_remote_browser_id(name):

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1,3 +1,4 @@
+import errno
 import hashlib
 import json
 import os
@@ -7,11 +8,11 @@ import subprocess
 import sys
 import time
 import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 from . import _ipc as ipc
-from . import auth
-from . import paths
+from . import auth, paths
 
 
 def _process_start_time(pid):
@@ -187,22 +188,31 @@ def daemon_alive(name=None):
     return ipc.ping(name or NAME, timeout=1.0)
 
 
-def daemon_browser_kind(name=None):
-    """'cloud' | 'cdp' | 'local' as self-reported by a live daemon, else None.
-
-    None covers unreachable daemons and pre-browser_kind daemons still running
-    from an older version."""
+def _daemon_browser_identity(name=None):
+    """Return a live daemon's browser kind and exact cloud id when available."""
     c = None
     try:
         c, token = ipc.connect(name or NAME, timeout=1.0)
         response = ipc.request(c, token, {"meta": "ping"})
         kind = response.get("browser_kind") if isinstance(response, dict) else None
-        return kind if kind in {"cloud", "cdp", "local"} else None
-    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError, ValueError):
-        return None
+        kind = kind if kind in {"cloud", "cdp", "local"} else None
+        browser_id = response.get("remote_browser_id") if isinstance(response, dict) else None
+        if not isinstance(browser_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
+            browser_id = None
+        return kind, browser_id if kind == "cloud" else None
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, OSError, ValueError):
+        return None, None
     finally:
         if c:
             c.close()
+
+
+def daemon_browser_kind(name=None):
+    """'cloud' | 'cdp' | 'local' as self-reported by a live daemon, else None.
+
+    None covers unreachable daemons and pre-browser_kind daemons still running
+    from an older version."""
+    return _daemon_browser_identity(name)[0]
 
 
 def _daemon_endpoint_names():
@@ -341,6 +351,13 @@ def run_doctor_fix_snap():
 def ensure_daemon(wait=60.0, name=None, env=None):
     """Idempotent. Self-heals stale daemon, closed Chrome (launches it), cold
     Chrome, and missing Allow on chrome://inspect."""
+    daemon_name = name or NAME
+    with _remote_daemon_lifecycle_lock(daemon_name):
+        return _ensure_daemon_locked(wait=wait, name=daemon_name, env=env)
+
+
+def _ensure_daemon_locked(wait=60.0, name=None, env=None):
+    """ensure_daemon() implementation while the per-name lifecycle lock is held."""
     if daemon_alive(name):
         # Stale daemons accept connects AND reply to meta:* (pure Python) even when the
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
@@ -354,7 +371,16 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             except Exception:
                 pass
             if not last: time.sleep(0.5)
-        restart_daemon(name)
+        daemon_name = name or NAME
+        daemon_kind = daemon_browser_kind(daemon_name)
+        has_remote_recovery = _read_remote_browser_id(daemon_name) is not None
+        if daemon_kind == "cloud" or has_remote_recovery:
+            # A cloud daemon that cannot answer CDP may still own a billable
+            # browser. Use the durable cleanup path before replacing it; if
+            # both daemon and direct Cloud stop fail, leave it alive.
+            _stop_remote_daemon_locked(daemon_name)
+        else:
+            restart_daemon(daemon_name)
 
     import subprocess, sys
     local = _is_local_chrome_mode(env)
@@ -469,25 +495,25 @@ def _persist_remote_browser_id(name, browser_id):
         raise RuntimeError("Browser Use Cloud returned an invalid browser id")
     state_path = ipc.remote_id_path(name)
     pending_path = state_path.with_name(state_path.name + ".pending")
-    pending_durable = False
+    pending_complete = False
     try:
         fd = os.open(pending_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as state_file:
             state_file.write(_encode_remote_browser_id(browser_id))
             state_file.flush()
             os.fsync(state_file.fileno())
+        pending_complete = True
         if sys.platform != "win32":
             os.chmod(pending_path, 0o600)
         _fsync_directory(state_path.parent)
-        pending_durable = True
         os.replace(pending_path, state_path)
         _fsync_directory(state_path.parent)
     except BaseException:
-        if not pending_durable:
+        if not pending_complete:
             try:
                 pending_path.unlink()
                 _fsync_directory(state_path.parent)
-            except FileNotFoundError:
+            except BaseException:
                 pass
         raise
 
@@ -557,35 +583,106 @@ def _fsync_directory(directory):
         os.close(fd)
 
 
+@contextmanager
+def _remote_daemon_lifecycle_lock(name):
+    """Serialize provisioning and cleanup for one daemon across processes."""
+    state_path = ipc.remote_id_path(name)
+    lock_path = state_path.with_name(state_path.name + ".lock")
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    locked = False
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            while True:
+                os.lseek(fd, 0, os.SEEK_SET)
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                    break
+                except OSError as exc:
+                    if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                        raise
+                    time.sleep(0.05)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        locked = True
+        yield
+    finally:
+        if locked:
+            if sys.platform == "win32":
+                import msvcrt
+
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def stop_remote_daemon(name="remote"):
     """Stop a remote daemon and its backing Browser Use cloud browser.
 
     Triggers the daemon's clean shutdown, which PATCHes
     /browsers/{id} {"action":"stop"} so billing ends and any profile
     state in the session is persisted."""
+    with _remote_daemon_lifecycle_lock(name):
+        return _stop_remote_daemon_locked(name)
+
+
+def _stop_remote_daemon_locked(name):
     # restart_daemon is misnamed — it only stops the daemon (sends
     # shutdown, SIGTERMs if needed, unlinks socket+pid). It never
     # restarts anything on its own; a follow-up `browser-harness`
     # call would auto-spawn a fresh one via ensure_daemon(). That
     # "run-it-again-to-restart" workflow is why it was named that way.
     if daemon_alive(name):
+        daemon_kind, daemon_browser_id = _daemon_browser_identity(name)
+        try:
+            persisted_browser_id = _read_remote_browser_id(name)
+        except RuntimeError:
+            # Preserve the established behavior for corrupt legacy state after
+            # a live daemon confirms a clean shutdown. There is no validated id
+            # that can be sent to Cloud safely.
+            persisted_browser_id = None
+        daemon_owns_persisted_browser = (
+            daemon_kind == "cloud"
+            and daemon_browser_id is not None
+            and daemon_browser_id == persisted_browser_id
+        )
         try:
             restart_daemon(name, require_clean=True)
         except Exception as daemon_error:
             # The daemon can die after the health probe or during the shutdown
             # response. Recover through the durable cloud id instead of treating
             # a missing/EOF response as proof that billing stopped.
-            browser_id = _read_remote_browser_id(name)
-            if not browser_id:
+            cleanup_ids = []
+            if daemon_kind == "cloud" and daemon_browser_id:
+                cleanup_ids.append(daemon_browser_id)
+            if persisted_browser_id and persisted_browser_id not in cleanup_ids:
+                cleanup_ids.append(persisted_browser_id)
+            if not cleanup_ids:
                 raise
             try:
-                _stop_cloud_browser(browser_id, strict=True)
+                for browser_id in cleanup_ids:
+                    _stop_cloud_browser(browser_id, strict=True)
                 restart_daemon(name)
             except Exception as fallback_error:
                 raise ExceptionGroup(
-                    "daemon shutdown and direct cloud browser cleanup both failed",
+                    "daemon shutdown and fallback cloud-browser recovery both failed",
                     [daemon_error, fallback_error],
                 )
+        else:
+            # A same-name local/CDP daemon, an older daemon without identity,
+            # or a cloud daemon for another id cannot own this recovery record.
+            # Stop the exact persisted resource before clearing its only handle.
+            if persisted_browser_id and not daemon_owns_persisted_browser:
+                _stop_cloud_browser(persisted_browser_id, strict=True)
         _clear_remote_browser_id(name)
         return
 
@@ -798,6 +895,13 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
 
     Returns the full browser dict including `liveUrl`. Prints the liveUrl and
     auto-opens it locally when a GUI is detected, so the user can watch along."""
+    with _remote_daemon_lifecycle_lock(name):
+        browser = _start_remote_daemon_locked(name, profileName=profileName, **create_kwargs)
+    _show_live_url(browser.get("liveUrl"))
+    return browser
+
+
+def _start_remote_daemon_locked(name, profileName=None, **create_kwargs):
     if daemon_alive(name):
         raise RuntimeError(f"daemon {name!r} already alive -- restart_daemon({name!r}) first")
     if _read_remote_browser_id(name):
@@ -814,7 +918,7 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
         # persistence in the same rollback boundary: a full disk or permission
         # error must stop the browser we just created instead of orphaning it.
         _persist_remote_browser_id(name, browser.get("id"))
-        ensure_daemon(
+        _ensure_daemon_locked(
             name=name,
             env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
         )
@@ -828,7 +932,6 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
             )
         _clear_remote_browser_id(name)
         raise
-    _show_live_url(browser.get("liveUrl"))
     return browser
 
 

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -463,6 +463,44 @@ def require_existing_daemon(name=None):
         raise RuntimeError(f"required daemon {daemon_name!r} failed its CDP health check")
 
 
+def _persist_remote_browser_id(name, browser_id):
+    if not isinstance(browser_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
+        raise RuntimeError("Browser Use Cloud returned an invalid browser id")
+    state_path = ipc.remote_id_path(name)
+    pending_path = state_path.with_name(state_path.name + ".pending")
+    try:
+        fd = os.open(pending_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as state_file:
+            state_file.write(browser_id + "\n")
+            state_file.flush()
+            os.fsync(state_file.fileno())
+        if sys.platform != "win32":
+            os.chmod(pending_path, 0o600)
+        os.replace(pending_path, state_path)
+    finally:
+        try:
+            pending_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _read_remote_browser_id(name):
+    try:
+        browser_id = ipc.remote_id_path(name).read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
+        raise RuntimeError(f"invalid remote browser recovery state for daemon {name!r}")
+    return browser_id
+
+
+def _clear_remote_browser_id(name):
+    try:
+        ipc.remote_id_path(name).unlink()
+    except FileNotFoundError:
+        pass
+
+
 def stop_remote_daemon(name="remote"):
     """Stop a remote daemon and its backing Browser Use cloud browser.
 
@@ -474,7 +512,17 @@ def stop_remote_daemon(name="remote"):
     # restarts anything on its own; a follow-up `browser-harness`
     # call would auto-spawn a fresh one via ensure_daemon(). That
     # "run-it-again-to-restart" workflow is why it was named that way.
-    restart_daemon(name, require_clean=True)
+    browser_id = _read_remote_browser_id(name)
+    if daemon_alive(name):
+        restart_daemon(name, require_clean=True)
+    elif browser_id:
+        # The daemon may have crashed or been SIGKILLed. Its environment is
+        # gone, so use the private runtime state to stop the exact cloud browser.
+        _stop_cloud_browser(browser_id, strict=True)
+        restart_daemon(name)
+    else:
+        restart_daemon(name, require_clean=True)
+    _clear_remote_browser_id(name)
 
 
 def restart_daemon(name=None, require_clean=False):
@@ -676,12 +724,20 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
     auto-opens it locally when a GUI is detected, so the user can watch along."""
     if daemon_alive(name):
         raise RuntimeError(f"daemon {name!r} already alive -- restart_daemon({name!r}) first")
+    if _read_remote_browser_id(name):
+        raise RuntimeError(
+            f"remote browser cleanup is still pending for daemon {name!r} -- call stop_remote_daemon({name!r}) first"
+        )
     if profileName:
         if "profileId" in create_kwargs:
             raise RuntimeError("pass profileName OR profileId, not both")
         create_kwargs["profileId"] = _resolve_profile_name(profileName)
     browser = _browser_use("/browsers", "POST", create_kwargs)
     try:
+        # Persist the exact billable resource before starting the daemon. Keep
+        # persistence in the same rollback boundary: a full disk or permission
+        # error must stop the browser we just created instead of orphaning it.
+        _persist_remote_browser_id(name, browser.get("id"))
         ensure_daemon(
             name=name,
             env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
@@ -694,6 +750,7 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
                 "remote daemon startup and cloud browser cleanup both failed",
                 [start_error, cleanup_error],
             )
+        _clear_remote_browser_id(name)
         raise
     _show_live_url(browser.get("liveUrl"))
     return browser

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -180,6 +180,19 @@ def log(msg):
     open(LOG, "a", encoding="utf-8", errors="replace").write(f"{msg}\n")
 
 
+def _safe_connection_label(url):
+    """Log only endpoint topology, never CDP credentials or provider session paths."""
+    try:
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.hostname:
+            return "<redacted-cdp-endpoint>"
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        port = f":{parsed.port}" if parsed.port else ""
+        return f"{parsed.scheme}://{host}{port}"
+    except (TypeError, ValueError):
+        return "<redacted-cdp-endpoint>"
+
+
 async def _silent(coro):
     try:
         await coro
@@ -507,7 +520,7 @@ class Daemon:
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
-        log(f"connecting to {url}")
+        log(f"connecting to {_safe_connection_label(url)}")
         self.cdp = _PatientCDPClient(url) if BROWSER_KIND == "local" else CDPClient(url)
         if BROWSER_KIND == "local":
             # Allow while this handshake is still parked on the popup

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -87,6 +87,7 @@ PROFILES = profile_dirs()
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
+_REMOTE_STOPPED = False
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
 # Chrome 144+ shows a per-connection popup. Keep popup open enough to click.
 LOCAL_HANDSHAKE_TIMEOUT = 45
@@ -302,21 +303,34 @@ def get_ws_url():
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 
-def stop_remote():
+def stop_remote(strict=False):
+    global _REMOTE_STOPPED
     if not REMOTE_ID:
-        return
-    try:
-        key = auth.get_browser_use_api_key()
-        req = urllib.request.Request(
-            f"{BU_API}/browsers/{REMOTE_ID}",
-            data=json.dumps({"action": "stop"}).encode(),
-            method="PATCH",
-            headers={"X-Browser-Use-API-Key": key, "Content-Type": "application/json"},
-        )
-        urllib.request.urlopen(req, timeout=15).read()
-        log(f"stopped remote browser {REMOTE_ID}")
-    except Exception as e:
-        log(f"stop_remote failed ({REMOTE_ID}): {e}")
+        return True
+    if _REMOTE_STOPPED:
+        return True
+    last_error = None
+    for attempt in range(3):
+        try:
+            key = auth.get_browser_use_api_key()
+            req = urllib.request.Request(
+                f"{BU_API}/browsers/{REMOTE_ID}",
+                data=json.dumps({"action": "stop"}).encode(),
+                method="PATCH",
+                headers={"X-Browser-Use-API-Key": key, "Content-Type": "application/json"},
+            )
+            urllib.request.urlopen(req, timeout=15).read()
+            _REMOTE_STOPPED = True
+            log(f"stopped remote browser {REMOTE_ID}")
+            return True
+        except Exception as e:
+            last_error = e
+            log(f"stop_remote attempt {attempt + 1}/3 failed ({REMOTE_ID}): {e}")
+            if attempt < 2:
+                time.sleep(0.5 * (attempt + 1))
+    if strict:
+        raise RuntimeError(f"failed to stop remote browser {REMOTE_ID}: {last_error}")
+    return False
 
 
 def is_real_page(t):
@@ -636,7 +650,13 @@ class Daemon:
             )))
             return {"session_id": new_session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
-        if meta == "shutdown":    self.stop.set(); return {"ok": True}
+        if meta == "shutdown":
+            try:
+                stop_remote(strict=True)
+            except Exception as e:
+                return {"error": str(e)}
+            self.stop.set()
+            return {"ok": True}
 
         method = req["method"]
         params = req.get("params") or {}
@@ -708,6 +728,16 @@ async def serve(d):
             t.cancel()
             try: await t
             except (asyncio.CancelledError, Exception): pass
+        # Named non-cloud daemons create one dedicated background tab. Close
+        # only that owned tab on shutdown; never close a user-selected tab.
+        if d.dedicated_target_id and d.cdp:
+            try:
+                await d.cdp.send_raw(
+                    "Target.closeTarget", {"targetId": d.dedicated_target_id}
+                )
+                d.dedicated_target_id = None
+            except Exception as e:
+                log(f"close dedicated tab on shutdown: {e}")
         ipc.cleanup_endpoint(NAME)
 
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -580,7 +580,15 @@ class Daemon:
         # daemon and not an unrelated process that reused our port post-crash.
         # `pid` lets restart_daemon() verify the live daemon's identity before
         # signaling — protects against SIGTERM-by-stale-pid-file after PID reuse.
-        if meta == "ping":        return {"pong": True, "pid": os.getpid(), "browser_kind": BROWSER_KIND}
+        # The cloud id lets admin compare durable recovery state with the exact
+        # resource this daemon owns before clearing either one.
+        if meta == "ping":
+            return {
+                "pong": True,
+                "pid": os.getpid(),
+                "browser_kind": BROWSER_KIND,
+                **({"remote_browser_id": REMOTE_ID} if REMOTE_ID else {}),
+            }
         if meta == "drain_events":
             out = list(self.events); self.events.clear()
             return {"events": out}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -38,21 +38,37 @@ _load_env()
 NAME = os.environ.get("BU_NAME", "default")
 SOCK = ipc.sock_addr(NAME)
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
+IPC_CONNECT_TIMEOUT_SECONDS = 5.0
+DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS = 5.0
+# Cloud screenshots routinely take longer than ordinary CDP round trips. Keep
+# their IPC socket alive within the caller's existing 90-second process budget.
+SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS = 60.0
 
 
-def _send(req):
-    c, token = ipc.connect(NAME, timeout=5.0)
+class _IPCResponseTimeout(TimeoutError):
+    pass
+
+
+def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
+    c, token = ipc.connect(NAME, timeout=IPC_CONNECT_TIMEOUT_SECONDS)
     try:
-        r = ipc.request(c, token, req)
+        c.settimeout(response_timeout)
+        try:
+            r = ipc.request(c, token, req)
+        except TimeoutError as e:
+            raise _IPCResponseTimeout from e
     finally:
         c.close()
     if "error" in r: raise RuntimeError(r["error"])
     return r
 
 
-def cdp(method, session_id=None, **params):
+def cdp(method, session_id=None, _response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS, **params):
     """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1)."""
-    return _send({"method": method, "params": params, "session_id": session_id}).get("result", {})
+    return _send(
+        {"method": method, "params": params, "session_id": session_id},
+        response_timeout=_response_timeout,
+    ).get("result", {})
 
 
 def drain_events():  return _send({"meta": "drain_events"})["events"]
@@ -243,7 +259,17 @@ def capture_screenshot(path=None, full=False, max_dim=None):
     """Save a PNG of the current viewport. Set max_dim=1800 on a 2× display to
     keep the file under the 2000px-per-side limit some image-aware LLMs enforce."""
     path = path or str(ipc._TMP / "shot.png")
-    r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
+    try:
+        r = cdp(
+            "Page.captureScreenshot",
+            _response_timeout=SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS,
+            format="png",
+            captureBeyondViewport=full,
+        )
+    except _IPCResponseTimeout as e:
+        raise RuntimeError(
+            f"Page.captureScreenshot timed out after {SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS:g}s"
+        ) from e
     open(path, "wb").write(base64.b64decode(r["data"]))
     if max_dim:
         from PIL import Image

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -361,7 +361,7 @@ def new_tab(url="about:blank"):
             cur_url = cur.get("url") or ""
             # Reuse attached tab when it's blank
             if (
-                cur_url in ("", "about:blank")
+                cur_url in ("", "about:blank", "data:text/html,")
                 or cur_url.startswith("about:blank#")
                 or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
             ):

--- a/src/browser_harness/recorder.py
+++ b/src/browser_harness/recorder.py
@@ -273,7 +273,12 @@ def _capture(d, helper, args=(), kwargs=None, duration=None):
         if k in event:
             event[k] = _scrub_url(event[k])
     try:
-        shot = helpers.cdp("Page.captureScreenshot", format="jpeg", quality=80)
+        shot = helpers.cdp(
+            "Page.captureScreenshot",
+            _response_timeout=helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS,
+            format="jpeg",
+            quality=80,
+        )
         number = sum(1 for _ in d.glob("*.jpg")) + 1
         data = base64.b64decode(shot["data"])
         while True:

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -19,6 +19,7 @@ from .admin import (
     list_cloud_profiles,
     list_local_profiles,
     print_update_banner,
+    require_existing_daemon,
     restart_daemon,
     run_doctor,
     run_doctor_fix_snap,
@@ -383,7 +384,10 @@ def _run(args):
         ):
             start_remote_daemon(NAME)
         try:
-            ensure_daemon()
+            if os.environ.get("BH_REQUIRE_EXISTING_DAEMON") == "1":
+                require_existing_daemon()
+            else:
+                ensure_daemon()
         except RuntimeError as e:
             # Setup/permission errors are instructions for calling agent
             print(f"browser-harness: {e}", file=sys.stderr)

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -375,8 +375,10 @@ def _run(args):
     # or BU_CDP_WS also blocks the spawn so we honour the precedence install.md promises.
     cloud_admin = code.lstrip().startswith(("start_remote_daemon(", "stop_remote_daemon("))
     if not cloud_admin:
+        require_existing = os.environ.get("BH_REQUIRE_EXISTING_DAEMON") == "1"
         if (
-            not daemon_alive()
+            not require_existing
+            and not daemon_alive()
             and not _local_chrome_listening()
             and not _explicit_cdp_configured()
             and _cloud_auth_configured()
@@ -384,7 +386,7 @@ def _run(args):
         ):
             start_remote_daemon(NAME)
         try:
-            if os.environ.get("BH_REQUIRE_EXISTING_DAEMON") == "1":
+            if require_existing:
                 require_existing_daemon()
             else:
                 ensure_daemon()

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -24,6 +24,67 @@ def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():
     assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
 
 
+def test_require_existing_daemon_fails_without_spawning(monkeypatch):
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+
+    with pytest.raises(RuntimeError, match="required daemon 'scoped' is not running"):
+        admin.require_existing_daemon("scoped")
+
+
+def test_require_existing_daemon_probes_cdp(monkeypatch):
+    sock = FakeSocket(response=b'{"result":{"targetInfos":[]}}\n')
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+    monkeypatch.setattr(admin.ipc, "connect", lambda _name, timeout: (sock, None))
+
+    admin.require_existing_daemon("scoped")
+
+    assert b'"method": "Target.getTargets"' in sock.sent
+    assert sock.closed is True
+
+
+def test_strict_remote_stop_propagates_daemon_error(monkeypatch):
+    sock = FakeSocket(response=b'{"error":"billing stop failed"}\n')
+    monkeypatch.setattr(admin.ipc, "identify", lambda _name, timeout: 123)
+    monkeypatch.setattr(admin, "_process_start_time", lambda _pid: 1)
+    monkeypatch.setattr(admin.ipc, "connect", lambda _name, timeout: (sock, None))
+
+    with pytest.raises(RuntimeError, match="billing stop failed"):
+        admin.stop_remote_daemon("scoped")
+
+    assert sock.closed is True
+
+
+def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch):
+    attempts = []
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(
+        admin,
+        "_browser_use",
+        lambda path, method, body=None: (
+            {"id": "browser-1", "cdpUrl": "https://cdp.example.test"}
+            if method == "POST"
+            else attempts.append((path, method, body))
+            or (_ for _ in ()).throw(OSError("billing stop failed"))
+        ),
+    )
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda _url: "wss://cdp.example.test/ws")
+    monkeypatch.setattr(
+        admin,
+        "ensure_daemon",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("daemon start failed")),
+    )
+    monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        admin.start_remote_daemon("scoped")
+
+    assert [str(error) for error in exc_info.value.exceptions] == [
+        "daemon start failed",
+        "failed to stop remote browser browser-1: billing stop failed",
+    ]
+    assert len(attempts) == 3
+
+
 def test_local_chrome_mode_is_false_when_process_env_provides_remote_cdp(monkeypatch):
     monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/1")
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -172,6 +172,17 @@ def test_dead_remote_daemon_stops_persisted_cloud_browser(monkeypatch, tmp_path)
     assert not state_path.exists()
 
 
+def test_remote_browser_recovery_promotes_valid_pending_state(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    pending_path = tmp_path / "remote-id.pending"
+    pending_path.write_text("browser-1\n")
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+
+    assert admin._read_remote_browser_id("scoped") == "browser-1"
+    assert state_path.read_text().strip() == "browser-1"
+    assert not pending_path.exists()
+
+
 def test_dead_remote_daemon_retains_recovery_state_when_stop_fails(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
     state_path.write_text("browser-1\n")

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -97,7 +97,7 @@ def test_remote_stop_falls_back_when_daemon_dies_after_outer_probe(monkeypatch, 
         if require_clean:
             raise RuntimeError("daemon vanished")
 
-    monkeypatch.setattr(admin, "restart_daemon", fake_restart)
+    monkeypatch.setattr(admin, "_restart_daemon_locked", fake_restart)
     monkeypatch.setattr(
         admin,
         "_stop_cloud_browser",
@@ -121,7 +121,7 @@ def test_remote_stop_fallback_error_describes_the_whole_recovery_step(monkeypatc
     def restart(_name, require_clean=False):
         raise RuntimeError("clean shutdown failed" if require_clean else "forced cleanup failed")
 
-    monkeypatch.setattr(admin, "restart_daemon", restart)
+    monkeypatch.setattr(admin, "_restart_daemon_locked", restart)
     monkeypatch.setattr(admin, "_stop_cloud_browser", lambda _browser_id, strict=False: True)
 
     with pytest.raises(ExceptionGroup, match="fallback cloud-browser recovery") as exc_info:
@@ -154,7 +154,7 @@ def test_live_daemon_stops_persisted_browser_only_when_it_is_not_the_exact_owner
     monkeypatch.setattr(admin, "_daemon_browser_identity", lambda _name: daemon_identity)
     monkeypatch.setattr(
         admin,
-        "restart_daemon",
+        "_restart_daemon_locked",
         lambda name, require_clean=False: restarts.append((name, require_clean)),
     )
     monkeypatch.setattr(
@@ -175,7 +175,7 @@ def test_remote_stop_ignores_corrupt_recovery_state_after_live_clean_shutdown(mo
     state_path.write_text("not a valid cloud id!\n")
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
-    monkeypatch.setattr(admin, "restart_daemon", lambda _name, require_clean=False: None)
+    monkeypatch.setattr(admin, "_restart_daemon_locked", lambda _name, require_clean=False: None)
 
     admin.stop_remote_daemon("scoped")
 
@@ -330,7 +330,7 @@ def test_ensure_daemon_self_heal_uses_durable_cleanup_for_cloud(monkeypatch, tmp
         "_stop_remote_daemon_locked",
         lambda name: stopped.append(name),
     )
-    monkeypatch.setattr(admin, "restart_daemon", lambda _name: pytest.fail("must clean cloud"))
+    monkeypatch.setattr(admin, "_restart_daemon_locked", lambda _name: pytest.fail("must clean cloud"))
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
     monkeypatch.setattr(admin.ipc, "log_path", lambda _name: tmp_path / "daemon.log")
     monkeypatch.setattr(admin.subprocess, "Popen", lambda *args, **kwargs: Process())
@@ -356,7 +356,7 @@ def test_dead_remote_daemon_stops_persisted_cloud_browser(monkeypatch, tmp_path)
     )
     monkeypatch.setattr(
         admin,
-        "restart_daemon",
+        "_restart_daemon_locked",
         lambda name, require_clean=False: restarted.append((name, require_clean)),
     )
 
@@ -963,6 +963,108 @@ def test_remote_start_serializes_against_ordinary_ensure(monkeypatch, tmp_path):
     assert spawn_envs[0]["BU_CDP_WS"] == "wss://cdp.example.test/ws"
     assert spawn_envs[0]["BU_BROWSER_ID"] == "browser-1"
     assert admin._read_remote_browser_id("scoped") == "browser-1"
+
+
+def test_reload_serializes_against_remote_provision(monkeypatch, tmp_path):
+    from browser_harness import run
+
+    state_path = tmp_path / "remote-id"
+    cloud_post_entered = threading.Event()
+    release_cloud_post = threading.Event()
+    reload_lock_attempted = threading.Event()
+    daemon_started = threading.Event()
+    restart_observations = []
+    errors = []
+    reload_thread = None
+    real_lifecycle_lock = admin._remote_daemon_lifecycle_lock
+
+    @contextmanager
+    def observed_lifecycle_lock(name):
+        if threading.current_thread() is reload_thread:
+            reload_lock_attempted.set()
+        with real_lifecycle_lock(name):
+            yield
+
+    def browser_use(path, method, body=None):
+        assert (path, method) == ("/browsers", "POST")
+        cloud_post_entered.set()
+        assert release_cloud_post.wait(timeout=2)
+        return {"id": "browser-1", "cdpUrl": "https://cdp.example.test"}
+
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "_remote_daemon_lifecycle_lock", observed_lifecycle_lock)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name=None: daemon_started.is_set())
+    monkeypatch.setattr(admin, "_browser_use", browser_use)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda _url: "wss://cdp.example.test/ws")
+    monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **_kwargs: daemon_started.set())
+    monkeypatch.setattr(admin, "_show_live_url", lambda _url: None)
+    monkeypatch.setattr(
+        admin,
+        "_restart_daemon_locked",
+        lambda name, require_clean=False: restart_observations.append(
+            (name, daemon_started.is_set(), require_clean)
+        ),
+    )
+
+    def start_remote():
+        try:
+            admin.start_remote_daemon(admin.NAME)
+        except BaseException as exc:
+            errors.append(exc)
+
+    def reload():
+        try:
+            # This is the exact imported function used by `browser-harness --reload`.
+            run.restart_daemon()
+        except BaseException as exc:
+            errors.append(exc)
+
+    provision_thread = threading.Thread(target=start_remote, daemon=True)
+    reload_thread = threading.Thread(target=reload, daemon=True)
+    provision_thread.start()
+    assert cloud_post_entered.wait(timeout=2)
+    reload_thread.start()
+    assert reload_lock_attempted.wait(timeout=2)
+    assert restart_observations == []
+    release_cloud_post.set()
+    provision_thread.join(timeout=2)
+    reload_thread.join(timeout=2)
+
+    assert not provision_thread.is_alive() and not reload_thread.is_alive()
+    assert errors == []
+    assert restart_observations == [(admin.NAME, True, False)]
+
+
+def test_remote_stop_uses_locked_restart_without_reacquiring_lifecycle_lock(monkeypatch):
+    active = False
+    lock_entries = []
+    restart_calls = []
+
+    @contextmanager
+    def non_reentrant_lifecycle_lock(name):
+        nonlocal active
+        assert not active, "already-locked callers must use _restart_daemon_locked"
+        active = True
+        lock_entries.append(name)
+        try:
+            yield
+        finally:
+            active = False
+
+    monkeypatch.setattr(admin, "_remote_daemon_lifecycle_lock", non_reentrant_lifecycle_lock)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(admin, "_read_remote_browser_id", lambda _name: None)
+    monkeypatch.setattr(admin, "_clear_remote_browser_id", lambda _name: None)
+    monkeypatch.setattr(
+        admin,
+        "_restart_daemon_locked",
+        lambda name, require_clean=False: restart_calls.append((name, require_clean)),
+    )
+
+    admin.stop_remote_daemon("scoped")
+
+    assert lock_entries == ["scoped"]
+    assert restart_calls == [("scoped", False)]
 
 
 # --- restart_daemon: PID-reuse safety ---

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -151,6 +151,49 @@ def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch, t
     assert admin._read_remote_browser_id("scoped") == "browser-1"
 
 
+def test_remote_start_retains_complete_pending_record_when_promotion_and_cleanup_fail(
+    monkeypatch, tmp_path
+):
+    state_path = tmp_path / "remote-id"
+    pending_path = tmp_path / "remote-id.pending"
+    attempts = []
+    real_replace = admin.os.replace
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(
+        admin,
+        "_browser_use",
+        lambda path, method, body=None: (
+            {"id": "browser-1", "cdpUrl": "https://cdp.example.test"}
+            if method == "POST"
+            else attempts.append((path, method, body))
+            or (_ for _ in ()).throw(OSError("billing stop failed"))
+        ),
+    )
+    monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(
+        admin.os,
+        "replace",
+        lambda _source, _destination: (_ for _ in ()).throw(OSError("rename failed")),
+    )
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        admin.start_remote_daemon("scoped")
+
+    assert [str(error) for error in exc_info.value.exceptions] == [
+        "rename failed",
+        "failed to stop remote browser browser-1: billing stop failed",
+    ]
+    assert len(attempts) == 3
+    assert pending_path.read_text() == admin._encode_remote_browser_id("browser-1")
+    assert not state_path.exists()
+
+    monkeypatch.setattr(admin.os, "replace", real_replace)
+    assert admin._read_remote_browser_id("scoped") == "browser-1"
+    assert state_path.read_text() == admin._encode_remote_browser_id("browser-1")
+    assert not pending_path.exists()
+
+
 def test_dead_remote_daemon_stops_persisted_cloud_browser(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
     write_remote_id(state_path, "browser-1")

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -3,6 +3,10 @@ import pytest
 from browser_harness import admin
 
 
+def write_remote_id(path, browser_id):
+    path.write_text(admin._encode_remote_browser_id(browser_id))
+
+
 class FakeSocket:
     def __init__(self, response=b'{"target_id":"target-1","session_id":"session-1","page":null}\n'):
         self.response = response
@@ -77,7 +81,7 @@ def test_restart_daemon_require_clean_rejects_eof_response(monkeypatch):
 
 def test_remote_stop_falls_back_when_daemon_dies_after_outer_probe(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
-    state_path.write_text("browser-1\n")
+    write_remote_id(state_path, "browser-1")
     restarts = []
     stopped = []
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
@@ -144,12 +148,12 @@ def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch, t
         "failed to stop remote browser browser-1: billing stop failed",
     ]
     assert len(attempts) == 3
-    assert (tmp_path / "remote-id").read_text().strip() == "browser-1"
+    assert admin._read_remote_browser_id("scoped") == "browser-1"
 
 
 def test_dead_remote_daemon_stops_persisted_cloud_browser(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
-    state_path.write_text("browser-1\n")
+    write_remote_id(state_path, "browser-1")
     stopped = []
     restarted = []
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
@@ -175,17 +179,30 @@ def test_dead_remote_daemon_stops_persisted_cloud_browser(monkeypatch, tmp_path)
 def test_remote_browser_recovery_promotes_valid_pending_state(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
     pending_path = tmp_path / "remote-id.pending"
-    pending_path.write_text("browser-1\n")
+    write_remote_id(pending_path, "browser-1")
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
 
     assert admin._read_remote_browser_id("scoped") == "browser-1"
-    assert state_path.read_text().strip() == "browser-1"
+    assert state_path.read_text() == admin._encode_remote_browser_id("browser-1")
     assert not pending_path.exists()
+
+
+def test_remote_browser_recovery_rejects_truncated_pending_id(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    pending_path = tmp_path / "remote-id.pending"
+    pending_path.write_text("browser-1")
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+
+    with pytest.raises(RuntimeError, match="invalid pending remote browser recovery state"):
+        admin._read_remote_browser_id("scoped")
+
+    assert pending_path.read_text() == "browser-1"
+    assert not state_path.exists()
 
 
 def test_dead_remote_daemon_retains_recovery_state_when_stop_fails(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
-    state_path.write_text("browser-1\n")
+    write_remote_id(state_path, "browser-1")
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
     monkeypatch.setattr(
@@ -197,7 +214,7 @@ def test_dead_remote_daemon_retains_recovery_state_when_stop_fails(monkeypatch, 
     with pytest.raises(RuntimeError, match="stop failed"):
         admin.stop_remote_daemon("scoped")
 
-    assert state_path.read_text().strip() == "browser-1"
+    assert admin._read_remote_browser_id("scoped") == "browser-1"
 
 
 def test_local_chrome_mode_is_false_when_process_env_provides_remote_cdp(monkeypatch):
@@ -627,7 +644,7 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     assert calls == [
         ("/browsers", "POST", {}),
     ]
-    assert (tmp_path / "remote-id").read_text().strip() == "browser-123"
+    assert admin._read_remote_browser_id("remote") == "browser-123"
 
 
 # --- restart_daemon: PID-reuse safety ---

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,3 +1,6 @@
+import threading
+from contextlib import contextmanager
+
 import pytest
 
 from browser_harness import admin
@@ -46,12 +49,14 @@ def test_require_existing_daemon_probes_cdp(monkeypatch):
     assert sock.closed is True
 
 
-def test_strict_remote_stop_propagates_daemon_error(monkeypatch):
+def test_strict_remote_stop_propagates_daemon_error(monkeypatch, tmp_path):
     sock = FakeSocket(response=b'{"error":"billing stop failed"}\n')
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
     monkeypatch.setattr(admin.ipc, "identify", lambda _name, timeout: 123)
     monkeypatch.setattr(admin, "_process_start_time", lambda _pid: 1)
     monkeypatch.setattr(admin.ipc, "connect", lambda _name, timeout: (sock, None))
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
+    monkeypatch.setattr(admin, "_daemon_browser_identity", lambda _name: (None, None))
 
     with pytest.raises(RuntimeError, match="billing stop failed"):
         admin.stop_remote_daemon("scoped")
@@ -106,6 +111,65 @@ def test_remote_stop_falls_back_when_daemon_dies_after_outer_probe(monkeypatch, 
     assert not state_path.exists()
 
 
+def test_remote_stop_fallback_error_describes_the_whole_recovery_step(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    write_remote_id(state_path, "browser-1")
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+    monkeypatch.setattr(admin, "_daemon_browser_identity", lambda _name: ("cloud", "browser-1"))
+
+    def restart(_name, require_clean=False):
+        raise RuntimeError("clean shutdown failed" if require_clean else "forced cleanup failed")
+
+    monkeypatch.setattr(admin, "restart_daemon", restart)
+    monkeypatch.setattr(admin, "_stop_cloud_browser", lambda _browser_id, strict=False: True)
+
+    with pytest.raises(ExceptionGroup, match="fallback cloud-browser recovery") as exc_info:
+        admin.stop_remote_daemon("scoped")
+
+    assert [str(error) for error in exc_info.value.exceptions] == [
+        "clean shutdown failed",
+        "forced cleanup failed",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("daemon_identity", "direct_stops"),
+    [
+        (("local", None), ["browser-1"]),
+        (("cdp", None), ["browser-1"]),
+        (("cloud", "browser-1"), []),
+        (("cloud", "browser-2"), ["browser-1"]),
+    ],
+)
+def test_live_daemon_stops_persisted_browser_only_when_it_is_not_the_exact_owner(
+    monkeypatch, tmp_path, daemon_identity, direct_stops
+):
+    state_path = tmp_path / "remote-id"
+    write_remote_id(state_path, "browser-1")
+    restarts = []
+    stopped = []
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+    monkeypatch.setattr(admin, "_daemon_browser_identity", lambda _name: daemon_identity)
+    monkeypatch.setattr(
+        admin,
+        "restart_daemon",
+        lambda name, require_clean=False: restarts.append((name, require_clean)),
+    )
+    monkeypatch.setattr(
+        admin,
+        "_stop_cloud_browser",
+        lambda browser_id, strict=False: stopped.append(browser_id) or True,
+    )
+
+    admin.stop_remote_daemon("scoped")
+
+    assert restarts == [("scoped", True)]
+    assert stopped == direct_stops
+    assert not state_path.exists()
+
+
 def test_remote_stop_ignores_corrupt_recovery_state_after_live_clean_shutdown(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
     state_path.write_text("not a valid cloud id!\n")
@@ -134,7 +198,7 @@ def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch, t
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda _url: "wss://cdp.example.test/ws")
     monkeypatch.setattr(
         admin,
-        "ensure_daemon",
+        "_ensure_daemon_locked",
         lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("daemon start failed")),
     )
     monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
@@ -192,6 +256,90 @@ def test_remote_start_retains_complete_pending_record_when_promotion_and_cleanup
     assert admin._read_remote_browser_id("scoped") == "browser-1"
     assert state_path.read_text() == admin._encode_remote_browser_id("browser-1")
     assert not pending_path.exists()
+
+
+def test_remote_id_persistence_retains_complete_pending_record_when_directory_fsync_fails(
+    monkeypatch, tmp_path
+):
+    state_path = tmp_path / "remote-id"
+    pending_path = tmp_path / "remote-id.pending"
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(
+        admin,
+        "_fsync_directory",
+        lambda _directory: (_ for _ in ()).throw(OSError("directory fsync failed")),
+    )
+
+    with pytest.raises(OSError, match="directory fsync failed"):
+        admin._persist_remote_browser_id("scoped", "browser-1")
+
+    assert pending_path.read_text() == admin._encode_remote_browser_id("browser-1")
+    assert not state_path.exists()
+
+
+def test_remote_id_persistence_cleanup_cannot_mask_original_write_failure(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    fsync_calls = 0
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+
+    def fail_fsync(_fd):
+        nonlocal fsync_calls
+        fsync_calls += 1
+        raise OSError("write fsync failed" if fsync_calls == 1 else "cleanup fsync failed")
+
+    monkeypatch.setattr(admin.os, "fsync", fail_fsync)
+
+    with pytest.raises(OSError, match="write fsync failed"):
+        admin._persist_remote_browser_id("scoped", "browser-1")
+
+    assert not (tmp_path / "remote-id.pending").exists()
+
+
+def test_ensure_daemon_self_heal_uses_durable_cleanup_for_cloud(monkeypatch, tmp_path):
+    alive = iter([True, True])
+    stopped = []
+    lock_entries = []
+    lock_active = False
+
+    @contextmanager
+    def non_reentrant_lock(name):
+        nonlocal lock_active
+        assert not lock_active, "ensure_daemon must not reacquire its lifecycle lock"
+        lock_active = True
+        lock_entries.append(name)
+        try:
+            yield
+        finally:
+            lock_active = False
+
+    class Process:
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name=None: next(alive))
+    monkeypatch.setattr(admin, "_remote_daemon_lifecycle_lock", non_reentrant_lock)
+    monkeypatch.setattr(
+        admin.ipc,
+        "connect",
+        lambda _name, timeout: (FakeSocket(response=b'{"error":"cdp disconnected"}\n'), None),
+    )
+    monkeypatch.setattr(admin, "daemon_browser_kind", lambda _name=None: "cloud")
+    monkeypatch.setattr(admin, "_read_remote_browser_id", lambda _name: "browser-1")
+    monkeypatch.setattr(
+        admin,
+        "_stop_remote_daemon_locked",
+        lambda name: stopped.append(name),
+    )
+    monkeypatch.setattr(admin, "restart_daemon", lambda _name: pytest.fail("must clean cloud"))
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
+    monkeypatch.setattr(admin.ipc, "log_path", lambda _name: tmp_path / "daemon.log")
+    monkeypatch.setattr(admin.subprocess, "Popen", lambda *args, **kwargs: Process())
+    monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+
+    admin.ensure_daemon(name="scoped", env={"BU_CDP_WS": "wss://cdp.example.test/ws"})
+
+    assert stopped == ["scoped"]
+    assert lock_entries == ["scoped"]
 
 
 def test_dead_remote_daemon_stops_persisted_cloud_browser(monkeypatch, tmp_path):
@@ -583,7 +731,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monke
     monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
-    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
 
     with pytest.raises(RuntimeError, match="boom"):
@@ -596,7 +744,9 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monke
     assert not (tmp_path / "remote-id").exists()
 
 
-def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_persist(monkeypatch):
+def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_persist(
+    monkeypatch, tmp_path
+):
     calls = []
     browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333"}
 
@@ -610,6 +760,7 @@ def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_pe
 
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
     monkeypatch.setattr(
         admin,
         "_persist_remote_browser_id",
@@ -617,7 +768,7 @@ def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_pe
     )
     monkeypatch.setattr(
         admin,
-        "ensure_daemon",
+        "_ensure_daemon_locked",
         lambda **_kwargs: pytest.fail("daemon must not start without recovery state"),
     )
     monkeypatch.setattr(admin, "_clear_remote_browser_id", lambda _name: None)
@@ -647,7 +798,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrup
     monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
-    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: (_ for _ in ()).throw(exc_type()))
+    monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **kwargs: (_ for _ in ()).throw(exc_type()))
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
 
     with pytest.raises(exc_type):
@@ -679,7 +830,7 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
-    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: None)
+    monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **kwargs: None)
     monkeypatch.setattr(admin, "_show_live_url", lambda url: None)
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
 
@@ -688,6 +839,130 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
         ("/browsers", "POST", {}),
     ]
     assert admin._read_remote_browser_id("remote") == "browser-123"
+
+
+def test_concurrent_same_name_remote_starts_provision_once(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    daemon_started = threading.Event()
+    first_provisioned = threading.Event()
+    release_first = threading.Event()
+    provisioned = []
+    results = []
+    errors = []
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: daemon_started.is_set())
+
+    def browser_use(path, method, body=None):
+        assert (path, method) == ("/browsers", "POST")
+        provisioned.append(body)
+        first_provisioned.set()
+        assert release_first.wait(timeout=2)
+        return {"id": "browser-1", "cdpUrl": "https://cdp.example.test"}
+
+    monkeypatch.setattr(admin, "_browser_use", browser_use)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda _url: "wss://cdp.example.test/ws")
+    monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **_kwargs: daemon_started.set())
+    monkeypatch.setattr(admin, "_show_live_url", lambda _url: None)
+
+    def start():
+        try:
+            results.append(admin.start_remote_daemon("scoped"))
+        except Exception as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=start)
+    second = threading.Thread(target=start)
+    first.start()
+    assert first_provisioned.wait(timeout=2)
+    second.start()
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert len(provisioned) == 1
+    assert [result["id"] for result in results] == ["browser-1"]
+    assert len(errors) == 1
+    assert "already alive" in str(errors[0])
+
+
+def test_remote_start_serializes_against_ordinary_ensure(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    daemon_started = threading.Event()
+    cloud_post_entered = threading.Event()
+    ordinary_lock_attempted = threading.Event()
+    release_cloud_post = threading.Event()
+    spawn_envs = []
+    results = []
+    errors = []
+    ordinary_thread = None
+    real_lifecycle_lock = admin._remote_daemon_lifecycle_lock
+
+    class Process:
+        def poll(self):
+            return None
+
+    @contextmanager
+    def observed_lifecycle_lock(name):
+        if threading.current_thread() is ordinary_thread:
+            ordinary_lock_attempted.set()
+        with real_lifecycle_lock(name):
+            yield
+
+    def browser_use(path, method, body=None):
+        assert (path, method) == ("/browsers", "POST")
+        cloud_post_entered.set()
+        assert release_cloud_post.wait(timeout=2)
+        return {"id": "browser-1", "cdpUrl": "https://cdp.example.test"}
+
+    def popen(*_args, **kwargs):
+        spawn_envs.append(kwargs["env"])
+        daemon_started.set()
+        return Process()
+
+    def connect(*_args, **_kwargs):
+        return FakeSocket(response=b'{"result":{"targetInfos":[]}}\n'), None
+
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin.ipc, "log_path", lambda _name: tmp_path / "daemon.log")
+    monkeypatch.setattr(admin, "_remote_daemon_lifecycle_lock", observed_lifecycle_lock)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name=None: daemon_started.is_set())
+    monkeypatch.setattr(admin, "_browser_use", browser_use)
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda _url: "wss://cdp.example.test/ws")
+    monkeypatch.setattr(admin, "_show_live_url", lambda _url: None)
+    monkeypatch.setattr(admin.subprocess, "Popen", popen)
+    monkeypatch.setattr(admin.ipc, "connect", connect)
+
+    def start_remote():
+        try:
+            results.append(admin.start_remote_daemon("scoped"))
+        except BaseException as exc:
+            errors.append(exc)
+
+    def ensure_ordinary():
+        try:
+            admin.ensure_daemon(name="scoped")
+        except BaseException as exc:
+            errors.append(exc)
+
+    remote_thread = threading.Thread(target=start_remote, daemon=True)
+    ordinary_thread = threading.Thread(target=ensure_ordinary, daemon=True)
+    remote_thread.start()
+    assert cloud_post_entered.wait(timeout=2)
+    ordinary_thread.start()
+    assert ordinary_lock_attempted.wait(timeout=2)
+    assert not daemon_started.is_set()
+    release_cloud_post.set()
+    remote_thread.join(timeout=2)
+    ordinary_thread.join(timeout=2)
+
+    assert not remote_thread.is_alive() and not ordinary_thread.is_alive()
+    assert errors == []
+    assert [result["id"] for result in results] == ["browser-1"]
+    assert len(spawn_envs) == 1
+    assert spawn_envs[0]["BU_CDP_WS"] == "wss://cdp.example.test/ws"
+    assert spawn_envs[0]["BU_BROWSER_ID"] == "browser-1"
+    assert admin._read_remote_browser_id("scoped") == "browser-1"
 
 
 # --- restart_daemon: PID-reuse safety ---

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -55,6 +55,65 @@ def test_strict_remote_stop_propagates_daemon_error(monkeypatch):
     assert sock.closed is True
 
 
+def test_restart_daemon_require_clean_rejects_missing_daemon(monkeypatch):
+    monkeypatch.setattr(admin.ipc, "identify", lambda _name, timeout: None)
+    monkeypatch.setattr(admin.ipc, "ping", lambda _name, timeout: False)
+
+    with pytest.raises(RuntimeError, match="unavailable for required clean shutdown"):
+        admin.restart_daemon("scoped", require_clean=True)
+
+
+def test_restart_daemon_require_clean_rejects_eof_response(monkeypatch):
+    sock = FakeSocket(response=b"")
+    monkeypatch.setattr(admin.ipc, "identify", lambda _name, timeout: None)
+    monkeypatch.setattr(admin.ipc, "ping", lambda _name, timeout: True)
+    monkeypatch.setattr(admin.ipc, "connect", lambda _name, timeout: (sock, None))
+
+    with pytest.raises(RuntimeError, match="did not confirm clean shutdown"):
+        admin.restart_daemon("scoped", require_clean=True)
+
+    assert sock.closed is True
+
+
+def test_remote_stop_falls_back_when_daemon_dies_after_outer_probe(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    state_path.write_text("browser-1\n")
+    restarts = []
+    stopped = []
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+
+    def fake_restart(name, require_clean=False):
+        restarts.append((name, require_clean))
+        if require_clean:
+            raise RuntimeError("daemon vanished")
+
+    monkeypatch.setattr(admin, "restart_daemon", fake_restart)
+    monkeypatch.setattr(
+        admin,
+        "_stop_cloud_browser",
+        lambda browser_id, strict=False: stopped.append((browser_id, strict)) or True,
+    )
+
+    admin.stop_remote_daemon("scoped")
+
+    assert restarts == [("scoped", True), ("scoped", False)]
+    assert stopped == [("browser-1", True)]
+    assert not state_path.exists()
+
+
+def test_remote_stop_ignores_corrupt_recovery_state_after_live_clean_shutdown(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    state_path.write_text("not a valid cloud id!\n")
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+    monkeypatch.setattr(admin, "restart_daemon", lambda _name, require_clean=False: None)
+
+    admin.stop_remote_daemon("scoped")
+
+    assert not state_path.exists()
+
+
 def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch, tmp_path):
     attempts = []
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -44,6 +44,7 @@ def test_require_existing_daemon_probes_cdp(monkeypatch):
 
 def test_strict_remote_stop_propagates_daemon_error(monkeypatch):
     sock = FakeSocket(response=b'{"error":"billing stop failed"}\n')
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
     monkeypatch.setattr(admin.ipc, "identify", lambda _name, timeout: 123)
     monkeypatch.setattr(admin, "_process_start_time", lambda _pid: 1)
     monkeypatch.setattr(admin.ipc, "connect", lambda _name, timeout: (sock, None))
@@ -54,7 +55,7 @@ def test_strict_remote_stop_propagates_daemon_error(monkeypatch):
     assert sock.closed is True
 
 
-def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch):
+def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch, tmp_path):
     attempts = []
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
     monkeypatch.setattr(
@@ -74,6 +75,7 @@ def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch):
         lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("daemon start failed")),
     )
     monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
 
     with pytest.raises(BaseExceptionGroup) as exc_info:
         admin.start_remote_daemon("scoped")
@@ -83,6 +85,49 @@ def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch):
         "failed to stop remote browser browser-1: billing stop failed",
     ]
     assert len(attempts) == 3
+    assert (tmp_path / "remote-id").read_text().strip() == "browser-1"
+
+
+def test_dead_remote_daemon_stops_persisted_cloud_browser(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    state_path.write_text("browser-1\n")
+    stopped = []
+    restarted = []
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(
+        admin,
+        "_stop_cloud_browser",
+        lambda browser_id, strict=False: stopped.append((browser_id, strict)) or True,
+    )
+    monkeypatch.setattr(
+        admin,
+        "restart_daemon",
+        lambda name, require_clean=False: restarted.append((name, require_clean)),
+    )
+
+    admin.stop_remote_daemon("scoped")
+
+    assert stopped == [("browser-1", True)]
+    assert restarted == [("scoped", False)]
+    assert not state_path.exists()
+
+
+def test_dead_remote_daemon_retains_recovery_state_when_stop_fails(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    state_path.write_text("browser-1\n")
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(
+        admin,
+        "_stop_cloud_browser",
+        lambda _browser_id, strict=False: (_ for _ in ()).throw(RuntimeError("stop failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        admin.stop_remote_daemon("scoped")
+
+    assert state_path.read_text().strip() == "browser-1"
 
 
 def test_local_chrome_mode_is_false_when_process_env_provides_remote_cdp(monkeypatch):
@@ -393,7 +438,7 @@ def test_doctor_page_output_truncates_long_text(monkeypatch, capsys):
     assert "https://example.t..." in out
 
 
-def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monkeypatch):
+def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monkeypatch, tmp_path):
     calls = []
     browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
 
@@ -409,6 +454,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monke
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
     monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
 
     with pytest.raises(RuntimeError, match="boom"):
         admin.start_remote_daemon()
@@ -417,10 +463,46 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monke
         ("/browsers", "POST", {}),
         ("/browsers/browser-123", "PATCH", {"action": "stop"}),
     ]
+    assert not (tmp_path / "remote-id").exists()
+
+
+def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_persist(monkeypatch):
+    calls = []
+    browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333"}
+
+    def fake_browser_use(path, method, body=None):
+        calls.append((path, method, body))
+        if (path, method) == ("/browsers", "POST"):
+            return browser
+        if (path, method) == ("/browsers/browser-123", "PATCH"):
+            return {}
+        raise AssertionError((path, method, body))
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
+    monkeypatch.setattr(
+        admin,
+        "_persist_remote_browser_id",
+        lambda *_args: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    monkeypatch.setattr(
+        admin,
+        "ensure_daemon",
+        lambda **_kwargs: pytest.fail("daemon must not start without recovery state"),
+    )
+    monkeypatch.setattr(admin, "_clear_remote_browser_id", lambda _name: None)
+
+    with pytest.raises(OSError, match="disk full"):
+        admin.start_remote_daemon("scoped")
+
+    assert calls == [
+        ("/browsers", "POST", {}),
+        ("/browsers/browser-123", "PATCH", {"action": "stop"}),
+    ]
 
 
 @pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
-def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrupted(monkeypatch, exc_type):
+def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrupted(monkeypatch, exc_type, tmp_path):
     calls = []
     browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
 
@@ -436,6 +518,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrup
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
     monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: (_ for _ in ()).throw(exc_type()))
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
 
     with pytest.raises(exc_type):
         admin.start_remote_daemon()
@@ -444,6 +527,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrup
         ("/browsers", "POST", {}),
         ("/browsers/browser-123", "PATCH", {"action": "stop"}),
     ]
+    assert not (tmp_path / "remote-id").exists()
 
 
 @pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
@@ -452,7 +536,7 @@ def test_stop_cloud_browser_swallows_baseexception_from_stop_request(monkeypatch
 
     admin._stop_cloud_browser("browser-123")
 
-def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatch):
+def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatch, tmp_path):
     calls = []
     browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
 
@@ -467,11 +551,13 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
     monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: None)
     monkeypatch.setattr(admin, "_show_live_url", lambda url: None)
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
 
     assert admin.start_remote_daemon() == browser
     assert calls == [
         ("/browsers", "POST", {}),
     ]
+    assert (tmp_path / "remote-id").read_text().strip() == "browser-123"
 
 
 # --- restart_daemon: PID-reuse safety ---

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -841,6 +841,31 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     assert admin._read_remote_browser_id("remote") == "browser-123"
 
 
+def test_start_remote_daemon_opens_live_view_by_default(monkeypatch):
+    browser = {"id": "browser-123", "liveUrl": "https://live.example"}
+    shown = []
+    monkeypatch.delenv("BH_OPEN_LIVE_URL", raising=False)
+    monkeypatch.setattr(admin, "_start_remote_daemon_locked", lambda *_args, **_kwargs: browser)
+    monkeypatch.setattr(admin, "_show_live_url", shown.append)
+
+    assert admin.start_remote_daemon("scoped") == browser
+    assert shown == ["https://live.example"]
+
+
+@pytest.mark.parametrize("value", ["0", "false", "NO", " off "])
+def test_start_remote_daemon_can_suppress_live_view_for_orchestrators(monkeypatch, value):
+    browser = {"id": "browser-123", "liveUrl": "https://live.example"}
+    monkeypatch.setenv("BH_OPEN_LIVE_URL", value)
+    monkeypatch.setattr(admin, "_start_remote_daemon_locked", lambda *_args, **_kwargs: browser)
+    monkeypatch.setattr(
+        admin,
+        "_show_live_url",
+        lambda _url: pytest.fail("suppressed live view must not be printed or opened"),
+    )
+
+    assert admin.start_remote_daemon("scoped") == browser
+
+
 def test_concurrent_same_name_remote_starts_provision_once(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
     daemon_started = threading.Event()

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -5,6 +5,22 @@ import pytest
 from browser_harness import daemon
 
 
+@pytest.mark.parametrize(
+    ("url", "label"),
+    [
+        (
+            "ws://openclaw-internal:secret@127.0.0.1:18792/devtools/browser/id?token=x",
+            "ws://127.0.0.1:18792",
+        ),
+        ("wss://provider.example/session/private-id?token=secret", "wss://provider.example"),
+        ("wss://[::1]:9222/devtools/browser/id", "wss://[::1]:9222"),
+        ("not-a-url", "<redacted-cdp-endpoint>"),
+    ],
+)
+def test_safe_connection_label_removes_credentials_paths_and_queries(url, label):
+    assert daemon._safe_connection_label(url) == label
+
+
 class _FakeCDP:
     """Records send_raw calls so tests can assert which CDP methods fired."""
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -21,6 +21,41 @@ def test_safe_connection_label_removes_credentials_paths_and_queries(url, label)
     assert daemon._safe_connection_label(url) == label
 
 
+def test_remote_stop_retries_and_succeeds(monkeypatch):
+    attempts = []
+    monkeypatch.setattr(daemon, "REMOTE_ID", "browser-1")
+    monkeypatch.setattr(daemon, "_REMOTE_STOPPED", False)
+    monkeypatch.setattr(daemon.auth, "get_browser_use_api_key", lambda: "key")
+    monkeypatch.setattr(daemon.time, "sleep", lambda _seconds: None)
+
+    def urlopen(_request, timeout):
+        attempts.append(timeout)
+        if len(attempts) < 3:
+            raise OSError("temporary")
+        return type("Response", (), {"read": lambda self: b""})()
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", urlopen)
+
+    assert daemon.stop_remote(strict=True) is True
+    assert attempts == [15, 15, 15]
+    assert daemon._REMOTE_STOPPED is True
+
+
+def test_shutdown_keeps_daemon_alive_when_cloud_stop_fails(monkeypatch):
+    d = daemon.Daemon()
+    d.stop = asyncio.Event()
+    monkeypatch.setattr(
+        daemon,
+        "stop_remote",
+        lambda strict=False: (_ for _ in ()).throw(RuntimeError("billing stop failed")),
+    )
+
+    response = asyncio.run(d.handle({"meta": "shutdown"}))
+
+    assert response == {"error": "billing stop failed"}
+    assert d.stop.is_set() is False
+
+
 class _FakeCDP:
     """Records send_raw calls so tests can assert which CDP methods fired."""
 
@@ -550,8 +585,8 @@ def test_named_local_attach_cleans_inspect_tabs_before_return(monkeypatch):
     assert d.cdp.closed == ["inspect-tab"]
 
 
-def test_shutdown_leaves_dedicated_tab_open(monkeypatch):
-    """The real serve shutdown path never closes a working or user tab."""
+def test_shutdown_closes_only_the_daemon_owned_tab(monkeypatch):
+    """Run cleanup closes the daemon-created tab without touching a user tab."""
     d = daemon.Daemon()
     d.cdp = _AttachCDP()
 
@@ -573,8 +608,8 @@ def test_shutdown_leaves_dedicated_tab_open(monkeypatch):
 
     asyncio.run(daemon.main())
 
-    assert d.cdp.closed == []
-    assert d.dedicated_target_id == "daemon-tab"
+    assert d.cdp.closed == ["daemon-tab"]
+    assert d.dedicated_target_id is None
     assert d.target_id == "user-selected-tab"
 
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -56,6 +56,17 @@ def test_shutdown_keeps_daemon_alive_when_cloud_stop_fails(monkeypatch):
     assert d.stop.is_set() is False
 
 
+def test_cloud_ping_reports_exact_remote_browser_id(monkeypatch):
+    d = daemon.Daemon()
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cloud")
+    monkeypatch.setattr(daemon, "REMOTE_ID", "browser-1")
+
+    response = asyncio.run(d.handle({"meta": "ping"}))
+
+    assert response["browser_kind"] == "cloud"
+    assert response["remote_browser_id"] == "browser-1"
+
+
 class _FakeCDP:
     """Records send_raw calls so tests can assert which CDP methods fired."""
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -29,6 +29,50 @@ def test_max_dim_default_is_no_resize(fake_png):
     assert _run(fake_png, 4592, 2286) == (4592, 2286)
 
 
+def test_send_keeps_connect_timeout_short_and_sets_response_budget():
+    class FakeSocket:
+        def __init__(self):
+            self.timeouts = []
+
+        def settimeout(self, value):
+            self.timeouts.append(value)
+
+        def close(self):
+            pass
+
+    socket = FakeSocket()
+    with patch("browser_harness.helpers.ipc.connect", return_value=(socket, None)) as connect, \
+         patch("browser_harness.helpers.ipc.request", return_value={}):
+        helpers._send({"meta": "ping"}, response_timeout=60.0)
+
+    connect.assert_called_once_with(helpers.NAME, timeout=helpers.IPC_CONNECT_TIMEOUT_SECONDS)
+    assert socket.timeouts == [60.0]
+
+
+def test_screenshot_uses_long_response_timeout_without_forwarding_it_to_cdp(fake_png, tmp_path):
+    with patch(
+        "browser_harness.helpers._send",
+        return_value={"result": {"data": fake_png(800, 400)}},
+    ) as send:
+        helpers.capture_screenshot(str(tmp_path / "shot.png"))
+
+    request = send.call_args.args[0]
+    assert request == {
+        "method": "Page.captureScreenshot",
+        "params": {"format": "png", "captureBeyondViewport": False},
+        "session_id": None,
+    }
+    assert send.call_args.kwargs == {
+        "response_timeout": helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS
+    }
+
+
+def test_screenshot_timeout_has_context(tmp_path):
+    with patch("browser_harness.helpers._send", side_effect=helpers._IPCResponseTimeout):
+        with pytest.raises(RuntimeError, match="Page.captureScreenshot timed out after 60s"):
+            helpers.capture_screenshot(str(tmp_path / "shot.png"))
+
+
 def _seed_skill(tmp_path):
     site = tmp_path / "domain-skills" / "example"
     site.mkdir(parents=True)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import tempfile
 import time
@@ -6,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from PIL import Image
 
-from browser_harness import helpers
+from browser_harness import helpers, recorder
 
 
 def _run(fake_png, width, height, **kwargs):
@@ -71,6 +72,18 @@ def test_screenshot_timeout_has_context(tmp_path):
     with patch("browser_harness.helpers._send", side_effect=helpers._IPCResponseTimeout):
         with pytest.raises(RuntimeError, match="Page.captureScreenshot timed out after 60s"):
             helpers.capture_screenshot(str(tmp_path / "shot.png"))
+
+
+def test_recorder_screenshot_uses_long_response_timeout(tmp_path):
+    with patch("browser_harness.helpers.js", return_value={}), patch(
+        "browser_harness.helpers.cdp",
+        return_value={"data": base64.b64encode(b"jpeg").decode()},
+    ) as cdp:
+        recorder._capture(tmp_path, "click")
+
+    screenshot = next(call for call in cdp.call_args_list if call.args == ("Page.captureScreenshot",))
+    assert screenshot.kwargs["_response_timeout"] == helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS
+    assert screenshot.kwargs["format"] == "jpeg"
 
 
 def _seed_skill(tmp_path):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -461,3 +461,21 @@ def test_new_tab_creates_and_attaches_in_background(monkeypatch):
     assert helpers.new_tab() == "target-new"
     assert ("Target.createTarget", {"url": "about:blank", "background": True}) in calls
     assert not any(method == "Target.activateTarget" for method, _ in calls)
+
+
+def test_new_tab_reuses_an_empty_data_document(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        helpers,
+        "current_tab",
+        lambda: {"targetId": "target-placeholder", "url": "data:text/html,"},
+    )
+    monkeypatch.setattr(helpers, "goto_url", lambda url: calls.append(("goto_url", url)))
+    monkeypatch.setattr(
+        helpers,
+        "cdp",
+        lambda method, **kwargs: calls.append((method, kwargs)) or {},
+    )
+
+    assert helpers.new_tab("https://example.com") == "target-placeholder"
+    assert calls == [("goto_url", "https://example.com")]

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -21,6 +21,19 @@ def test_stdin_executes_code():
     assert stdout.getvalue().strip() == "hello from stdin"
 
 
+def test_require_existing_daemon_never_auto_starts(monkeypatch):
+    monkeypatch.setenv("BH_REQUIRE_EXISTING_DAEMON", "1")
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
+         patch("browser_harness.run.require_existing_daemon") as mock_require, \
+         patch("browser_harness.run.ensure_daemon") as mock_ensure, \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+
+    mock_require.assert_called_once_with()
+    mock_ensure.assert_not_called()
+
+
 def test_c_flag_is_rejected():
     with patch.object(sys, "argv", ["browser-harness", "-c", "print('old path')"]), \
          patch("sys.stdin", StringIO("print('ignored')")):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -34,6 +34,25 @@ def test_require_existing_daemon_never_auto_starts(monkeypatch):
     mock_ensure.assert_not_called()
 
 
+def test_require_existing_daemon_blocks_cloud_autospawn(monkeypatch):
+    monkeypatch.setenv("BH_REQUIRE_EXISTING_DAEMON", "1")
+    monkeypatch.setenv("BU_AUTOSPAWN", "1")
+    monkeypatch.setenv("BROWSER_USE_API_KEY", "test-key")
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
+         patch("browser_harness.run.daemon_alive", return_value=False), \
+         patch("browser_harness.run._local_chrome_listening", return_value=False), \
+         patch("browser_harness.run.start_remote_daemon") as mock_start, \
+         patch("browser_harness.run.require_existing_daemon") as mock_require, \
+         patch("browser_harness.run.ensure_daemon") as mock_ensure, \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+
+    mock_start.assert_not_called()
+    mock_require.assert_called_once_with()
+    mock_ensure.assert_not_called()
+
+
 def test_c_flag_is_rejected():
     with patch.object(sys, "argv", ["browser-harness", "-c", "print('old path')"]), \
          patch("sys.stdin", StringIO("print('ignored')")):


### PR DESCRIPTION
## Summary

Make Browser Harness safe to run behind an orchestrator-owned browser transport:

- redact credentials, provider paths, and query tokens from daemon connection logs
- add `BH_REQUIRE_EXISTING_DAEMON=1`, which checks the exact named daemon and fails closed before Cloud autospawn or local discovery
- add `BH_OPEN_LIVE_URL=0`, which lets a trusted orchestrator suppress both credential-bearing live-view URL output and `webbrowser.open` while preserving standalone/default behavior
- persist the exact Browser Use Cloud browser ID atomically in a versioned, checksummed, mode-0600 recovery record with file and directory fsync
- accept only complete recovery records; retain complete pending state and never mask the originating startup or cleanup error
- require an exact clean-shutdown acknowledgement; daemon loss, EOF, and provider failure fall back to a direct authenticated Cloud stop
- report the authenticated daemon's exact browser kind and Cloud ID, so cleanup cannot confuse local/CDP, different-Cloud, or same-name replacement ownership
- serialize every same-name health check, self-heal, provision, reload, spawn, and stop behind one cross-process lifecycle lock, with non-recursive locked helpers and a second liveness check inside the lock
- keep IPC connect/default responses at 5 seconds while giving explicit and recorder screenshots a bounded 60-second response budget
- close only the background tab created by a named daemon, never a user-selected tab
- reuse OpenClaw's exact non-networked `data:text/html,` relay placeholder as the first navigation tab instead of creating a second blank tab
- bump the package to 0.1.10 for the new lifecycle contract

The resulting mode is orchestrator-agnostic: a trusted host provisions a scoped daemon with `BH_RUNTIME_DIR` + `BU_NAME`, then lets model-authored Browser Harness calls reuse it without placing the upstream CDP credential in the model process.

## Validation

Exact head: `1f42c644bdc63e20ae54b27bdf10bd23f2e0448f`

- full pytest suite: `185 passed`
- Python `compileall` passed
- `git diff --check` passed
- CodeQL, GitGuardian, skill review, and the AI reviewer are green

Coverage includes daemon-loss fail-closed behavior, CDP health probing, crash-durable Cloud-ID recovery, complete pending-record promotion, truncated-record rejection, rename/fsync/disk-write failure retention, SIGKILL/EOF fallback, Cloud stop retry/propagation, dual startup/cleanup failures, exact local/CDP/Cloud ownership, concurrent same-name start/ensure/reload races, non-recursive stale self-heal, recorder screenshot timeout, exact owned-tab cleanup, exact relay-placeholder reuse, and live-view suppression/default preservation.

OpenClaw exact-head smoke [32323962207](https://github.com/browser-use/new-eval-platform/actions/runs/32323962207) exercised the immediate integration parent: 2/2 semantic passes, zero tool failures, exact Cloud connect/attach/listen/stop per task, valid retained PNGs, and zero Harness IPC/screenshot errors. Final smoke [32328656001](https://github.com/browser-use/new-eval-platform/actions/runs/32328656001) passed 2/2 with exact Cloud attach/listen/stop, valid retained screenshots, and zero Harness IPC or capture errors.

OpenClaw requires Browser Harness `>=0.1.10`; the current public PyPI release is 0.1.9. This PR must merge and 0.1.10 must be tagged/published before OpenClaw can ship the new engine as its default.