### PR TITLE
domain-skills: skool — read classroom content via __NEXT_DATA__

### DIFF
--- a/domain-skills/facebook/groups.md
+++ b/domain-skills/facebook/groups.md
@@ -35,7 +35,7 @@ hold up well. Anchor on those, not on hashed CSS classes.
 
 | Anchor | Selector | Notes |
 |--------|----------|-------|
-| Each post container | `div[role="article"]` | Stable. One per visible post. |
+| Each post container | direct children of `div[role="feed"]` (real posts have `innerText.length > 100`) | **`div[role="article"]` stopped matching group-feed posts (observed 2026-08-14)** — iterate feed children instead |
 | Post permalink | `a[href*="/groups/"][href*="/posts/"], a[href*="/groups/"][href*="/permalink/"]` | First match per article = the post link |
 | Post body text | `div[data-ad-preview="message"], div[data-ad-comet-preview="message"]` | One of these is the visible body |
 | Post author | `h3 a, h4 a` (first inside the article) | Falls back to `strong a` |
@@ -234,3 +234,21 @@ downstream task (competitor inventory, pricing intel, boat listings, etc).
 - **2026-04-18:** Fresh install verified. People-search URL requires login;
   page search `/search/pages/?q=` works the same way. Groups feed defaults to
   algorithmic sort — always append `?sorting_setting=CHRONOLOGICAL`.
+- **2026-08-15:** The feed only lazy-loads while the tab is VISIBLE. A background
+  tab freezes at ~5 posts: `scrollY` moves but page height never grows, and every
+  collect round returns the same 1-5 posts. Fix: `cdp("Page.bringToFront")` right
+  after `goto` (activates the tab without focusing the Chrome app).
+- **2026-08-15:** `div[role="article"]` no longer matches group-feed posts; use
+  `div[role="feed"]` direct children (see anchors table). Group search results
+  (`/search/groups/?q=`) DO still carry member count + posts/day in each card's
+  innerText, and public groups' `/about` pages (rules, activity stats) are
+  readable without joining.
+- **2026-08-15:** "See more" truncation hides the bottom of long posts, which is
+  where contact details (email/phone) usually sit. Before each collect round,
+  click every `div[role="button"]` whose trimmed innerText === "See more", then
+  wait ~1.5s. On permalink pages the post may render inside `div[role="dialog"]`;
+  prefer that container's innerText when present.
+- **2026-08-15:** Some posts carry an anti-scrape watermark: hundreds of scrambled
+  single characters with combining mark U+034F interleaved in innerText. Strip or
+  ignore when parsing. Post innerText is also polluted with repeated "Facebook"
+  strings (SVG titles) and UI residue ("Comment as X", reaction counts).

--- a/domain-skills/facebook/pages.md
+++ b/domain-skills/facebook/pages.md
@@ -293,3 +293,24 @@ underneath; personal profiles have a cover photo component and a "Friends" tab.
   contexts. Run the self-inspection block on first live use to confirm no drift
   since the groups.md verification date, and append a note here with what you
   found.
+- **2026-08-17:** On Page feeds, post bodies are NO LONGER inside
+  `div[role="article"]` (matches the groups.md drift note) — iterate
+  `div[data-ad-preview="message"], div[data-ad-comet-preview="message"]`
+  directly and walk up ~7 parents for the post container (reaction counts,
+  tail text). Permalink anchors (`pfbid` etc.) often have no href until
+  hover, so key posts by `body.innerText.slice(0,80)` instead of URL when you
+  only need content + engagement, not permalinks.
+- **2026-08-17:** `role="article"` DOES still match Messenger chat-dock
+  bubbles — if the user has a chat open, an unscoped `div[role="article"]`
+  sweep reads their private messages. Scope everything to
+  `div[role="main"]`.
+- **2026-08-17:** Repeated js()/scroll() round-trips over a long collect loop
+  wedged the daemon twice on heavy Page feeds (client hangs, needs
+  `restart_daemon()` + a fresh Chrome Allow click). Do the whole
+  scroll+collect as ONE `js()` call: an in-page `async` IIFE that loops
+  `window.scrollBy` + `await sleep(2500)` and returns the collected JSON at
+  the end. One round-trip, no wedge, ~12 scrolls ≈ 35 s.
+- **2026-08-17:** Engagement extraction without hover: collect `span` texts
+  matching `/^[0-9][0-9.,]*[KM]?$/` in the post container and take the max as
+  the reaction count proxy; parse `([\d.,]+[KM]?) comments|shares` from the
+  container's trailing innerText.

--- a/domain-skills/skool/reading-content.md
+++ b/domain-skills/skool/reading-content.md
@@ -1,0 +1,39 @@
+# Skool — reading community and classroom content
+
+Skool (skool.com) communities are login-walled Next.js apps. Do not scrape the DOM for
+classroom content — the structured data is already on the page.
+
+## URL patterns
+
+- Community feed: `skool.com/<group>`
+- Classroom (course list): `skool.com/<group>/classroom`
+- Course: `skool.com/<group>/classroom/<courseSlug>` (slug is 8 hex chars, not the course id)
+- Lesson: `skool.com/<group>/classroom/<courseSlug>?md=<lessonId>` (32-hex module id)
+
+## Private data source: `__NEXT_DATA__`
+
+All classroom data lives in `window.__NEXT_DATA__.props.pageProps`:
+
+- `allCourses` — every course in the group (id, name/slug, metadata.title, metadata.desc,
+  metadata.hasAccess). Available on any classroom page.
+- `course` — populated ONLY on a course page (`/classroom/<slug>`): full tree of
+  `{course: {id, metadata: {title, desc, videoLink}}, children: [...]}` covering modules
+  and lessons. This gives you every module/lesson title and id in one read.
+- Lesson body: `metadata.desc` of the lesson node — but it is only populated for the
+  lesson currently loaded via `?md=<id>`. To pull N lessons, do N full-page navigations
+  (`?md=` each id) and read that lesson's `desc` from the refreshed `course` tree each time.
+
+`desc` format: the string starts with `[v2]` followed by ProseMirror-style rich-text JSON
+(`{"type":"paragraph","content":[{"type":"text","text":...}]}` nodes, plus `codeBlock`,
+`image` with `src` on assets.skool.com, `heading`, lists). Strip the `[v2]` prefix and
+walk `content` recursively collecting `text` nodes to get plain text.
+
+## Traps
+
+- Course cards on `/classroom` are NOT `<a href>` links — `querySelectorAll('a[href*="/classroom/"]')`
+  returns nothing. Click the card (locate by its title text, click the bounding-box centre),
+  or navigate directly by URL once you know the slug.
+- SPA sidebar lesson clicks are unreliable for switching lessons; full-page navigation to
+  `?md=<lessonId>` always works and repopulates `__NEXT_DATA__`.
+- `metadata.hasAccess` gates paid tiers — lessons in locked courses have no `desc`.
+- Community feed posts also live in `pageProps` (renderData) — check there before DOM-scraping.


### PR DESCRIPTION
Adds a skool.com domain skill: URL patterns, pulling course trees and lesson bodies from Next.js pageProps instead of DOM scraping, the [v2] rich-text desc format, and the non-anchor course-card trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Skool domain skill that reads classroom data from `__NEXT_DATA__` instead of DOM scraping, and updates Facebook groups/pages skills for August 2026 selector drift to keep feed collection stable.

- Old vs new: Skool lessons previously required DOM traversal; now we parse `pageProps` for course trees and lesson bodies. Facebook post anchors previously used `div[role="article"]`; now we key off feed children or message bodies and adjust scrolling.

**Skool classroom extraction**
- Read `allCourses` and the full course tree from `window.__NEXT_DATA__.props.pageProps` instead of the DOM.
- Fetch lesson bodies by navigating to `/classroom/<slug>?md=<lessonId>`; only the active lesson’s `metadata.desc` is populated.
- Strip the `[v2]` prefix from `desc` and parse the ProseMirror-style JSON; collect text or handle blocks as needed.
- Migration: Do not rely on anchor tags for course cards; navigate by slug or click the card. Respect `metadata.hasAccess` (locked lessons have no `desc`).

**Facebook groups/pages drift**
- Replace `div[role="article"]` selection: iterate direct children of `div[role="feed"]` (groups) or collect `div[data-ad-preview="message"]` and walk up to the container (pages). Key content by body text when permalinks are hover-lazy.
- Bring the tab to front before scrolling to avoid lazy-load stalls; click all “See more” buttons before collecting and prefer dialog containers on permalinks.
- Scope to `div[role="main"]` to avoid Messenger chat bubbles; run scroll+collect in one in-page async loop to prevent wedges.
- Clean innerText noise and U+034F watermark junk; extract engagement via numeric spans and trailing text when hover counts are unavailable.

<sup>Written for commit fd18abf830dcc75def70a99d5c466dcb8c5d5d6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

