### PR TITLE
Add x.com timeline scraping domain skill

### DIFF
--- a/domain-skills/x/scraping.md
+++ b/domain-skills/x/scraping.md
@@ -1,0 +1,37 @@
+# x.com (Twitter) — profile timeline scraping
+
+Requires a logged-in session (use the user's Chrome). Logged-out x.com shows a login wall after ~2 tweets.
+
+## Timeline extraction
+
+- Each tweet is `article[data-testid="tweet"]`.
+- Permalink + timestamp: the `a[href*="/status/"]` that contains a `time` element (`time.getAttribute('datetime')`).
+- Text: `[data-testid="tweetText"]` innerText. Two of these in one article means the second is a quoted tweet.
+- Engagement: the `[role="group"][aria-label]` aria-label carries "N replies, N reposts, N likes, N bookmarks, N views" in one string.
+- Truncation: long posts show `[data-testid="tweet-text-show-more-link"]`. Timeline text stops mid-sentence at ~280 visible chars.
+- Pinned/repost banner: `[data-testid="socialContext"]`.
+- Media: `[data-testid="tweetPhoto"]`, `video`. Link cards: `[data-testid="card.wrapper"]`.
+
+## Virtualized scroll loop
+
+The timeline unloads offscreen tweets, so extract-then-scroll in a loop and dedupe by permalink in Python:
+
+```python
+seen = {}
+for i in range(30):
+    for tw in json.loads(js(EXTRACT_JS) or "[]"):
+        seen.setdefault(tw["link"], tw)
+    js("window.scrollBy(0, 2200)")
+    wait(1.4)
+```
+
+~60 tweets in ~30 iterations. Faster scrolling skips tweets; 1.4s per step was reliable.
+
+## Full text of long posts
+
+Open the status page (`x.com/<user>/status/<id>`): the detail view renders the complete text in the first `article[data-testid="tweet"]`, no Show more click needed. Wait ~2.5s after load.
+
+## Traps
+
+- Standalone link-reply tweets (self-replies carrying just a URL card) have empty `tweetText`; filter on text length.
+- Aria-label omits zero-count stats ("667 views" only), so parse defensively.


### PR DESCRIPTION
Selectors, virtualized-scroll dedupe loop, full-text-via-status-page pattern, and traps learned scraping a profile timeline (63 tweets) on a logged-in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guide for scraping x.com profile timelines, covering stable selectors, a deduped virtualized-scroll loop, and a full-text retrieval pattern. This documents a reliable approach where none existed, enabling consistent extraction from logged-in sessions.

- New doc `domain-skills/x/scraping.md` details tweet/article selectors, engagement parsing via `aria-label`, handling truncation, and media/card selectors.
- Recommends extract-then-scroll loop with permalink-based dedupe (~30 iterations, ~1.4s delay) to mitigate virtualization and skipping.
- Describes full-text retrieval by opening the status URL and waiting ~2.5s; no “Show more” click needed.
- Notes constraints and traps: login wall when logged out, empty `tweetText` for link-reply tweets, and missing zero-count metrics in `aria-label`.

<sup>Written for commit 5b57048e7f4c732f7af6c448c2af6427c4658df7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

