### PR TITLE
feat: allow disabling update checks

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -795,6 +795,8 @@ def check_for_update():
 def print_update_banner(out=None):
     """Print the update banner to stderr once per day. Silent when up-to-date or offline."""
     import sys
+    if os.environ.get("BH_UPDATE_CHECK", "").strip().lower() in {"0", "false", "no", "off"}:
+        return
     out = out or sys.stderr
     cache = _cache_read()
     today = time.strftime("%Y-%m-%d")

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -20,6 +20,31 @@ class FakeSocket:
         self.closed = True
 
 
+@pytest.mark.parametrize("value", ["0", "false", "NO", " off "])
+def test_update_banner_can_be_disabled_without_network_or_cache_access(monkeypatch, value):
+    monkeypatch.setenv("BH_UPDATE_CHECK", value)
+    monkeypatch.setattr(admin, "_cache_read", lambda: pytest.fail("cache should not be read"))
+    monkeypatch.setattr(admin, "check_for_update", lambda: pytest.fail("network should not run"))
+
+    admin.print_update_banner()
+
+
+def test_update_banner_remains_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("BH_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(admin, "_cache_read", lambda: {"banner_shown_on": "1970-01-01"})
+    called = []
+
+    def fake_check_for_update():
+        called.append(True)
+        return "0.1.0", "0.1.0", False
+
+    monkeypatch.setattr(admin, "check_for_update", fake_check_for_update)
+
+    admin.print_update_banner()
+
+    assert called == [True]
+
+
 def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():
     assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
 


### PR DESCRIPTION
## Summary

- add `BH_UPDATE_CHECK=0` to disable the CLI update banner before cache or network access
- preserve existing standalone behavior when the variable is unset
- cover accepted false values and the default-enabled path

## Why

Long-lived orchestrators can run Browser Harness in isolated runtime directories. Their lifecycle probes and cleanup commands should not make an unrelated PyPI request or wait on its timeout. This gives trusted callers a narrow opt-out without changing normal CLI behavior.

## Validation

- `uv run --with pytest pytest -q` (145 passed)
- `python3 -m compileall -q src tests`
- `git diff --check`

This is intentionally separate from #626 and is not merged.


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow disabling update banner update checks via the BH_UPDATE_CHECK environment variable to avoid network/cache access in CI or hermetic environments. Previously, print_update_banner always read cache and could trigger a network call; now it can be skipped.

- When BH_UPDATE_CHECK is set to 0/false/no/off (case-insensitive, trims whitespace), print_update_banner returns immediately without reading the cache or calling check_for_update.
- Default remains enabled; behavior is unchanged when the variable is unset.
- Tests cover disabled behavior (no cache/network) and default behavior (still performs the check).
- To disable in CI: set BH_UPDATE_CHECK=0.

<sup>Written for commit 37849b8687480f8887ab8de7bccec9262b9adeec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

