### PR TITLE
docs: add SIMchapter DNN HTML and asset workflow

### DIFF
--- a/domain-skills/simchapter/dnn-html-and-assets.md
+++ b/domain-skills/simchapter/dnn-html-and-assets.md
@@ -1,0 +1,39 @@
+# SIMchapter DNN custom HTML and asset workflow
+
+Applies to `simchapter.cvsapphire.com` sites that use DNN HTML modules and 2sxc/ADAM-managed assets.
+
+## DNN HTML modules
+
+- Use the core DNN `HTML` module for independent custom-code sections.
+- Edit the module with the Basic Text Box, then set **Render Mode** to `Raw` before saving custom HTML, CSS, or JavaScript. `Text` mode inserts `<br>` elements into line breaks and can corrupt scripts and layout.
+- Treat a save as published unless the site has workflow enabled. Verify the signed-out page after every save; an authenticated editor view can hide permissions or version-state problems.
+- The rich-text editor may sanitize `<style>`, `<script>`, classes, and attributes. Do not paste custom code through the rich-text surface.
+
+## 2sxc edit calls
+
+- When opening a specific entity with the client API, pass entity identifiers inside `params`:
+
+  ```js
+  cms.run({ action: 'edit', params: { entityId, entityGuid } })
+  ```
+
+- Flattening `entityId` or `entityGuid` at the top level is ignored and can open an empty item editor.
+
+## ADAM image URLs
+
+- The public ADAM URL segment comes from the entity field's internal name, not necessarily the friendly label shown in the editor.
+- For a field labeled “Right Side Image” whose internal name is `Image`, the durable public shape is:
+
+  ```text
+  /Portals/SDI/adam/Components/<entity-guid>/Image/<filename>
+  ```
+
+- Do not manufacture the path from the UI label. Use the upload response or inspect the rendered source, then confirm the exact URL signed out with HTTP 200 and `Content-Type: image/*`.
+- Use collision-safe filenames and verify the returned public bytes against the local source hash when migrating legacy Higher Logic images.
+
+## Verification checklist
+
+- Test the target route with no cookies.
+- Confirm every migrated image request uses `/Portals/SDI/` and no legacy Higher Logic image URL remains in the custom modules.
+- Check the browser console, runtime component counts, and horizontal overflow at desktop and mobile widths.
+- Click every source-page CTA signed out; a correct `href` can still appear broken when the destination DNN page does not exist.


### PR DESCRIPTION
Documents durable SIMchapter/DNN behavior discovered during a live content migration: Raw render mode for custom modules, nested 2sxc edit params, ADAM internal field-name paths, and signed-out asset/CTA verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the SIMchapter DNN HTML and asset workflow to prevent content corruption and broken assets during migrations to `simchapter.cvsapphire.com`. Previously, editors sometimes used Text render mode, flattened 2sxc edit params, or derived ADAM paths from UI labels; this guidance standardizes Raw render, nested params, and internal-name-based paths.

**Required migration actions**
- For custom code, use the DNN `HTML` module with Render Mode set to Raw; do not paste through the rich‑text surface. Treat a save as published and verify the page signed out after each save.
- Open specific 2sxc entities with cms.run({ action: 'edit', params: { entityId, entityGuid } }); top‑level IDs are ignored and can open an empty editor.
- Build ADAM URLs from the field’s internal name, not the label. Confirm signed‑out URLs return 200 with image content.
- Use collision‑safe filenames and verify returned bytes (hash) when migrating Higher Logic images.
- Validate signed‑out UX: load routes with no cookies, ensure all images use /Portals/SDI/, check console/overflow at desktop and mobile widths, and click each CTA to confirm the destination page exists.

<sup>Written for commit b78f17efaaa3bde47a5392c77d8e3ab7d4464162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

