### PR TITLE
fix(cloud): close the create-to-persist crash window

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -7,6 +7,7 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.error
 import urllib.request
 import uuid
 from contextlib import contextmanager
@@ -374,7 +375,7 @@ def _ensure_daemon_locked(wait=60.0, name=None, env=None):
             if not last: time.sleep(0.5)
         daemon_name = name or NAME
         daemon_kind = daemon_browser_kind(daemon_name)
-        has_remote_recovery = _read_remote_browser_id(daemon_name) is not None
+        has_remote_recovery = _read_remote_browser_recovery(daemon_name) is not None
         if daemon_kind == "cloud" or has_remote_recovery:
             # A cloud daemon that cannot answer CDP may still own a billable
             # browser. Use the durable cleanup path before replacing it; if
@@ -492,15 +493,22 @@ def require_existing_daemon(name=None):
 
 
 def _persist_remote_browser_id(name, browser_id):
-    if not isinstance(browser_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
-        raise RuntimeError("Browser Use Cloud returned an invalid browser id")
+    return _persist_remote_browser_recovery(name, browser_id=browser_id)
+
+
+def _persist_remote_browser_recovery(name, *, client_session_id=None, browser_id=None):
+    if client_session_id is None and browser_id is None:
+        raise RuntimeError("remote browser recovery state needs a client key or browser id")
+    encoded = _encode_remote_browser_recovery(
+        client_session_id=client_session_id, browser_id=browser_id
+    )
     state_path = ipc.remote_id_path(name)
     pending_path = state_path.with_name(state_path.name + ".pending")
     pending_complete = False
     try:
         fd = os.open(pending_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as state_file:
-            state_file.write(_encode_remote_browser_id(browser_id))
+            state_file.write(encoded)
             state_file.flush()
             os.fsync(state_file.fileno())
         pending_complete = True
@@ -519,6 +527,30 @@ def _persist_remote_browser_id(name, browser_id):
         raise
 
 
+def _validate_remote_browser_identifier(value, label):
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", value):
+        raise RuntimeError(f"Browser Use Cloud returned an invalid {label}")
+    return value
+
+
+def _encode_remote_browser_recovery(*, client_session_id=None, browser_id=None):
+    if client_session_id is None:
+        return _encode_remote_browser_id(browser_id)
+    _validate_remote_browser_identifier(client_session_id, "client session id")
+    if browser_id is not None:
+        _validate_remote_browser_identifier(browser_id, "browser id")
+    payload = {
+        "browser_id": browser_id,
+        "client_session_id": client_session_id,
+        "version": 2,
+    }
+    digest_source = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    payload["sha256"] = hashlib.sha256(
+        f"browser-harness-remote-id-v2\0{digest_source}".encode()
+    ).hexdigest()
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"
+
+
 def _encode_remote_browser_id(browser_id):
     if not isinstance(browser_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,256}", browser_id):
         raise RuntimeError("Browser Use Cloud returned an invalid browser id")
@@ -530,19 +562,41 @@ def _encode_remote_browser_id(browser_id):
     ) + "\n"
 
 
-def _decode_remote_browser_id(raw, *, name, pending):
+def _decode_remote_browser_recovery(raw, *, name, pending):
     label = "pending remote browser recovery state" if pending else "remote browser recovery state"
     try:
         record = json.loads(raw)
-        browser_id = record["browser_id"]
+        version = record["version"]
+        if version == 1:
+            browser_id = record["browser_id"]
+            expected = _encode_remote_browser_id(browser_id)
+            recovery = {"browser_id": browser_id, "client_session_id": None}
+        elif version == 2:
+            browser_id = record.get("browser_id")
+            client_session_id = record["client_session_id"]
+            expected = _encode_remote_browser_recovery(
+                client_session_id=client_session_id, browser_id=browser_id
+            )
+            recovery = {
+                "browser_id": browser_id,
+                "client_session_id": client_session_id,
+            }
+        else:
+            raise KeyError("version")
     except (json.JSONDecodeError, KeyError, TypeError):
         raise RuntimeError(f"invalid {label} for daemon {name!r}") from None
-    if raw != _encode_remote_browser_id(browser_id):
+    except RuntimeError:
+        raise RuntimeError(f"invalid {label} for daemon {name!r}") from None
+    if raw != expected:
         raise RuntimeError(f"invalid {label} for daemon {name!r}")
-    return browser_id
+    return recovery
 
 
-def _read_remote_browser_id(name):
+def _decode_remote_browser_id(raw, *, name, pending):
+    return _decode_remote_browser_recovery(raw, name=name, pending=pending)["browser_id"]
+
+
+def _read_remote_browser_recovery(name):
     state_path = ipc.remote_id_path(name)
     try:
         raw = state_path.read_text(encoding="utf-8")
@@ -552,11 +606,16 @@ def _read_remote_browser_id(name):
             raw = pending_path.read_text(encoding="utf-8")
         except FileNotFoundError:
             return None
-        browser_id = _decode_remote_browser_id(raw, name=name, pending=True)
+        recovery = _decode_remote_browser_recovery(raw, name=name, pending=True)
         os.replace(pending_path, state_path)
         _fsync_directory(state_path.parent)
-        return browser_id
-    return _decode_remote_browser_id(raw, name=name, pending=False)
+        return recovery
+    return _decode_remote_browser_recovery(raw, name=name, pending=False)
+
+
+def _read_remote_browser_id(name):
+    recovery = _read_remote_browser_recovery(name)
+    return recovery["browser_id"] if recovery is not None else None
 
 
 def _clear_remote_browser_id(name):
@@ -645,7 +704,11 @@ def _stop_remote_daemon_locked(name):
     if daemon_alive(name):
         daemon_kind, daemon_browser_id = _daemon_browser_identity(name)
         try:
-            persisted_browser_id = _read_remote_browser_id(name)
+            persisted_recovery = _read_remote_browser_recovery(name)
+            persisted_browser_id = (
+                _resolve_remote_browser_recovery(name, persisted_recovery)
+                if persisted_recovery is not None else None
+            )
         except RuntimeError:
             # Preserve the established behavior for corrupt legacy state after
             # a live daemon confirms a clean shutdown. There is no validated id
@@ -687,11 +750,11 @@ def _stop_remote_daemon_locked(name):
         _clear_remote_browser_id(name)
         return
 
-    browser_id = _read_remote_browser_id(name)
-    if browser_id:
+    recovery = _read_remote_browser_recovery(name)
+    if recovery is not None:
         # The daemon may have crashed or been SIGKILLed. Its environment is
-        # gone, so use the private runtime state to stop the exact cloud browser.
-        _stop_cloud_browser(browser_id, strict=True)
+        # gone, so resolve the durable client key and stop the exact server browser.
+        _stop_remote_browser_recovery(name, recovery, strict=True)
     _restart_daemon_locked(name)
     _clear_remote_browser_id(name)
 
@@ -800,6 +863,32 @@ def _browser_use(path, method, body=None):
         headers={"X-Browser-Use-API-Key": key, "Content-Type": "application/json"},
     )
     return json.loads(urllib.request.urlopen(req, timeout=60).read() or b"{}")
+
+
+def _resolve_remote_browser_recovery(name, recovery):
+    browser_id = recovery.get("browser_id")
+    if browser_id:
+        return _validate_remote_browser_identifier(browser_id, "browser id")
+    client_session_id = recovery.get("client_session_id")
+    if not client_session_id:
+        raise RuntimeError(f"remote browser recovery state for daemon {name!r} has no identifier")
+    try:
+        browser = _browser_use(f"/browsers/client-session/{client_session_id}", "GET")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+    browser_id = browser.get("id") if isinstance(browser, dict) else None
+    _validate_remote_browser_identifier(browser_id, "browser id")
+    _persist_remote_browser_recovery(
+        name, client_session_id=client_session_id, browser_id=browser_id
+    )
+    return browser_id
+
+
+def _stop_remote_browser_recovery(name, recovery, strict=False):
+    browser_id = _resolve_remote_browser_recovery(name, recovery)
+    return True if browser_id is None else _stop_cloud_browser(browser_id, strict=strict)
 
 
 def _stop_cloud_browser(browser_id, strict=False):
@@ -918,7 +1007,7 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
 def _start_remote_daemon_locked(name, profileName=None, **create_kwargs):
     if daemon_alive(name):
         raise RuntimeError(f"daemon {name!r} already alive -- restart_daemon({name!r}) first")
-    if _read_remote_browser_id(name):
+    if _read_remote_browser_recovery(name) is not None:
         raise RuntimeError(
             f"remote browser cleanup is still pending for daemon {name!r} -- call stop_remote_daemon({name!r}) first"
         )
@@ -929,26 +1018,30 @@ def _start_remote_daemon_locked(name, profileName=None, **create_kwargs):
 
     if "clientSessionId" in create_kwargs:
         raise ValueError("clientSessionId is managed internally by browser-harness")
-    browser_id = str(uuid.uuid4())
-    # Persist the exact future provider ID before the billable POST. Cloud's
-    # optional clientSessionId contract makes this the BrowserSession row/VM
-    # ID, so SIGKILL after the request is sent remains exactly recoverable.
-    _persist_remote_browser_id(name, browser_id)
+    client_session_id = str(uuid.uuid4())
+    # Persist the project-scoped idempotency key before the billable POST. Cloud
+    # resolves it to the server-owned browser ID after an interrupted response.
+    _persist_remote_browser_recovery(name, client_session_id=client_session_id)
     try:
         browser = _browser_use(
             "/browsers",
             "POST",
-            {**create_kwargs, "clientSessionId": browser_id},
+            {**create_kwargs, "clientSessionId": client_session_id},
         )
-        if browser.get("id") != browser_id:
-            raise RuntimeError("cloud returned a different browser session ID")
+        browser_id = browser.get("id") if isinstance(browser, dict) else None
+        _validate_remote_browser_identifier(browser_id, "browser id")
+        _persist_remote_browser_recovery(
+            name, client_session_id=client_session_id, browser_id=browser_id
+        )
         _ensure_daemon_locked(
             name=name,
             env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser_id},
         )
     except BaseException as start_error:
         try:
-            _stop_cloud_browser(browser_id, strict=True)
+            recovery = _read_remote_browser_recovery(name)
+            if recovery is not None:
+                _stop_remote_browser_recovery(name, recovery, strict=True)
         except BaseException as cleanup_error:
             raise BaseExceptionGroup(
                 "remote daemon startup and cloud browser cleanup both failed",

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -925,19 +926,29 @@ def _start_remote_daemon_locked(name, profileName=None, **create_kwargs):
         if "profileId" in create_kwargs:
             raise RuntimeError("pass profileName OR profileId, not both")
         create_kwargs["profileId"] = _resolve_profile_name(profileName)
-    browser = _browser_use("/browsers", "POST", create_kwargs)
+
+    if "clientSessionId" in create_kwargs:
+        raise ValueError("clientSessionId is managed internally by browser-harness")
+    browser_id = str(uuid.uuid4())
+    # Persist the exact future provider ID before the billable POST. Cloud's
+    # optional clientSessionId contract makes this the BrowserSession row/VM
+    # ID, so SIGKILL after the request is sent remains exactly recoverable.
+    _persist_remote_browser_id(name, browser_id)
     try:
-        # Persist the exact billable resource before starting the daemon. Keep
-        # persistence in the same rollback boundary: a full disk or permission
-        # error must stop the browser we just created instead of orphaning it.
-        _persist_remote_browser_id(name, browser.get("id"))
+        browser = _browser_use(
+            "/browsers",
+            "POST",
+            {**create_kwargs, "clientSessionId": browser_id},
+        )
+        if browser.get("id") != browser_id:
+            raise RuntimeError("cloud returned a different browser session ID")
         _ensure_daemon_locked(
             name=name,
-            env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
+            env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser_id},
         )
     except BaseException as start_error:
         try:
-            _stop_cloud_browser(browser.get("id"), strict=True)
+            _stop_cloud_browser(browser_id, strict=True)
         except BaseException as cleanup_error:
             raise BaseExceptionGroup(
                 "remote daemon startup and cloud browser cleanup both failed",

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,4 +1,5 @@
 import threading
+import urllib.error
 from contextlib import contextmanager
 
 import pytest
@@ -245,12 +246,16 @@ def test_remote_start_does_not_post_when_recovery_state_cannot_promote(monkeypat
         admin.start_remote_daemon("scoped")
 
     assert attempts == []
-    assert pending_path.read_text() == admin._encode_remote_browser_id("browser-1")
+    expected = admin._encode_remote_browser_recovery(client_session_id="browser-1")
+    assert pending_path.read_text() == expected
     assert not state_path.exists()
 
     monkeypatch.setattr(admin.os, "replace", real_replace)
-    assert admin._read_remote_browser_id("scoped") == "browser-1"
-    assert state_path.read_text() == admin._encode_remote_browser_id("browser-1")
+    assert admin._read_remote_browser_recovery("scoped") == {
+        "browser_id": None,
+        "client_session_id": "browser-1",
+    }
+    assert state_path.read_text() == expected
     assert not pending_path.exists()
 
 
@@ -761,8 +766,8 @@ def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_pe
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
     monkeypatch.setattr(
         admin,
-        "_persist_remote_browser_id",
-        lambda *_args: (_ for _ in ()).throw(OSError("disk full")),
+        "_persist_remote_browser_recovery",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
     )
     monkeypatch.setattr(
         admin,
@@ -815,12 +820,15 @@ def test_stop_cloud_browser_swallows_baseexception_from_stop_request(monkeypatch
 
 def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatch, tmp_path):
     calls = []
-    browser = {"id": "browser-123", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
+    browser = {"id": "server-browser-456", "cdpUrl": "http://127.0.0.1:9333", "liveUrl": "https://live.example"}
 
     def fake_browser_use(path, method, body=None):
         calls.append((path, method, body))
         if (path, method) == ("/browsers", "POST"):
-            assert admin._read_remote_browser_id("remote") == "browser-123"
+            assert admin._read_remote_browser_recovery("remote") == {
+                "browser_id": None,
+                "client_session_id": "browser-123",
+            }
             return browser
         raise AssertionError((path, method, body))
 
@@ -836,7 +844,10 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     assert calls == [
         ("/browsers", "POST", {"clientSessionId": "browser-123"}),
     ]
-    assert admin._read_remote_browser_id("remote") == "browser-123"
+    assert admin._read_remote_browser_recovery("remote") == {
+        "browser_id": "server-browser-456",
+        "client_session_id": "browser-123",
+    }
 
 
 def test_start_remote_daemon_rejects_client_session_id_override(monkeypatch):
@@ -851,28 +862,51 @@ def test_start_remote_daemon_rejects_client_session_id_override(monkeypatch):
         admin.start_remote_daemon(clientSessionId="caller-selected")
 
 
-def test_start_remote_daemon_rejects_mismatched_cloud_id_and_cleans_up(monkeypatch, tmp_path):
+def test_crash_recovery_resolves_client_key_before_stopping_server_browser(monkeypatch, tmp_path):
     calls = []
+    state_path = tmp_path / "remote-id"
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    admin._persist_remote_browser_recovery("remote", client_session_id="client-key-123")
 
     def browser_use(path, method, body=None):
         calls.append((path, method, body))
-        if method == "POST":
-            return {"id": "different-id", "cdpUrl": "https://cdp.example.test"}
-        return {}
+        if (path, method) == ("/browsers/client-session/client-key-123", "GET"):
+            return {"id": "server-browser-456"}
+        if (path, method) == ("/browsers/server-browser-456", "PATCH"):
+            return {}
+        raise AssertionError((path, method, body))
 
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
-    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-123")
     monkeypatch.setattr(admin, "_browser_use", browser_use)
-    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
+    monkeypatch.setattr(admin, "_restart_daemon_locked", lambda _name: None)
 
-    with pytest.raises(RuntimeError, match="different browser session ID"):
-        admin.start_remote_daemon()
+    admin.stop_remote_daemon("remote")
 
     assert calls == [
-        ("/browsers", "POST", {"clientSessionId": "browser-123"}),
-        ("/browsers/browser-123", "PATCH", {"action": "stop"}),
+        ("/browsers/client-session/client-key-123", "GET", None),
+        ("/browsers/server-browser-456", "PATCH", {"action": "stop"}),
     ]
-    assert not (tmp_path / "remote-id").exists()
+    assert not state_path.exists()
+
+
+def test_crash_recovery_clears_key_when_cloud_never_created_a_session(monkeypatch, tmp_path):
+    state_path = tmp_path / "remote-id"
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    admin._persist_remote_browser_recovery("remote", client_session_id="client-key-123")
+
+    def browser_use(path, method, body=None):
+        assert (path, method, body) == (
+            "/browsers/client-session/client-key-123", "GET", None
+        )
+        raise urllib.error.HTTPError(path, 404, "not found", None, None)
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(admin, "_browser_use", browser_use)
+    monkeypatch.setattr(admin, "_restart_daemon_locked", lambda _name: None)
+
+    admin.stop_remote_daemon("remote")
+
+    assert not state_path.exists()
 
 
 def test_start_remote_daemon_opens_live_view_by_default(monkeypatch):

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -185,6 +185,7 @@ def test_remote_stop_ignores_corrupt_recovery_state_after_live_clean_shutdown(mo
 def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch, tmp_path):
     attempts = []
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-1")
     monkeypatch.setattr(
         admin,
         "_browser_use",
@@ -215,14 +216,13 @@ def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch, t
     assert admin._read_remote_browser_id("scoped") == "browser-1"
 
 
-def test_remote_start_retains_complete_pending_record_when_promotion_and_cleanup_fail(
-    monkeypatch, tmp_path
-):
+def test_remote_start_does_not_post_when_recovery_state_cannot_promote(monkeypatch, tmp_path):
     state_path = tmp_path / "remote-id"
     pending_path = tmp_path / "remote-id.pending"
     attempts = []
     real_replace = admin.os.replace
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-1")
     monkeypatch.setattr(
         admin,
         "_browser_use",
@@ -241,14 +241,10 @@ def test_remote_start_retains_complete_pending_record_when_promotion_and_cleanup
         lambda _source, _destination: (_ for _ in ()).throw(OSError("rename failed")),
     )
 
-    with pytest.raises(BaseExceptionGroup) as exc_info:
+    with pytest.raises(OSError, match="rename failed"):
         admin.start_remote_daemon("scoped")
 
-    assert [str(error) for error in exc_info.value.exceptions] == [
-        "rename failed",
-        "failed to stop remote browser browser-1: billing stop failed",
-    ]
-    assert len(attempts) == 3
+    assert attempts == []
     assert pending_path.read_text() == admin._encode_remote_browser_id("browser-1")
     assert not state_path.exists()
 
@@ -729,6 +725,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monke
         raise AssertionError((path, method, body))
 
     monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-123")
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
     monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
@@ -738,7 +735,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_fails(monke
         admin.start_remote_daemon()
 
     assert calls == [
-        ("/browsers", "POST", {}),
+        ("/browsers", "POST", {"clientSessionId": "browser-123"}),
         ("/browsers/browser-123", "PATCH", {"action": "stop"}),
     ]
     assert not (tmp_path / "remote-id").exists()
@@ -759,6 +756,7 @@ def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_pe
         raise AssertionError((path, method, body))
 
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-123")
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
     monkeypatch.setattr(
@@ -776,10 +774,7 @@ def test_start_remote_daemon_stops_created_browser_when_recovery_state_cannot_pe
     with pytest.raises(OSError, match="disk full"):
         admin.start_remote_daemon("scoped")
 
-    assert calls == [
-        ("/browsers", "POST", {}),
-        ("/browsers/browser-123", "PATCH", {"action": "stop"}),
-    ]
+    assert calls == []
 
 
 @pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
@@ -796,6 +791,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrup
         raise AssertionError((path, method, body))
 
     monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-123")
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
     monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **kwargs: (_ for _ in ()).throw(exc_type()))
@@ -805,7 +801,7 @@ def test_start_remote_daemon_stops_created_browser_when_daemon_start_is_interrup
         admin.start_remote_daemon()
 
     assert calls == [
-        ("/browsers", "POST", {}),
+        ("/browsers", "POST", {"clientSessionId": "browser-123"}),
         ("/browsers/browser-123", "PATCH", {"action": "stop"}),
     ]
     assert not (tmp_path / "remote-id").exists()
@@ -824,10 +820,12 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
     def fake_browser_use(path, method, body=None):
         calls.append((path, method, body))
         if (path, method) == ("/browsers", "POST"):
+            assert admin._read_remote_browser_id("remote") == "browser-123"
             return browser
         raise AssertionError((path, method, body))
 
     monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-123")
     monkeypatch.setattr(admin, "_browser_use", fake_browser_use)
     monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda url: "ws://example.test/devtools/browser/1")
     monkeypatch.setattr(admin, "_ensure_daemon_locked", lambda **kwargs: None)
@@ -836,9 +834,45 @@ def test_start_remote_daemon_does_not_stop_created_browser_on_success(monkeypatc
 
     assert admin.start_remote_daemon() == browser
     assert calls == [
-        ("/browsers", "POST", {}),
+        ("/browsers", "POST", {"clientSessionId": "browser-123"}),
     ]
     assert admin._read_remote_browser_id("remote") == "browser-123"
+
+
+def test_start_remote_daemon_rejects_client_session_id_override(monkeypatch):
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(
+        admin,
+        "_browser_use",
+        lambda *_args, **_kwargs: pytest.fail("invalid caller input must not reach Cloud"),
+    )
+
+    with pytest.raises(ValueError, match="managed internally"):
+        admin.start_remote_daemon(clientSessionId="caller-selected")
+
+
+def test_start_remote_daemon_rejects_mismatched_cloud_id_and_cleans_up(monkeypatch, tmp_path):
+    calls = []
+
+    def browser_use(path, method, body=None):
+        calls.append((path, method, body))
+        if method == "POST":
+            return {"id": "different-id", "cdpUrl": "https://cdp.example.test"}
+        return {}
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-123")
+    monkeypatch.setattr(admin, "_browser_use", browser_use)
+    monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: tmp_path / "remote-id")
+
+    with pytest.raises(RuntimeError, match="different browser session ID"):
+        admin.start_remote_daemon()
+
+    assert calls == [
+        ("/browsers", "POST", {"clientSessionId": "browser-123"}),
+        ("/browsers/browser-123", "PATCH", {"action": "stop"}),
+    ]
+    assert not (tmp_path / "remote-id").exists()
 
 
 def test_start_remote_daemon_opens_live_view_by_default(monkeypatch):
@@ -875,6 +909,7 @@ def test_concurrent_same_name_remote_starts_provision_once(monkeypatch, tmp_path
     results = []
     errors = []
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-1")
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: daemon_started.is_set())
 
     def browser_use(path, method, body=None):
@@ -949,6 +984,7 @@ def test_remote_start_serializes_against_ordinary_ensure(monkeypatch, tmp_path):
         return FakeSocket(response=b'{"result":{"targetInfos":[]}}\n'), None
 
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-1")
     monkeypatch.setattr(admin.ipc, "log_path", lambda _name: tmp_path / "daemon.log")
     monkeypatch.setattr(admin, "_remote_daemon_lifecycle_lock", observed_lifecycle_lock)
     monkeypatch.setattr(admin, "daemon_alive", lambda _name=None: daemon_started.is_set())
@@ -1017,6 +1053,7 @@ def test_reload_serializes_against_remote_provision(monkeypatch, tmp_path):
         return {"id": "browser-1", "cdpUrl": "https://cdp.example.test"}
 
     monkeypatch.setattr(admin.ipc, "remote_id_path", lambda _name: state_path)
+    monkeypatch.setattr(admin.uuid, "uuid4", lambda: "browser-1")
     monkeypatch.setattr(admin, "_remote_daemon_lifecycle_lock", observed_lifecycle_lock)
     monkeypatch.setattr(admin, "daemon_alive", lambda _name=None: daemon_started.is_set())
     monkeypatch.setattr(admin, "_browser_use", browser_use)


### PR DESCRIPTION
## What Problem This Solves

A hard crash after Browser Use Cloud accepted `POST /browsers` but before Browser Harness persisted the returned browser ID could leave a billable browser with no exact cleanup handle.

## Why This Change Was Made

Browser Harness now persists a fresh project-scoped client idempotency key before network I/O and sends it as `clientSessionId`. Cloud keeps its own tenant-scoped browser ID and exposes a lookup from the client key to that exact ID.

Recovery state is versioned and checksummed:

- existing v1 records containing an exact browser ID remain readable;
- v2 first stores the client key, then atomically enriches the same record with the server browser ID after a successful response;
- after SIGKILL or a lost response, cleanup resolves the key through `GET /browsers/client-session/{key}` and PATCHes the exact returned browser;
- a `404` means the server never claimed the key, so the local recovery record can be cleared safely;
- caller-provided `clientSessionId` remains rejected so cleanup authority stays internal.

## User Impact

- Public Browser Harness commands and local/profile daemon behavior are unchanged.
- Cloud creation becomes recoverable across the former POST-to-persist crash window.
- Existing durable v1 recovery records remain backward compatible.
- This PR is stacked on #626 and depends on [Browser Use Cloud #5609](https://github.com/browser-use/cloud/pull/5609). It must not ship until that API is deployed and `BROWSER_CLIENT_SESSION_ID_ENABLED` is enabled; an older or gated-off API rejects the new field.
- Do not roll the Cloud API back while this Browser Harness version can create new Cloud sessions; disable/drain the client first.

## Evidence

- Full Browser Harness suite: 188 passed.
- `python -m compileall -q src tests`: passed.
- `git diff --check`: passed.
- Regressions cover pre-POST durability, atomic pending promotion, distinct server IDs, key-only crash lookup and exact stop, 404/no-resource recovery, startup cleanup retention, persistence failures, and caller override rejection.
- Browser Use Cloud #5609 received a separate independent correctness and customer-impact review before this PR was made ready.
- The exact combined Browser Harness candidate was exercised by the final Hermes 106-task Cloud-browser evaluation: 92/106 semantic passes, 106/106 explicit remote-browser stops, zero Harness IPC timeouts, and zero screenshot capture errors.
