### PR TITLE
fix: redact CDP credentials from daemon logs

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -180,6 +180,19 @@ def log(msg):
     open(LOG, "a", encoding="utf-8", errors="replace").write(f"{msg}\n")
 
 
+def _safe_connection_label(url):
+    """Log only endpoint topology, never CDP credentials or provider session paths."""
+    try:
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.hostname:
+            return "<redacted-cdp-endpoint>"
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        port = f":{parsed.port}" if parsed.port else ""
+        return f"{parsed.scheme}://{host}{port}"
+    except (TypeError, ValueError):
+        return "<redacted-cdp-endpoint>"
+
+
 async def _silent(coro):
     try:
         await coro
@@ -507,7 +520,7 @@ class Daemon:
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
-        log(f"connecting to {url}")
+        log(f"connecting to {_safe_connection_label(url)}")
         self.cdp = _PatientCDPClient(url) if BROWSER_KIND == "local" else CDPClient(url)
         if BROWSER_KIND == "local":
             # Allow while this handshake is still parked on the popup

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -5,6 +5,22 @@ import pytest
 from browser_harness import daemon
 
 
+@pytest.mark.parametrize(
+    ("url", "label"),
+    [
+        (
+            "ws://openclaw-internal:secret@127.0.0.1:18792/devtools/browser/id?token=x",
+            "ws://127.0.0.1:18792",
+        ),
+        ("wss://provider.example/session/private-id?token=secret", "wss://provider.example"),
+        ("wss://[::1]:9222/devtools/browser/id", "wss://[::1]:9222"),
+        ("not-a-url", "<redacted-cdp-endpoint>"),
+    ],
+)
+def test_safe_connection_label_removes_credentials_paths_and_queries(url, label):
+    assert daemon._safe_connection_label(url) == label
+
+
 class _FakeCDP:
     """Records send_raw calls so tests can assert which CDP methods fired."""
 


### PR DESCRIPTION
## What Problem This Solves

Remote CDP websocket URLs can contain provider session paths or embedded credentials. Browser Harness currently writes the complete endpoint to its daemon log when connecting.

## Why This Change Was Made

Log only the endpoint scheme, host, and port. Malformed endpoints receive a fixed redacted label. Connection behavior is unchanged.

## User Impact

Users can retain daemon logs for debugging without copying Cloud CDP credentials into those logs.

## Evidence

- Diff is limited to 2 files: one production file and one focused test file.
- `uv run --with pytest pytest -q tests/unit/test_daemon.py`: 27 passed.
- `git diff --check`: passed.
- This exact patch was included in the Browser Harness head used by the OpenClaw 106-task evaluation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts CDP credentials and session paths from daemon logs. Previously we logged the full WebSocket URL; now we log only scheme, host, and port, and use <redacted-cdp-endpoint> for malformed URLs. Connection behavior is unchanged.

- Introduces `daemon._safe_connection_label(url)` and calls it in `start()` to format the logged endpoint.
- Tests cover credential stripping, path/query removal, IPv6 hosts, and malformed inputs.

<sup>Written for commit 11dbb41594db48855a42450997ce88c29d7273c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

