### PR TITLE
feat: fail closed for orchestrator-owned daemons

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -166,6 +166,9 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 
 - Coordinate clicks default. CDP mouse events pass through iframes/shadow/cross-origin at the compositor level.
 - Keep the connection model simple: use the default daemon, `BU_NAME`, `BU_CDP_URL`, `BU_CDP_WS`, or `start_remote_daemon(...)`.
+- Trusted orchestrators that already provisioned an exact named daemon can set
+  `BH_REQUIRE_EXISTING_DAEMON=1`. Each CLI call then health-checks and reuses
+  that daemon or fails closed; it never auto-starts or discovers another Chrome.
 - Core helpers stay short. Put task-specific helper additions in `$BH_AGENT_WORKSPACE/agent_helpers.py`.
 
 ## Gotchas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.9"
+version = "0.1.10"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -441,6 +441,28 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
 
 
+def require_existing_daemon(name=None):
+    """Require a healthy existing daemon without spawning or reconnecting.
+
+    Trusted orchestrators use this after they provision a scoped CDP transport.
+    Failing closed prevents a later CLI call from silently discovering a
+    different local Chrome when that orchestrator-owned daemon dies.
+    """
+    daemon_name = name or NAME
+    if not daemon_alive(daemon_name):
+        raise RuntimeError(f"required daemon {daemon_name!r} is not running")
+    try:
+        s, token = ipc.connect(daemon_name, timeout=3.0)
+        try:
+            resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
+        finally:
+            s.close()
+    except Exception as exc:
+        raise RuntimeError(f"required daemon {daemon_name!r} is unhealthy: {exc}") from exc
+    if not isinstance(resp, dict) or "result" not in resp:
+        raise RuntimeError(f"required daemon {daemon_name!r} failed its CDP health check")
+
+
 def stop_remote_daemon(name="remote"):
     """Stop a remote daemon and its backing Browser Use cloud browser.
 
@@ -452,10 +474,10 @@ def stop_remote_daemon(name="remote"):
     # restarts anything on its own; a follow-up `browser-harness`
     # call would auto-spawn a fresh one via ensure_daemon(). That
     # "run-it-again-to-restart" workflow is why it was named that way.
-    restart_daemon(name)
+    restart_daemon(name, require_clean=True)
 
 
-def restart_daemon(name=None):
+def restart_daemon(name=None, require_clean=False):
     """Best-effort daemon shutdown + socket/pid cleanup.
 
     Name is historical: callers typically follow this with another
@@ -492,12 +514,20 @@ def restart_daemon(name=None):
     daemon_start = _process_start_time(daemon_pid)
 
     if daemon_alive:
+        c = None
         try:
-            c, token = ipc.connect(name, timeout=5.0)
-            ipc.request(c, token, {"meta": "shutdown"})
-            c.close()
+            c, token = ipc.connect(name, timeout=50.0 if require_clean else 5.0)
+            response = ipc.request(c, token, {"meta": "shutdown"})
+            if require_clean and isinstance(response, dict) and response.get("error"):
+                raise RuntimeError(response["error"])
         except Exception:
-            pass
+            if require_clean:
+                raise
+        finally:
+            if c is not None:
+                close = getattr(c, "close", None)
+                if close:
+                    close()
 
     if daemon_pid is not None:
         for _ in range(75):
@@ -544,13 +574,21 @@ def _browser_use(path, method, body=None):
     return json.loads(urllib.request.urlopen(req, timeout=60).read() or b"{}")
 
 
-def _stop_cloud_browser(browser_id):
+def _stop_cloud_browser(browser_id, strict=False):
     if not browser_id:
-        return
-    try:
-        _browser_use(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
-    except BaseException:
-        pass
+        return True
+    last_error = None
+    for attempt in range(3):
+        try:
+            _browser_use(f"/browsers/{browser_id}", "PATCH", {"action": "stop"})
+            return True
+        except BaseException as exc:
+            last_error = exc
+            if attempt < 2:
+                time.sleep(0.5 * (attempt + 1))
+    if strict:
+        raise RuntimeError(f"failed to stop remote browser {browser_id}: {last_error}")
+    return False
 
 
 def _cdp_ws_from_url(cdp_url):
@@ -648,8 +686,14 @@ def start_remote_daemon(name="remote", profileName=None, **create_kwargs):
             name=name,
             env={"BU_CDP_WS": _cdp_ws_from_url(browser["cdpUrl"]), "BU_BROWSER_ID": browser["id"]},
         )
-    except BaseException:
-        _stop_cloud_browser(browser.get("id"))
+    except BaseException as start_error:
+        try:
+            _stop_cloud_browser(browser.get("id"), strict=True)
+        except BaseException as cleanup_error:
+            raise BaseExceptionGroup(
+                "remote daemon startup and cloud browser cleanup both failed",
+                [start_error, cleanup_error],
+            )
         raise
     _show_live_url(browser.get("liveUrl"))
     return browser

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -353,7 +353,13 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             except Exception:
                 pass
             if not last: time.sleep(0.5)
-        restart_daemon(name)
+        if daemon_browser_kind(name) == "cloud":
+            # A stale Cloud daemon still owns a billable browser. Its shutdown
+            # handler stops that browser before acknowledging, and stays alive
+            # when the Cloud stop fails so a later call can retry cleanup.
+            stop_remote_daemon(name or NAME)
+        else:
+            restart_daemon(name)
 
     import subprocess, sys
     local = _is_local_chrome_mode(env)
@@ -484,6 +490,9 @@ def restart_daemon(name=None, require_clean=False):
     `browser-harness` invocation, which auto-spawns a fresh daemon via
     ensure_daemon(). The function itself only stops.
 
+    With require_clean=True, an unavailable daemon or any response other than
+    {"ok": true} raises before endpoint cleanup or process termination.
+
     Identity is verified via ipc.identify() before any process signal, so
     a stale pid file whose number has been reused by an unrelated process
     is never SIGTERM'd. If the daemon is unreachable, we just clean up the
@@ -504,6 +513,8 @@ def restart_daemon(name=None, require_clean=False):
     #     while the process stayed alive.
     daemon_pid = ipc.identify(name, timeout=5.0)
     daemon_alive = daemon_pid is not None or ipc.ping(name, timeout=1.0)
+    if require_clean and not daemon_alive:
+        raise RuntimeError(f"daemon {name!r} is unavailable for required clean shutdown")
     # Snapshot the daemon's process start-time as a secondary identity check.
     # The IPC socket can disappear before the process exits (e.g. the shutdown
     # path tears down the socket and then waits on a slow remote `stop` PATCH),
@@ -518,11 +529,20 @@ def restart_daemon(name=None, require_clean=False):
         try:
             c, token = ipc.connect(name, timeout=50.0 if require_clean else 5.0)
             response = ipc.request(c, token, {"meta": "shutdown"})
-            if require_clean and isinstance(response, dict) and response.get("error"):
-                raise RuntimeError(response["error"])
-        except Exception:
+            if require_clean and (
+                not isinstance(response, dict)
+                or response.get("ok") is not True
+                or bool(response.get("error"))
+            ):
+                error = response.get("error") if isinstance(response, dict) else None
+                raise RuntimeError(error or f"daemon {name!r} did not confirm clean shutdown")
+        except Exception as exc:
             if require_clean:
-                raise
+                if isinstance(exc, RuntimeError):
+                    raise
+                raise RuntimeError(
+                    f"daemon {name!r} did not confirm clean shutdown: {exc}"
+                ) from exc
         finally:
             if c is not None:
                 close = getattr(c, "close", None)

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -353,10 +353,14 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             except Exception:
                 pass
             if not last: time.sleep(0.5)
-        if daemon_browser_kind(name) == "cloud":
+        browser_kind = daemon_browser_kind(name)
+        if browser_kind in {"cloud", None}:
             # A stale Cloud daemon still owns a billable browser. Its shutdown
             # handler stops that browser before acknowledging, and stays alive
-            # when the Cloud stop fails so a later call can retry cleanup.
+            # when the Cloud stop fails so a later call can retry cleanup. Treat
+            # an unknown kind the same way: the health failure that made the
+            # daemon stale may also prevent classification, and replacing an
+            # unclassified daemon best-effort could orphan a Cloud browser.
             stop_remote_daemon(name or NAME)
         else:
             restart_daemon(name)

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -87,6 +87,7 @@ PROFILES = profile_dirs()
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
 BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
+_REMOTE_STOPPED = False
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
 # Chrome 144+ shows a per-connection popup. Keep popup open enough to click.
 LOCAL_HANDSHAKE_TIMEOUT = 45
@@ -302,21 +303,34 @@ def get_ws_url():
     raise RuntimeError(f"DevToolsActivePort not found in {[str(p) for p in PROFILES]} — enable chrome://inspect/#remote-debugging, or set BU_CDP_WS for a remote browser")
 
 
-def stop_remote():
+def stop_remote(strict=False):
+    global _REMOTE_STOPPED
     if not REMOTE_ID:
-        return
-    try:
-        key = auth.get_browser_use_api_key()
-        req = urllib.request.Request(
-            f"{BU_API}/browsers/{REMOTE_ID}",
-            data=json.dumps({"action": "stop"}).encode(),
-            method="PATCH",
-            headers={"X-Browser-Use-API-Key": key, "Content-Type": "application/json"},
-        )
-        urllib.request.urlopen(req, timeout=15).read()
-        log(f"stopped remote browser {REMOTE_ID}")
-    except Exception as e:
-        log(f"stop_remote failed ({REMOTE_ID}): {e}")
+        return True
+    if _REMOTE_STOPPED:
+        return True
+    last_error = None
+    for attempt in range(3):
+        try:
+            key = auth.get_browser_use_api_key()
+            req = urllib.request.Request(
+                f"{BU_API}/browsers/{REMOTE_ID}",
+                data=json.dumps({"action": "stop"}).encode(),
+                method="PATCH",
+                headers={"X-Browser-Use-API-Key": key, "Content-Type": "application/json"},
+            )
+            urllib.request.urlopen(req, timeout=15).read()
+            _REMOTE_STOPPED = True
+            log(f"stopped remote browser {REMOTE_ID}")
+            return True
+        except Exception as e:
+            last_error = e
+            log(f"stop_remote attempt {attempt + 1}/3 failed ({REMOTE_ID}): {e}")
+            if attempt < 2:
+                time.sleep(0.5 * (attempt + 1))
+    if strict:
+        raise RuntimeError(f"failed to stop remote browser {REMOTE_ID}: {last_error}")
+    return False
 
 
 def is_real_page(t):
@@ -636,7 +650,13 @@ class Daemon:
             )))
             return {"session_id": new_session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
-        if meta == "shutdown":    self.stop.set(); return {"ok": True}
+        if meta == "shutdown":
+            try:
+                stop_remote(strict=True)
+            except Exception as e:
+                return {"error": str(e)}
+            self.stop.set()
+            return {"ok": True}
 
         method = req["method"]
         params = req.get("params") or {}
@@ -708,6 +728,16 @@ async def serve(d):
             t.cancel()
             try: await t
             except (asyncio.CancelledError, Exception): pass
+        # Named non-cloud daemons create one dedicated background tab. Close
+        # only that owned tab on shutdown; never close a user-selected tab.
+        if d.dedicated_target_id and d.cdp:
+            try:
+                await d.cdp.send_raw(
+                    "Target.closeTarget", {"targetId": d.dedicated_target_id}
+                )
+                d.dedicated_target_id = None
+            except Exception as e:
+                log(f"close dedicated tab on shutdown: {e}")
         ipc.cleanup_endpoint(NAME)
 
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -94,6 +94,9 @@ LOCAL_HANDSHAKE_TIMEOUT = 45
 # How long get_ws_url() keeps waiting for DevToolsActivePort before giving up
 NO_TOGGLE_GRACE = 3
 TOGGLE_BOOT_GRACE = 12
+# Cancellation should make an in-flight CDP call finish immediately. Keep the
+# drain bounded anyway so shutdown fails closed if a client ignores cancellation.
+RECOVERY_CANCEL_DRAIN_TIMEOUT = 2
 
 
 def _devtools_port_live(base):
@@ -391,6 +394,7 @@ class Daemon:
         self._dedicated_target_lock = asyncio.Lock()
         self._session_state_lock = asyncio.Lock()
         self._active_recoveries = 0
+        self._recovery_tasks = set()
         self._recoveries_idle = asyncio.Event()
         self._recoveries_idle.set()
         self._shutting_down = False
@@ -535,6 +539,41 @@ class Daemon:
         while len(self._session_replacements) > 32:
             self._session_replacements.pop(next(iter(self._session_replacements)))
 
+    def _begin_recovery(self):
+        """Register the current IPC handler unless shutdown has started."""
+        if self._shutting_down:
+            return None
+        task = asyncio.current_task()
+        if task is None:
+            return None
+        self._recovery_tasks.add(task)
+        self._active_recoveries += 1
+        self._recoveries_idle.clear()
+        return task
+
+    def _finish_recovery(self, task):
+        self._recovery_tasks.discard(task)
+        self._active_recoveries -= 1
+        if self._active_recoveries == 0:
+            self._recoveries_idle.set()
+
+    async def _cancel_and_drain_recoveries(self):
+        """Cancel active stale-session handlers and wait a bounded time."""
+        current = asyncio.current_task()
+        tasks = [
+            task for task in self._recovery_tasks
+            if task is not current and not task.done()
+        ]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            _done, pending = await asyncio.wait(
+                tasks, timeout=RECOVERY_CANCEL_DRAIN_TIMEOUT
+            )
+            if pending:
+                return False
+        return self._recoveries_idle.is_set()
+
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
@@ -655,14 +694,17 @@ class Daemon:
             return {"session_id": new_session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":
-            # Stop new stale-session recovery before waiting for recovery that
-            # is already in flight. Otherwise serve() can close a replacement
-            # dedicated tab while its handler is still attaching/retrying it.
-            async with self._session_state_lock:
-                if self._shutting_down:
-                    return {"error": "shutdown already in progress"}
-                self._shutting_down = True
-            await self._recoveries_idle.wait()
+            # Flip the barrier synchronously with recovery registration, then
+            # cancel/drain existing handlers. In particular, a CDP replay that
+            # never answers must not prevent Cloud cleanup from being attempted.
+            if self._shutting_down:
+                return {"error": "shutdown already in progress"}
+            self._shutting_down = True
+            if not await self._cancel_and_drain_recoveries():
+                # Preserve the daemon as a retryable cleanup authority. The
+                # strict caller will leave its endpoint and PID file intact.
+                self._shutting_down = False
+                return {"error": "stale-session recovery did not stop"}
             try:
                 stop_remote(strict=True)
             except Exception as e:
@@ -688,15 +730,14 @@ class Daemon:
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):
                     return {"error": msg}
-                recovery_started = False
+                recovery_task = self._begin_recovery()
+                if recovery_task is None:
+                    return {"error": "daemon is shutting down"}
                 try:
                     recovered_here = False
                     async with self._session_state_lock:
                         if self._shutting_down:
                             return {"error": "daemon is shutting down"}
-                        self._active_recoveries += 1
-                        self._recoveries_idle.clear()
-                        recovery_started = True
                         replacement_session = self._session_replacements.get(sid)
                         if replacement_session is None and sid == self.session:
                             log(f"stale session {sid}, re-attaching")
@@ -719,11 +760,7 @@ class Daemon:
                         except Exception as retry_error:
                             return {"error": str(retry_error)}
                 finally:
-                    if recovery_started:
-                        async with self._session_state_lock:
-                            self._active_recoveries -= 1
-                            if self._active_recoveries == 0:
-                                self._recoveries_idle.set()
+                    self._finish_recovery(recovery_task)
             return {"error": msg}
 
 
@@ -759,24 +796,26 @@ async def serve(d):
             except (asyncio.CancelledError, Exception): pass
         # A server crash/cancellation does not pass through meta=shutdown.
         # Establish the same recovery barrier before touching owned targets.
-        async with d._session_state_lock:
-            d._shutting_down = True
-        await d._recoveries_idle.wait()
+        d._shutting_down = True
+        recoveries_drained = await d._cancel_and_drain_recoveries()
         # Named non-cloud daemons create one dedicated background tab. Shutdown
         # has blocked new recovery and drained active recovery before setting
         # d.stop (or finalization established the barrier after a server crash).
         # Take the same locks, in the same order as recovery, so cleanup closes
         # exactly the final daemon-owned target and never races creation.
-        async with d._session_state_lock:
-            async with d._dedicated_target_lock:
-                if d.dedicated_target_id and d.cdp:
-                    try:
-                        await d.cdp.send_raw(
-                            "Target.closeTarget", {"targetId": d.dedicated_target_id}
-                        )
-                        d.dedicated_target_id = None
-                    except Exception as e:
-                        log(f"close dedicated tab on shutdown: {e}")
+        if recoveries_drained:
+            async with d._session_state_lock:
+                async with d._dedicated_target_lock:
+                    if d.dedicated_target_id and d.cdp:
+                        try:
+                            await d.cdp.send_raw(
+                                "Target.closeTarget", {"targetId": d.dedicated_target_id}
+                            )
+                            d.dedicated_target_id = None
+                        except Exception as e:
+                            log(f"close dedicated tab on shutdown: {e}")
+        else:
+            log("skip dedicated-tab cleanup: stale-session recovery did not stop")
         ipc.cleanup_endpoint(NAME)
 
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -390,6 +390,10 @@ class Daemon:
         self.dedicated_target_id = None
         self._dedicated_target_lock = asyncio.Lock()
         self._session_state_lock = asyncio.Lock()
+        self._active_recoveries = 0
+        self._recoveries_idle = asyncio.Event()
+        self._recoveries_idle.set()
+        self._shutting_down = False
         self._session_replacements = {}
         self.events = deque(maxlen=BUF)
         self.dialog = None
@@ -651,9 +655,21 @@ class Daemon:
             return {"session_id": new_session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":
+            # Stop new stale-session recovery before waiting for recovery that
+            # is already in flight. Otherwise serve() can close a replacement
+            # dedicated tab while its handler is still attaching/retrying it.
+            async with self._session_state_lock:
+                if self._shutting_down:
+                    return {"error": "shutdown already in progress"}
+                self._shutting_down = True
+            await self._recoveries_idle.wait()
             try:
                 stop_remote(strict=True)
             except Exception as e:
+                # A failed Cloud stop must leave the daemon usable so a later
+                # shutdown request can retry the billable-browser cleanup.
+                async with self._session_state_lock:
+                    self._shutting_down = False
                 return {"error": str(e)}
             self.stop.set()
             return {"ok": True}
@@ -672,29 +688,42 @@ class Daemon:
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):
                     return {"error": msg}
-                recovered_here = False
-                async with self._session_state_lock:
-                    replacement_session = self._session_replacements.get(sid)
-                    if replacement_session is None and sid == self.session:
-                        log(f"stale session {sid}, re-attaching")
-                        if not await self.attach_first_page(
-                            replaces_session=sid, enable_domains=False
-                        ):
-                            return {"error": msg}
+                recovery_started = False
+                try:
+                    recovered_here = False
+                    async with self._session_state_lock:
+                        if self._shutting_down:
+                            return {"error": "daemon is shutting down"}
+                        self._active_recoveries += 1
+                        self._recoveries_idle.clear()
+                        recovery_started = True
                         replacement_session = self._session_replacements.get(sid)
-                        recovered_here = replacement_session is not None
-                if recovered_here:
-                    await self._enable_default_domains(replacement_session)
-                # Retry only on a session known to replace this exact stale
-                # session. self.session may instead have changed because the
-                # user deliberately switched tabs while this request waited.
-                if replacement_session:
-                    try:
-                        return {"result": await self.cdp.send_raw(
-                            method, params, session_id=replacement_session
-                        )}
-                    except Exception as retry_error:
-                        return {"error": str(retry_error)}
+                        if replacement_session is None and sid == self.session:
+                            log(f"stale session {sid}, re-attaching")
+                            if not await self.attach_first_page(
+                                replaces_session=sid, enable_domains=False
+                            ):
+                                return {"error": msg}
+                            replacement_session = self._session_replacements.get(sid)
+                            recovered_here = replacement_session is not None
+                    if recovered_here:
+                        await self._enable_default_domains(replacement_session)
+                    # Retry only on a session known to replace this exact stale
+                    # session. self.session may instead have changed because the
+                    # user deliberately switched tabs while this request waited.
+                    if replacement_session:
+                        try:
+                            return {"result": await self.cdp.send_raw(
+                                method, params, session_id=replacement_session
+                            )}
+                        except Exception as retry_error:
+                            return {"error": str(retry_error)}
+                finally:
+                    if recovery_started:
+                        async with self._session_state_lock:
+                            self._active_recoveries -= 1
+                            if self._active_recoveries == 0:
+                                self._recoveries_idle.set()
             return {"error": msg}
 
 
@@ -728,16 +757,26 @@ async def serve(d):
             t.cancel()
             try: await t
             except (asyncio.CancelledError, Exception): pass
-        # Named non-cloud daemons create one dedicated background tab. Close
-        # only that owned tab on shutdown; never close a user-selected tab.
-        if d.dedicated_target_id and d.cdp:
-            try:
-                await d.cdp.send_raw(
-                    "Target.closeTarget", {"targetId": d.dedicated_target_id}
-                )
-                d.dedicated_target_id = None
-            except Exception as e:
-                log(f"close dedicated tab on shutdown: {e}")
+        # A server crash/cancellation does not pass through meta=shutdown.
+        # Establish the same recovery barrier before touching owned targets.
+        async with d._session_state_lock:
+            d._shutting_down = True
+        await d._recoveries_idle.wait()
+        # Named non-cloud daemons create one dedicated background tab. Shutdown
+        # has blocked new recovery and drained active recovery before setting
+        # d.stop (or finalization established the barrier after a server crash).
+        # Take the same locks, in the same order as recovery, so cleanup closes
+        # exactly the final daemon-owned target and never races creation.
+        async with d._session_state_lock:
+            async with d._dedicated_target_lock:
+                if d.dedicated_target_id and d.cdp:
+                    try:
+                        await d.cdp.send_raw(
+                            "Target.closeTarget", {"targetId": d.dedicated_target_id}
+                        )
+                        d.dedicated_target_id = None
+                    except Exception as e:
+                        log(f"close dedicated tab on shutdown: {e}")
         ipc.cleanup_endpoint(NAME)
 
 

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -19,6 +19,7 @@ from .admin import (
     list_cloud_profiles,
     list_local_profiles,
     print_update_banner,
+    require_existing_daemon,
     restart_daemon,
     run_doctor,
     run_doctor_fix_snap,
@@ -383,7 +384,10 @@ def _run(args):
         ):
             start_remote_daemon(NAME)
         try:
-            ensure_daemon()
+            if os.environ.get("BH_REQUIRE_EXISTING_DAEMON") == "1":
+                require_existing_daemon()
+            else:
+                ensure_daemon()
         except RuntimeError as e:
             # Setup/permission errors are instructions for calling agent
             print(f"browser-harness: {e}", file=sys.stderr)

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -375,18 +375,19 @@ def _run(args):
     # or BU_CDP_WS also blocks the spawn so we honour the precedence install.md promises.
     cloud_admin = code.lstrip().startswith(("start_remote_daemon(", "stop_remote_daemon("))
     if not cloud_admin:
-        if (
-            not daemon_alive()
-            and not _local_chrome_listening()
-            and not _explicit_cdp_configured()
-            and _cloud_auth_configured()
-            and os.environ.get("BU_AUTOSPAWN")
-        ):
-            start_remote_daemon(NAME)
+        require_existing = os.environ.get("BH_REQUIRE_EXISTING_DAEMON") == "1"
         try:
-            if os.environ.get("BH_REQUIRE_EXISTING_DAEMON") == "1":
+            if require_existing:
                 require_existing_daemon()
             else:
+                if (
+                    not daemon_alive()
+                    and not _local_chrome_listening()
+                    and not _explicit_cdp_configured()
+                    and _cloud_auth_configured()
+                    and os.environ.get("BU_AUTOSPAWN")
+                ):
+                    start_remote_daemon(NAME)
                 ensure_daemon()
         except RuntimeError as e:
             # Setup/permission errors are instructions for calling agent

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -24,6 +24,67 @@ def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():
     assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
 
 
+def test_require_existing_daemon_fails_without_spawning(monkeypatch):
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+
+    with pytest.raises(RuntimeError, match="required daemon 'scoped' is not running"):
+        admin.require_existing_daemon("scoped")
+
+
+def test_require_existing_daemon_probes_cdp(monkeypatch):
+    sock = FakeSocket(response=b'{"result":{"targetInfos":[]}}\n')
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+    monkeypatch.setattr(admin.ipc, "connect", lambda _name, timeout: (sock, None))
+
+    admin.require_existing_daemon("scoped")
+
+    assert b'"method": "Target.getTargets"' in sock.sent
+    assert sock.closed is True
+
+
+def test_strict_remote_stop_propagates_daemon_error(monkeypatch):
+    sock = FakeSocket(response=b'{"error":"billing stop failed"}\n')
+    monkeypatch.setattr(admin.ipc, "identify", lambda _name, timeout: 123)
+    monkeypatch.setattr(admin, "_process_start_time", lambda _pid: 1)
+    monkeypatch.setattr(admin.ipc, "connect", lambda _name, timeout: (sock, None))
+
+    with pytest.raises(RuntimeError, match="billing stop failed"):
+        admin.stop_remote_daemon("scoped")
+
+    assert sock.closed is True
+
+
+def test_remote_start_retries_cleanup_and_preserves_both_failures(monkeypatch):
+    attempts = []
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
+    monkeypatch.setattr(
+        admin,
+        "_browser_use",
+        lambda path, method, body=None: (
+            {"id": "browser-1", "cdpUrl": "https://cdp.example.test"}
+            if method == "POST"
+            else attempts.append((path, method, body))
+            or (_ for _ in ()).throw(OSError("billing stop failed"))
+        ),
+    )
+    monkeypatch.setattr(admin, "_cdp_ws_from_url", lambda _url: "wss://cdp.example.test/ws")
+    monkeypatch.setattr(
+        admin,
+        "ensure_daemon",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("daemon start failed")),
+    )
+    monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        admin.start_remote_daemon("scoped")
+
+    assert [str(error) for error in exc_info.value.exceptions] == [
+        "daemon start failed",
+        "failed to stop remote browser browser-1: billing stop failed",
+    ]
+    assert len(attempts) == 3
+
+
 def test_local_chrome_mode_is_false_when_process_env_provides_remote_cdp(monkeypatch):
     monkeypatch.setenv("BU_CDP_WS", "ws://example.test/devtools/browser/1")
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -21,6 +21,41 @@ def test_safe_connection_label_removes_credentials_paths_and_queries(url, label)
     assert daemon._safe_connection_label(url) == label
 
 
+def test_remote_stop_retries_and_succeeds(monkeypatch):
+    attempts = []
+    monkeypatch.setattr(daemon, "REMOTE_ID", "browser-1")
+    monkeypatch.setattr(daemon, "_REMOTE_STOPPED", False)
+    monkeypatch.setattr(daemon.auth, "get_browser_use_api_key", lambda: "key")
+    monkeypatch.setattr(daemon.time, "sleep", lambda _seconds: None)
+
+    def urlopen(_request, timeout):
+        attempts.append(timeout)
+        if len(attempts) < 3:
+            raise OSError("temporary")
+        return type("Response", (), {"read": lambda self: b""})()
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", urlopen)
+
+    assert daemon.stop_remote(strict=True) is True
+    assert attempts == [15, 15, 15]
+    assert daemon._REMOTE_STOPPED is True
+
+
+def test_shutdown_keeps_daemon_alive_when_cloud_stop_fails(monkeypatch):
+    d = daemon.Daemon()
+    d.stop = asyncio.Event()
+    monkeypatch.setattr(
+        daemon,
+        "stop_remote",
+        lambda strict=False: (_ for _ in ()).throw(RuntimeError("billing stop failed")),
+    )
+
+    response = asyncio.run(d.handle({"meta": "shutdown"}))
+
+    assert response == {"error": "billing stop failed"}
+    assert d.stop.is_set() is False
+
+
 class _FakeCDP:
     """Records send_raw calls so tests can assert which CDP methods fired."""
 
@@ -550,8 +585,8 @@ def test_named_local_attach_cleans_inspect_tabs_before_return(monkeypatch):
     assert d.cdp.closed == ["inspect-tab"]
 
 
-def test_shutdown_leaves_dedicated_tab_open(monkeypatch):
-    """The real serve shutdown path never closes a working or user tab."""
+def test_shutdown_closes_only_the_daemon_owned_tab(monkeypatch):
+    """Run cleanup closes the daemon-created tab without touching a user tab."""
     d = daemon.Daemon()
     d.cdp = _AttachCDP()
 
@@ -573,8 +608,8 @@ def test_shutdown_leaves_dedicated_tab_open(monkeypatch):
 
     asyncio.run(daemon.main())
 
-    assert d.cdp.closed == []
-    assert d.dedicated_target_id == "daemon-tab"
+    assert d.cdp.closed == ["daemon-tab"]
+    assert d.dedicated_target_id is None
     assert d.target_id == "user-selected-tab"
 
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -21,6 +21,19 @@ def test_stdin_executes_code():
     assert stdout.getvalue().strip() == "hello from stdin"
 
 
+def test_require_existing_daemon_never_auto_starts(monkeypatch):
+    monkeypatch.setenv("BH_REQUIRE_EXISTING_DAEMON", "1")
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("x = 1")), \
+         patch("browser_harness.run.require_existing_daemon") as mock_require, \
+         patch("browser_harness.run.ensure_daemon") as mock_ensure, \
+         patch("browser_harness.run.print_update_banner"):
+        run.main()
+
+    mock_require.assert_called_once_with()
+    mock_ensure.assert_not_called()
+
+
 def test_c_flag_is_rejected():
     with patch.object(sys, "argv", ["browser-harness", "-c", "print('old path')"]), \
          patch("sys.stdin", StringIO("print('ignored')")):


### PR DESCRIPTION
## What Problem This Solves

A trusted orchestrator can provision an exact named Cloud browser daemon, but a later Browser Harness CLI call currently falls through to normal daemon discovery and startup if that daemon is gone. That can silently attach a different browser instead of failing the run.

## Why This Change Was Made

Add `BH_REQUIRE_EXISTING_DAEMON=1`. In that mode each CLI call health-checks the exact named daemon and fails closed without discovery or startup. The same change makes Cloud shutdown retry and surface cleanup failures, and closes only the dedicated daemon-owned non-Cloud tab during shutdown. Standalone behavior remains unchanged when the variable is absent.

This PR is intentionally stacked on #639 so each review stays focused. Merge #639 first, then retarget this PR to `main`.

## User Impact

Orchestrators can bind Browser Harness to one pre-provisioned browser without any fallback to local Chrome or a replacement daemon. The package version becomes 0.1.10 for this new contract.

## Evidence

- 8 changed files, including 3 focused test files and the agent-facing contract documentation.
- `uv run --with pytest pytest -q tests/unit/test_admin.py tests/unit/test_daemon.py tests/unit/test_run.py`: 87 passed.
- `git diff --check`: passed.
- The exact combined tree was source-built in the OpenClaw evaluation and reused the orchestrator-owned Cloud daemon on every task.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed when an orchestrator binds `browser-harness` to a pre-provisioned, exact-named daemon. Previously, if that daemon was gone, the CLI fell back to discovery/auto-start and could attach a different browser; now, with BH_REQUIRE_EXISTING_DAEMON=1, each call health-checks the exact daemon and exits on failure. Cloud shutdown now retries and surfaces cleanup errors, and shutdown closes only the daemon-owned tab. Bumps version to 0.1.10.

- Rollout
  - Orchestrators must set BH_REQUIRE_EXISTING_DAEMON=1 and pre-provision the named daemon; the CLI will not auto-start or discover another Chrome.
  - Expect non-zero exit if the required daemon is missing or unhealthy; handle the error in the orchestrator.
  - Standalone/local behavior is unchanged when the variable is unset.

<sup>Written for commit 98d729b9463bd405f9abd1b99e68faeba89243d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

