### PR TITLE
fix: separate screenshot response timeout from IPC connect timeout

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -38,21 +38,37 @@ _load_env()
 NAME = os.environ.get("BU_NAME", "default")
 SOCK = ipc.sock_addr(NAME)
 INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension://", "about:")
+IPC_CONNECT_TIMEOUT_SECONDS = 5.0
+DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS = 5.0
+# Cloud screenshots routinely take longer than ordinary CDP round trips. Keep
+# their IPC socket alive within the caller's existing 90-second process budget.
+SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS = 60.0
 
 
-def _send(req):
-    c, token = ipc.connect(NAME, timeout=5.0)
+class _IPCResponseTimeout(TimeoutError):
+    pass
+
+
+def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
+    c, token = ipc.connect(NAME, timeout=IPC_CONNECT_TIMEOUT_SECONDS)
     try:
-        r = ipc.request(c, token, req)
+        c.settimeout(response_timeout)
+        try:
+            r = ipc.request(c, token, req)
+        except TimeoutError as e:
+            raise _IPCResponseTimeout from e
     finally:
         c.close()
     if "error" in r: raise RuntimeError(r["error"])
     return r
 
 
-def cdp(method, session_id=None, **params):
+def cdp(method, session_id=None, _response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS, **params):
     """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1)."""
-    return _send({"method": method, "params": params, "session_id": session_id}).get("result", {})
+    return _send(
+        {"method": method, "params": params, "session_id": session_id},
+        response_timeout=_response_timeout,
+    ).get("result", {})
 
 
 def drain_events():  return _send({"meta": "drain_events"})["events"]
@@ -243,7 +259,17 @@ def capture_screenshot(path=None, full=False, max_dim=None):
     """Save a PNG of the current viewport. Set max_dim=1800 on a 2× display to
     keep the file under the 2000px-per-side limit some image-aware LLMs enforce."""
     path = path or str(ipc._TMP / "shot.png")
-    r = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
+    try:
+        r = cdp(
+            "Page.captureScreenshot",
+            _response_timeout=SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS,
+            format="png",
+            captureBeyondViewport=full,
+        )
+    except _IPCResponseTimeout as e:
+        raise RuntimeError(
+            f"Page.captureScreenshot timed out after {SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS:g}s"
+        ) from e
     open(path, "wb").write(base64.b64decode(r["data"]))
     if max_dim:
         from PIL import Image

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -29,6 +29,50 @@ def test_max_dim_default_is_no_resize(fake_png):
     assert _run(fake_png, 4592, 2286) == (4592, 2286)
 
 
+def test_send_keeps_connect_timeout_short_and_sets_response_budget():
+    class FakeSocket:
+        def __init__(self):
+            self.timeouts = []
+
+        def settimeout(self, value):
+            self.timeouts.append(value)
+
+        def close(self):
+            pass
+
+    socket = FakeSocket()
+    with patch("browser_harness.helpers.ipc.connect", return_value=(socket, None)) as connect, \
+         patch("browser_harness.helpers.ipc.request", return_value={}):
+        helpers._send({"meta": "ping"}, response_timeout=60.0)
+
+    connect.assert_called_once_with(helpers.NAME, timeout=helpers.IPC_CONNECT_TIMEOUT_SECONDS)
+    assert socket.timeouts == [60.0]
+
+
+def test_screenshot_uses_long_response_timeout_without_forwarding_it_to_cdp(fake_png, tmp_path):
+    with patch(
+        "browser_harness.helpers._send",
+        return_value={"result": {"data": fake_png(800, 400)}},
+    ) as send:
+        helpers.capture_screenshot(str(tmp_path / "shot.png"))
+
+    request = send.call_args.args[0]
+    assert request == {
+        "method": "Page.captureScreenshot",
+        "params": {"format": "png", "captureBeyondViewport": False},
+        "session_id": None,
+    }
+    assert send.call_args.kwargs == {
+        "response_timeout": helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS
+    }
+
+
+def test_screenshot_timeout_has_context(tmp_path):
+    with patch("browser_harness.helpers._send", side_effect=helpers._IPCResponseTimeout):
+        with pytest.raises(RuntimeError, match="Page.captureScreenshot timed out after 60s"):
+            helpers.capture_screenshot(str(tmp_path / "shot.png"))
+
+
 def _seed_skill(tmp_path):
     site = tmp_path / "domain-skills" / "example"
     site.mkdir(parents=True)


### PR DESCRIPTION
## What Problem This Solves

`Page.captureScreenshot` can take longer than the 5-second local IPC connection budget when the daemon is attached to a remote Cloud browser. The connected socket currently reuses that 5-second value for the entire screenshot response, causing recoverable screenshot calls to time out.

## Why This Change Was Made

Keep the 5-second IPC connect and default response budget, but give screenshot responses a bounded 60-second budget. Timeout errors remain generic and do not expose endpoint details.

## User Impact

Remote viewport and full-page screenshots can complete without weakening the timeout applied to ordinary Browser Harness commands.

## Evidence

- Diff is limited to 2 files: the helper implementation and focused tests.
- `uv run --with pytest pytest -q tests/unit/test_helpers.py`: 24 passed.
- `git diff --check`: passed.
- In the final OpenClaw evaluation head, the earlier screenshot IPC timeout signature remained at zero.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates the IPC connect timeout from the response timeout so screenshots don’t inherit the 5s budget. Previously a single 5s timeout covered connect and response; now connect stays 5s and default responses stay 5s, while `Page.captureScreenshot` uses a 60s response budget without weakening other commands or exposing endpoint details.

- Introduces `IPC_CONNECT_TIMEOUT_SECONDS` (5s), `DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS` (5s), and `SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS` (60s); `_send` sets per-call socket timeouts and raises `_IPCResponseTimeout` on response timeouts.
- `cdp` accepts `_response_timeout`; `capture_screenshot` uses the 60s budget and converts screenshot timeouts into a contextual `RuntimeError`. Tests cover the new budgets and error message.

<sup>Written for commit 742d3edc2027db1eceb854088e9cbd7a60601fea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

