### PR TITLE
Reuse one tab for agent browsing instead of opening one per page

### DIFF
--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -7,12 +7,19 @@ Use **CDP for control**, **UI automation for user-visible order**.
 ```python
 tabs = list_tabs()                    # includes chrome:// pages too
 real_tabs = list_tabs(include_chrome=False)
-tid = new_tab("https://example.com")  # create + attach in the background
+tid = new_tab("https://example.com")  # reuse this harness's tab, else create
+tid = new_tab("https://example.com", force=True)   # insist on a second tab
 switch_tab(tid)                       # attach harness, move the horse marker
 activate_tab(tid)                     # optional: explicitly show it in Chrome
 print(current_tab())
 print(page_info())
 ```
+
+Sweeping many pages is `new_tab(url)` in a loop, not a tab per page. It
+navigates the tab this harness already owns, so a twenty page sweep leaves one
+tab rather than twenty. `force=True` is for the cases that genuinely need two at
+once, such as comparing pages side by side or following a popup. A tab the user
+opened is never taken over.
 
 What CDP is good at:
 - attach to a tab

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -294,44 +294,60 @@ def _owned_tab_path():
     return config_dir() / f"agent-tab-{ipc._check(NAME)}"
 
 
-def _owned_tab_lock(timeout=5.0):
+def _owned_tab_lock(wait=5.0, stale_after=120.0):
     """Serialise select-or-create so two agents do not each open a tab.
 
-    O_CREAT|O_EXCL rather than fcntl because the daemon runs on Windows too. A
-    lock older than the timeout is treated as abandoned, and a lock that cannot
-    be taken at all is proceeded past rather than raised: a crashed neighbour
-    should cost a duplicate tab at worst, never a failed call.
+    O_CREAT|O_EXCL rather than fcntl because the daemon runs on Windows too.
+
+    The two timeouts are deliberately different, and collapsing them into one
+    was a bug. The create path holds this across createTarget, attach and
+    goto_url, so a slow page load looks exactly like a crashed holder: a waiter
+    on the same threshold evicts a live holder, both run, and the duplicate tab
+    the lock exists to prevent comes back. `wait` is how long a caller queues,
+    `stale_after` is how old a lock must be before it is presumed abandoned, and
+    it sits well above any plausible hold.
+
+    Each holder stamps a token and removes only a lock still carrying it, so a
+    holder evicted despite that cannot delete its successor's lock on the way
+    out and let a third caller in.
     """
     import contextlib
+    import secrets
 
     @contextlib.contextmanager
     def _cm():
         path = _owned_tab_path().with_name(_owned_tab_path().name + ".lock")
-        deadline = time.time() + timeout
-        fd = None
+        token = f"{os.getpid()}-{secrets.token_hex(8)}"
+        deadline = time.time() + wait
+        held = False
         while True:
             try:
                 fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                try:
+                    os.write(fd, token.encode())
+                finally:
+                    os.close(fd)
+                held = True
                 break
             except FileExistsError:
                 try:
-                    if time.time() - os.path.getmtime(path) > timeout:
+                    if time.time() - os.path.getmtime(path) > stale_after:
                         os.unlink(path)
-                        continue
+                        continue  # race for it again; the winner stamps its own
                 except OSError:
                     pass
                 if time.time() >= deadline:
-                    break
+                    break  # proceed unlocked rather than fail the call
                 time.sleep(0.05)
             except OSError:
                 break
         try:
             yield
         finally:
-            if fd is not None:
-                os.close(fd)
+            if held:
                 try:
-                    os.unlink(path)
+                    if path.read_text() == token:
+                        os.unlink(path)
                 except OSError:
                     pass
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -288,7 +288,54 @@ def current_tab():
 
 def _owned_tab_path():
     from .paths import config_dir
-    return config_dir() / "agent-tab"
+    # Named daemons share one Chrome, so the record has to be per BU_NAME or one
+    # agent adopts another's live tab and navigates it out from under it. Same
+    # convention the recorder uses for its active marker.
+    return config_dir() / f"agent-tab-{ipc._check(NAME)}"
+
+
+def _owned_tab_lock(timeout=5.0):
+    """Serialise select-or-create so two agents do not each open a tab.
+
+    O_CREAT|O_EXCL rather than fcntl because the daemon runs on Windows too. A
+    lock older than the timeout is treated as abandoned, and a lock that cannot
+    be taken at all is proceeded past rather than raised: a crashed neighbour
+    should cost a duplicate tab at worst, never a failed call.
+    """
+    import contextlib
+
+    @contextlib.contextmanager
+    def _cm():
+        path = _owned_tab_path().with_name(_owned_tab_path().name + ".lock")
+        deadline = time.time() + timeout
+        fd = None
+        while True:
+            try:
+                fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                break
+            except FileExistsError:
+                try:
+                    if time.time() - os.path.getmtime(path) > timeout:
+                        os.unlink(path)
+                        continue
+                except OSError:
+                    pass
+                if time.time() >= deadline:
+                    break
+                time.sleep(0.05)
+            except OSError:
+                break
+        try:
+            yield
+        finally:
+            if fd is not None:
+                os.close(fd)
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+    return _cm()
 
 
 def _owned_tab():
@@ -365,7 +412,12 @@ def new_tab(url="about:blank", force=False):
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    if url != "about:blank" and not force:
+    if url == "about:blank" or force:
+        return _create_tab(url, own=False)
+
+    # Held across select-and-create so two agents cannot both find nothing to
+    # reuse and both open a tab.
+    with _owned_tab_lock():
         try:
             owned = _owned_tab()
             live = {_target_id(t) for t in list_tabs()}
@@ -390,11 +442,15 @@ def new_tab(url="about:blank", force=False):
                 return target
         except Exception:
             pass
+        return _create_tab(url, own=True)
+
+
+def _create_tab(url, own):
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)
-        if not force:
+        if own:
             _own_tab(tid)
     return tid
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -294,22 +294,44 @@ def _owned_tab_path():
     return config_dir() / f"agent-tab-{ipc._check(NAME)}"
 
 
-def _owned_tab_lock(wait=5.0, stale_after=120.0):
+def _holder_is_alive(pid):
+    """Whether the process that stamped a lock is still running.
+
+    Only a dead holder's lock is ever taken, which is what removes the release
+    race: nobody can replace a live holder's lock, so a holder always finds its
+    own stamp when it exits. POSIX only. Elsewhere the answer is a conservative
+    yes, so the lock is simply never reclaimed and callers fall through to
+    running unlocked.
+    """
+    if not hasattr(os, "kill"):
+        return True
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True  # exists but not ours to signal
+
+
+def _owned_tab_lock(wait=5.0):
     """Serialise select-or-create so two agents do not each open a tab.
 
     O_CREAT|O_EXCL rather than fcntl because the daemon runs on Windows too.
 
-    The two timeouts are deliberately different, and collapsing them into one
-    was a bug. The create path holds this across createTarget, attach and
-    goto_url, so a slow page load looks exactly like a crashed holder: a waiter
-    on the same threshold evicts a live holder, both run, and the duplicate tab
-    the lock exists to prevent comes back. `wait` is how long a caller queues,
-    `stale_after` is how old a lock must be before it is presumed abandoned, and
-    it sits well above any plausible hold.
+    Reclaiming by age was wrong twice over and both attempts are worth recording.
+    A shared timeout made a slow goto_url look like a crash, so a waiter evicted
+    a live holder. Splitting the timeouts narrowed that but left the release
+    unsafe: between a holder reading its own stamp and unlinking, a waiter could
+    reclaim and a successor could take the lock, and the departing holder then
+    deleted the successor's. There is no atomic compare-and-unlink to close that
+    window with.
 
-    Each holder stamps a token and removes only a lock still carrying it, so a
-    holder evicted despite that cannot delete its successor's lock on the way
-    out and let a third caller in.
+    So age does not reclaim anything here. A lock is taken only when the process
+    that stamped it is gone, which no living holder can be, and a lock that
+    cannot be taken is waited on and then run past unlocked. The worst case is
+    the duplicate tab this lock exists to avoid, never a wedged caller and never
+    a holder deleting someone else's lock.
     """
     import contextlib
     import secrets
@@ -317,24 +339,25 @@ def _owned_tab_lock(wait=5.0, stale_after=120.0):
     @contextlib.contextmanager
     def _cm():
         path = _owned_tab_path().with_name(_owned_tab_path().name + ".lock")
-        token = f"{os.getpid()}-{secrets.token_hex(8)}"
+        stamp = f"{os.getpid()}:{secrets.token_hex(8)}"
         deadline = time.time() + wait
         held = False
         while True:
             try:
                 fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 try:
-                    os.write(fd, token.encode())
+                    os.write(fd, stamp.encode())
                 finally:
                     os.close(fd)
                 held = True
                 break
             except FileExistsError:
                 try:
-                    if time.time() - os.path.getmtime(path) > stale_after:
+                    holder = path.read_text().split(":", 1)[0]
+                    if not _holder_is_alive(int(holder)):
                         os.unlink(path)
                         continue  # race for it again; the winner stamps its own
-                except OSError:
+                except (OSError, ValueError):
                     pass
                 if time.time() >= deadline:
                     break  # proceed unlocked rather than fail the call
@@ -346,7 +369,7 @@ def _owned_tab_lock(wait=5.0, stale_after=120.0):
         finally:
             if held:
                 try:
-                    if path.read_text() == token:
+                    if path.read_text() == stamp:
                         os.unlink(path)
                 except OSError:
                     pass

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -294,83 +294,89 @@ def _owned_tab_path():
     return config_dir() / f"agent-tab-{ipc._check(NAME)}"
 
 
-def _holder_is_alive(pid):
-    """Whether the process that stamped a lock is still running.
+def _try_lock_fd(fd):
+    """Take an exclusive advisory lock on an open fd, or raise if held.
 
-    Only a dead holder's lock is ever taken, which is what removes the release
-    race: nobody can replace a live holder's lock, so a holder always finds its
-    own stamp when it exits. POSIX only. Elsewhere the answer is a conservative
-    yes, so the lock is simply never reclaimed and callers fall through to
-    running unlocked.
+    The kernel drops it when the holder exits, however it exits, which is the
+    property the hand-rolled version could not have.
     """
-    if not hasattr(os, "kill"):
-        return True
     try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except OSError:
-        return True  # exists but not ours to signal
+        import fcntl
+    except ImportError:
+        import msvcrt
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        return
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_fd(fd):
+    try:
+        import fcntl
+    except ImportError:
+        import msvcrt
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        return
+    fcntl.flock(fd, fcntl.LOCK_UN)
 
 
 def _owned_tab_lock(wait=5.0):
     """Serialise select-or-create so two agents do not each open a tab.
 
-    O_CREAT|O_EXCL rather than fcntl because the daemon runs on Windows too.
+    This is an advisory lock held on an open descriptor, not a lock file whose
+    existence means something. Three earlier rounds of this were a file plus a
+    stamp plus a staleness rule, and each round closed one hole and left another:
+    a shared timeout let a waiter evict a live holder mid goto_url; splitting the
+    timeouts left the release racing a successor with no atomic
+    compare-and-unlink to fix it; and pinning ownership to a pid inherited both a
+    window where a crash leaves the record unwritten and the question of what a
+    reused pid means. The kernel answers all of that by releasing on exit, so the
+    machinery is gone rather than repaired.
 
-    Reclaiming by age was wrong twice over and both attempts are worth recording.
-    A shared timeout made a slow goto_url look like a crash, so a waiter evicted
-    a live holder. Splitting the timeouts narrowed that but left the release
-    unsafe: between a holder reading its own stamp and unlinking, a waiter could
-    reclaim and a successor could take the lock, and the departing holder then
-    deleted the successor's. There is no atomic compare-and-unlink to close that
-    window with.
+    The file is only a handle to lock. It is never unlinked, so no caller can
+    delete a lock another one is holding, and an empty or leftover file means
+    nothing to anybody.
 
-    So age does not reclaim anything here. A lock is taken only when the process
-    that stamped it is gone, which no living holder can be, and a lock that
-    cannot be taken is waited on and then run past unlocked. The worst case is
-    the duplicate tab this lock exists to avoid, never a wedged caller and never
-    a holder deleting someone else's lock.
+    A lock that cannot be taken within `wait` is run past unlocked rather than
+    raised on: the worst case is the duplicate tab this exists to avoid, and a
+    wedged neighbour should not take the harness down with it.
     """
     import contextlib
-    import secrets
 
     @contextlib.contextmanager
     def _cm():
         path = _owned_tab_path().with_name(_owned_tab_path().name + ".lock")
-        stamp = f"{os.getpid()}:{secrets.token_hex(8)}"
-        deadline = time.time() + wait
+        fd = None
         held = False
-        while True:
-            try:
-                fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-                try:
-                    os.write(fd, stamp.encode())
-                finally:
-                    os.close(fd)
-                held = True
-                break
-            except FileExistsError:
-                try:
-                    holder = path.read_text().split(":", 1)[0]
-                    if not _holder_is_alive(int(holder)):
-                        os.unlink(path)
-                        continue  # race for it again; the winner stamps its own
-                except (OSError, ValueError):
-                    pass
-                if time.time() >= deadline:
-                    break  # proceed unlocked rather than fail the call
-                time.sleep(0.05)
-            except OSError:
-                break
         try:
+            try:
+                fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+            except OSError:
+                yield  # cannot even open a lock file; proceed unlocked
+                return
+            deadline = time.time() + wait
+            while True:
+                try:
+                    _try_lock_fd(fd)
+                    held = True
+                    break
+                except OSError:
+                    if time.time() >= deadline:
+                        break
+                    time.sleep(0.05)
             yield
         finally:
-            if held:
+            if fd is not None:
+                if held:
+                    try:
+                        _unlock_fd(fd)
+                    except OSError:
+                        pass
                 try:
-                    if path.read_text() == stamp:
-                        os.unlink(path)
+                    os.close(fd)
                 except OSError:
                     pass
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -286,6 +286,31 @@ def current_tab():
         "title": r["title"],
     }
 
+def _owned_tab_path():
+    from .paths import config_dir
+    return config_dir() / "agent-tab"
+
+
+def _owned_tab():
+    """The tab this harness opened for browsing, remembered across processes.
+
+    Each heredoc invocation is a fresh process, so module state cannot carry
+    this, and the title marker cannot either because page loads overwrite it.
+    A file survives both.
+    """
+    try:
+        return _owned_tab_path().read_text().strip() or None
+    except Exception:
+        return None
+
+
+def _own_tab(target_id):
+    try:
+        _owned_tab_path().write_text(str(target_id))
+    except Exception:
+        pass
+
+
 def _mark_tab():
     """Prepend horse emoji to tab title so the user can see which tab the agent controls."""
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
@@ -325,28 +350,52 @@ def switch_tab(target, activate=False):
     _mark_tab()
     return sid
 
-def new_tab(url="about:blank"):
+def new_tab(url="about:blank", force=False):
+    """Open `url`, reusing the agent's own tab rather than opening another one.
+
+    An agent sweeping many pages calls this in a loop, and a tab per page leaves
+    the user closing dozens by hand. So a call carrying a real url navigates the
+    attached tab whenever that tab is blank or is one the harness already owns,
+    which `_mark_tab` records by prefixing the title with the horse marker. A
+    tab the user opened has no marker and is never taken over.
+
+    Pass force=True for the rare case that genuinely needs a second tab, such as
+    comparing two pages side by side or following a popup flow.
+    """
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    if url != "about:blank":
+    if url != "about:blank" and not force:
         try:
+            owned = _owned_tab()
+            live = {_target_id(t) for t in list_tabs()}
             cur = current_tab()
+            cur_id = cur.get("targetId") or cur.get("target_id")
             cur_url = cur.get("url") or ""
-            # Reuse attached tab when it's blank
-            if (
+            blank = (
                 cur_url in ("", "about:blank")
                 or cur_url.startswith("about:blank#")
                 or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
-            ):
+            )
+            # Reuse the tab this harness opened, or the attached tab if blank.
+            # The title marker cannot carry ownership: goto_url replaces the
+            # title as the page loads, so a marker written before the load is
+            # gone by the next call and every call opens another tab.
+            target = owned if owned in live else (cur_id if blank else None)
+            if target:
+                if target != cur_id:
+                    switch_tab(target)
                 goto_url(url)
-                return cur.get("targetId") or cur.get("target_id")
+                _own_tab(target)
+                return target
         except Exception:
             pass
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)
+        if not force:
+            _own_tab(tid)
     return tid
 
 def close_tab(target=None):

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -294,33 +294,34 @@ def _owned_tab_path():
     return config_dir() / f"agent-tab-{ipc._check(NAME)}"
 
 
+try:
+    import fcntl as _fcntl
+except ImportError:  # Windows
+    _fcntl = None
+    import msvcrt as _msvcrt
+else:
+    _msvcrt = None
+
+
 def _try_lock_fd(fd):
     """Take an exclusive advisory lock on an open fd, or raise if held.
 
     The kernel drops it when the holder exits, however it exits, which is the
-    property the hand-rolled version could not have.
+    property a lock file whose contents encode ownership cannot have.
     """
-    try:
-        import fcntl
-    except ImportError:
-        import msvcrt
-
-        os.lseek(fd, 0, os.SEEK_SET)
-        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
         return
-    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    os.lseek(fd, 0, os.SEEK_SET)
+    _msvcrt.locking(fd, _msvcrt.LK_NBLCK, 1)
 
 
 def _unlock_fd(fd):
-    try:
-        import fcntl
-    except ImportError:
-        import msvcrt
-
-        os.lseek(fd, 0, os.SEEK_SET)
-        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_UN)
         return
-    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.lseek(fd, 0, os.SEEK_SET)
+    _msvcrt.locking(fd, _msvcrt.LK_UNLCK, 1)
 
 
 def _owned_tab_lock(wait=5.0):
@@ -348,7 +349,8 @@ def _owned_tab_lock(wait=5.0):
 
     @contextlib.contextmanager
     def _cm():
-        path = _owned_tab_path().with_name(_owned_tab_path().name + ".lock")
+        record = _owned_tab_path()
+        path = record.with_name(record.name + ".lock")
         fd = None
         held = False
         try:

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -487,3 +487,73 @@ def test_new_tab_force_opens_a_second_tab_even_when_one_is_owned(monkeypatch, tm
     assert helpers.new_tab("https://b.test", force=True) == "target-created"
     assert any(method == "Target.createTarget" for method, _ in calls)
     assert (tmp_path / "agent-tab").read_text() == "target-owned"
+
+
+def test_owned_tab_record_is_scoped_by_bu_name(monkeypatch, tmp_path):
+    # Named daemons share one Chrome. An unscoped record lets one agent adopt
+    # another's live tab, which is the whole reason the name is in the filename.
+    monkeypatch.setattr(helpers.paths, "config_dir", lambda: tmp_path)
+
+    monkeypatch.setattr(helpers, "NAME", "alpha")
+    alpha = helpers._owned_tab_path()
+    monkeypatch.setattr(helpers, "NAME", "beta")
+    beta = helpers._owned_tab_path()
+
+    assert alpha != beta
+    assert alpha.name.endswith("alpha") and beta.name.endswith("beta")
+
+
+def test_owned_tab_path_rejects_a_traversing_bu_name(monkeypatch, tmp_path):
+    monkeypatch.setattr(helpers.paths, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(helpers, "NAME", "../escape")
+    with pytest.raises(ValueError):
+        helpers._owned_tab_path()
+
+
+def test_owned_tab_lock_breaks_a_stale_lock_rather_than_hanging(monkeypatch, tmp_path):
+    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
+    stale = tmp_path / "agent-tab.lock"
+    stale.write_text("")
+    os.utime(stale, (time.time() - 3600, time.time() - 3600))
+
+    started = time.time()
+    with helpers._owned_tab_lock(timeout=1.0):
+        pass
+    # Broken immediately, not waited out.
+    assert time.time() - started < 0.5
+
+
+def test_concurrent_new_tab_calls_share_one_tab(monkeypatch, tmp_path):
+    import threading
+
+    created = []
+    state = {"tabs": [{"targetId": "target-user", "url": "https://user.test", "title": "u"}]}
+    lock = threading.Lock()
+
+    def fake_cdp(method, **kwargs):
+        if method == "Target.createTarget":
+            with lock:
+                tid = f"target-{len(created)}"
+                created.append(tid)
+                state["tabs"].append({"targetId": tid, "url": "", "title": ""})
+            return {"targetId": tid}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "s"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+    monkeypatch.setattr(helpers, "goto_url", lambda url: time.sleep(0.02))
+    monkeypatch.setattr(helpers, "list_tabs", lambda *a, **k: list(state["tabs"]))
+    monkeypatch.setattr(helpers, "current_tab", lambda: state["tabs"][0])
+    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
+
+    out = []
+    threads = [threading.Thread(target=lambda: out.append(helpers.new_tab("https://a.test")))
+               for _ in range(4)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    assert len(created) == 1, f"opened {len(created)} tabs for 4 concurrent calls"
+    assert len(set(out)) == 1

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -404,3 +404,86 @@ def test_new_tab_creates_and_attaches_in_background(monkeypatch):
     assert helpers.new_tab() == "target-new"
     assert ("Target.createTarget", {"url": "about:blank", "background": True}) in calls
     assert not any(method == "Target.activateTarget" for method, _ in calls)
+
+
+def _tab_stubs(monkeypatch, tmp_path, live_tabs, current):
+    """Wire new_tab's collaborators so only the reuse decision is under test."""
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "target-created"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-new"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+    monkeypatch.setattr(helpers, "goto_url", lambda url: calls.append(("goto", url)))
+    monkeypatch.setattr(helpers, "list_tabs", lambda *a, **k: live_tabs)
+    monkeypatch.setattr(helpers, "current_tab", lambda: current)
+    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
+    return calls
+
+
+def test_new_tab_reuses_the_owned_tab_instead_of_opening_another(monkeypatch, tmp_path):
+    (tmp_path / "agent-tab").write_text("target-owned")
+    calls = _tab_stubs(
+        monkeypatch, tmp_path,
+        live_tabs=[{"targetId": "target-owned", "url": "https://a.test", "title": "a"}],
+        current={"targetId": "target-owned", "url": "https://a.test", "title": "a"},
+    )
+
+    assert helpers.new_tab("https://b.test") == "target-owned"
+    assert ("goto", "https://b.test") in calls
+    assert not any(method == "Target.createTarget" for method, _ in calls)
+
+
+def test_new_tab_records_the_tab_it_creates_so_the_next_call_reuses_it(monkeypatch, tmp_path):
+    _tab_stubs(
+        monkeypatch, tmp_path,
+        live_tabs=[{"targetId": "target-user", "url": "https://user.test", "title": "user"}],
+        current={"targetId": "target-user", "url": "https://user.test", "title": "user"},
+    )
+
+    assert helpers.new_tab("https://a.test") == "target-created"
+    assert (tmp_path / "agent-tab").read_text() == "target-created"
+
+
+def test_new_tab_does_not_take_over_a_tab_the_user_opened(monkeypatch, tmp_path):
+    # No record on disk, and the attached tab holds a real page: creating is right.
+    calls = _tab_stubs(
+        monkeypatch, tmp_path,
+        live_tabs=[{"targetId": "target-user", "url": "https://user.test", "title": "user"}],
+        current={"targetId": "target-user", "url": "https://user.test", "title": "user"},
+    )
+
+    assert helpers.new_tab("https://a.test") == "target-created"
+    assert any(method == "Target.createTarget" for method, _ in calls)
+
+
+def test_new_tab_creates_again_when_the_recorded_tab_is_gone(monkeypatch, tmp_path):
+    (tmp_path / "agent-tab").write_text("target-closed")
+    calls = _tab_stubs(
+        monkeypatch, tmp_path,
+        live_tabs=[{"targetId": "target-user", "url": "https://user.test", "title": "user"}],
+        current={"targetId": "target-user", "url": "https://user.test", "title": "user"},
+    )
+
+    assert helpers.new_tab("https://a.test") == "target-created"
+    assert any(method == "Target.createTarget" for method, _ in calls)
+
+
+def test_new_tab_force_opens_a_second_tab_even_when_one_is_owned(monkeypatch, tmp_path):
+    (tmp_path / "agent-tab").write_text("target-owned")
+    calls = _tab_stubs(
+        monkeypatch, tmp_path,
+        live_tabs=[{"targetId": "target-owned", "url": "https://a.test", "title": "a"}],
+        current={"targetId": "target-owned", "url": "https://a.test", "title": "a"},
+    )
+
+    assert helpers.new_tab("https://b.test", force=True) == "target-created"
+    assert any(method == "Target.createTarget" for method, _ in calls)
+    assert (tmp_path / "agent-tab").read_text() == "target-owned"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -510,63 +510,92 @@ def test_owned_tab_path_rejects_a_traversing_bu_name(monkeypatch, tmp_path):
         helpers._owned_tab_path()
 
 
-def test_owned_tab_lock_reclaims_a_dead_holders_lock(monkeypatch, tmp_path):
-    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
-    lock = tmp_path / "agent-tab.lock"
-    lock.write_text("999999:deadholder")
-    monkeypatch.setattr(helpers, "_holder_is_alive", lambda pid: False)
+def test_owned_tab_lock_is_exclusive_between_processes(monkeypatch, tmp_path):
+    # Two subprocesses race for the lock; the second must wait rather than run
+    # alongside the first.
+    import subprocess
+    import sys
+    import textwrap
 
+    script = textwrap.dedent(f"""
+        import sys, time
+        sys.path.insert(0, {str(__import__('pathlib').Path(helpers.__file__).parents[2])!r})
+        from browser_harness import helpers
+        helpers._owned_tab_path = lambda: __import__('pathlib').Path({str(tmp_path / 'agent-tab')!r})
+        hold = sys.argv[1] == 'hold'
+        with helpers._owned_tab_lock(wait=5.0):
+            print(time.time(), flush=True)
+            if hold:
+                time.sleep(1.0)
+        print(time.time(), flush=True)
+    """)
+    src = tmp_path / "race.py"
+    src.write_text(script)
+
+    a = subprocess.Popen([sys.executable, str(src), "hold"], stdout=subprocess.PIPE, text=True)
+    time.sleep(0.3)
+    b = subprocess.Popen([sys.executable, str(src), "wait"], stdout=subprocess.PIPE, text=True)
+    a_out = a.communicate()[0].split()
+    b_out = b.communicate()[0].split()
+
+    a_enter, a_exit = float(a_out[0]), float(a_out[1])
+    b_enter = float(b_out[0])
+    assert b_enter >= a_exit - 0.05, "second process entered while the first held the lock"
+
+
+def test_owned_tab_lock_is_released_when_the_holder_dies(monkeypatch, tmp_path):
+    # The kernel drops an advisory lock on exit, so a killed holder cannot
+    # wedge the next caller. This is the property the stamp-and-pid version
+    # had to reason about and this one gets for free.
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(f"""
+        import sys, time
+        sys.path.insert(0, {str(__import__('pathlib').Path(helpers.__file__).parents[2])!r})
+        from browser_harness import helpers
+        helpers._owned_tab_path = lambda: __import__('pathlib').Path({str(tmp_path / 'agent-tab')!r})
+        with helpers._owned_tab_lock(wait=5.0):
+            print("in", flush=True)
+            time.sleep(30)
+    """)
+    src = tmp_path / "holder.py"
+    src.write_text(script)
+
+    holder = subprocess.Popen([sys.executable, str(src)], stdout=subprocess.PIPE, text=True)
+    assert holder.stdout.readline().strip() == "in"
+    holder.kill()
+    holder.wait()
+
+    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
     started = time.time()
-    with helpers._owned_tab_lock(wait=1.0):
-        assert lock.read_text().startswith(f"{os.getpid()}:")
-    assert time.time() - started < 0.5
-    assert not lock.exists()
+    with helpers._owned_tab_lock(wait=5.0):
+        pass
+    assert time.time() - started < 1.0, "a dead holder's lock was still blocking"
 
 
-def test_owned_tab_lock_never_takes_a_live_holders_lock(monkeypatch, tmp_path):
-    # The create path holds this across goto_url. A slow page must not be
-    # mistaken for a crash, which is what age-based reclaiming did.
+def test_owned_tab_lock_proceeds_unlocked_rather_than_raising(monkeypatch, tmp_path):
+    # A neighbour that never lets go must not take the harness down with it.
     monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
-    lock = tmp_path / "agent-tab.lock"
-    lock.write_text("424242:liveholder")
-    os.utime(lock, (time.time() - 86400, time.time() - 86400))  # ancient, but alive
-    monkeypatch.setattr(helpers, "_holder_is_alive", lambda pid: True)
 
+    def always_held(fd):
+        raise OSError("held")
+
+    monkeypatch.setattr(helpers, "_try_lock_fd", always_held)
+    ran = False
     with helpers._owned_tab_lock(wait=0.2):
-        assert lock.read_text() == "424242:liveholder"
-    assert lock.read_text() == "424242:liveholder"
+        ran = True
+    assert ran
 
 
-def test_owned_tab_lock_holder_does_not_delete_a_successors_lock(monkeypatch, tmp_path):
+def test_owned_tab_lock_never_unlinks_the_lock_file(monkeypatch, tmp_path):
+    # Nothing deletes it, so no caller can remove a lock another one holds.
     monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
     lock = tmp_path / "agent-tab.lock"
-
-    cm = helpers._owned_tab_lock(wait=1.0)
-    cm.__enter__()
-    assert lock.read_text().startswith(f"{os.getpid()}:")
-    # Simulate the lock having been taken over despite everything.
-    lock.write_text("777:successor")
-    cm.__exit__(None, None, None)
-
-    assert lock.exists() and lock.read_text() == "777:successor"
-
-
-def test_holder_is_alive_says_no_for_a_pid_that_is_gone(monkeypatch):
-    def gone(pid, sig):
-        raise ProcessLookupError
-
-    monkeypatch.setattr(helpers.os, "kill", gone)
-    assert helpers._holder_is_alive(999999) is False
-
-
-def test_holder_is_alive_is_conservative_when_it_cannot_tell(monkeypatch):
-    # A pid owned by another user raises PermissionError: it exists, so the lock
-    # stays. Same for a platform without os.kill.
-    def not_ours(pid, sig):
-        raise PermissionError
-
-    monkeypatch.setattr(helpers.os, "kill", not_ours)
-    assert helpers._holder_is_alive(1) is True
+    with helpers._owned_tab_lock(wait=1.0):
+        assert lock.exists()
+    assert lock.exists()
 
 
 def test_concurrent_new_tab_calls_share_one_tab(monkeypatch, tmp_path):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -547,9 +547,11 @@ def test_owned_tab_lock_is_exclusive_between_processes(tmp_path):
     import subprocess
     import sys
 
-    # The holder announces that it is inside before it starts holding, so the
-    # waiter is launched on that signal rather than on a sleep the machine has
-    # to be fast enough to honour.
+    # The holder prints from inside the locked block, so the line means the lock
+    # is already taken and the waiter can be launched on it rather than on a
+    # sleep the machine has to be fast enough to honour. Keep the print inside
+    # the with: moved outside it would announce intent rather than possession,
+    # and the waiter could then start first and the assertion would be vacuous.
     holder = _lock_race_child(tmp_path, "holder", """
         with helpers._owned_tab_lock(wait=5.0):
             print("held", flush=True)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -510,46 +510,63 @@ def test_owned_tab_path_rejects_a_traversing_bu_name(monkeypatch, tmp_path):
         helpers._owned_tab_path()
 
 
-def test_owned_tab_lock_breaks_a_stale_lock_rather_than_hanging(monkeypatch, tmp_path):
-    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
-    stale = tmp_path / "agent-tab.lock"
-    stale.write_text("someone-else")
-    os.utime(stale, (time.time() - 3600, time.time() - 3600))
-
-    started = time.time()
-    with helpers._owned_tab_lock(wait=1.0, stale_after=60.0):
-        pass
-    # Broken immediately, not waited out.
-    assert time.time() - started < 0.5
-
-
-def test_owned_tab_lock_does_not_evict_a_slow_but_live_holder(monkeypatch, tmp_path):
-    # The create path holds the lock across goto_url. A slow page must not look
-    # like a crash, which is what one shared timeout made it look like.
+def test_owned_tab_lock_reclaims_a_dead_holders_lock(monkeypatch, tmp_path):
     monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
     lock = tmp_path / "agent-tab.lock"
-    lock.write_text("live-holder")
-    os.utime(lock, (time.time() - 10, time.time() - 10))
+    lock.write_text("999999:deadholder")
+    monkeypatch.setattr(helpers, "_holder_is_alive", lambda pid: False)
 
-    with helpers._owned_tab_lock(wait=0.2, stale_after=120.0):
-        # Waiter gave up and proceeded unlocked; the holder's lock is untouched.
-        assert lock.read_text() == "live-holder"
-    assert lock.read_text() == "live-holder"
+    started = time.time()
+    with helpers._owned_tab_lock(wait=1.0):
+        assert lock.read_text().startswith(f"{os.getpid()}:")
+    assert time.time() - started < 0.5
+    assert not lock.exists()
+
+
+def test_owned_tab_lock_never_takes_a_live_holders_lock(monkeypatch, tmp_path):
+    # The create path holds this across goto_url. A slow page must not be
+    # mistaken for a crash, which is what age-based reclaiming did.
+    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
+    lock = tmp_path / "agent-tab.lock"
+    lock.write_text("424242:liveholder")
+    os.utime(lock, (time.time() - 86400, time.time() - 86400))  # ancient, but alive
+    monkeypatch.setattr(helpers, "_holder_is_alive", lambda pid: True)
+
+    with helpers._owned_tab_lock(wait=0.2):
+        assert lock.read_text() == "424242:liveholder"
+    assert lock.read_text() == "424242:liveholder"
 
 
 def test_owned_tab_lock_holder_does_not_delete_a_successors_lock(monkeypatch, tmp_path):
     monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
     lock = tmp_path / "agent-tab.lock"
 
-    cm = helpers._owned_tab_lock(wait=1.0, stale_after=120.0)
+    cm = helpers._owned_tab_lock(wait=1.0)
     cm.__enter__()
-    mine = lock.read_text()
-    assert mine
-    # Simulate being evicted and a successor taking the lock.
-    lock.write_text("successor-token")
+    assert lock.read_text().startswith(f"{os.getpid()}:")
+    # Simulate the lock having been taken over despite everything.
+    lock.write_text("777:successor")
     cm.__exit__(None, None, None)
 
-    assert lock.exists() and lock.read_text() == "successor-token"
+    assert lock.exists() and lock.read_text() == "777:successor"
+
+
+def test_holder_is_alive_says_no_for_a_pid_that_is_gone(monkeypatch):
+    def gone(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(helpers.os, "kill", gone)
+    assert helpers._holder_is_alive(999999) is False
+
+
+def test_holder_is_alive_is_conservative_when_it_cannot_tell(monkeypatch):
+    # A pid owned by another user raises PermissionError: it exists, so the lock
+    # stays. Same for a platform without os.kill.
+    def not_ours(pid, sig):
+        raise PermissionError
+
+    monkeypatch.setattr(helpers.os, "kill", not_ours)
+    assert helpers._holder_is_alive(1) is True
 
 
 def test_concurrent_new_tab_calls_share_one_tab(monkeypatch, tmp_path):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -513,14 +513,43 @@ def test_owned_tab_path_rejects_a_traversing_bu_name(monkeypatch, tmp_path):
 def test_owned_tab_lock_breaks_a_stale_lock_rather_than_hanging(monkeypatch, tmp_path):
     monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
     stale = tmp_path / "agent-tab.lock"
-    stale.write_text("")
+    stale.write_text("someone-else")
     os.utime(stale, (time.time() - 3600, time.time() - 3600))
 
     started = time.time()
-    with helpers._owned_tab_lock(timeout=1.0):
+    with helpers._owned_tab_lock(wait=1.0, stale_after=60.0):
         pass
     # Broken immediately, not waited out.
     assert time.time() - started < 0.5
+
+
+def test_owned_tab_lock_does_not_evict_a_slow_but_live_holder(monkeypatch, tmp_path):
+    # The create path holds the lock across goto_url. A slow page must not look
+    # like a crash, which is what one shared timeout made it look like.
+    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
+    lock = tmp_path / "agent-tab.lock"
+    lock.write_text("live-holder")
+    os.utime(lock, (time.time() - 10, time.time() - 10))
+
+    with helpers._owned_tab_lock(wait=0.2, stale_after=120.0):
+        # Waiter gave up and proceeded unlocked; the holder's lock is untouched.
+        assert lock.read_text() == "live-holder"
+    assert lock.read_text() == "live-holder"
+
+
+def test_owned_tab_lock_holder_does_not_delete_a_successors_lock(monkeypatch, tmp_path):
+    monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
+    lock = tmp_path / "agent-tab.lock"
+
+    cm = helpers._owned_tab_lock(wait=1.0, stale_after=120.0)
+    cm.__enter__()
+    mine = lock.read_text()
+    assert mine
+    # Simulate being evicted and a successor taking the lock.
+    lock.write_text("successor-token")
+    cm.__exit__(None, None, None)
+
+    assert lock.exists() and lock.read_text() == "successor-token"
 
 
 def test_concurrent_new_tab_calls_share_one_tab(monkeypatch, tmp_path):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -510,63 +510,85 @@ def test_owned_tab_path_rejects_a_traversing_bu_name(monkeypatch, tmp_path):
         helpers._owned_tab_path()
 
 
-def test_owned_tab_lock_is_exclusive_between_processes(monkeypatch, tmp_path):
-    # Two subprocesses race for the lock; the second must wait rather than run
-    # alongside the first.
-    import subprocess
-    import sys
+def _lock_race_child(tmp_path, body):
+    """A child script that takes the lock on the same file this test uses.
+
+    The path comes through PYTHONPATH rather than being computed inside the
+    script: this is a src layout, so deriving it from helpers.__file__ is one
+    parents[] index away from a ModuleNotFoundError on a fresh checkout, and it
+    only worked here because an editable install happened to be on the path.
+    """
     import textwrap
 
-    script = textwrap.dedent(f"""
-        import sys, time
-        sys.path.insert(0, {str(__import__('pathlib').Path(helpers.__file__).parents[2])!r})
+    src = tmp_path / f"child_{abs(hash(body)) % 10000}.py"
+    src.write_text(textwrap.dedent(f"""
+        import pathlib, sys, time
         from browser_harness import helpers
-        helpers._owned_tab_path = lambda: __import__('pathlib').Path({str(tmp_path / 'agent-tab')!r})
-        hold = sys.argv[1] == 'hold'
+        helpers._owned_tab_path = lambda: pathlib.Path({str(tmp_path / 'agent-tab')!r})
+        {body}
+    """))
+    return src
+
+
+def _child_env():
+    import sys
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
+    return env
+
+
+def test_owned_tab_lock_is_exclusive_between_processes(tmp_path):
+    import subprocess
+    import sys
+
+    holder = _lock_race_child(tmp_path, """
         with helpers._owned_tab_lock(wait=5.0):
             print(time.time(), flush=True)
-            if hold:
-                time.sleep(1.0)
+            time.sleep(1.0)
         print(time.time(), flush=True)
     """)
-    src = tmp_path / "race.py"
-    src.write_text(script)
+    waiter = _lock_race_child(tmp_path, """
+        with helpers._owned_tab_lock(wait=5.0):
+            print(time.time(), flush=True)
+        print(time.time(), flush=True)
+    """)
 
-    a = subprocess.Popen([sys.executable, str(src), "hold"], stdout=subprocess.PIPE, text=True)
+    env = _child_env()
+    a = subprocess.Popen([sys.executable, str(holder)], stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, text=True, env=env)
     time.sleep(0.3)
-    b = subprocess.Popen([sys.executable, str(src), "wait"], stdout=subprocess.PIPE, text=True)
-    a_out = a.communicate()[0].split()
-    b_out = b.communicate()[0].split()
+    b = subprocess.Popen([sys.executable, str(waiter)], stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, text=True, env=env)
+    a_out, a_err = a.communicate(timeout=30)
+    b_out, b_err = b.communicate(timeout=30)
+    assert a.returncode == 0, a_err
+    assert b.returncode == 0, b_err
 
-    a_enter, a_exit = float(a_out[0]), float(a_out[1])
-    b_enter = float(b_out[0])
+    a_exit = float(a_out.split()[1])
+    b_enter = float(b_out.split()[0])
     assert b_enter >= a_exit - 0.05, "second process entered while the first held the lock"
 
 
 def test_owned_tab_lock_is_released_when_the_holder_dies(monkeypatch, tmp_path):
-    # The kernel drops an advisory lock on exit, so a killed holder cannot
-    # wedge the next caller. This is the property the stamp-and-pid version
-    # had to reason about and this one gets for free.
+    # The kernel drops an advisory lock on exit, so a killed holder cannot wedge
+    # the next caller. This is the property the earlier stamp-and-pid version had
+    # to reason about and this one gets for free.
     import subprocess
     import sys
-    import textwrap
 
-    script = textwrap.dedent(f"""
-        import sys, time
-        sys.path.insert(0, {str(__import__('pathlib').Path(helpers.__file__).parents[2])!r})
-        from browser_harness import helpers
-        helpers._owned_tab_path = lambda: __import__('pathlib').Path({str(tmp_path / 'agent-tab')!r})
+    holder = _lock_race_child(tmp_path, """
         with helpers._owned_tab_lock(wait=5.0):
             print("in", flush=True)
             time.sleep(30)
     """)
-    src = tmp_path / "holder.py"
-    src.write_text(script)
-
-    holder = subprocess.Popen([sys.executable, str(src)], stdout=subprocess.PIPE, text=True)
-    assert holder.stdout.readline().strip() == "in"
-    holder.kill()
-    holder.wait()
+    proc = subprocess.Popen([sys.executable, str(holder)], stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, text=True, env=_child_env())
+    try:
+        assert proc.stdout.readline().strip() == "in", proc.stderr.read()
+    finally:
+        proc.kill()
+        proc.wait(timeout=30)
 
     monkeypatch.setattr(helpers, "_owned_tab_path", lambda: tmp_path / "agent-tab")
     started = time.time()

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -510,17 +510,22 @@ def test_owned_tab_path_rejects_a_traversing_bu_name(monkeypatch, tmp_path):
         helpers._owned_tab_path()
 
 
-def _lock_race_child(tmp_path, body):
+def _lock_race_child(tmp_path, name, body):
     """A child script that takes the lock on the same file this test uses.
 
     The path comes through PYTHONPATH rather than being computed inside the
     script: this is a src layout, so deriving it from helpers.__file__ is one
     parents[] index away from a ModuleNotFoundError on a fresh checkout, and it
     only worked here because an editable install happened to be on the path.
+
+    `name` is given by the caller. Deriving it from the body via hash() would be
+    PYTHONHASHSEED-randomised and could collide, and a collision would have both
+    children run the same body and quietly make the exclusivity assertion
+    vacuous.
     """
     import textwrap
 
-    src = tmp_path / f"child_{abs(hash(body)) % 10000}.py"
+    src = tmp_path / f"child_{name}.py"
     src.write_text(textwrap.dedent(f"""
         import pathlib, sys, time
         from browser_harness import helpers
@@ -542,32 +547,37 @@ def test_owned_tab_lock_is_exclusive_between_processes(tmp_path):
     import subprocess
     import sys
 
-    holder = _lock_race_child(tmp_path, """
+    # The holder announces that it is inside before it starts holding, so the
+    # waiter is launched on that signal rather than on a sleep the machine has
+    # to be fast enough to honour.
+    holder = _lock_race_child(tmp_path, "holder", """
         with helpers._owned_tab_lock(wait=5.0):
-            print(time.time(), flush=True)
+            print("held", flush=True)
             time.sleep(1.0)
         print(time.time(), flush=True)
     """)
-    waiter = _lock_race_child(tmp_path, """
+    waiter = _lock_race_child(tmp_path, "waiter", """
         with helpers._owned_tab_lock(wait=5.0):
             print(time.time(), flush=True)
-        print(time.time(), flush=True)
     """)
 
     env = _child_env()
     a = subprocess.Popen([sys.executable, str(holder)], stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE, text=True, env=env)
-    time.sleep(0.3)
-    b = subprocess.Popen([sys.executable, str(waiter)], stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE, text=True, env=env)
-    a_out, a_err = a.communicate(timeout=30)
-    b_out, b_err = b.communicate(timeout=30)
+    try:
+        assert a.stdout.readline().strip() == "held", a.stderr.read()
+        b = subprocess.Popen([sys.executable, str(waiter)], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, text=True, env=env)
+        a_out, a_err = a.communicate(timeout=30)
+        b_out, b_err = b.communicate(timeout=30)
+    finally:
+        a.kill()
     assert a.returncode == 0, a_err
     assert b.returncode == 0, b_err
 
-    a_exit = float(a_out.split()[1])
-    b_enter = float(b_out.split()[0])
-    assert b_enter >= a_exit - 0.05, "second process entered while the first held the lock"
+    a_released = float(a_out.split()[0])
+    b_entered = float(b_out.split()[0])
+    assert b_entered >= a_released - 0.05, "second process entered while the first held the lock"
 
 
 def test_owned_tab_lock_is_released_when_the_holder_dies(monkeypatch, tmp_path):
@@ -577,15 +587,15 @@ def test_owned_tab_lock_is_released_when_the_holder_dies(monkeypatch, tmp_path):
     import subprocess
     import sys
 
-    holder = _lock_race_child(tmp_path, """
+    holder = _lock_race_child(tmp_path, "dying_holder", """
         with helpers._owned_tab_lock(wait=5.0):
-            print("in", flush=True)
+            print("held", flush=True)
             time.sleep(30)
     """)
     proc = subprocess.Popen([sys.executable, str(holder)], stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, text=True, env=_child_env())
     try:
-        assert proc.stdout.readline().strip() == "in", proc.stderr.read()
+        assert proc.stdout.readline().strip() == "held", proc.stderr.read()
     finally:
         proc.kill()
         proc.wait(timeout=30)


### PR DESCRIPTION
## The problem

`new_tab` opens a window per call. An agent sweeping a search result set calls it
in a loop, so a twenty page sweep leaves twenty tabs behind. In our use the user
closed dozens by hand twice in two days.

Telling the agent not to do it does not hold. A prompt is a request, and the loop
is in the code.

## The change

`new_tab(url)` now navigates a tab this harness already owns, and only creates a
target when there is nothing to reuse. `force=True` is there for the cases that
genuinely need a second tab, side by side comparison or a popup flow.

A tab the user opened is never taken over: reuse happens only for a tab the
harness itself opened, or for the attached tab when it is blank, which is the
behaviour that was already there.

## Why ownership is a file

Two simpler options do not work, and both fail in a way that looks fine at first.

Module state cannot carry it. Each heredoc invocation is a fresh process, so the
record is gone before the next call.

The title marker cannot carry it either. `_mark_tab` writes the horse prefix, but
`goto_url` triggers a load and the page replaces `document.title`, taking the
marker with it. A marker-based version reuses exactly once and then opens a tab
per page again, which is worse than no fix because it looks like it works.

So ownership lives in `config_dir()/agent-tab`, which survives both.

## Tests

Five cases, one per branch: reuse the recorded tab, record a newly created tab,
leave a user tab alone, create again when the recorded tab was closed, honour
`force`. The third is the one that catches the marker-based version.

`pytest tests/unit` passes, 128 tests.

## Verified against a live Chrome

Five navigations in one process, then three more in separate processes, all land
on one target with the tab count unchanged.

```
tabs before: 18
  https://example.com                     tabs=19  tid=02E32278C5FD
  https://example.org                     tabs=19  tid=02E32278C5FD
  https://www.iana.org/domains/reserved   tabs=19  tid=02E32278C5FD
  https://example.com/index.html          tabs=19  tid=02E32278C5FD
  https://www.rfc-editor.org/rfc/rfc2606  tabs=19  tid=02E32278C5FD
distinct tabs used: 1
```

Before the change the same loop produced five tabs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses a single agent-owned tab per daemon instead of opening a new tab on every call, reducing tab bloat and preventing cross-daemon interference. Previously each `new_tab` created a tab; now `new_tab(url)` navigates the owned tab and only creates when reuse is not possible.

- Behavior
  - For real URLs: reuse a live owned tab; otherwise reuse the attached tab if it is blank; otherwise create and record a new owned tab.
  - For `about:blank` or when `force=True`: always create a fresh tab.
  - Never takes over user tabs; only reuses a recorded owned tab or a blank attached tab.
  - Ownership is scoped per daemon under `config_dir()/agent-tab-{BU_NAME}` and is recreated if the recorded tab no longer exists.
  - Updates `interaction-skills/tabs.md` to instruct agents to loop on `new_tab(url)`, use `force=True` when two tabs are needed, and note that user tabs are never taken over.

- Concurrency and tests
  - Serializes select-or-create with a kernel advisory lock (flock on POSIX, `msvcrt.locking` on Windows); proceeds unlocked if not acquired within 5s; the OS releases the lock on process exit.
  - Tests cover reuse vs create, user-tab respect, per-daemon scoping, `force`, cross-process exclusivity, killed-holder release, proceed-unlocked fallback, and concurrent calls sharing one created tab. Subprocess tests inherit `PYTHONPATH`, use named child scripts to avoid `PYTHONHASHSEED` collisions, and launch the waiter on the holder’s “held” signal.

<sup>Written for commit 98f951506944ee9e39e1b71c06068bea23679200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

