### PR TITLE
docs: add YouTube transcript extraction playbook

### DIFF
--- a/domain-skills/youtube/playback.md
+++ b/domain-skills/youtube/playback.md
@@ -1,0 +1,102 @@
+# YouTube playback and transcript extraction
+
+Use this playbook for public desktop video pages when you need reliable metadata or the visible transcript. YouTube lazy-renders the transcript control, so a newly loaded watch page usually does not expose it until the description is expanded.
+
+## Open and hydrate the watch page
+
+Open a new tab rather than replacing the user's active tab, then give the Polymer app a few seconds to hydrate.
+
+```python
+tab = new_tab("https://www.youtube.com/watch?v=<VIDEO_ID>")
+wait_for_load(tab)
+wait(4)
+```
+
+Keep using `target_id=tab` for later calls. YouTube pages can create or reuse additional targets, and target-free JavaScript may otherwise run in a different watch tab.
+
+## Read stable metadata
+
+The hydrated player response is more stable than scraping rendered title and channel elements:
+
+```python
+metadata = js("""
+(() => {
+  const response = window.ytInitialPlayerResponse;
+  if (!response) return null;
+  const details = response.videoDetails || {};
+  const microformat = response.microformat?.playerMicroformatRenderer || {};
+  return {
+    id: details.videoId,
+    title: details.title,
+    author: details.author,
+    duration_seconds: Number(details.lengthSeconds || 0),
+    views: Number(details.viewCount || 0),
+    publish_date: microformat.publishDate || null,
+    description: details.shortDescription || "",
+    caption_tracks:
+      response.captions?.playerCaptionsTracklistRenderer?.captionTracks || []
+  };
+})()
+""", target_id=tab)
+```
+
+If the response is briefly absent, wait for hydration and retry before falling back to DOM scraping.
+
+## Open the transcript panel
+
+1. Expand the description using the visible `#expand` control. YouTube may keep hidden duplicates in the DOM, so filter by rendered geometry.
+2. After expansion, find a leaf whose trimmed text is exactly `Show transcript`; click its closest semantic button.
+3. Wait for the side panel to render.
+
+```python
+js("""
+(() => {
+  const expand = [...document.querySelectorAll('tp-yt-paper-button#expand')]
+    .find(el => el.getClientRects().length);
+  if (!expand) return false;
+  expand.click();
+  return true;
+})()
+""", target_id=tab)
+wait(1)
+
+js("""
+(() => {
+  const leaf = [...document.querySelectorAll('body *')]
+    .find(el => el.children.length === 0 &&
+      el.textContent.trim() === 'Show transcript' &&
+      el.getClientRects().length);
+  const button = leaf?.closest('button, tp-yt-paper-button');
+  if (!button) return false;
+  button.click();
+  return true;
+})()
+""", target_id=tab)
+wait(2)
+```
+
+Avoid coordinate clicks here. The description height and transcript-button position vary with viewport, localization, experiments, and description length.
+
+## Extract the rendered transcript
+
+For the standard English desktop UI, the panel text begins at `Transcript\nSearch transcript`. Reading `innerText` after the panel opens returns the timestamps and caption lines in display order:
+
+```python
+transcript = js("""
+(() => {
+  const text = document.body.innerText;
+  const marker = 'Transcript\\nSearch transcript';
+  const start = text.indexOf(marker);
+  return start >= 0 ? text.slice(start) : null;
+})()
+""", target_id=tab)
+```
+
+Treat auto-generated captions as fallible, especially for names, dates, numbers, and technical terms. Preserve timestamps when a questionable claim needs to be checked against the audio.
+
+## Common failure modes
+
+- `Show transcript` is missing: expand the description first, then wait for the action row to render.
+- JavaScript returns metadata from the wrong video: pass the watch tab's `target_id` on every call.
+- A hidden duplicate receives the click: require `getClientRects().length` for both the expansion control and transcript text leaf.
+- The marker is absent: the UI may be localized, captions may be unavailable, or the panel may still be loading. Inspect the screenshot before changing selectors.


### PR DESCRIPTION
Documents stable YouTube metadata extraction and the lazy-rendered transcript-panel workflow, including target selection and hidden-element traps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a playbook for reliably extracting YouTube metadata and the visible transcript on desktop watch pages. It documents a lazy-render-aware flow to avoid flaky selectors and hidden-element clicks.

- Use `window.ytInitialPlayerResponse` for id, title, author, duration, views, publish_date, description, and caption_tracks; retry after hydration before falling back to DOM.
- Open the video in a new tab and pass that tab’s `target_id` to every JS call to avoid cross-target reads.
- Expand the description via the visible `#expand`, then click the nearest button to a leaf with text exactly `Show transcript`; require `getClientRects().length` to skip hidden duplicates.
- Avoid coordinate clicks; wait for the panel to render, then read `innerText` starting at `Transcript\nSearch transcript`.
- Handle localization or missing captions; inspect a screenshot before adjusting selectors.

<sup>Written for commit 93687b0d5baadcc0127206a3cdba9fb0c49c07aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

