### PR TITLE
fix(linux): discover and prefer native Brave

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -815,10 +815,20 @@ def _chrome_running():
     try:
         if system == "Windows":
             out = subprocess.check_output(["tasklist"], text=True, errors="replace", timeout=5)
-            names = ("chrome.exe", "msedge.exe", "helium.exe")
+            names = ("chrome.exe", "msedge.exe", "brave.exe", "helium.exe")
         else:
             out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, errors="replace", timeout=5)
-            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium")
+            names = (
+                "Google Chrome",
+                "chrome",
+                "chromium",
+                "Microsoft Edge",
+                "msedge",
+                "Brave Browser",
+                "brave-browser",
+                "brave",
+                "helium",
+            )
         return any(n.lower() in out.lower() for n in names)
     except Exception:
         return False
@@ -837,7 +847,15 @@ _BROWSER_LAUNCH = (
 )
 _DEFAULT_LAUNCH = (
     "Google Chrome",
-    ("google-chrome-stable", "google-chrome", "chromium", "chromium-browser", "microsoft-edge"),
+    (
+        "google-chrome-stable",
+        "google-chrome",
+        "chromium",
+        "chromium-browser",
+        "brave-browser",
+        "brave",
+        "microsoft-edge",
+    ),
     "chrome",
 )
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -51,6 +51,7 @@ _LINUX_PROFILES = (
     ".config/google-chrome",
     ".config/chromium",
     ".config/chromium-browser",
+    ".config/BraveSoftware/Brave-Browser",
     ".config/microsoft-edge",
     ".config/microsoft-edge-beta",
     ".config/microsoft-edge-dev",

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -160,6 +160,34 @@ def test_chrome_running_detects_helium_on_linux(monkeypatch):
     assert admin._chrome_running()
 
 
+@pytest.mark.parametrize("process_name", ["brave", "brave-browser", "Brave Browser"])
+def test_chrome_running_detects_brave_on_linux(monkeypatch, process_name):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *args, **kwargs: f"systemd\n{process_name}\nxdg-desktop-portal\n",
+    )
+
+    assert admin._chrome_running()
+
+
+def test_chrome_running_detects_brave_on_windows(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda *args, **kwargs: "Image Name\nbrave.exe\n",
+    )
+
+    assert admin._chrome_running()
+
+
+def test_default_linux_launch_prefers_brave_before_edge():
+    commands = admin._DEFAULT_LAUNCH[1]
+
+    assert commands.index("brave-browser") < commands.index("microsoft-edge")
+    assert commands.index("brave") < commands.index("microsoft-edge")
+
+
 @pytest.mark.parametrize(
     "path, expected",
     [

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,8 +1,18 @@
 import asyncio
+from pathlib import Path
 
 import pytest
 
 from browser_harness import daemon
+
+
+def test_linux_profile_dirs_include_native_brave_before_edge():
+    profiles = daemon.profile_dirs("Linux")
+    native_brave = Path.home() / ".config/BraveSoftware/Brave-Browser"
+    native_edge = Path.home() / ".config/microsoft-edge"
+
+    assert native_brave in profiles
+    assert profiles.index(native_brave) < profiles.index(native_edge)
 
 
 class _FakeCDP:


### PR DESCRIPTION
## Summary

- discover native Linux Brave profiles at `~/.config/BraveSoftware/Brave-Browser`
- recognize Brave process names in the running-browser check
- prefer Brave before the existing Edge fallback when no discovered profile selects a browser
- keep Chrome, Chromium, Flatpak Brave, and Edge discovery behavior unchanged

## Why

Native Brave packages use a profile path that Browser Harness did not scan. As a result, a logged-in Brave profile with a live `DevToolsActivePort` could be skipped and a different installed browser selected.

This fills the Linux-native gap previously proposed in #135 and #160. It also includes a current-main, tested implementation of the process-detection change proposed in #287 and #432, which are currently merge-conflicted.

## Tests

- `uv run --with pytest pytest -q` (146 passed)
- `uv build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects native Brave on Linux and prefers it over Edge when no profile is explicitly selected. Previously we didn’t scan the native Brave profile directory, so a running Brave session could be skipped and another browser chosen.

- Scan `~/.config/BraveSoftware/Brave-Browser` and order it before the Edge profile directory.
- Recognize Brave processes in the running-browser check (Linux: `Brave Browser`, `brave-browser`, `brave`; Windows: `brave.exe`).
- Add `brave-browser` and `brave` to the default launch commands before `microsoft-edge`.
- Add unit tests covering Brave detection and preference ordering.

<sup>Written for commit b64d6e685722f675bdb1ac17e3b06d9cc3fbb394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

