### PR TITLE
fix(windows): open chrome://inspect via the browser, not the shell

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -911,11 +911,50 @@ def _launch_browser():
         return False
 
 
+def _windows_chrome_exe():
+    """Path to a Chromium-family exe on Windows, or None.
+
+    `chrome:` is NOT a registered Windows protocol (AssocQueryStringW returns
+    ERROR_NO_ASSOCIATION / 0x80070483) — it is an internal Chromium scheme.
+    Handing `chrome://inspect` to the shell therefore pops Windows' "Get an app
+    to open this 'chrome' link" / Microsoft Store picker instead of opening a
+    tab. Passing the same URL to chrome.exe as an ARGUMENT works fine, so we
+    need the binary itself.
+    """
+    import os as _os, shutil
+    for key in ("BH_CHROME_PATH", "CHROME_PATH"):
+        raw = (_os.environ.get(key) or "").strip()
+        if raw and Path(raw).expanduser().is_file():
+            return str(Path(raw).expanduser())
+    for name in ("chrome.exe", "chromium.exe", "brave.exe", "msedge.exe"):
+        found = shutil.which(name)
+        if found:
+            return found
+    bases = (
+        _os.environ.get("ProgramFiles"),
+        _os.environ.get("ProgramFiles(x86)"),
+        _os.environ.get("LOCALAPPDATA"),
+    )
+    parts = (
+        ("Google", "Chrome", "Application", "chrome.exe"),
+        ("Chromium", "Application", "chrome.exe"),
+        ("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+        ("Microsoft", "Edge", "Application", "msedge.exe"),
+    )
+    for base in filter(None, bases):
+        for tail in parts:
+            candidate = Path(base, *tail)
+            if candidate.is_file():
+                return str(candidate)
+    return None
+
+
 def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
     import platform, subprocess, webbrowser
     url = "chrome://inspect/#remote-debugging"
-    if platform.system() == "Darwin":
+    system = platform.system()
+    if system == "Darwin":
         try:
             r = subprocess.run([
                 "osascript",
@@ -926,6 +965,23 @@ def _open_chrome_inspect():
                 return True
         except Exception:
             pass
+    if system == "Windows":
+        # NEVER hand `chrome://` to the Windows shell (webbrowser.open ->
+        # WindowsDefault -> os.startfile -> ShellExecute): the scheme has no
+        # registered handler, so the user gets the "Get an app to open this
+        # 'chrome' link" Store dialog instead of the inspect page. Spawn the
+        # browser binary with the URL as an argv instead.
+        exe = _windows_chrome_exe()
+        if not exe:
+            return False
+        try:
+            subprocess.Popen(
+                [exe, url],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
+            )
+            return True
+        except (OSError, subprocess.SubprocessError):
+            return False
     try:
         return bool(webbrowser.open(url, new=2))
     except Exception:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -911,8 +911,8 @@ def _launch_browser():
         return False
 
 
-def _windows_chrome_exe():
-    """Path to a Chromium-family exe on Windows, or None.
+def _windows_chrome_exes():
+    """Yield Chromium-family binaries on Windows, best candidate first.
 
     `chrome:` is NOT a registered Windows protocol (AssocQueryStringW returns
     ERROR_NO_ASSOCIATION / 0x80070483) — it is an internal Chromium scheme.
@@ -920,19 +920,31 @@ def _windows_chrome_exe():
     to open this 'chrome' link" / Microsoft Store picker instead of opening a
     tab. Passing the same URL to chrome.exe as an ARGUMENT works fine, so we
     need the binary itself.
+
+    Yields every candidate rather than just the first so a path that exists
+    but cannot execute falls through to the remaining ones, matching
+    _launch_browser().
     """
     import os as _os, shutil
+    seen = set()
     for key in ("BH_CHROME_PATH", "CHROME_PATH"):
         raw = (_os.environ.get(key) or "").strip()
         if raw and Path(raw).expanduser().is_file():
-            return str(Path(raw).expanduser())
+            candidate = str(Path(raw).expanduser())
+            if candidate not in seen:
+                seen.add(candidate)
+                yield candidate
     for name in ("chrome.exe", "chromium.exe", "brave.exe", "msedge.exe"):
         found = shutil.which(name)
-        if found:
-            return found
+        if found and found not in seen:
+            seen.add(found)
+            yield found
     bases = (
         _os.environ.get("ProgramFiles"),
         _os.environ.get("ProgramFiles(x86)"),
+        # A 32-bit Python sees ProgramFiles as "...(x86)"; ProgramW6432 is the
+        # only way it can reach a system-wide 64-bit install.
+        _os.environ.get("ProgramW6432"),
         _os.environ.get("LOCALAPPDATA"),
     )
     parts = (
@@ -945,8 +957,10 @@ def _windows_chrome_exe():
         for tail in parts:
             candidate = Path(base, *tail)
             if candidate.is_file():
-                return str(candidate)
-    return None
+                resolved = str(candidate)
+                if resolved not in seen:
+                    seen.add(resolved)
+                    yield resolved
 
 
 def _open_chrome_inspect():
@@ -971,17 +985,17 @@ def _open_chrome_inspect():
         # registered handler, so the user gets the "Get an app to open this
         # 'chrome' link" Store dialog instead of the inspect page. Spawn the
         # browser binary with the URL as an argv instead.
-        exe = _windows_chrome_exe()
-        if not exe:
-            return False
-        try:
-            subprocess.Popen(
-                [exe, url],
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
-            )
-            return True
-        except (OSError, subprocess.SubprocessError):
-            return False
+        for exe in _windows_chrome_exes():
+            try:
+                subprocess.Popen(
+                    [exe, url],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
+                )
+                return True
+            except (OSError, subprocess.SubprocessError):
+                # Exists but won't execute (permissions, wrong arch): try the next.
+                continue
+        return False
     try:
         return bool(webbrowser.open(url, new=2))
     except Exception:

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,3 +1,7 @@
+import platform
+import subprocess
+import webbrowser
+
 import pytest
 
 from browser_harness import admin
@@ -46,6 +50,48 @@ def test_stale_websocket_does_not_open_chrome_inspect():
     msg = "no close frame received or sent"
 
     assert not admin._needs_chrome_remote_debugging_prompt(msg)
+
+
+def test_windows_open_chrome_inspect_spawns_browser_instead_of_shell(monkeypatch):
+    """`chrome:` has no Windows protocol handler.
+
+    Dispatching it through the shell (webbrowser -> os.startfile -> ShellExecute)
+    raises the "Get an app to open this 'chrome' link" Store picker instead of
+    opening the page, so the URL must be passed to the browser as an argument.
+    """
+    spawned = []
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(admin, "_windows_chrome_exe", lambda: r"C:\chrome.exe")
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kw: spawned.append(cmd))
+    monkeypatch.setattr(
+        webbrowser,
+        "open",
+        lambda *a, **kw: pytest.fail("chrome:// must never reach the Windows shell"),
+    )
+
+    assert admin._open_chrome_inspect()
+    assert spawned == [[r"C:\chrome.exe", "chrome://inspect/#remote-debugging"]]
+
+
+def test_windows_open_chrome_inspect_reports_failure_without_browser(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(admin, "_windows_chrome_exe", lambda: None)
+    monkeypatch.setattr(
+        webbrowser,
+        "open",
+        lambda *a, **kw: pytest.fail("chrome:// must never reach the Windows shell"),
+    )
+
+    assert not admin._open_chrome_inspect()
+
+
+def test_windows_chrome_exe_prefers_env_override(tmp_path, monkeypatch):
+    exe = tmp_path / "chrome.exe"
+    exe.touch()
+    monkeypatch.setenv("BH_CHROME_PATH", str(exe))
+
+    assert admin._windows_chrome_exe() == str(exe)
 
 
 def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,4 +1,5 @@
 import platform
+import shutil
 import subprocess
 import webbrowser
 
@@ -62,7 +63,7 @@ def test_windows_open_chrome_inspect_spawns_browser_instead_of_shell(monkeypatch
     spawned = []
 
     monkeypatch.setattr(platform, "system", lambda: "Windows")
-    monkeypatch.setattr(admin, "_windows_chrome_exe", lambda: r"C:\chrome.exe")
+    monkeypatch.setattr(admin, "_windows_chrome_exes", lambda: iter([r"C:\chrome.exe"]))
     monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kw: spawned.append(cmd))
     monkeypatch.setattr(
         webbrowser,
@@ -74,9 +75,28 @@ def test_windows_open_chrome_inspect_spawns_browser_instead_of_shell(monkeypatch
     assert spawned == [[r"C:\chrome.exe", "chrome://inspect/#remote-debugging"]]
 
 
+def test_windows_open_chrome_inspect_falls_through_to_next_candidate(monkeypatch):
+    """A path that exists but cannot execute must not abort discovery."""
+    spawned = []
+
+    def fake_popen(cmd, **kw):
+        if cmd[0] == r"C:roken.exe":
+            raise OSError(8, "Exec format error")
+        spawned.append(cmd)
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        admin, "_windows_chrome_exes", lambda: iter([r"C:roken.exe", r"C:\chrome.exe"])
+    )
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    assert admin._open_chrome_inspect()
+    assert spawned == [[r"C:\chrome.exe", "chrome://inspect/#remote-debugging"]]
+
+
 def test_windows_open_chrome_inspect_reports_failure_without_browser(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
-    monkeypatch.setattr(admin, "_windows_chrome_exe", lambda: None)
+    monkeypatch.setattr(admin, "_windows_chrome_exes", lambda: iter([]))
     monkeypatch.setattr(
         webbrowser,
         "open",
@@ -86,12 +106,28 @@ def test_windows_open_chrome_inspect_reports_failure_without_browser(monkeypatch
     assert not admin._open_chrome_inspect()
 
 
-def test_windows_chrome_exe_prefers_env_override(tmp_path, monkeypatch):
+def test_windows_chrome_exes_prefers_env_override(tmp_path, monkeypatch):
     exe = tmp_path / "chrome.exe"
     exe.touch()
     monkeypatch.setenv("BH_CHROME_PATH", str(exe))
 
-    assert admin._windows_chrome_exe() == str(exe)
+    assert next(admin._windows_chrome_exes()) == str(exe)
+
+
+def test_windows_chrome_exes_searches_programw6432_for_32bit_python(tmp_path, monkeypatch):
+    """A 32-bit Python sees ProgramFiles as "...(x86)"; only ProgramW6432 reaches
+    a system-wide 64-bit install."""
+    exe = tmp_path / "Google" / "Chrome" / "Application" / "chrome.exe"
+    exe.parent.mkdir(parents=True)
+    exe.touch()
+
+    monkeypatch.delenv("BH_CHROME_PATH", raising=False)
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setenv("ProgramFiles", str(tmp_path / "missing-x86"))
+    monkeypatch.setenv("ProgramW6432", str(tmp_path))
+
+    assert str(exe) in list(admin._windows_chrome_exes())
 
 
 def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

On Windows, the remote-debugging setup path pops a **"Get an app to open this 'chrome' link"** Store picker instead of opening the inspect page.

`_open_chrome_inspect()` hands `chrome://inspect/#remote-debugging` to `webbrowser.open()`. On Windows that resolves to `WindowsDefault` → `os.startfile()` → `ShellExecute`. But `chrome:` is **not** a registered Windows protocol — it is an internal Chromium scheme, so the shell has nothing to dispatch to:

```python
>>> AssocQueryStringW(ASSOCF_IS_PROTOCOL, ASSOCSTR_COMMAND, "chrome", ...)
0x80070483  # ERROR_NO_ASSOCIATION
>>> # ...while http/https resolve fine:
'"C:\Program Files\Google\Chrome\Application\chrome.exe" --single-argument %1'
```

Windows spawns `OpenWith.exe` and the user gets the dialog.

The failure is **silent to the caller**: `webbrowser.open()` returns `True` and `os.startfile()` raises nothing, so the harness records success and moves on while the user stares at a Store picker. `_open_chrome_inspect_once()` then touches the marker file, suppressing retries for `INSPECT_REOPEN_TTL`.

This is a bad moment for it to fail: it fires from the `remote-debugging-setup` branch, which raises a `RuntimeError` telling the user to tick "Allow remote debugging for this browser instance" — on a page they can no longer reach.

## Fix

Chromium accepts `chrome://` URLs as an argv entry, so on Windows resolve a Chromium-family binary and spawn it directly instead of going through the shell.

Discovery mirrors the existing `_launch_browser()` precedence: `BH_CHROME_PATH` / `CHROME_PATH`, then `PATH`, then the standard install dirs for Chrome, Chromium, Brave and Edge.

macOS and Linux behaviour is unchanged.

## Verification

Reproduced and verified on Windows 11, Chrome 144, `browser-harness` 0.1.9:

- **Before** — `_open_chrome_inspect()` returns `True`, `OpenWith.exe` appears, no inspect page.
- **After** — `_open_chrome_inspect()` returns `True`, Chrome opens the page, no `OpenWith.exe`.

Three regression tests added. They fail without the source change (`AttributeError: no attribute '_windows_chrome_exe'`) and pass with it; the shell path is stubbed with `pytest.fail` so a regression that reaches `webbrowser.open` is caught rather than silently passing.

```
tests/unit/test_admin.py -k windows    3 passed
tests/unit                           123 passed, 3 failed
```

The 3 failures are pre-existing on Windows and unrelated (`test_doctor_probe_preserves_snap_bin_*` are Linux/snap symlink tests, plus `test_packaged_skill_frontmatter_is_valid_simple_yaml`). Baseline on `main` without this patch is identical: 120 passed, the same 3 failed.
