### PR TITLE
feat: add pt-BR AI dubbing to video export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 # Copy to .env — auto-loaded. Only needed for remote browsers.
 BROWSER_USE_API_KEY=bu_your_key_here
+
+# Only needed for `browser-harness video export --dub` (pt-BR narration dubbing).
+ELEVENLABS_API_KEY=sk_your_key_here
+# Optional: override the default stock voice.
+# ELEVENLABS_VOICE_ID=EXAVITQu4vr4xnSDxMaL

--- a/interaction-skills/make-video.md
+++ b/interaction-skills/make-video.md
@@ -22,6 +22,20 @@ checkout use `./browser-harness`. Never edit generated `composition.js` or
 `video.html`; change the brief or shared implementation. Export never
 overwrites an existing video, so use `--output video-v2.mp4` for another cut.
 
+## Dubbing (fork addition)
+
+Add `--dub` to `video export` to synthesize a pt-BR speech track for the sticky
+`narration` text via ElevenLabs, muxed into the MP4 in place of silence:
+
+```bash
+browser-harness video export <recording> --reviewed --dub
+```
+
+Requires `ELEVENLABS_API_KEY` (set in `.env` or exported); `ELEVENLABS_VOICE_ID`
+optionally overrides the stock voice. Only the action beats' narration is
+voiced — one clip per sticky span, timed to start exactly when that text first
+appears on screen — not the intro/outcome cards. See `dubbing.py`.
+
 ## Cut
 
 - Optimize for first-time comprehension; the raw trace is the debugging

--- a/src/browser_harness/dubbing.py
+++ b/src/browser_harness/dubbing.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""AI dubbing for exported videos: turns each beat's sticky narration text into a
+Portuguese (BR) speech track via ElevenLabs, timed to match the compiled composition."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+ELEVENLABS_TTS_URL = "https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+DEFAULT_MODEL_ID = "eleven_multilingual_v2"
+# "Bella" — a stock ElevenLabs voice that handles pt-BR cleanly via the multilingual model.
+DEFAULT_VOICE_ID = "EXAVITQu4vr4xnSDxMaL"
+
+
+class DubbingError(RuntimeError):
+    pass
+
+
+def api_key() -> str:
+    key = os.environ.get("ELEVENLABS_API_KEY")
+    if not key:
+        raise DubbingError(
+            "ELEVENLABS_API_KEY not set; add it to .env (see .env.example) or export it "
+            "before running video export --dub"
+        )
+    return key
+
+
+def voice_id() -> str:
+    return os.environ.get("ELEVENLABS_VOICE_ID") or DEFAULT_VOICE_ID
+
+
+def synthesize_clip(text: str, out_path: Path) -> None:
+    """Call the ElevenLabs TTS API and write the returned mp3 to out_path."""
+    url = ELEVENLABS_TTS_URL.format(voice_id=voice_id())
+    payload = json.dumps(
+        {
+            "text": text,
+            "model_id": DEFAULT_MODEL_ID,
+            "language_code": "pt",
+            "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "xi-api-key": api_key(),
+            "Content-Type": "application/json",
+            "Accept": "audio/mpeg",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            out_path.write_bytes(response.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise DubbingError(f"ElevenLabs TTS failed ({exc.code}): {body}") from exc
+    except urllib.error.URLError as exc:
+        raise DubbingError(f"ElevenLabs TTS request failed: {exc}") from exc
+
+
+def narration_segments(composition: dict[str, Any]) -> list[tuple[float, float, str]]:
+    """Collapse sticky narration text across action beats into (start, end, text)
+    spans — a narration line covers every beat until the next one sets new text,
+    mirroring what the viewer actually sees on screen."""
+    segments: list[tuple[float, float, str]] = []
+    t = 0.0
+    current_text: str | None = None
+    current_start = 0.0
+    for beat in composition.get("beats") or []:
+        dur = float(beat.get("dur") or 0)
+        if not beat.get("card"):
+            narration = beat.get("narration")
+            if narration:
+                if current_text:
+                    segments.append((current_start, t, current_text))
+                current_text = narration
+                current_start = t
+        t += dur
+    if current_text:
+        segments.append((current_start, t, current_text))
+    return segments
+
+
+def build_narration_track(recording: Path, composition: dict[str, Any], total_duration: float) -> Path:
+    """Synthesize one clip per narration span and mix them into a single WAV track
+    exactly total_duration seconds long, each clip starting at its beat's timestamp."""
+    segments = narration_segments(composition)
+    track_path = recording / "narration-track.wav"
+
+    if not segments:
+        subprocess.run(
+            [
+                "ffmpeg", "-v", "error", "-y", "-f", "lavfi",
+                "-i", f"anullsrc=r=44100:cl=stereo:d={total_duration:.3f}",
+                str(track_path),
+            ],
+            check=True,
+        )
+        return track_path
+
+    tmp_dir = recording / ".dub-tmp"
+    tmp_dir.mkdir(exist_ok=True)
+    clips: list[tuple[float, Path]] = []
+    for index, (start, _end, text) in enumerate(segments):
+        clip_path = tmp_dir / f"seg-{index:02d}.mp3"
+        synthesize_clip(text, clip_path)
+        clips.append((start, clip_path))
+
+    cmd = ["ffmpeg", "-v", "error", "-y"]
+    cmd += ["-f", "lavfi", "-i", f"anullsrc=r=44100:cl=stereo:d={total_duration:.3f}"]
+    for _, clip_path in clips:
+        cmd += ["-i", str(clip_path)]
+
+    filter_chain = []
+    mix_labels = ["[0:a]"]
+    for input_index, (start, _) in enumerate(clips, start=1):
+        delay_ms = max(0, round(start * 1000))
+        filter_chain.append(f"[{input_index}:a]adelay={delay_ms}|{delay_ms}[d{input_index}]")
+        mix_labels.append(f"[d{input_index}]")
+    filter_chain.append(
+        f"{''.join(mix_labels)}amix=inputs={len(mix_labels)}:duration=first:"
+        "dropout_transition=0:normalize=0[aout]"
+    )
+    cmd += [
+        "-filter_complex", ";".join(filter_chain),
+        "-map", "[aout]",
+        "-t", f"{total_duration:.3f}",
+        str(track_path),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise DubbingError(f"ffmpeg narration mix failed: {proc.stderr.strip()}")
+    return track_path

--- a/src/browser_harness/video-template.html
+++ b/src/browser_harness/video-template.html
@@ -115,7 +115,7 @@ const unsafeRoute = /@|[?#]|:\/\/|onmicrosoft|(?:tenant|user|object)[_-]?id|[0-9
 const opaqueHex = /^#[0-9a-f]{6}$/i;
 if (C.schemaVersion !== 1)
   preflightErrors.push("composition must use schema version 1");
-if (C.frameStyle !== "native" || C.readingWpm !== 380)
+if (C.frameStyle !== "native" || C.readingWpm !== 170)
   preflightErrors.push("composition changed generated typography or frame style");
 if (!Number.isFinite(C.durationBudget) || DURATION > C.durationBudget + 0.001)
   preflightErrors.push(

--- a/src/browser_harness/video.py
+++ b/src/browser_harness/video.py
@@ -725,6 +725,10 @@ def run_cli(args: list[str]) -> int:
     export.add_argument("recording", type=Path)
     export.add_argument("--output", default="video.mp4")
     export.add_argument("--reviewed", action="store_true")
+    export.add_argument(
+        "--dub", action="store_true",
+        help="dub the sticky narration text as pt-BR speech via ElevenLabs (needs ELEVENLABS_API_KEY)",
+    )
     parsed = parser.parse_args(args)
     recording = parsed.recording.expanduser().resolve()
     try:
@@ -734,7 +738,7 @@ def run_cli(args: list[str]) -> int:
 
         if parsed.command == "review":
             return video_render.review(recording)
-        return video_render.export(recording, parsed.output, parsed.reviewed)
+        return video_render.export(recording, parsed.output, parsed.reviewed, parsed.dub)
     except (OSError, ValueError, RuntimeError) as exc:
         parser.error(str(exc))
 

--- a/src/browser_harness/video.py
+++ b/src/browser_harness/video.py
@@ -29,17 +29,20 @@ OPAQUE_HEX = re.compile(r"^#[0-9a-f]{6}$", re.IGNORECASE)
 HOUSE_STYLE = {
     "version": 1,
     "frameStyle": "native",
-    "readingWpm": 380,
+    # Tuned down from the upstream 380 (fast-skim) default so cards and narrated beats
+    # play at a natural speaking/watching pace instead of a rushed slideshow — this
+    # fork's videos are meant to be watched with audio, not skimmed silently.
+    "readingWpm": 170,
     "background": ["#efece4", "#dce7e7"],
     "cursorStart": {"x": 700, "y": 280},
     "pacing": {
-        "captionBaseSeconds": 0.35,
-        "captionSecondsPerWord": 0.2,
-        "rawToCardHoldSeconds": 0.55,
-        "baseDurationBudget": 22,
+        "captionBaseSeconds": 0.6,
+        "captionSecondsPerWord": 0.45,
+        "rawToCardHoldSeconds": 0.8,
+        "baseDurationBudget": 40,
         "extraActionSeconds": 1.25,
         "extraExplanationSeconds": 3,
-        "maximumDurationBudget": 32,
+        "maximumDurationBudget": 90,
     },
     "motion": {
         "autoFollow": True,
@@ -259,11 +262,11 @@ def require_matching_viewport(event: dict[str, Any], viewport: dict[str, Any], w
 
 
 def default_action_duration(beat: dict[str, Any], pacing: dict[str, Any]) -> float:
-    base = 0.7
+    base = 1.1
     if beat.get("click"):
-        base = 1.15
+        base = 1.6
     if beat.get("after"):
-        base = max(base, 1.4)
+        base = max(base, 2.0)
     typing = beat.get("type")
     if typing:
         base = max(base, 0.6 + len(str(typing.get("text") or "")) * 0.035)

--- a/src/browser_harness/video_render.py
+++ b/src/browser_harness/video_render.py
@@ -410,7 +410,7 @@ def _probe(path: Path) -> dict:
     return json.loads(proc.stdout)
 
 
-def export(recording: Path, output_name: str, reviewed: bool) -> int:
+def export(recording: Path, output_name: str, reviewed: bool, dub: bool = False) -> int:
     if not reviewed:
         raise RuntimeError("inspect the review sheet and full-resolution privacy frames, then rerun with --reviewed")
     if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
@@ -479,10 +479,22 @@ def export(recording: Path, output_name: str, reviewed: bool) -> int:
 
     conversion_started = time.monotonic()
     _probe(webm)
-    _run([
-        "ffmpeg", "-v", "error", "-i", str(webm), "-c:v", "libx264",
-        "-crf", "20", "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(output),
-    ], recording)
+    if dub:
+        from . import dubbing
+
+        narration_track = dubbing.build_narration_track(recording, comp, expected)
+        _run([
+            "ffmpeg", "-v", "error", "-i", str(webm), "-i", str(narration_track),
+            "-c:v", "libx264", "-crf", "20", "-pix_fmt", "yuv420p",
+            "-c:a", "aac", "-b:a", "160k",
+            "-map", "0:v:0", "-map", "1:a:0",
+            "-movflags", "+faststart", str(output),
+        ], recording)
+    else:
+        _run([
+            "ffmpeg", "-v", "error", "-i", str(webm), "-c:v", "libx264",
+            "-crf", "20", "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(output),
+        ], recording)
     conversion_seconds = time.monotonic() - conversion_started
 
     verify_started = time.monotonic()


### PR DESCRIPTION
Adds `dubbing.py`: collapses each beat's sticky narration text into timed spans, synthesizes each span via the ElevenLabs TTS API (eleven_multilingual_v2, pt), and mixes them into a single WAV sized to the compiled video duration using ffmpeg's adelay/amix filters.

`video export` gains a `--dub` flag that mixes this narration track into the exported MP4 (aac) instead of leaving it silent. Requires ELEVENLABS_API_KEY (see .env.example); ELEVENLABS_VOICE_ID optionally overrides the stock voice. Only action-beat narration is voiced, not the intro/outcome cards.