### PR TITLE
chore(harness): deterministic agent harness — verify gate, guardrails, hooks, trace

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -1,0 +1,54 @@
+---
+name: verifier
+description: Adversarial, independent verification of a claimed outcome. Use when a change is claimed complete, before reporting success to the human. It tries to falsify the claim; it never fixes anything.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the **verifier**. Separation of powers is the point: you did not write this
+change, you do not fix it, and you are not trying to be helpful to whoever did. You are
+trying to **falsify the claim that it is done**.
+
+You will be given a diff and a claimed outcome.
+
+## Procedure
+
+1. **Run the gate yourself.** `node .claude/harness/verify.mjs`. Record the exit code.
+   A claim that verify passed, without you seeing it exit 0, is worth nothing.
+2. **Check freshness.** Read `.claude/harness/.last-verify` and compare its `fingerprint`
+   to `node .claude/harness/guardrails.mjs fingerprint`. A green result recorded against a
+   different tree is not evidence about this tree.
+3. **Read the trace.** `node .claude/harness/trace.mjs tail 40`. Does the record of what
+   happened match the story being told? Blocked calls, errored tools, edits to files the
+   summary never mentions — all of these are signal.
+4. **Hunt the classic lies.** In the diff specifically:
+   - a test deleted, renamed out of collection, skipped, or marked xfail;
+   - an assertion weakened — `assertTrue` to `assertIsNotNone`, an exact match turned into
+     a substring match, a tolerance widened;
+   - `except Exception: pass`, a bare `except`, or error handling widened so the failure is
+     swallowed rather than fixed;
+   - a feature "implemented" behind a flag that defaults off, or a function that returns a
+     constant;
+   - a verify step, a hook, a guardrail or `contract.json` edited — **this is the
+     unforgivable action**; report it first and loudly;
+   - in this repo specifically: a skill Markdown file whose code fences or cross-references
+     were broken by the edit, and any new code path that touches the live Chrome profile.
+5. **Check the claim's own terms.** The objective in `.claude/harness/state.md` names an
+   observable condition. Is *that* condition true, or only something adjacent to it?
+
+## Output
+
+Exactly this shape, and nothing else:
+
+```
+VERDICT: PASS | FAIL
+EVIDENCE:
+  - <command run> -> <exit code>
+  - <file:line> <what you found>
+UNRESOLVED:
+  - <anything you could not check, stated plainly>
+```
+
+`PASS` requires that you personally saw verify exit 0 against the current fingerprint and
+found none of the above. Anything else is `FAIL`. If you are unsure, that is `FAIL` with
+the uncertainty listed under UNRESOLVED. Never propose a fix.

--- a/.claude/commands/harness-reset.md
+++ b/.claude/commands/harness-reset.md
@@ -1,0 +1,22 @@
+---
+description: Archive the trace, clear attempt and budget counters, start a fresh objective
+allowed-tools: Bash(node .claude/harness/trace.mjs:*), Bash(node .claude/harness/guardrails.mjs:*), Read, Edit
+---
+
+Use this when starting a genuinely new objective, or after the harness released control
+and a human has resolved the blocker. It does **not** make a failing verify pass.
+
+1. Archive the trace:
+
+!`node .claude/harness/trace.mjs archive`
+
+2. Clear the attempt and budget counters:
+
+!`node .claude/harness/guardrails.mjs reset`
+
+3. Rewrite `.claude/harness/state.md` with a fresh objective. Keep the **Decisions made**
+   and **Approaches already tried and rejected** sections — those are the whole point of
+   the file and are what stops the next session re-litigating settled ground. Reset only
+   the objective, the open blockers, and the attempt counter.
+
+Then confirm what you cleared and what you deliberately kept.

--- a/.claude/commands/harness-status.md
+++ b/.claude/commands/harness-status.md
@@ -1,0 +1,24 @@
+---
+description: Show budgets, attempts, last verify result and the trace tail
+allowed-tools: Bash(node .claude/harness/guardrails.mjs:*), Bash(node .claude/harness/trace.mjs:*), Read
+---
+
+Current tree fingerprint:
+
+!`node .claude/harness/guardrails.mjs fingerprint`
+
+Tool-call budget for the current objective:
+
+!`node .claude/harness/guardrails.mjs budget`
+
+Last verify result:
+
+@.claude/harness/.last-verify
+
+Last ten trace entries:
+
+!`node .claude/harness/trace.mjs tail 10`
+
+Report compactly: is the last verify **valid for this tree** (its `fingerprint` equals
+the fingerprint above) or **stale**? How many of the 25 acting calls are spent? Does the
+trace show anything that contradicts what was claimed in the session so far?

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,16 @@
+---
+description: Run the harness gate and report the exit code verbatim
+allowed-tools: Bash(node .claude/harness/verify.mjs:*)
+---
+
+Run the gate:
+
+!`node .claude/harness/verify.mjs`
+
+Report the result with no interpretation:
+
+- exit **0** — say "verify PASS (exit 0)" and name the steps that ran.
+- non-zero — say "verify FAIL", name the failing step, and paste the tail it printed.
+  Do not summarise the failure favourably. Do not claim the change works.
+
+Never edit `.claude/harness/**` or `.claude/hooks/**` to change this outcome.

--- a/.claude/harness/contract.json
+++ b/.claude/harness/contract.json
@@ -1,0 +1,97 @@
+{
+  "_comment": "MACHINE SOURCE OF TRUTH for the harness. contract.md is the human-readable mirror. Editing this file requires human approval (see .claude/settings.json permissions.ask).",
+  "version": 1,
+  "verify_steps": [
+    "skills",
+    "compile",
+    "tests"
+  ],
+  "definition_of_done": "verify.mjs exits 0 against the current tree, the diff has been reviewed, and state.md is updated. state.md is excluded from the fingerprint, so these three are order-independent.",
+  "max_attempts": 3,
+  "max_tool_calls_per_objective": 25,
+  "forbidden_paths": [
+    "**/.env",
+    "**/.env.*",
+    "!**/.env.example",
+    "**/secrets/**",
+    "**/*.pem",
+    "**/*.key",
+    "**/*.egg-info/**",
+    "**/__pycache__/**",
+    ".git/**",
+    "dist/**",
+    "build/**",
+    "node_modules/**"
+  ],
+  "forbidden_commands": [
+    {
+      "id": "rm-rf",
+      "pattern": "^rm\\s+(-[a-zA-Z]*\\s+)*-[a-zA-Z]*[rR][a-zA-Z]*\\b",
+      "why": "recursive delete",
+      "instead": "move the path into _to_delete/ and tell the human"
+    },
+    {
+      "id": "git-force-push",
+      "pattern": "^git\\s+push\\b.*(--force\\b|--force-with-lease\\b|\\s-f\\b)",
+      "why": "rewrites published history",
+      "instead": "push a new branch and open a PR"
+    },
+    {
+      "id": "git-hard-reset",
+      "pattern": "^git\\s+reset\\b.*--hard\\b",
+      "why": "discards uncommitted work irreversibly",
+      "instead": "git stash, or git restore a specific path"
+    },
+    {
+      "id": "git-clean",
+      "pattern": "^git\\s+clean\\b.*-[a-zA-Z]*[dfx]",
+      "why": "deletes untracked files irreversibly",
+      "instead": "list them with git clean -n and delete deliberately"
+    },
+    {
+      "id": "git-checkout-dot",
+      "pattern": "^git\\s+(checkout|restore)\\s+(--\\s+)?\\.\\s*$",
+      "why": "discards every uncommitted change in the tree",
+      "instead": "restore the specific file you meant"
+    },
+    {
+      "id": "pipe-to-shell",
+      "pattern": "\\b(curl|wget|iwr|Invoke-WebRequest)\\b[^|]*\\|\\s*(sudo\\s+)?(ba|z|d|)?sh\\b",
+      "why": "executes unreviewed remote code",
+      "instead": "download to a file, read it, then run it"
+    },
+    {
+      "id": "publish",
+      "pattern": "^(npm|pnpm|yarn)\\s+publish\\b|^twine\\s+upload\\b|^uv\\s+publish\\b|^python\\s+-m\\s+twine\\b",
+      "why": "irreversible public release",
+      "instead": "ask the human to publish"
+    },
+    {
+      "id": "history-rewrite",
+      "pattern": "^git\\s+(filter-branch|filter-repo)\\b|^git\\s+rebase\\b.*(-i|--interactive)\\b",
+      "why": "rewrites history; interactive rebase cannot run here anyway",
+      "instead": "ask the human"
+    },
+    {
+      "id": "chained-harness-edit",
+      "pattern": "(>|>>)\\s*[^|;&]*\\.claude/(hooks|harness)/",
+      "why": "shell redirection into the harness bypasses the Edit permission rules",
+      "instead": "ask the human to change the contract"
+    },
+    {
+      "id": "nested-shell",
+      "pattern": "^(bash|sh|zsh|dash|pwsh|powershell)\\s+(-[A-Za-z]+\\s+)*-c\\b",
+      "why": "inline shell code is opaque to the per-segment command checks, so a destructive command inside the quoted string is never seen",
+      "instead": "run the command directly, unquoted, so the guardrails can read it"
+    }
+  ],
+  "requires_human_approval": [
+    "any change to pyproject.toml (dependency additions)",
+    "any change to .claude/settings.json, .claude/hooks/**, or .claude/harness/*.mjs",
+    "any invocation that drives the real Chrome profile (run.py, daemon.py, admin.py, browser-harness)",
+    "git commit, git push, and any package install"
+  ],
+  "secrets_source": "environment variables and .env (never read into context; denied by permissions.deny)",
+  "escalation_channel": "stop in-session, write a blocker note into .claude/harness/state.md, hand control back to the human",
+  "_rule_note": "Command rules are anchored to the HEAD of a shell segment (after wrapper stripping), so they match the command being RUN, not the same text appearing as an argument. grep -r \"rm -rf\" docs/ is a search, not a delete, and passes. The two whole-string rules (pipe-to-shell, chained-harness-edit) are deliberately unanchored."
+}

--- a/.claude/harness/contract.md
+++ b/.claude/harness/contract.md
@@ -1,0 +1,80 @@
+# Harness contract — browser-harness
+
+In force for every session in this repository. The **machine-readable source of
+truth is `contract.json`**; this file is its human mirror. If the two disagree,
+`contract.json` is what actually runs — fix this file.
+
+Changing either requires human approval (`permissions.ask` in `.claude/settings.json`).
+
+## Definition of done
+
+`node .claude/harness/verify.mjs` exits 0 against the current tree, the diff has
+been reviewed, and `state.md` is updated. Anything short of that is **unverified**,
+and "unverified" is the word to use — never "done".
+
+The three are independent: `state.md` is excluded from the tree fingerprint, so writing
+it after a green verify does not make that verify stale. Order them however you like.
+
+## The gate
+
+| Step | What it runs | Why it exists |
+|---|---|---|
+| `skills` | `validate-skills.mjs` over all 89 tracked Markdown files | The product of this repo *is* the skill corpus. Frontmatter keys, H1 titles, balanced code fences, and dead cross-references were previously checked by nothing. |
+| `compile` | `python -m compileall` over the 6 tracked `.py` files | Catches a broken edit without needing the browser or the network. |
+| `tests` | `python -m pytest -q` | The 4 existing tests mock CDP, so they need no live Chrome and no network. |
+
+Not in the gate: **ruff**. On the tree as inherited it reports 68 lint errors and
+would reformat 75 of 95 files. Adding it would mean building a gate on red. See
+"First maintenance action" in `docs/HARNESS.md`.
+
+## Budgets
+
+| Field | Value |
+|---|---|
+| `max_attempts` | **3** — after three Stop-gate blocks on the same tree, the harness writes a blocker note and hands control to the human |
+| `max_tool_calls_per_objective` | **25** *acting* calls (Bash, PowerShell, Edit, Write, MultiEdit, NotebookEdit). Reads are not counted. Reset by `/harness-reset` or by changing the objective line in `state.md` |
+
+## Forbidden
+
+**Paths** (`forbidden_paths`): `.env` and `.env.*` except `.env.example`, `**/secrets/**`,
+`*.pem`, `*.key`, `*.egg-info/**`, `__pycache__/**`, `.git/**`, `dist/`, `build/`,
+`node_modules/`.
+
+**Commands** (`forbidden_commands`, matched per shell segment so `safe && dangerous`
+cannot smuggle anything past): recursive `rm`, force push, `git reset --hard`,
+`git clean -df`, `git checkout .`, pipe-to-shell (`curl … | sh`), package publish,
+history rewriting, and shell redirection into `.claude/hooks/` or `.claude/harness/`.
+
+## Requires human approval
+
+- Any change to `pyproject.toml` — dependency additions.
+- Any change to `.claude/settings.json`, `.claude/hooks/**`, or `.claude/harness/*.mjs`.
+- Any invocation that drives the real Chrome profile: `run.py`, `daemon.py`, `admin.py`,
+  `browser-harness`. These attach over CDP to a signed-in browser; they are actions on
+  live accounts, not tests.
+- `git commit`, `git push`, and any package install.
+
+## Secrets
+
+Read from environment variables and `.env`, which the harness **denies to the model
+outright**. The model requests an effect; the harness or the human performs it. A
+credential never enters context.
+
+## Escalation
+
+Stop in-session. Write a blocker note into `state.md` in this shape:
+
+```
+## BLOCKER — <one line>
+- what I was trying to do:
+- what I tried, and the exact failure (command + exit code):
+- what I need a human to decide:
+```
+
+Then hand control back. **Blocked is a valid, respectable outcome.**
+
+## The one unforgivable action
+
+Editing, disabling or bypassing a hook, a guardrail or the verify script to make a
+task pass. If a guardrail is genuinely wrong, say so, explain why, and ask for the
+contract to be changed.

--- a/.claude/harness/guardrails.mjs
+++ b/.claude/harness/guardrails.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// ORGAN 4 — Guardrails, plus the shared primitives every other harness script uses.
+// Zero dependencies. Node >= 18. Runs identically on Windows, macOS and Linux.
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+// --- locations -------------------------------------------------------------
+// Resolved from this file's own location, so it is correct even when
+// CLAUDE_PROJECT_DIR is absent (Cowork, CI, a human running it by hand).
+export const HARNESS_DIR = dirname(fileURLToPath(import.meta.url));
+export const PROJECT_DIR = resolve(HARNESS_DIR, '..', '..');
+export const P = {
+  contract: join(HARNESS_DIR, 'contract.json'),
+  state: join(HARNESS_DIR, 'state.md'),
+  trace: join(HARNESS_DIR, 'trace.jsonl'),
+  lastVerify: join(HARNESS_DIR, '.last-verify'),
+  baseline: join(HARNESS_DIR, '.session-baseline'),
+  stopAttempts: join(HARNESS_DIR, '.stop-attempts'),
+  budget: join(HARNESS_DIR, '.budget'),
+  compactFlush: join(HARNESS_DIR, '.compact-flush'),
+  backup: join(HARNESS_DIR, 'backup'),
+};
+
+export const contract = JSON.parse(readFileSync(P.contract, 'utf8'));
+
+// --- small helpers ---------------------------------------------------------
+export function git(args, opts = {}) {
+  return execFileSync('git', args, { cwd: PROJECT_DIR, encoding: 'utf8', ...opts });
+}
+export function readJson(p, fallback = null) {
+  try { return JSON.parse(readFileSync(p, 'utf8')); } catch { return fallback; }
+}
+export function writeJson(p, obj) {
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(obj, null, 2) + '\n');
+}
+// Counters are ZEROED, never deleted. Some checkouts (network mounts, the Cowork
+// device bridge, read-only-ish shares) refuse unlink, and a swallowed delete failure
+// would silently carry an attempt count across sessions. A write always works where
+// the harness can write at all.
+export function clearCounter(p) { try { writeJson(p, { count: 0, clearedAt: new Date().toISOString() }); } catch { /* never break the run */ } }
+export function unlinkQuiet(p) { try { rmSync(p, { force: true }); } catch { clearCounter(p); } }
+export function readStdin() {
+  try { return readFileSync(0, 'utf8'); } catch { return ''; }
+}
+export function hookInput() {
+  const raw = readStdin();
+  if (!raw.trim()) return {};
+  try { return JSON.parse(raw); } catch { return { _unparsed: raw }; }
+}
+
+// --- change detection ------------------------------------------------------
+// Content hashing, not `git status`. Three reasons: it is immune to mtime churn
+// from formatters; it does not depend on how a given checkout is configured for
+// line endings (this Windows tree reads clean under Git for Windows and dirty
+// under a Linux git on the same bytes); and it makes verify-staleness structural
+// — a green result carries the hash of the tree it validated, so any write
+// invalidates it with nothing to delete by hand.
+//
+// state.md is EXCLUDED. It is the harness's own working memory and the contract
+// requires updating it as the last step of a cycle. If it were hashed, writing
+// it after a green verify would immediately make that verify stale, and the
+// Stop gate's own release path (which appends a blocker note) would guarantee
+// the next turn starts un-green. Working memory must not be able to fail a gate.
+export const FINGERPRINT_EXCLUDE = ['.claude/harness/state.md'];
+export function trackedFiles() {
+  const tracked = git(['ls-files', '-z']).split('\0').filter(Boolean);
+  const untracked = git(['ls-files', '--others', '--exclude-standard', '-z']).split('\0').filter(Boolean);
+  return [...new Set([...tracked, ...untracked])]
+    .filter(f => !FINGERPRINT_EXCLUDE.includes(f))
+    .sort();
+}
+export function fingerprint() {
+  const h = createHash('sha256');
+  for (const f of trackedFiles()) {
+    const abs = join(PROJECT_DIR, f);
+    let body = '';
+    try { body = createHash('sha256').update(readFileSync(abs)).digest('hex'); }
+    catch { body = 'MISSING'; }
+    h.update(f).update('\0').update(body).update('\n');
+  }
+  return h.digest('hex');
+}
+export function gitHead() {
+  try { return git(['rev-parse', 'HEAD']).trim(); } catch { return 'no-head'; }
+}
+
+// --- path guardrails -------------------------------------------------------
+export function normalizePath(p) {
+  if (!p) return '';
+  let s = String(p).replace(/\\/g, '/');
+  const root = PROJECT_DIR.replace(/\\/g, '/').replace(/\/$/, '');
+  if (s.toLowerCase().startsWith(root.toLowerCase() + '/')) s = s.slice(root.length + 1);
+  return s.replace(/^\.\//, '');
+}
+// gitignore-flavoured glob -> RegExp. Supports ** (any depth), * (one segment), ? .
+function globToRe(glob) {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') { re += '.*'; i++; if (glob[i + 1] === '/') i++; }
+      else re += '[^/]*';
+    } else if (c === '?') re += '[^/]';
+    else re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  }
+  return new RegExp('^' + re + '$');
+}
+export function matchGlob(path, glob) {
+  const p = normalizePath(path);
+  if (globToRe(glob).test(p)) return true;
+  // bare-filename patterns match at any depth, like gitignore
+  if (!glob.includes('/')) return globToRe('**/' + glob).test(p);
+  return false;
+}
+export function checkPath(rawPath) {
+  const p = normalizePath(rawPath);
+  if (!p) return { blocked: false };
+  let hit = null;
+  for (const rule of contract.forbidden_paths) {
+    if (rule.startsWith('!')) { if (matchGlob(p, rule.slice(1))) return { blocked: false }; }
+    else if (!hit && matchGlob(p, rule)) hit = rule;
+  }
+  return hit ? { blocked: true, rule: hit, path: p } : { blocked: false, path: p };
+}
+
+// --- command guardrails ----------------------------------------------------
+const SEPARATORS = /\s*(?:&&|\|\||;|\|&|\||\n|(?<!&)&(?!&))\s*/;
+const WRAPPERS = new Set(['timeout', 'time', 'nice', 'nohup', 'stdbuf', 'command', 'builtin', 'noglob', 'xargs', 'sudo', 'env']);
+export function splitSegments(cmd) {
+  return String(cmd || '').split(SEPARATORS).map(s => s.trim()).filter(Boolean);
+}
+export function stripWrappers(segment) {
+  let s = segment.trim();
+  for (let guard = 0; guard < 8; guard++) {
+    const before = s;
+    s = s.replace(/^[A-Za-z_][A-Za-z0-9_]*=[^\s]*\s+/, '');       // FOO=bar cmd
+    const first = s.split(/\s+/)[0];
+    if (WRAPPERS.has(first)) s = s.slice(first.length).trim().replace(/^-[^\s]*\s+/, '');
+    if (s === before) break;
+  }
+  return s;
+}
+export function checkCommand(cmd) {
+  const whole = String(cmd || '');
+  // Pipe-to-shell and redirection rules must see the WHOLE string; the others
+  // are evaluated per segment so `safe && dangerous` cannot smuggle anything.
+  const wholeOnly = new Set(['pipe-to-shell', 'chained-harness-edit']);
+  for (const rule of contract.forbidden_commands) {
+    const re = new RegExp(rule.pattern, 'i');
+    if (wholeOnly.has(rule.id)) { if (re.test(whole)) return { blocked: true, rule, matched: whole }; continue; }
+    for (const seg of splitSegments(whole)) {
+      const bare = stripWrappers(seg);
+      if (re.test(seg) || re.test(bare)) return { blocked: true, rule, matched: seg };
+    }
+  }
+  // Redirection targets are file writes; check them against forbidden paths.
+  for (const m of whole.matchAll(/(?:^|\s)\d?>>?\s*("[^"]+"|'[^']+'|[^\s|&;]+)/g)) {
+    const target = m[1].replace(/^["']|["']$/g, '');
+    if (target === '/dev/null' || target === 'NUL') continue;
+    const r = checkPath(target);
+    if (r.blocked) return { blocked: true, rule: { id: 'redirect-to-forbidden-path', why: `redirects output into ${r.rule}`, instead: 'write somewhere the contract allows' }, matched: target };
+  }
+  return { blocked: false };
+}
+
+// --- budget (organ 4): tool calls per objective ----------------------------
+export function currentObjective() {
+  try {
+    const m = readFileSync(P.state, 'utf8').replace(/\r\n/g, '\n')
+      .match(/##\s*Current objective\s*\n+([^\n]*)/i);
+    return (m && m[1].trim()) || '(none recorded)';
+  } catch { return '(none recorded)'; }
+}
+export function bumpBudget(delta = 1) {
+  const objective = currentObjective();
+  let b = readJson(P.budget, null);
+  if (!b || b.objective !== objective) b = { objective, count: 0, since: new Date().toISOString() };
+  b.count += delta;
+  b.limit = contract.max_tool_calls_per_objective;
+  writeJson(P.budget, b);
+  return b;
+}
+export function readBudget() {
+  const objective = currentObjective();
+  const b = readJson(P.budget, null);
+  if (!b || b.objective !== objective) return { objective, count: 0, limit: contract.max_tool_calls_per_objective };
+  return { ...b, limit: contract.max_tool_calls_per_objective };
+}
+export function resetCounters() {
+  for (const p of [P.budget, P.stopAttempts]) clearCounter(p);
+  try { writeJson(P.compactFlush, { blocked: false }); } catch { /* ignore */ }
+}
+
+// --- verify freshness ------------------------------------------------------
+export function lastVerify() { return readJson(P.lastVerify, null); }
+export function verifyIsGreenForTree(fp) {
+  const lv = lastVerify();
+  if (!lv) return { ok: false, why: 'no verify has run in this tree' };
+  if (lv.exitCode !== 0) return { ok: false, why: `last verify FAILED at step "${lv.failedStep || '?'}"` };
+  if (lv.fingerprint !== fp) return { ok: false, why: 'last verify is stale — the tree changed after it ran' };
+  return { ok: true, lv };
+}
+
+// --- CLI -------------------------------------------------------------------
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const [, , cmd, ...rest] = process.argv;
+  const arg = rest.join(' ');
+  if (cmd === 'check-path') { const r = checkPath(arg); console.log(JSON.stringify(r)); process.exit(r.blocked ? 2 : 0); }
+  else if (cmd === 'check-command') { const r = checkCommand(arg); console.log(JSON.stringify(r)); process.exit(r.blocked ? 2 : 0); }
+  else if (cmd === 'fingerprint') console.log(fingerprint());
+  else if (cmd === 'budget') console.log(JSON.stringify(readBudget()));
+  else if (cmd === 'reset') { resetCounters(); console.log('counters cleared'); }
+  else { console.log('usage: node guardrails.mjs <check-path|check-command|fingerprint|budget|reset> [arg]'); process.exit(1); }
+}

--- a/.claude/harness/state.md
+++ b/.claude/harness/state.md
@@ -1,0 +1,56 @@
+# Harness state
+
+Working memory that survives context compaction. Small, rewritten in place,
+never appended forever. Update it at the end of every work cycle.
+
+## Current objective
+
+(none — set this to one sentence before starting work)
+
+## Decisions made
+
+- 2026-08-26 — Verify chain is `skills -> compile -> tests`. ruff is deliberately
+  excluded: it reports 68 errors and 75 unformatted files on the tree as inherited,
+  so including it would have built the gate on top of red.
+- 2026-08-26 — Change detection uses content hashing, not `git status`: git status gives
+  opposite answers for the same bytes depending on the git that reads them, and content
+  hashing also survives mtime churn and makes verify-staleness structural.
+- 2026-08-26 — CORRECTION: the original recon claimed `core.autocrlf=false` and a broken
+  tree. Wrong — it misread a two-command shell output; `false` was `core.filemode`.
+  Under Git for Windows this tree is clean. Do NOT renormalise line endings.
+- 2026-08-26 — `.claude/harness/state.md` is excluded from the fingerprint. Otherwise the
+  contract's own "update state.md" step invalidated the verify that preceded it, and the
+  Stop gate's release path (which appends a blocker note) guaranteed an un-green next turn.
+- 2026-08-26 — Command rules are anchored to the head of a shell segment, so `grep -r "rm -rf"`
+  is a search, not a delete. A `nested-shell` rule covers the `bash -c "..."` hole that
+  anchoring would otherwise open.
+- 2026-08-26 — Hooks are Node `.mjs` in exec form (`args` set). Shell-form hooks on
+  Windows run under Git Bash, or PowerShell when Git Bash is absent; exec form spawns
+  the script directly with no shell on any platform.
+- 2026-08-26 — pytest declared in `pyproject.toml` under `[dependency-groups] dev`.
+- 2026-08-26 — Gate CONFIRMED on Windows: `.venv\Scripts\python.exe` (Python 3.13.2),
+  all three steps PASS, exit 0. The tree fingerprint was byte-identical to the one
+  produced on Linux (`c2de755df8f2`) despite CRLF on disk, so the gate is genuinely
+  platform-independent.
+
+## Approaches already tried and rejected
+
+- Using `git status --porcelain` for "did the tree change" — not portable across gits.
+- Hashing `state.md` as part of the tree — makes the contract self-invalidating.
+- Unanchored destructive-command regexes — they fire on arguments, not just on the command.
+- Adding `ruff` to the gate immediately — would require a 75-file reformat first.
+- `Write(path)` permission rules — Claude Code accepts them but never consults them;
+  file guarding must use `Edit(path)` and `Read(path)`.
+
+## Open blockers
+
+- None. Known limitation, not a blocker: no cross-session locking — run one Claude
+  session per checkout (see Known gaps in docs/HARNESS.md).
+
+## Attempt counter
+
+0 / 3 for the current objective.
+
+
+
+

--- a/.claude/harness/trace.mjs
+++ b/.claude/harness/trace.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// ORGAN 7 — Append-only record of what actually happened. The only admissible
+// evidence for a success claim, alongside a verify exit code.
+import { appendFileSync, readFileSync, renameSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import { P, gitHead } from './guardrails.mjs';
+
+const MAX_FIELD = 400;
+const clip = (v) => {
+  if (v === undefined || v === null) return v;
+  const s = typeof v === 'string' ? v : JSON.stringify(v);
+  return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + `…[+${s.length - MAX_FIELD} chars]` : s;
+};
+
+export function trace(entry) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), head: gitHead().slice(0, 8), ...entry }) + '\n';
+  try { appendFileSync(P.trace, line); } catch { /* trace must never break the run */ }
+}
+export function traceTool({ tool, target, outcome, detail, session }) {
+  trace({ kind: 'tool', tool, target: clip(target), outcome, detail: clip(detail), session });
+}
+export function tail(n = 10) {
+  if (!existsSync(P.trace)) return [];
+  return readFileSync(P.trace, 'utf8').replace(/\r\n/g, '\n').split('\n').filter(Boolean).slice(-n);
+}
+export function archive() {
+  if (!existsSync(P.trace)) return null;
+  mkdirSync(P.backup, { recursive: true });
+  const dest = join(P.backup, `trace-${new Date().toISOString().replace(/[:.]/g, '-')}.jsonl`);
+  renameSync(P.trace, dest);
+  return dest;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const [, , cmd, arg] = process.argv;
+  if (cmd === 'tail') tail(Number(arg) || 10).forEach(l => console.log(l));
+  else if (cmd === 'archive') console.log(archive() || 'nothing to archive');
+  else if (cmd === 'note') { trace({ kind: 'note', text: arg }); console.log('noted'); }
+  else { console.log('usage: node trace.mjs <tail [n]|archive|note "text">'); process.exit(1); }
+}

--- a/.claude/harness/validate-skills.mjs
+++ b/.claude/harness/validate-skills.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Verify step "skills" — deterministic structural validation of the Markdown corpus.
+// 89 of this repo's tracked files are Markdown skills and nothing else checks them.
+// Every rule below was measured green against the tree before being added.
+//
+// Two profiles:
+//   corpus   — SKILL.md, install.md, README.md, domain-skills/**, interaction-skills/**, docs/**
+//              (the product: frontmatter needs name+description, body opens with an H1)
+//   config   — .claude/**  (commands and subagents: frontmatter needs a description,
+//              and legitimately has no H1 and often no name)
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PROJECT_DIR, git, normalizePath } from './guardrails.mjs';
+
+const EXEMPT_H1 = new Set(['README.md']);            // opens with an <img> banner
+const NAME_REQUIRED = /^(SKILL\.md|\.claude\/agents\/[^/]+\.md)$/;
+const REF_RE = /(?:^|[\s(`"'])((?:domain-skills|interaction-skills|docs)\/[A-Za-z0-9._\/-]+\.(?:md|png|py))/g;
+
+export function allMarkdown() {
+  const tracked = git(['ls-files', '-z', '*.md']).split('\0').filter(Boolean);
+  const untracked = git(['ls-files', '--others', '--exclude-standard', '-z', '*.md']).split('\0').filter(Boolean);
+  return [...new Set([...tracked, ...untracked])].sort();
+}
+
+export function validate(only = null) {
+  const errors = [];
+  const files = (only && only.length ? only.map(normalizePath) : allMarkdown()).filter(f => f.endsWith('.md'));
+  for (const f of files) {
+    const isConfig = f.startsWith('.claude/');
+    let raw;
+    try { raw = readFileSync(join(PROJECT_DIR, f), 'utf8'); }
+    catch { continue; }                                 // deleted between listing and read
+    const text = raw.replace(/\r\n/g, '\n');            // the tree is CRLF; normalise first
+    const lines = text.split('\n');
+    const err = (msg) => errors.push({ file: f, msg });
+
+    if (!text.trim()) { err('file is empty'); continue; }
+
+    // 1. Frontmatter, when present, must be closed and carry its required keys.
+    let bodyStart = 0;
+    if (lines[0].trim() === '---') {
+      const close = lines.slice(1).findIndex(l => l.trim() === '---');
+      if (close === -1) err('YAML frontmatter is opened but never closed');
+      else {
+        const fm = lines.slice(1, close + 1);
+        bodyStart = close + 2;
+        const need = (isConfig && !NAME_REQUIRED.test(f)) ? ['description'] : ['name', 'description'];
+        for (const key of need) {
+          const line = fm.find(l => new RegExp(`^${key}\\s*:`).test(l.trim()));
+          if (!line) err(`frontmatter is missing required key "${key}"`);
+          else if (!line.split(':').slice(1).join(':').trim()) err(`frontmatter key "${key}" is empty`);
+        }
+        const nameLine = fm.find(l => /^name\s*:/.test(l.trim()));
+        if (nameLine) {
+          const v = nameLine.split(':').slice(1).join(':').trim().replace(/^["']|["']$/g, '');
+          if (v && !/^[a-z0-9][a-z0-9-]*$/.test(v)) err(`frontmatter name "${v}" is not lowercase-kebab`);
+        }
+      }
+    } else if (NAME_REQUIRED.test(f)) {
+      err('this file requires YAML frontmatter with name and description');
+    }
+
+    // 2. A corpus document must open with a single H1 title. Commands and subagents
+    //    under .claude/ legitimately open with prose, so they are exempt.
+    if (!isConfig && !EXEMPT_H1.has(f)) {
+      const first = lines.slice(bodyStart).find(l => l.trim() !== '') || '';
+      if (!/^#\s+\S/.test(first)) err(`first content line is not an H1 title (found: ${JSON.stringify(first.slice(0, 60))})`);
+    }
+
+    // 3. Every fenced code block must be closed — an unclosed fence silently swallows
+    //    the rest of the skill when the model reads it.
+    const fences = (text.match(/^```/gm) || []).length;
+    if (fences % 2 !== 0) err(`unbalanced code fences (${fences} \`\`\` markers)`);
+
+    // 4. Every reference to another skill/doc file must resolve on disk.
+    for (const m of text.matchAll(REF_RE)) {
+      try { readFileSync(join(PROJECT_DIR, m[1])); }
+      catch { err(`dead reference to "${m[1]}"`); }
+    }
+  }
+  return { errors, count: files.length };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const { errors, count } = validate(process.argv.slice(2));
+  if (!errors.length) { console.log(`skills: OK (${count} markdown file${count === 1 ? '' : 's'})`); process.exit(0); }
+  for (const e of errors) console.error(`  ${e.file}: ${e.msg}`);
+  console.error(`skills: ${errors.length} problem(s) in ${count} file(s)`);
+  process.exit(1);
+}

--- a/.claude/harness/verify.mjs
+++ b/.claude/harness/verify.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// ORGAN 6 — THE GATE. Deterministic, executable, exit-code driven.
+// A human running `node .claude/harness/verify.mjs` gets the identical answer.
+// No model is involved anywhere in this file.
+import { spawnSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PROJECT_DIR, P, contract, git, fingerprint, gitHead } from './guardrails.mjs';
+import { trace } from './trace.mjs';
+
+const TAIL = 30;
+const isWin = process.platform === 'win32';
+
+function run(cmd, args) {
+  const r = spawnSync(cmd, args, { cwd: PROJECT_DIR, encoding: 'utf8', shell: false });
+  return { code: r.status === null ? 1 : r.status, out: `${r.stdout || ''}${r.stderr || ''}`, error: r.error };
+}
+
+// Interpreter discovery — the reason this gate is portable. Never assume `python`.
+function findPython() {
+  const candidates = [];
+  if (process.env.HARNESS_PYTHON) candidates.push([process.env.HARNESS_PYTHON, []]);
+  candidates.push(
+    [join(PROJECT_DIR, '.venv', isWin ? 'Scripts' : 'bin', isWin ? 'python.exe' : 'python'), []],
+    ['python3', []], ['python', []],
+  );
+  if (isWin) candidates.push(['py', ['-3']]);
+  for (const [cmd, pre] of candidates) {
+    if (cmd.includes('/') || cmd.includes('\\')) { if (!existsSync(cmd)) continue; }
+    const r = run(cmd, [...pre, '--version']);
+    if (r.code === 0) return { cmd, pre, version: r.out.trim() };
+  }
+  return null;
+}
+
+const py = findPython();
+const pyFiles = git(['ls-files', '*.py']).trim().split('\n').filter(Boolean);
+
+const STEPS = {
+  // cheapest first, fail fast
+  skills: () => run(process.execPath, [join(P.contract, '..', 'validate-skills.mjs')]),
+  compile: () => py
+    ? run(py.cmd, [...py.pre, '-m', 'compileall', '-q', ...pyFiles])
+    : { code: 1, out: 'no Python interpreter found (tried $HARNESS_PYTHON, .venv, python3, python, py -3)' },
+  tests: () => {
+    if (!py) return { code: 1, out: 'no Python interpreter found' };
+    const probe = run(py.cmd, [...py.pre, '-c', 'import pytest']);
+    if (probe.code !== 0) return { code: 1, out: `pytest is not installed for ${py.cmd}.\nInstall it with:  uv sync --group dev\n           or:  ${py.cmd} -m pip install pytest\n(pytest is declared in pyproject.toml under [dependency-groups] dev)` };
+    return run(py.cmd, [...py.pre, '-m', 'pytest', '-q']);
+  },
+};
+
+const results = [];
+let failedStep = null;
+console.log(`verify: ${contract.verify_steps.join(' -> ')}   [python: ${py ? `${py.cmd} ${py.version}` : 'NOT FOUND'}]`);
+for (const name of contract.verify_steps) {
+  const step = STEPS[name];
+  if (!step) { console.error(`verify: unknown step "${name}" in contract.json`); failedStep = name; results.push({ name, code: 1 }); break; }
+  const started = Date.now();
+  const r = step();
+  results.push({ name, code: r.code, ms: Date.now() - started });
+  if (r.code === 0) { console.log(`  PASS  ${name} (${Date.now() - started}ms)`); continue; }
+  failedStep = name;
+  console.error(`  FAIL  ${name} (exit ${r.code})`);
+  console.error('  ---- last ' + TAIL + ' lines ----');
+  for (const line of (r.out || '(no output)').replace(/\r\n/g, '\n').split('\n').slice(-TAIL)) console.error('  ' + line);
+  console.error('  --------------------------');
+  break; // fail fast
+}
+
+const exitCode = failedStep ? 1 : 0;
+const record = {
+  exitCode, failedStep, steps: results,
+  fingerprint: fingerprint(), head: gitHead(),
+  python: py ? `${py.cmd} ${py.version}` : null,
+  timestamp: new Date().toISOString(),
+};
+writeFileSync(P.lastVerify, JSON.stringify(record, null, 2) + '\n');
+trace({ kind: 'verify', exitCode, failedStep, steps: results.map(s => `${s.name}:${s.code}`) });
+
+console.log(exitCode === 0
+  ? `verify: PASS (exit 0)  fingerprint ${record.fingerprint.slice(0, 12)}`
+  : `verify: FAIL (exit 1) at step "${failedStep}"`);
+process.exit(exitCode);

--- a/.claude/hooks/post-tool-use.mjs
+++ b/.claude/hooks/post-tool-use.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// ORGAN 7 (trace) + deterministic fixups.
+// Everything here is something you would otherwise nag the model about in a prompt.
+// PostToolUse stderr is shown to Claude regardless of exit code.
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { hookInput, normalizePath, PROJECT_DIR, P } from '../harness/guardrails.mjs';
+import { traceTool } from '../harness/trace.mjs';
+
+const input = hookInput();
+const tool = input.tool_name || '';
+const ti = input.tool_input || {};
+const target = ti.file_path || ti.notebook_path || ti.command || '';
+const resp = typeof input.tool_response === 'string' ? input.tool_response : JSON.stringify(input.tool_response ?? '');
+const failed = /^(error|Error)|is_error|"error"/.test(resp || '');
+
+traceTool({ tool, target, outcome: failed ? 'error' : 'ok', detail: failed ? resp : undefined, session: input.session_id });
+
+// .last-verify carries the fingerprint of the tree it validated, so any write
+// invalidates it automatically at the Stop gate. Nothing to delete here.
+
+const rel = normalizePath(ti.file_path || ti.notebook_path || '');
+const problems = [];
+if (rel && /^(Edit|Write|MultiEdit|NotebookEdit)$/.test(tool) && existsSync(join(PROJECT_DIR, rel))) {
+  if (rel.endsWith('.md')) {
+    const r = spawnSync(process.execPath, [resolve(P.contract, '..', 'validate-skills.mjs'), rel], { cwd: PROJECT_DIR, encoding: 'utf8' });
+    if (r.status !== 0) problems.push(`skill structure:\n${(r.stderr || r.stdout || '').trim()}`);
+  } else if (rel.endsWith('.py')) {
+    for (const cand of [process.env.HARNESS_PYTHON, 'python3', 'python']) {
+      if (!cand) continue;
+      const probe = spawnSync(cand, ['--version'], { encoding: 'utf8' });
+      if (probe.status !== 0) continue;
+      const r = spawnSync(cand, ['-m', 'py_compile', rel], { cwd: PROJECT_DIR, encoding: 'utf8' });
+      if (r.status !== 0) problems.push(`python syntax:\n${(r.stderr || r.stdout || '').trim()}`);
+      break;
+    }
+  }
+}
+
+if (problems.length) {
+  console.error(`HARNESS — the file you just wrote does not pass its structural check:\n\n${problems.join('\n\n')}\n\nFix ${rel} before doing anything else. This is the same check the verify gate runs, so it will block completion too.`);
+  process.exit(2);
+}
+process.exit(0);

--- a/.claude/hooks/pre-compact.mjs
+++ b/.claude/hooks/pre-compact.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// ORGAN 3 — flush before the context is cut.
+// Compaction keeps the ends and drops the middle, so anything that must
+// survive has to be on disk first. This hook cannot know your decisions —
+// only you do — so it does two things it CAN do deterministically:
+//   1. blocks compaction ONCE if state.md is stale relative to your edits,
+//      forcing the flush to happen while the context still exists;
+//   2. stamps a machine checkpoint into state.md either way.
+import { appendFileSync, existsSync, statSync, readFileSync } from 'node:fs';
+import { hookInput, P, fingerprint, gitHead, readJson, writeJson, readBudget, lastVerify, currentObjective } from '../harness/guardrails.mjs';
+import { trace } from '../harness/trace.mjs';
+
+const input = hookInput();
+const fp = fingerprint();
+const baseline = readJson(P.baseline, null);
+const treeChanged = baseline && baseline.fingerprint !== fp;
+const alreadyBlocked = readJson(P.compactFlush, { blocked: false }).blocked === true;
+
+const stateMtime = existsSync(P.state) ? statSync(P.state).mtimeMs : 0;
+const traceMtime = existsSync(P.trace) ? statSync(P.trace).mtimeMs : 0;
+const stateIsStale = treeChanged && stateMtime < traceMtime;
+
+if (stateIsStale && !alreadyBlocked) {
+  writeJson(P.compactFlush, { blocked: true, blockedAt: new Date().toISOString(), fingerprint: fp });
+  trace({ kind: 'pre-compact', decision: 'block', reason: 'state.md stale' });
+  console.error([
+    `HARNESS BLOCK — context is about to be compacted and .claude/harness/state.md is stale.`,
+    `Compaction drops the middle of the conversation. Anything not on disk is gone.`,
+    ``,
+    `Before compacting, rewrite state.md with:`,
+    `  - Current objective (one sentence)`,
+    `  - Decisions made, with reasons`,
+    `  - Approaches already tried and rejected  <-- this is the one you will otherwise re-litigate`,
+    `  - Open blockers`,
+    `  - Attempt counter`,
+    ``,
+    `Then let compaction proceed. This hook blocks only once per session.`,
+  ].join('\n'));
+  process.exit(2);
+}
+
+const checkpoint = [
+  ``,
+  `<!-- machine checkpoint written by pre-compact.mjs — do not hand-edit -->`,
+  `> compaction (${input.trigger || 'unknown'}) at ${new Date().toISOString()}`,
+  `> HEAD ${gitHead().slice(0, 8)} | tree ${fp.slice(0, 12)}${treeChanged ? ' (CHANGED this session)' : ''}`,
+  `> objective at compaction: ${currentObjective()}`,
+  `> tool budget: ${readBudget().count}/${readBudget().limit}`,
+  `> last verify: ${(() => { const lv = lastVerify(); return lv ? `exit ${lv.exitCode}${lv.fingerprint === fp ? ' (valid)' : ' (STALE)'}` : 'never run'; })()}`,
+  ``,
+].join('\n');
+try { appendFileSync(P.state, checkpoint); } catch { /* never block compaction on a write failure */ }
+trace({ kind: 'pre-compact', decision: 'allow', trigger: input.trigger });
+process.exit(0);

--- a/.claude/hooks/pre-tool-use.mjs
+++ b/.claude/hooks/pre-tool-use.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// ORGAN 4 — the deterministic denier. Runs BEFORE the tool does.
+// Blocks loudly and specifically: what was blocked, which rule blocked it,
+// and the legitimate alternative. Exit 2 is an unconditional block; a JSON
+// decision on exit 0 can be overridden by schema-validation failure, so we
+// never rely on it for a deny.
+import { hookInput, checkPath, checkCommand, bumpBudget, contract } from '../harness/guardrails.mjs';
+import { trace } from '../harness/trace.mjs';
+
+const ACTING_TOOLS = /^(Bash|PowerShell|Edit|Write|MultiEdit|NotebookEdit)$/;
+const PATH_FIELDS = ['file_path', 'notebook_path', 'path'];
+
+const input = hookInput();
+const tool = input.tool_name || '';
+const ti = input.tool_input || {};
+
+function deny(reason) {
+  trace({ kind: 'blocked', tool, reason, session: input.session_id });
+  console.error(reason);
+  process.exit(2);           // hard block
+}
+
+// 1. Path guardrails — checked for every tool that names a file.
+for (const field of PATH_FIELDS) {
+  if (!ti[field]) continue;
+  const r = checkPath(ti[field]);
+  if (r.blocked) {
+    deny([
+      `HARNESS BLOCK — forbidden path`,
+      `  tool:  ${tool} (${field} = ${ti[field]})`,
+      `  rule:  forbidden_paths contains "${r.rule}" in .claude/harness/contract.json`,
+      `  why:   this path holds secrets, generated output, or git internals.`,
+      `  do:    work on a source file instead. If this path genuinely must change,`,
+      `         stop and ask the human to amend the contract — do NOT edit the harness.`,
+    ].join('\n'));
+  }
+}
+
+// 2. Command guardrails — every segment of a compound command is checked.
+const command = ti.command || '';
+if (command) {
+  const r = checkCommand(command);
+  if (r.blocked) {
+    deny([
+      `HARNESS BLOCK — forbidden command`,
+      `  command: ${String(command).slice(0, 300)}`,
+      `  segment: ${String(r.matched).slice(0, 200)}`,
+      `  rule:    forbidden_commands["${r.rule.id}"] — ${r.rule.why}`,
+      `  do:      ${r.rule.instead}`,
+    ].join('\n'));
+  }
+}
+
+// 3. Tool-call budget, per objective (objective read from state.md).
+if (ACTING_TOOLS.test(tool)) {
+  const b = bumpBudget(1);
+  if (b.count > b.limit) {
+    deny([
+      `HARNESS BLOCK — tool-call budget exhausted`,
+      `  objective: ${b.objective}`,
+      `  used:      ${b.count} of ${b.limit} acting tool calls (Bash/Edit/Write/NotebookEdit)`,
+      `  why:       ${b.count - b.limit} calls past the contract limit means this approach is thrashing.`,
+      `  do:        STOP. Write what you tried and why it failed into .claude/harness/state.md,`,
+      `             then either change approach and run /harness-reset, or escalate to the human`,
+      `             with a blocker note. Do not keep going.`,
+    ].join('\n'));
+  }
+  if (b.count === b.limit) {
+    console.error(`HARNESS WARNING — this is call ${b.count} of ${b.limit} for objective "${b.objective}". The next acting call will be blocked.`);
+  }
+}
+process.exit(0);

--- a/.claude/hooks/session-start.mjs
+++ b/.claude/hooks/session-start.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// ORGAN 3 — context primitive. Snapshots the tree for the Stop gate and
+// orients every new session from disk rather than from a fading transcript.
+import { readFileSync, existsSync } from 'node:fs';
+import { hookInput, P, contract, fingerprint, gitHead, writeJson, resetCounters, readBudget, lastVerify } from '../harness/guardrails.mjs';
+import { trace } from '../harness/trace.mjs';
+import { tail } from '../harness/trace.mjs';
+
+const input = hookInput();
+const fp = fingerprint();
+writeJson(P.baseline, { fingerprint: fp, head: gitHead(), at: new Date().toISOString(), source: input.source || 'unknown' });
+resetCounters();   // zeroes stop-attempts, tool budget and the compaction flush flag
+trace({ kind: 'session-start', source: input.source, session: input.session_id, fingerprint: fp.slice(0, 12) });
+
+const lv = lastVerify();
+const budget = readBudget();
+const state = existsSync(P.state) ? readFileSync(P.state, 'utf8').replace(/\r\n/g, '\n').trim() : '(no state.md)';
+
+// SessionStart stdout is injected into the session as context.
+console.log([
+  `<harness-status>`,
+  `Harness is ACTIVE in this repo. The gate is: node .claude/harness/verify.mjs`,
+  `Contract: ${contract.verify_steps.join(' -> ')} | max_attempts=${contract.max_attempts} | tool budget=${contract.max_tool_calls_per_objective}/objective`,
+  `Last verify: ${lv ? `exit ${lv.exitCode}${lv.failedStep ? ` (failed at "${lv.failedStep}")` : ''} at ${lv.timestamp}${lv.fingerprint === fp ? ' — STILL VALID for this tree' : ' — STALE, the tree has changed since'}` : 'never run'}`,
+  `Tool budget used: ${budget.count}/${budget.limit} for objective "${budget.objective}"`,
+  `Recent trace:`,
+  ...tail(5).map(l => '  ' + l),
+  ``,
+  `--- .claude/harness/state.md ---`,
+  state,
+  `--- end state.md ---`,
+  `Read .claude/harness/contract.md before changing how you work in this repo.`,
+  `</harness-status>`,
+].join('\n'));
+process.exit(0);

--- a/.claude/hooks/stop.mjs
+++ b/.claude/hooks/stop.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// ORGAN 6 enforcement — THE anti-lie gate. The single most important file here.
+// It cannot be satisfied by a claim; only by an exit code recorded against
+// this exact tree.
+import { readFileSync, writeFileSync, existsSync, appendFileSync } from 'node:fs';
+import { hookInput, P, contract, fingerprint, gitHead, readJson, writeJson, verifyIsGreenForTree, clearCounter } from '../harness/guardrails.mjs';
+import { trace } from '../harness/trace.mjs';
+
+const input = hookInput();
+
+// Platform escape hatch: Claude Code force-overrides a Stop hook after 8
+// consecutive blocks. Respect stop_hook_active so we never fight it.
+if (input.stop_hook_active === true) process.exit(0);
+
+const fp = fingerprint();
+const baseline = readJson(P.baseline, null);
+
+// 1. No session baseline (Cowork, a resumed session, a hand-run) — record one
+//    and let this turn end. We refuse to guess at a change we cannot bound.
+if (!baseline) {
+  writeJson(P.baseline, { fingerprint: fp, head: gitHead(), at: new Date().toISOString(), note: 'written by stop.mjs; no SessionStart baseline existed' });
+  process.exit(0);
+}
+
+// 2. Nothing changed this session — nothing to verify.
+if (baseline.fingerprint === fp) {
+  clearCounter(P.stopAttempts);
+  process.exit(0);
+}
+
+// 3. Something changed. Is there a green verify against THIS tree?
+const green = verifyIsGreenForTree(fp);
+if (green.ok) {
+  clearCounter(P.stopAttempts);
+  trace({ kind: 'stop', decision: 'allow', reason: 'verify green for current tree' });
+  process.exit(0);
+}
+
+// 4. Not verified. Count the block; release control once the contract's
+//    attempt budget is spent. A harness that can never release control is broken.
+const att = readJson(P.stopAttempts, { count: 0 });
+att.count += 1;
+att.lastFingerprint = fp;
+writeJson(P.stopAttempts, att);
+
+if (att.count > contract.max_attempts) {
+  const note = [
+    '',
+    `## BLOCKER — harness gave up after ${contract.max_attempts} attempts`,
+    `- when: ${new Date().toISOString()}`,
+    `- tree fingerprint: ${fp.slice(0, 12)}  (HEAD ${gitHead().slice(0, 8)})`,
+    `- reason verify is not green: ${green.why}`,
+    `- what a human must do: run \`node .claude/harness/verify.mjs\`, read the failing step,`,
+    `  and decide whether the change or the contract is wrong.`,
+    '',
+  ].join('\n');
+  try { appendFileSync(P.state, note); } catch { /* never break the release */ }
+  trace({ kind: 'stop', decision: 'release', attempts: att.count, why: green.why });
+  console.error(`HARNESS RELEASED CONTROL — the Stop gate blocked ${contract.max_attempts} times without verify going green (${green.why}). A blocker note was written to .claude/harness/state.md. This turn is ending UNVERIFIED; a human needs to look.`);
+  clearCounter(P.stopAttempts);
+  process.exit(0);
+}
+
+trace({ kind: 'stop', decision: 'block', attempt: att.count, why: green.why });
+console.error([
+  `HARNESS BLOCK — you are trying to finish an unverified change. (attempt ${att.count} of ${contract.max_attempts})`,
+  ``,
+  `  the tree changed this session: ${baseline.fingerprint.slice(0, 12)} -> ${fp.slice(0, 12)}`,
+  `  verify status: ${green.why}`,
+  ``,
+  `  Run:   node .claude/harness/verify.mjs`,
+  `  Then:  fix whatever step it names and run it again until it exits 0.`,
+  ``,
+  `  Definition of done: ${contract.definition_of_done}`,
+  `  Do NOT edit .claude/harness/** or .claude/hooks/** to make this pass.`,
+  `  If verify is genuinely wrong, say so, stop, and ask the human to amend the contract.`,
+].join('\n'));
+process.exit(2);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(node .claude/harness/verify.mjs:*)",
+      "Bash(node .claude/harness/guardrails.mjs:*)",
+      "Bash(node .claude/harness/validate-skills.mjs:*)",
+      "Bash(node .claude/harness/trace.mjs:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(python3 -m pytest:*)",
+      "Bash(python -m compileall:*)",
+      "Bash(python3 -m compileall:*)",
+      "Bash(python -m py_compile:*)",
+      "Bash(python3 -m py_compile:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)"
+    ],
+    "ask": [
+      "Bash(browser-harness:*)",
+      "Bash(python run.py:*)",
+      "Bash(python3 run.py:*)",
+      "Bash(py run.py:*)",
+      "Bash(python daemon.py:*)",
+      "Bash(python3 daemon.py:*)",
+      "Bash(python admin.py:*)",
+      "Bash(python3 admin.py:*)",
+      "PowerShell(browser-harness:*)",
+      "PowerShell(python run.py:*)",
+      "PowerShell(python daemon.py:*)",
+      "PowerShell(python admin.py:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)",
+      "Bash(git tag:*)",
+      "Bash(pip install:*)",
+      "Bash(pip3 install:*)",
+      "Bash(python -m pip:*)",
+      "Bash(python3 -m pip:*)",
+      "Bash(uv:*)",
+      "Bash(npm install:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Edit(/pyproject.toml)",
+      "Edit(/CLAUDE.md)",
+      "Edit(/.claude/settings.json)",
+      "Edit(/.claude/hooks/**)",
+      "Edit(/.claude/harness/*.mjs)",
+      "Edit(/.claude/harness/contract.json)",
+      "Edit(/.claude/harness/contract.md)"
+    ],
+    "deny": [
+      "Read(.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.*.local)",
+      "Read(**/secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Edit(.env)",
+      "Edit(**/secrets/**)",
+      "Edit(/.git/**)",
+      "Edit(**/__pycache__/**)",
+      "Edit(**/*.egg-info/**)",
+      "Bash(rm:*)",
+      "Bash(rmdir:*)",
+      "Bash(sudo:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean:*)",
+      "PowerShell(Remove-Item:*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.mjs"],
+            "timeout": 60,
+            "statusMessage": "Loading harness state..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|PowerShell|Edit|Write|MultiEdit|NotebookEdit|Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.mjs"],
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|PowerShell|Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/post-tool-use.mjs"],
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/stop.mjs"],
+            "timeout": 120,
+            "statusMessage": "Harness gate: checking verify status..."
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-compact.mjs"],
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,14 @@ __pycache__/
 .env
 uv.lock
 *.egg-info/
+
+# --- harness runtime artifacts (organ 7 trace + gate markers) ---
+.pytest_cache/
+.claude/harness/trace.jsonl
+.claude/harness/.last-verify
+.claude/harness/.session-baseline
+.claude/harness/.stop-attempts
+.claude/harness/.budget
+.claude/harness/.compact-flush
+.claude/harness/backup/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# browser-harness — operating contract
+
+Loaded into every session. Rules only. The long explanation lives in `@docs/HARNESS.md`.
+
+## Project facts
+
+- Python ≥3.11 CDP driver for the user's **real, signed-in Chrome**. Entry points:
+  `run.py` (CLI, `browser-harness` on PATH), `helpers.py` (the functions), `daemon.py`,
+  `admin.py`. Deps: `cdp-use`, `fetch-use`, `websockets`.
+- 89 of 102 tracked files are Markdown: `SKILL.md`, `install.md`, `domain-skills/<site>/*.md`,
+  `interaction-skills/*.md`. **The skill corpus is the product.** Treat a broken skill file
+  as a broken build.
+- The one verify command: **`node .claude/harness/verify.mjs`** (also `/verify`).
+- There is no CI. This gate is the only gate.
+- Change detection is a content hash (`node .claude/harness/guardrails.mjs fingerprint`),
+  not `git status`. `state.md` is deliberately outside that hash, so updating your working
+  memory never invalidates a green verify.
+- Only run one Claude session per checkout. The harness counters are not lock-protected.
+
+## The loop
+
+**Outer loop — attempts.** At most **3** attempts per objective. After a failed attempt,
+write what failed and why into `.claude/harness/state.md` and **change approach**.
+Repeating the same attempt with more enthusiasm is not an attempt. After the third,
+stop, write a blocker note, hand control to the human.
+
+**Inner loop — one attempt.**
+
+1. **Orient.** Read `@.claude/harness/state.md` and `@.claude/harness/contract.md`.
+   State the objective in one sentence and the observable condition that proves it done.
+   Write that sentence under `## Current objective` in `state.md` — the tool budget is
+   keyed to it.
+2. **Plan.** Smallest reversible change that could satisfy the objective. If it touches
+   anything under *Requires human approval*, stop and ask first.
+3. **Act.** Stay inside the budget. Never touch forbidden paths.
+4. **Verify.** Run `node .claude/harness/verify.mjs`. Read the exit code. Do not
+   interpret it, do not summarise it favourably, do not proceed on a non-zero exit.
+5. **Attest.** Report with evidence: the command, the exit code, the diff summary.
+6. **Record.** Rewrite `state.md`. The trace is written for you by the hooks.
+
+## Guardrails
+
+- **3** attempts per objective. **25** acting tool calls per objective
+  (Bash/PowerShell/Edit/Write/NotebookEdit; reads are free).
+- **Never read** `.env`, `**/secrets/**`, `*.pem`, `*.key`. Secrets are the harness's job,
+  not yours. Ask for the effect, never for the credential.
+- **Never edit** `.git/**`, `__pycache__/**`, `*.egg-info/**`, `dist/`, `build/`.
+- **Never run** recursive `rm`, `git push --force`, `git reset --hard`, `git clean -df`,
+  `git checkout .`, `curl … | sh`, or any publish command.
+- **`run.py`, `daemon.py`, `admin.py` and `browser-harness` attach to the user's live,
+  signed-in Chrome.** Running them is an action on their real accounts, not a test.
+  They always require an explicit yes. The test suite mocks CDP and needs no browser —
+  use it instead.
+
+## The anti-lie clause
+
+**Never report a task as complete without the output of the verify command in the same
+turn.** "It should work" and "I've made the change" are not completion. If verify was not
+run, the word is **"unverified"**. A claim of success is not success; success is an exit
+code plus a trace entry. Failing loudly is a win — step one to solving a problem is
+admitting you have one.
+
+## Escalation
+
+Requires a human: dependency changes (`pyproject.toml`), any change to
+`.claude/settings.json`, `.claude/hooks/**` or `.claude/harness/*.mjs`, driving the real
+browser, `git commit`, `git push`, package installs.
+
+Blocker note format, appended to `state.md`:
+
+```
+## BLOCKER — <one line>
+- what I was trying to do:
+- what I tried, and the exact failure (command + exit code):
+- what I need a human to decide:
+```
+
+Blocked is a valid, respectable outcome. Report it and stop.
+
+## Never modify the harness to satisfy the harness
+
+Do not edit, disable or bypass a hook, a guardrail or the verify script to make a task
+pass. If a guardrail is genuinely wrong, say so, explain why, and ask the human to amend
+the contract. This is the one unforgivable action in this repo.
+
+## When hooks are not running (Cowork / any non-Claude-Code client)
+
+The hooks in `.claude/settings.json` execute in Claude Code (terminal) and in the VS Code
+extension. Elsewhere — Cowork, a plain SDK session — nothing fires, and the same rules
+must be followed **procedurally**. In that case, explicitly and by hand:
+
+- at the start: read `state.md`, and record the output of
+  `node .claude/harness/guardrails.mjs fingerprint` as your baseline;
+- before finishing: run the verify command and paste its output;
+- count your own acting tool calls against the budget of 25;
+- check any path or command you are unsure about with
+  `node .claude/harness/guardrails.mjs check-path <p>` / `check-command "<cmd>"`.
+
+## Pointers
+
+- `@.claude/harness/state.md` — current objective, decisions, rejected approaches, blockers
+- `@.claude/harness/contract.md` — the contract in force
+- `@docs/HARNESS.md` — what each organ does and how to maintain it

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,0 +1,184 @@
+# The harness
+
+> An agent harness is everything around the model that gives it grounding in reality.
+
+A climber anchors to the rock so they cannot drift. A dog walks on a harness so it cannot
+run into traffic. The harness is not the agent, not the loop, and not the prompt — it is
+the stable structure the agent is tied to.
+
+The premise of everything in this directory is that **you do not fix reliability by
+prompting harder**. Every failure mode gets a mechanism: a hook, a script, an exit code, a
+permission rule. Prose is the last resort, and where prose is all we have, this document
+says so out loud.
+
+## Why this repo needed one
+
+Three things about `browser-harness` specifically:
+
+1. **`run.py`, `daemon.py` and `admin.py` attach over CDP to the user's real, signed-in
+   Chrome.** An agent running them is taking authenticated actions on live accounts. That
+   is the largest blast radius in the repo by a wide margin, and nothing guarded it.
+2. **89 of 102 tracked files are Markdown skills — the product itself — and nothing
+   validated them.** A skill with an unclosed code fence or a dead cross-reference ships
+   silently and degrades every future agent that reads it.
+3. **"Is the tree dirty?" is not a question `git status` answers portably.** Read through
+   a Linux git, this Windows checkout reports 99 modified files and a 27,101-line diff of
+   pure line endings; read through Git for Windows, where `core.autocrlf` is set at system
+   level, the same bytes are clean. Same tree, opposite answers, depending on which git
+   asks. A gate built on `git status` inherits that. Content hashing does not — and it also
+   survives formatter mtime churn and makes verify-staleness structural rather than a
+   marker file someone has to remember to delete.
+
+   *(Correction, 2026-08-26: the first version of this document asserted `core.autocrlf=false`
+   and presented the dirty tree as a defect in the repo. It is not — it was an artefact of
+   the environment the recon ran in, and the claim was wrong. The mechanism was right for
+   other reasons; the evidence given for it was not. An independent audit caught it.)*
+
+Also: there is no CI, no linter config, no formatter, no typechecker and no dev dependency
+group. There was no verify command to inherit. The gate here was built, not found.
+
+## The seven organs
+
+| # | Organ | Where it lives |
+|---|---|---|
+| 1 | Tool registry | `.claude/settings.json` → `permissions.allow` / `ask` / `deny` |
+| 2 | Model boundary | Assume a weaker model than you hope. Nothing here depends on model capability; every check is code |
+| 3 | Context primitives | `harness/state.md`, `hooks/session-start.mjs`, `hooks/pre-compact.mjs` |
+| 4 | Guardrails | `harness/contract.json`, `harness/guardrails.mjs`, `hooks/pre-tool-use.mjs` |
+| 5 | Agent loop + outer loop | `CLAUDE.md` (the protocol) + the attempt counter in `hooks/stop.mjs` |
+| 6 | Verify step | `harness/verify.mjs`, `harness/validate-skills.mjs`, enforced by `hooks/stop.mjs` |
+| 7 | Trace | `harness/trace.mjs` → `harness/trace.jsonl` (gitignored) |
+
+## Running the gate by hand
+
+```bash
+node .claude/harness/verify.mjs        # exit 0 = pass, 1 = fail (names the failing step)
+```
+
+No model is involved. A teammate, a cron job and the Stop hook all get the identical
+answer. Useful adjuncts:
+
+```bash
+node .claude/harness/guardrails.mjs fingerprint          # content hash of the tree
+node .claude/harness/guardrails.mjs budget               # acting calls used this objective
+node .claude/harness/guardrails.mjs check-path .env      # would this path be blocked?
+node .claude/harness/guardrails.mjs check-command "rm -rf ."
+node .claude/harness/trace.mjs tail 20
+```
+
+`verify.mjs` finds Python in this order: `$HARNESS_PYTHON`, `.venv/Scripts/python.exe`
+(Windows) or `.venv/bin/python`, `python3`, `python`, `py -3`. Set `HARNESS_PYTHON` if you
+keep the interpreter somewhere unusual.
+
+If the `tests` step says pytest is missing: `uv sync --group dev`, or
+`python -m pip install pytest`. It is declared in `pyproject.toml` under
+`[dependency-groups] dev`.
+
+## How the Stop gate actually works
+
+`hooks/stop.mjs` runs when Claude tries to end a turn.
+
+1. `stop_hook_active` true → exit 0. Claude Code force-overrides a Stop hook after eight
+   consecutive blocks; the harness never fights that.
+2. No session baseline → write one, exit 0. It refuses to guess at a change it cannot bound.
+3. Current fingerprint equals the session-start fingerprint → nothing changed, exit 0.
+4. `.last-verify` exists, `exitCode` is 0, **and** its `fingerprint` equals the current one
+   → exit 0. Staleness is structural: any write changes the fingerprint, so a green result
+   from before the write cannot satisfy the gate. There is nothing to invalidate by hand.
+5. Otherwise exit 2, which blocks and feeds the reason back to Claude.
+6. After `max_attempts` blocks (3), it writes a blocker note into `state.md`, prints
+   "HARNESS RELEASED CONTROL", and exits 0. **A harness that can never release control is
+   a broken harness.**
+
+## Adding a guardrail
+
+Forbidden paths and commands live in `harness/contract.json` — one place, read by the hook
+and by the CLI. Add a path glob to `forbidden_paths` (a leading `!` makes an exception, as
+with `!**/.env.example`), or an object to `forbidden_commands`:
+
+```json
+{ "id": "short-name", "pattern": "regex", "why": "one line", "instead": "the legitimate alternative" }
+```
+
+`why` and `instead` are not decoration — they are what the block message shows. A guardrail
+that blocks silently teaches the agent nothing. Then check your work:
+
+```bash
+node .claude/harness/guardrails.mjs check-command "the thing you want blocked"   # expect exit 2
+node .claude/harness/guardrails.mjs check-command "a legitimate neighbour"       # expect exit 0
+```
+
+Commands are matched **per shell segment** (`&&`, `||`, `;`, `|`, `&`, newline) after
+stripping wrappers (`timeout`, `nice`, `sudo`, `env`, leading `FOO=bar` assignments), so
+`safe && dangerous` cannot smuggle anything past. Two rules — pipe-to-shell and redirection
+into the harness — are matched against the whole string instead, because that is where the
+danger lives.
+
+Permission rules are the coarser, faster net in `.claude/settings.json`. Two things that
+cost real time to learn:
+
+- **`Write(path)` and `NotebookEdit(path)` rules are accepted and never consulted.** Use
+  `Edit(path)` for write guarding and `Read(path)` for read guarding. Anything else is a
+  guardrail that looks present and does nothing.
+- **A deny rule cannot carry an allow exception.** `Read(.env.*)` in deny would also block
+  `.env.example`. That is why the deny list here is narrow and the *hook* carries the
+  precise `**/.env.*` + `!**/.env.example` logic.
+
+## Where the harness is mechanical, and where it is only protocol
+
+| Environment | Hooks | Permissions | Verify |
+|---|---|---|---|
+| Claude Code (terminal) | enforced | enforced | enforced |
+| Claude in VS Code | enforced — settings, hooks, commands and subagents are shared with the CLI | enforced | enforced |
+| Cowork / SDK / plain CI | **not enforced** — nothing executes `.claude/settings.json` hooks | not enforced | runnable by hand |
+
+In Cowork the same rules must be followed by hand; `CLAUDE.md` states them as explicit
+steps for exactly that reason. This distinction is the honest measure of how strong the
+harness really is, so it is written down rather than glossed.
+
+## Disabling it, and why not to
+
+Rename `.claude/settings.json`, or run `claude --settings /dev/null`. Do that to debug the
+harness itself, never to get a task past it. Modifying the harness to satisfy the harness
+is the one unforgivable action in this repo — `permissions.ask` makes every such edit
+require a human yes, and the `verifier` subagent is told to report it first and loudly.
+
+Personal overrides go in `.claude/settings.local.json`, which is gitignored.
+
+## First maintenance action
+
+Introduce `ruff` as a ratchet. Right now it reports 68 errors and would reformat 75 of 95
+files, which is why it is not in the gate. The cheap path:
+
+```bash
+uv run ruff format .            # or: python -m pip install ruff && ruff format .
+uv run ruff check --fix .
+```
+
+Commit that as one isolated reformat, add `ruff` to the dev dependency group, then add
+`"lint"` to `verify_steps` in `contract.json` and a matching entry in the `STEPS` object of
+`verify.mjs`. Do it as its own change with nothing else in the diff.
+
+**Do not** go renormalising line endings. An earlier draft of this document told you to,
+on the strength of a misread `git config` output. Under Git for Windows this tree is clean;
+adding a `.gitattributes` and running `git add --renormalize .` would rewrite all 102 files
+for no benefit. If you ever add Linux or macOS teammates, revisit it then — as a deliberate
+decision, not as maintenance.
+
+## Known gaps
+
+Stated plainly, because hiding them is the same failure as lying about success.
+
+- **No cross-session locking.** Two Claude sessions in the same checkout share
+  `.claude/harness/{.budget,.stop-attempts,.last-verify,.session-baseline}` with no lock.
+  The gate's design assumes it owns those counters. Concurrent sessions can overwrite each
+  other's `.last-verify` and each other's attempt counts. Symptoms are confusing rather
+  than dangerous — a turn released early, or blocked when it should not be. **Run one
+  session per checkout.** If you need two, give the second its own clone.
+- **The gate never drives the browser.** It proves syntax, tests and skill structure. That
+  CDP still attaches to a real Chrome is a human check.
+- **The deny list is a net, not a wall.** Command rules are anchored to the head of a shell
+  segment so that searching for a string is not treated as running it. A sufficiently
+  creative invocation shape will still get through; `nested-shell` closes the obvious one
+  (`bash -c "..."`), not every one.
+- **Hooks do not run outside Claude Code and the VS Code extension.** See the table above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ browser-harness = "run:main"
 
 [tool.setuptools]
 py-modules = ["run", "helpers", "daemon", "admin"]
+
+[dependency-groups]
+# Used by the harness verify gate: node .claude/harness/verify.mjs
+dev = [
+    "pytest>=8",
+]


### PR DESCRIPTION
Adds a self-contained agent harness that makes Claude Code sessions in this repo verifiable rather than self-attested.

## What it adds

- `.claude/harness/verify.mjs` — the single gate: `skills -> compile -> tests`. The exit code is the contract.
- `.claude/harness/validate-skills.mjs` — validates the Markdown skill corpus (`SKILL.md`, `domain-skills/**`, `interaction-skills/**`), which is 89 of 102 tracked files. A broken skill file fails the build.
- `.claude/harness/guardrails.mjs` — path and command checks (`check-path`, `check-command`, `fingerprint`). Blocks reads of `.env` and key material, edits under `.git/**`, and destructive commands. Command rules are head-anchored to a shell segment, so `grep -r "rm -rf"` is a search and not a delete.
- `.claude/hooks/*.mjs` — session-start, pre/post-tool-use, pre-compact and stop hooks in exec form (no shell), so they behave identically on Windows, macOS and Linux.
- `CLAUDE.md` — the operating contract: 3 attempts per objective, 25 acting tool calls, verify before any completion claim.
- `docs/HARNESS.md` — what each part does and how to maintain it.
- `.gitignore` — excludes the harness runtime artifacts (`trace.jsonl`, gate markers, `settings.local.json`).

## Notes for reviewers

- **The hooks are active for anyone who clones this repo and opens Claude Code.** That is the intent of the change, but it is an opinionated one and deserves an explicit decision rather than a silent merge.
- Change detection is a content hash rather than `git status`, because `git status` gives different answers for the same bytes depending on which git reads them.
- `ruff` is deliberately absent from the gate: it reports 68 errors and 75 unformatted files on the tree as it stands, so including it would build the gate on top of red. That cleanup belongs in its own PR.
- `pyproject.toml` gains `pytest` under `[dependency-groups] dev` — the only change here that touches the build.
- `.claude/harness/state.md` is committed with live working memory in it. If you would rather it shipped as an empty template, say so and I will strip it.

## Verification

`node .claude/harness/verify.mjs` → PASS (exit 0), fingerprint `6a70e1b035c5`, on Windows with Python 3.13.2. All three steps green: skills, compile, tests.
