### PR TITLE
fix: clean up unused browser recovery launch

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -982,6 +982,7 @@ def _launch_browser():
     known_profiles = enabled + [
         base for base in PROFILES if base not in enabled and (base / "Local State").exists()
     ]
+    system = platform.system()
     for key in ("BH_CHROME_PATH", "CHROME_PATH"):
         raw = (os.environ.get(key) or "").strip()
         if raw and Path(raw).expanduser().is_file():
@@ -994,7 +995,7 @@ def _launch_browser():
                 profile = next(
                     (base for base in known_profiles if _browser_binary_matches_profile(binary, base)),
                     None,
-                )
+                ) if system not in ("Darwin", "Windows") else None
                 return process, profile
             except (OSError, subprocess.SubprocessError):
                 # A path that exists but can't execute (permissions, wrong arch)
@@ -1005,7 +1006,6 @@ def _launch_browser():
     mac_app, posix_cmds, win_target = _browser_launch_spec(base) if base else _DEFAULT_LAUNCH
     profile_args = _profile_directory_args(base)
     try:
-        system = platform.system()
         if system == "Darwin":
             cmd = ["open", "-a", mac_app] + (["--args"] + profile_args if profile_args else [])
             r = subprocess.run(cmd, timeout=10, check=False, capture_output=True)

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -367,7 +367,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
 
     import subprocess, sys
     local = _is_local_chrome_mode(env)
-    launched_browser = False
+    launched_browser = None
     opened_inspect = False
     for _ in range(3):
         e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
@@ -385,7 +385,9 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         deadline = spawned + wait
         hinted = not local
         while time.time() < deadline:
-            if daemon_alive(name): return
+            if daemon_alive(name):
+                _cleanup_unattached_browser_launch(launched_browser)
+                return
             if p.poll() is not None: break
             if not hinted and time.time() - spawned > 2 and (_log_tail(name) or "").startswith("handshake-wait"):
                 action = (
@@ -411,11 +413,11 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             raise RuntimeError(
                 "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
             )
-        if local and not launched_browser and _chrome_not_running(msg):
+        if local and launched_browser is None and _chrome_not_running(msg):
             # Chrome is closed — launch the browser and retry
-            launched_browser = True
             restart_daemon(name)
-            if not _launch_browser():
+            launched_browser = _launch_browser()
+            if launched_browser is None:
                 raise RuntimeError(
                     "chrome-not-running: no supported browser is running and none could be launched -- ask the user to open Chrome, then retry."
                 )
@@ -953,7 +955,13 @@ def _profile_directory_args(base):
 
 
 def _launch_browser():
-    """Prefers the browser whose profile already has perm box checked"""
+    """Prefers the browser whose profile already has perm box checked.
+
+    Returns ``(process, profile)`` on success. ``process`` is available only
+    when we launched the browser directly; ``profile`` is the user-data dir we
+    expect that browser to use. The caller uses both to clean up a direct
+    launch that never becomes reachable over CDP.
+    """
     import platform, shutil, subprocess
     from .daemon import PROFILES, remote_debugging_toggle_profiles
 
@@ -961,11 +969,11 @@ def _launch_browser():
         raw = (os.environ.get(key) or "").strip()
         if raw and Path(raw).expanduser().is_file():
             try:
-                subprocess.Popen(
+                process = subprocess.Popen(
                     [str(Path(raw).expanduser())],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
                 )
-                return True
+                return process, None
             except (OSError, subprocess.SubprocessError):
                 # A path that exists but can't execute (permissions, wrong arch)
                 # must fall through to normal discovery, not abort
@@ -983,19 +991,48 @@ def _launch_browser():
             if r.returncode != 0 and mac_app != "Google Chrome":
                 # Different app → its profile dir may not match; launch plain
                 r = subprocess.run(["open", "-a", "Google Chrome"], timeout=10, check=False, capture_output=True)
-            return r.returncode == 0
+            return (None, base) if r.returncode == 0 else None
         if system == "Windows":
             # `start <name>` resolves browsers via App Paths without knowing the install dir
             subprocess.Popen(["cmd", "/c", "start", "", win_target or "chrome"] + profile_args, **ipc.spawn_kwargs())
-            return True
+            return None, base
         for cmd in posix_cmds or _DEFAULT_LAUNCH[1]:
             w = shutil.which(cmd)
             if w:
-                subprocess.Popen([w] + profile_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs())
-                return True
-        return False
+                process = subprocess.Popen(
+                    [w] + profile_args,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    **ipc.spawn_kwargs(),
+                )
+                return process, base
+        return None
     except (OSError, subprocess.SubprocessError):
-        return False
+        return None
+
+
+def _cleanup_unattached_browser_launch(launch):
+    """Stop a browser we launched when the daemon attached somewhere else."""
+    if not launch:
+        return
+    process, profile = launch
+    if process is None or profile is None or process.poll() is not None:
+        return
+
+    from .daemon import _devtools_port_live
+
+    if _devtools_port_live(profile):
+        return
+
+    import signal
+
+    try:
+        if ipc.IS_WINDOWS:
+            process.terminate()
+        else:
+            os.killpg(process.pid, signal.SIGTERM)
+    except (OSError, subprocess.SubprocessError):
+        pass
 
 
 def _open_chrome_inspect():

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -940,6 +940,19 @@ def _browser_launch_spec(base):
     return _DEFAULT_LAUNCH
 
 
+def _browser_binary_matches_profile(binary, base):
+    """True when an explicit browser binary belongs to ``base``."""
+    name = Path(binary).name.lower().removesuffix(".exe")
+    mac_app, posix_cmds, win_target = _browser_launch_spec(base)
+    candidates = (mac_app, *posix_cmds, win_target)
+
+    def normalize(value):
+        return "".join(char for char in (value or "").lower() if char.isalnum())
+
+    normalized_name = normalize(name)
+    return any(normalized_name == normalize(candidate) for candidate in candidates)
+
+
 def _profile_directory_args(base):
     """Relaunch skips Chrome's profile picker"""
     if not base:
@@ -965,21 +978,29 @@ def _launch_browser():
     import platform, shutil, subprocess
     from .daemon import PROFILES, remote_debugging_toggle_profiles
 
+    enabled = remote_debugging_toggle_profiles()
+    known_profiles = enabled + [
+        base for base in PROFILES if base not in enabled and (base / "Local State").exists()
+    ]
     for key in ("BH_CHROME_PATH", "CHROME_PATH"):
         raw = (os.environ.get(key) or "").strip()
         if raw and Path(raw).expanduser().is_file():
             try:
+                binary = Path(raw).expanduser()
                 process = subprocess.Popen(
-                    [str(Path(raw).expanduser())],
+                    [str(binary)],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
                 )
-                return process, None
+                profile = next(
+                    (base for base in known_profiles if _browser_binary_matches_profile(binary, base)),
+                    None,
+                )
+                return process, profile
             except (OSError, subprocess.SubprocessError):
                 # A path that exists but can't execute (permissions, wrong arch)
                 # must fall through to normal discovery, not abort
                 continue
 
-    enabled = remote_debugging_toggle_profiles()
     base = enabled[0] if enabled else next((b for b in PROFILES if (b / "Local State").exists()), None)
     mac_app, posix_cmds, win_target = _browser_launch_spec(base) if base else _DEFAULT_LAUNCH
     profile_args = _profile_directory_args(base)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -66,7 +66,7 @@ def test_cleanup_unattached_browser_launch_ignores_unowned_launch(monkeypatch):
 
 
 @pytest.mark.parametrize("env_key", ["BH_CHROME_PATH", "CHROME_PATH"])
-def test_explicit_chrome_path_retains_matching_profile(monkeypatch, tmp_path, env_key):
+def test_explicit_chrome_path_retains_matching_profile_on_linux(monkeypatch, tmp_path, env_key):
     binary = tmp_path / "google-chrome-stable"
     binary.touch()
     profile = tmp_path / ".config" / "google-chrome"
@@ -79,9 +79,42 @@ def test_explicit_chrome_path_retains_matching_profile(monkeypatch, tmp_path, en
     monkeypatch.delenv(other_key, raising=False)
     monkeypatch.setattr("browser_harness.daemon.PROFILES", [profile])
     monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [profile])
+    monkeypatch.setattr("browser_harness.daemon._devtools_port_live", lambda _profile: False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
     monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: process)
+    killed = []
+    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
+    monkeypatch.setattr(admin.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
 
-    assert admin._launch_browser() == (process, profile)
+    launch = admin._launch_browser()
+    assert launch == (process, profile)
+
+    admin._cleanup_unattached_browser_launch(launch)
+    assert killed == [(process.pid, signal.SIGTERM)]
+
+
+@pytest.mark.parametrize("system", ["Darwin", "Windows"])
+def test_explicit_chrome_path_remains_unowned_without_platform_cleanup(monkeypatch, tmp_path, system):
+    binary = tmp_path / ("chrome.exe" if system == "Windows" else "Google Chrome")
+    binary.touch()
+    profile = tmp_path / ".config" / "google-chrome"
+    (profile / "Default").mkdir(parents=True)
+    (profile / "Local State").write_text('{}')
+    process = FakeProcess()
+
+    monkeypatch.setenv("BH_CHROME_PATH", str(binary))
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+    monkeypatch.setattr("browser_harness.daemon.PROFILES", [profile])
+    monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [profile])
+    monkeypatch.setattr("platform.system", lambda: system)
+    monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(admin.os, "killpg", lambda *_args: pytest.fail("must not terminate an unowned browser"))
+
+    launch = admin._launch_browser()
+    assert launch == (process, None)
+
+    admin._cleanup_unattached_browser_launch(launch)
+    assert process.terminated is False
 
 
 def test_explicit_unknown_browser_path_remains_unowned(monkeypatch, tmp_path):

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -65,6 +65,42 @@ def test_cleanup_unattached_browser_launch_ignores_unowned_launch(monkeypatch):
     admin._cleanup_unattached_browser_launch((None, Path("/profile")))
 
 
+@pytest.mark.parametrize("env_key", ["BH_CHROME_PATH", "CHROME_PATH"])
+def test_explicit_chrome_path_retains_matching_profile(monkeypatch, tmp_path, env_key):
+    binary = tmp_path / "google-chrome-stable"
+    binary.touch()
+    profile = tmp_path / ".config" / "google-chrome"
+    (profile / "Default").mkdir(parents=True)
+    (profile / "Local State").write_text('{}')
+    process = FakeProcess()
+
+    other_key = "CHROME_PATH" if env_key == "BH_CHROME_PATH" else "BH_CHROME_PATH"
+    monkeypatch.setenv(env_key, str(binary))
+    monkeypatch.delenv(other_key, raising=False)
+    monkeypatch.setattr("browser_harness.daemon.PROFILES", [profile])
+    monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [profile])
+    monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: process)
+
+    assert admin._launch_browser() == (process, profile)
+
+
+def test_explicit_unknown_browser_path_remains_unowned(monkeypatch, tmp_path):
+    binary = tmp_path / "custom-browser"
+    binary.touch()
+    profile = tmp_path / ".config" / "google-chrome"
+    profile.mkdir(parents=True)
+    (profile / "Local State").write_text('{}')
+    process = FakeProcess()
+
+    monkeypatch.setenv("BH_CHROME_PATH", str(binary))
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+    monkeypatch.setattr("browser_harness.daemon.PROFILES", [profile])
+    monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [profile])
+    monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: process)
+
+    assert admin._launch_browser() == (process, None)
+
+
 @pytest.mark.parametrize("value", ["0", "false", "NO", " off "])
 def test_update_banner_can_be_disabled_without_network_or_cache_access(monkeypatch, value):
     monkeypatch.setenv("BH_UPDATE_CHECK", value)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,3 +1,6 @@
+import signal
+from pathlib import Path
+
 import pytest
 
 from browser_harness import admin
@@ -18,6 +21,48 @@ class FakeSocket:
 
     def close(self):
         self.closed = True
+
+
+class FakeProcess:
+    def __init__(self, pid=123, returncode=None):
+        self.pid = pid
+        self.returncode = returncode
+        self.terminated = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+
+def test_cleanup_unattached_browser_launch_stops_posix_process_group(monkeypatch):
+    process = FakeProcess()
+    killed = []
+    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
+    monkeypatch.setattr("browser_harness.daemon._devtools_port_live", lambda _profile: False)
+    monkeypatch.setattr(admin.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+
+    admin._cleanup_unattached_browser_launch((process, Path("/profile")))
+
+    assert killed == [(123, signal.SIGTERM)]
+
+
+def test_cleanup_unattached_browser_launch_keeps_cdp_browser(monkeypatch):
+    process = FakeProcess()
+    monkeypatch.setattr("browser_harness.daemon._devtools_port_live", lambda _profile: True)
+    monkeypatch.setattr(admin.os, "killpg", lambda _pid, _sig: pytest.fail("must keep the attached browser"))
+
+    admin._cleanup_unattached_browser_launch((process, Path("/profile")))
+
+
+def test_cleanup_unattached_browser_launch_ignores_unowned_launch(monkeypatch):
+    monkeypatch.setattr(
+        "browser_harness.daemon._devtools_port_live",
+        lambda _profile: pytest.fail("must not probe an unowned launch"),
+    )
+
+    admin._cleanup_unattached_browser_launch((None, Path("/profile")))
 
 
 @pytest.mark.parametrize("value", ["0", "false", "NO", " off "])


### PR DESCRIPTION
## Summary

- keep the process handle and expected profile for Chrome launched by `ensure_daemon()`
- after recovery attaches, stop only the directly launched POSIX process group when that profile never exposed a live DevTools port
- leave attached, unowned, macOS, and Windows browsers untouched

Fixes #652

## Tests

- `uv run --with pytest pytest tests/unit/test_admin.py -q` — 52 passed
- `uv run --with pytest pytest tests/unit -q` — 146 passed
- `uv build` — passed
- `git diff --check` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leftover Chrome processes after daemon recovery by stopping only the browser that `ensure_daemon()` launched directly when its profile never exposed a live DevTools port, leaving attached browsers, macOS, and Windows launches untouched. Fixes #652.

Also retains profile ownership for browsers launched from explicit `BH_CHROME_PATH`/`CHROME_PATH` binaries on POSIX systems only, so those launches are cleaned up too when they never connect.

<sup>Written for commit 10f2af39e1e5423c8eef5be2fe4503a711afaf25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

