### PR TITLE
docs: retry hidden-tab scrolling after activation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -30,6 +30,11 @@ PY
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background; call `activate_tab(target)` only when the user explicitly asks
   or a page demonstrably pauses rendering while hidden.
+- A timed-out `scroll(...)` on an attached background tab is evidence that the
+  page needs to be visible. Call `activate_tab(current_tab())`, retry the same
+  scroll once, then re-read the scroll position. This visibly switches tabs,
+  so do not use it when the user has forbidden foreground changes. Do not
+  invent a `Runtime.evaluate` scroll replacement or a cross-frame JS walker.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome

--- a/interaction-skills/scrolling.md
+++ b/interaction-skills/scrolling.md
@@ -1,3 +1,19 @@
 # Scrolling
 
 Separate page scroll, nested containers, virtualized lists, and dropdown menus, and identify which element is actually consuming wheel events before scrolling.
+
+## Hidden tabs
+
+Start with the normal `scroll(...)` helper. Chrome on Windows can leave a
+mouse-wheel command unanswered when the attached tab is not visible. If that
+scroll times out:
+
+1. Call `activate_tab(current_tab())` so Chrome shows the attached tab.
+2. Retry the same `scroll(...)` once.
+3. Re-read the page or container scroll position before continuing.
+
+The activation is visible to the user, so it is a fallback after a proven
+timeout, not the default. If the user has forbidden visible tab changes, stop
+and name that exact limitation instead. Do not replace wheel input with custom
+`Runtime.evaluate` scrolling or a cross-frame JavaScript walker; those paths
+change page semantics and require context the agent does not have.


### PR DESCRIPTION
## What changed

- Teach the Browser Harness skill to treat a timed-out background-tab scroll as a visibility failure.
- Activate the attached tab, retry the same native wheel scroll once, and re-read its position.
- Make the visible tab switch explicit and stop when the user has forbidden foreground changes.
- Tell agents not to replace wheel input with `Runtime.evaluate` scrolling or a cross-frame JavaScript walker.

## Why this is smaller

Chrome on Windows can leave a mouse-wheel command unanswered when the attached tab is hidden. The earlier version of this PR tried to reproduce browser scrolling in custom JavaScript. That changed page semantics and required nested-frame logic the agent did not understand.

The skill already owns the foreground/background policy. A proven timeout is enough context for it to use the existing `activate_tab(current_tab())` helper and retry native input once.

## Validation

- `pytest tests/unit/test_skill.py -q`: 1 passed
- full unit suite: 168 passed
- source distribution and wheel build passed
- `compileall` and `git diff --check` passed
- exact commit-range TruffleHog scan: 0 verified or unverified findings
