### PR TITLE
fix(daemon): detect windowless Chrome before handshake

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -197,6 +197,39 @@ def _safe_connection_label(url):
         return "<redacted-cdp-endpoint>"
 
 
+def _local_page_target_status(ws_url):
+    """Return whether local Chrome exposes a page, or None if unknown.
+
+    Require consecutive empty results so a just-launched Chrome has time to
+    publish its first page target after the DevTools port becomes reachable.
+    """
+    try:
+        parsed = urlparse(ws_url)
+        if parsed.scheme != "ws" or parsed.hostname not in (
+            "127.0.0.1", "localhost", "::1"
+        ):
+            return None
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    except (OSError, TypeError, ValueError):
+        return None
+    endpoint = f"http://{host}:{parsed.port}/json/list"
+    for attempt in range(3):
+        try:
+            targets = json.loads(urllib.request.urlopen(endpoint, timeout=1).read())
+        except (OSError, TypeError, ValueError):
+            return None
+        if not isinstance(targets, list):
+            return None
+        if any(
+            isinstance(target, dict) and target.get("type") == "page"
+            for target in targets
+        ):
+            return True
+        if attempt < 2:
+            time.sleep(0.2)
+    return False
+
+
 async def _silent(coro):
     try:
         await coro
@@ -577,6 +610,11 @@ class Daemon:
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
+        if BROWSER_KIND == "local" and _local_page_target_status(url) is False:
+            raise RuntimeError(
+                "chrome-windowless: Chrome has no open window -- open a Chrome window "
+                "(or relaunch without --no-startup-window), then retry"
+            )
         log(f"connecting to {_safe_connection_label(url)}")
         self.cdp = _PatientCDPClient(url) if BROWSER_KIND == "local" else CDPClient(url)
         if BROWSER_KIND == "local":

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
-import asyncio, json, os, platform, socket, sys, time, urllib.error, urllib.request
+import asyncio, http.client, json, os, platform, socket, sys, time, urllib.error, urllib.request
 from urllib.parse import urlparse
 from collections import deque
 from pathlib import Path
@@ -210,20 +210,23 @@ def _local_page_target_status(ws_url):
         ):
             return None
         host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        port = parsed.port
     except (OSError, TypeError, ValueError):
         return None
-    endpoint = f"http://{host}:{parsed.port}/json/list"
+    endpoint = f"http://{host}:{port}/json/list"
     for attempt in range(3):
         try:
             targets = json.loads(urllib.request.urlopen(endpoint, timeout=1).read())
-        except (OSError, TypeError, ValueError):
+        except (http.client.HTTPException, OSError, TypeError, ValueError):
             return None
         if not isinstance(targets, list):
             return None
-        if any(
-            isinstance(target, dict) and target.get("type") == "page"
+        if not all(
+            isinstance(target, dict) and isinstance(target.get("type"), str)
             for target in targets
         ):
+            return None
+        if any(target["type"] == "page" for target in targets):
             return True
         if attempt < 2:
             time.sleep(0.2)

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -75,6 +75,7 @@ def test_local_page_target_status_allows_page_to_appear_during_startup(monkeypat
     [
         "wss://remote.example/devtools/browser/id",
         "not-a-websocket-url",
+        "ws://127.0.0.1:bad/devtools/browser/id",
     ],
 )
 def test_local_page_target_status_skips_non_loopback_or_invalid_urls(
@@ -94,6 +95,50 @@ def test_local_page_target_status_is_unknown_when_probe_fails(monkeypatch):
         daemon.urllib.request,
         "urlopen",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("unavailable")),
+    )
+
+    assert daemon._local_page_target_status(
+        "ws://127.0.0.1:9222/devtools/browser/browser-id"
+    ) is None
+
+
+def test_local_page_target_status_is_unknown_for_malformed_http(monkeypatch):
+    monkeypatch.setattr(
+        daemon.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            daemon.http.client.BadStatusLine("malformed")
+        ),
+    )
+
+    assert daemon._local_page_target_status(
+        "ws://127.0.0.1:9222/devtools/browser/browser-id"
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "targets",
+    [
+        [{}],
+        [{"type": 7}],
+        ["page"],
+        [{"type": "page"}, {}],
+    ],
+)
+def test_local_page_target_status_is_unknown_for_malformed_targets(
+    monkeypatch, targets
+):
+    class Response:
+        def read(self):
+            return daemon.json.dumps(targets).encode()
+
+    monkeypatch.setattr(
+        daemon.urllib.request, "urlopen", lambda *_args, **_kwargs: Response()
+    )
+    monkeypatch.setattr(
+        daemon.time,
+        "sleep",
+        lambda _seconds: pytest.fail("malformed targets must fail open immediately"),
     )
 
     assert daemon._local_page_target_status(

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -21,6 +21,126 @@ def test_safe_connection_label_removes_credentials_paths_and_queries(url, label)
     assert daemon._safe_connection_label(url) == label
 
 
+@pytest.mark.parametrize(
+    ("targets", "expected", "expected_requests"),
+    [
+        ([{"id": "page-1", "type": "page"}], True, 1),
+        ([{"id": "worker-1", "type": "service_worker"}], False, 3),
+        ([], False, 3),
+    ],
+)
+def test_local_page_target_status_uses_devtools_http_endpoint(
+    monkeypatch, targets, expected, expected_requests
+):
+    requests = []
+
+    class Response:
+        def read(self):
+            return daemon.json.dumps(targets).encode()
+
+    def urlopen(url, timeout):
+        requests.append((url, timeout))
+        return Response()
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(daemon.time, "sleep", lambda _seconds: None)
+
+    assert daemon._local_page_target_status(
+        "ws://127.0.0.1:9222/devtools/browser/browser-id"
+    ) is expected
+    assert requests == [("http://127.0.0.1:9222/json/list", 1)] * expected_requests
+
+
+def test_local_page_target_status_allows_page_to_appear_during_startup(monkeypatch):
+    payloads = iter([b"[]", b'[{"id": "page-1", "type": "page"}]'])
+    sleeps = []
+
+    class Response:
+        def read(self):
+            return next(payloads)
+
+    monkeypatch.setattr(
+        daemon.urllib.request, "urlopen", lambda *_args, **_kwargs: Response()
+    )
+    monkeypatch.setattr(daemon.time, "sleep", sleeps.append)
+
+    assert daemon._local_page_target_status(
+        "ws://127.0.0.1:9222/devtools/browser/browser-id"
+    ) is True
+    assert sleeps == [0.2]
+
+
+@pytest.mark.parametrize(
+    "ws_url",
+    [
+        "wss://remote.example/devtools/browser/id",
+        "not-a-websocket-url",
+    ],
+)
+def test_local_page_target_status_skips_non_loopback_or_invalid_urls(
+    monkeypatch, ws_url
+):
+    monkeypatch.setattr(
+        daemon.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("must not probe a non-local endpoint"),
+    )
+
+    assert daemon._local_page_target_status(ws_url) is None
+
+
+def test_local_page_target_status_is_unknown_when_probe_fails(monkeypatch):
+    monkeypatch.setattr(
+        daemon.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("unavailable")),
+    )
+
+    assert daemon._local_page_target_status(
+        "ws://127.0.0.1:9222/devtools/browser/browser-id"
+    ) is None
+
+
+def test_start_reports_windowless_chrome_before_handshake(monkeypatch):
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "local")
+    monkeypatch.setattr(
+        daemon,
+        "get_ws_url",
+        lambda: "ws://127.0.0.1:9222/devtools/browser/browser-id",
+    )
+    monkeypatch.setattr(daemon, "_local_page_target_status", lambda _url: False)
+
+    d = daemon.Daemon()
+    with pytest.raises(
+        RuntimeError, match="chrome-windowless: Chrome has no open window"
+    ):
+        asyncio.run(d.start())
+
+    assert d.cdp is None
+
+
+def test_start_preserves_handshake_when_page_probe_is_unknown(monkeypatch):
+    class FailingClient:
+        async def start(self):
+            raise RuntimeError("sentinel handshake failure")
+
+    client = FailingClient()
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "local")
+    monkeypatch.setattr(
+        daemon, "get_ws_url", lambda: "ws://127.0.0.1:9222/devtools/browser/id"
+    )
+    monkeypatch.setattr(daemon, "_local_page_target_status", lambda _url: None)
+    monkeypatch.setattr(daemon, "_PatientCDPClient", lambda _url: client)
+    monkeypatch.setattr(daemon, "remote_debugging_user_enabled", lambda: False)
+    monkeypatch.setattr(daemon, "log", lambda _message: None)
+
+    with pytest.raises(
+        RuntimeError, match="CDP WS handshake failed: sentinel handshake failure"
+    ):
+        asyncio.run(daemon.Daemon().start())
+
+
 def test_remote_stop_retries_and_succeeds(monkeypatch):
     attempts = []
     monkeypatch.setattr(daemon, "REMOTE_ID", "browser-1")


### PR DESCRIPTION
## What

- Probe the local DevTools `/json/list` endpoint before starting the browser WebSocket handshake.
- Fail fast with a `chrome-windowless` diagnostic when Chrome consistently exposes no page target.
- Preserve the existing handshake path whenever the probe is unavailable, malformed, non-local, or a page appears during startup.

## Why

A local Chrome launched with `--no-startup-window` cannot render the remote-debugging permission popup. The daemon currently waits for the full 45-second handshake timeout and then tells the user to click a popup that does not exist.

## Design

The probe is restricted to loopback `ws://` endpoints in local-browser mode. It requires three consecutive empty target lists, spaced 200 ms apart, so a newly launched Chrome can publish its first page target before being classified as windowless. Any ambiguous probe result fails open to the existing handshake behavior.

## Verification

- `uv run --python 3.12 --with pytest python -m pytest tests/unit/test_daemon.py -q` — 38 passed
- Full unit suite on Windows — 166 passed; the same 3 pre-existing platform-specific failures seen on the unmodified baseline remain
- `uv run --python 3.12 --with ruff ruff check --select E9,F63,F7,F82 src/browser_harness/daemon.py tests/unit/test_daemon.py`
- `uv run --python 3.12 --with build python -m build`
- Red/green and mutation checks cover no-page detection and the startup race

Fixes #554

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 45-second handshake timeout caused by Chrome launched with `--no-startup-window`, which cannot show the remote-debugging permission popup. The daemon now probes the local DevTools `/json/list` endpoint before the handshake and fails fast with a `chrome-windowless` diagnostic when Chrome consistently exposes no page target.

- The probe only runs on loopback `ws://` endpoints and falls back to the existing handshake for any ambiguous or malformed result.
- Requires three consecutive probe responses with no page target, 200 ms apart, so a freshly launched Chrome can publish its first page.

Fixes #554.

<sup>Written for commit f95d4747e6fe6ca02675a2dcd94cba697ab93b2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

