### PR TITLE
docs: prevent duplicate tabs across harness calls

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,7 +25,13 @@ PY
 
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
-- First navigation is `new_tab(url)`, not `goto_url(url)`.
+- First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
+  preserves the attached tab across separate CLI invocations, so do not call
+  `new_tab()` again in every script.
+- Keep one working tab per task/site. Before opening another, inspect
+  `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
+  tab. Do not leave duplicate tabs on the same URL or close tabs you did not
+  create.
 - `new_tab()` and `switch_tab()` attach and move the horse marker without
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background; call `activate_tab(target)` only when the user explicitly asks


### PR DESCRIPTION
Closes #663

## Summary
- clarify that `new_tab()` is first navigation per task, not per CLI invocation
- tell agents to reuse matching tabs through `current_tab()`, `list_tabs()`, and `switch_tab()`
- explicitly prohibit duplicate task tabs and closing user-owned tabs

## Tests
- `uv run --with pytest pytest -q tests/unit/test_skill.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the browser harness docs so agents stop opening duplicate tabs on the same URL across separate CLI invocations. The daemon preserves the attached tab between calls, so `new_tab()` is now documented as a per-task, first-navigation action; agents must inspect `current_tab()` and `list_tabs()` and reuse a matching tab with `switch_tab()` instead. The docs also forbid duplicate task tabs and closing user-owned tabs. Closes #663.

<sup>Written for commit 36769c87317f74f29871e0e9571c370abd1265a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

