### PR TITLE
docs: clarify disabling CDP touch emulation

### DIFF
--- a/interaction-skills/viewport.md
+++ b/interaction-skills/viewport.md
@@ -1,3 +1,16 @@
 # Viewport
 
 Cover how viewport size changes affect layout, coordinate clicks, and any workflow that depends on stable geometry.
+
+## Touch emulation
+
+`maxTouchPoints` is optional, but Chrome validates it as 1–16 even when touch
+emulation is being disabled. Omit it when disabling:
+
+```python
+cdp("Emulation.setTouchEmulationEnabled", enabled=True, maxTouchPoints=5)
+cdp("Emulation.setTouchEmulationEnabled", enabled=False)
+```
+
+Do not pass `maxTouchPoints=0`; Chrome rejects the supplied value before acting
+on `enabled=False`.


### PR DESCRIPTION
Closes #664

## Summary
- document that Chrome validates a supplied `maxTouchPoints` value even when disabling touch emulation
- show the correct disable call with `maxTouchPoints` omitted
- retain raw `cdp()` behavior without rewriting protocol arguments

## Tests
- documentation-only change
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that Chrome validates `maxTouchPoints` as 1–16 even when touch emulation is being disabled. Documents the correct disable call with `maxTouchPoints` omitted and warns against passing 0.

<sup>Written for commit 4726ab80c5ff2cbea91b693c3bc7bcd3acca0261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

