### PR TITLE
domain-skills: add webmotors and olx (Brazilian car classifieds)

### DIFF
--- a/agent-workspace/domain-skills/olx/search.md
+++ b/agent-workspace/domain-skills/olx/search.md
@@ -1,0 +1,69 @@
+# OLX Brasil (olx.com.br) — Car search results
+
+Field-tested against olx.com.br (Autos > Carros, vans e utilitários) on 2026-08-27 from a real
+Chrome session (CDP). Needs the browser: `http_get()`/curl get **403** on every search page.
+
+## Search URL
+
+```
+https://www.olx.com.br/autos-e-pecas/carros-vans-e-utilitarios/{tipo}/estado-{uf}/{regiao}/{sub-regiao}?{filters}
+```
+
+- `{tipo}` is optional body type: `suv`, `hatch`, `sedan`, `pick-up`, ...
+- Region slugs come from the site's own location tree, e.g.
+  `estado-rj/rio-de-janeiro-e-regiao/teresopolis-e-regiao`, `estado-rj/regiao-serrana` (does not exist for cars — use the former).
+
+Confirmed query params:
+
+| param | meaning |
+|---|---|
+| `rs` | model-year **from** (`rs=2022`) |
+| `re` | model-year **to** |
+| `me` | max mileage (km) |
+| `pe` | max price (BRL) |
+| `ps` | min price |
+| `sf=1` | sort: most recent |
+
+Example: `.../suv/estado-rj/rio-de-janeiro-e-regiao/teresopolis-e-regiao?rs=2022&me=50000&pe=150000&sf=1`
+
+Result count is in `innerText` as `/\d+ resultados/`.
+
+## No `__NEXT_DATA__` any more
+
+`window.__NEXT_DATA__` is `undefined` on the 2026 results page (older skills that read
+`pageProps.ads` will silently get 0). Read the DOM instead.
+
+## Ad links live on a regional subdomain
+
+Ad anchors point to `https://rj.olx.com.br/...` (state subdomain), **not** `www.olx.com.br`.
+Match `a[href*="olx.com.br/"]` and require the numeric id suffix `-\d{9,}` to skip nav links.
+
+```python
+cards = json.loads(js(r"""JSON.stringify((()=>{
+  const seen=new Set(), out=[];
+  for (const a of document.querySelectorAll('a[href*="olx.com.br/"]')) {
+    if (!/-\d{9,}/.test(a.href) || seen.has(a.href)) continue;
+    seen.add(a.href);
+    // walk up to the smallest ancestor holding exactly one price and a km figure
+    let el=a, best=null;
+    for (let i=0;i<8 && el.parentElement;i++) {
+      el=el.parentElement; const t=el.innerText||''; const n=(t.match(/R\$/g)||[]).length;
+      if (n===1 && /km/i.test(t)) { best=el; break; }
+      if (n>1) break;
+    }
+    out.push({href:a.href, text:((best||a).innerText||'').replace(/\s+/g,' ').trim()});
+  }
+  return out;})())"""))
+```
+
+Card text looks like:
+`Hyundai Creta Platinum 1.0 TB 12V Flex AUT 2023 26.000 km Prata 1.0 R$ 117.900 Teresópolis, Várzea Hoje, 16:03`
+→ title (ends with year) · km · colour · engine · optional "Aceita trocas" / "Reduziu o preço" · price · city, neighbourhood · posted.
+
+Traps:
+- Only the cards currently rendered have full text; the list is lazy — `scroll()` a few times
+  before extracting, or the lower cards come back with the title only.
+- The page has "Mais recentes em Carros" and sponsored blocks with the same anchor shape;
+  they sit **after** the `Próxima página` pagination text in `innerText` — cut there.
+- A dedicated "abaixo da FIPE" filter exists in the sidebar but has no obvious URL param;
+  FIPE % is not in the card — compute it yourself.

--- a/agent-workspace/domain-skills/webmotors/search.md
+++ b/agent-workspace/domain-skills/webmotors/search.md
@@ -1,0 +1,106 @@
+# Webmotors (webmotors.com.br) — Used-car search & listing data
+
+Field-tested against webmotors.com.br on 2026-08-27 from a real Chrome session (CDP).
+Brazil's largest car classifieds. Fully behind PerimeterX (HUMAN) — plain HTTP does not work.
+
+## Bot detection: use the page's own fetch, never `http_get`/curl
+
+- `http_get()` / curl on any page **or** on `/api/search/car` returns **403** with a PerimeterX
+  captcha JSON (`{"appId":"PX7Vv0zOst", ... "blockScript": ...}`).
+- Loading the site in the attached Chrome tab passes silently, and a **same-origin `fetch()` from
+  page context** to the internal search API also passes (cookies + PX token ride along).
+
+So the pattern is: `navigate()` to any webmotors.com.br page once, then call the JSON API via `js()`.
+
+## Private search API (10× faster than scraping cards)
+
+The results page itself calls:
+
+```
+GET /api/search/car?url=<url-encoded search URL>&displayPerPage=47&actualPage=<n>
+    &showMenu=false&showCount=true&showBreadCrumb=false&testAB=false&returnUrl=false
+```
+
+`url` is a **search URL of the form `https://www.webmotors.com.br/carros/rj-teresopolis?<filters>`**
+(city slug in the path, everything else as query params). The pretty SEO URL the browser shows
+(`/carros/rj-teresopolis/suv/de.2022/ate.2026?...`) is *not* what the API wants — passing it
+returns `SearchResults: null` / `Count: null`.
+
+Confirmed filter params (query-string on the inner URL):
+
+| param | meaning | example |
+|---|---|---|
+| `localizacao` | lat,lng + radius | `-22.4169605%2C-42.9756016x50km` |
+| `estadocidade` | state-city label | `Rio%20de%20Janeiro-teresopolis` |
+| `marca1=suv` | body-type pseudo-brand (also works for hatch/sedan) | `suv` |
+| `anode` / `anoate` | model-year min / max | `2022` / `2026` |
+| `kmate` / `kmde` | max / min odometer | `50000` |
+| `precoate` / `precode` | max / min price | `150000` |
+| `ordenarpor` | sort: `1` relevance, `2` price asc | `2` |
+| `page` | page number (also pass `actualPage`) | `1` |
+
+`displayPerPage=47` is what the site uses; 47 items per page came back reliably.
+`Pagination.PageTotal` tells you how many pages. ~20 pages / 918 rows pulled in ~30 s with a 0.4 s sleep.
+
+```python
+import json, time, urllib.parse
+navigate("https://www.webmotors.com.br/carros/rj-teresopolis")   # any WM page, once
+wait_for_load(); time.sleep(3)
+
+inner = ("https://www.webmotors.com.br/carros/rj-teresopolis?ordenarpor=2&tipoveiculo=carros"
+         "&localizacao=-22.4169605%2C-42.9756016x50km&estadocidade=Rio%20de%20Janeiro-teresopolis"
+         "&marca1=suv&kmate=50000&anode=2022&anoate=2026&precoate=150000")
+rows = []
+for p in range(1, 40):
+    url = ("/api/search/car?url=" + urllib.parse.quote(inner + f"&page={p}", safe="")
+           + f"&displayPerPage=47&actualPage={p}&showMenu=false&showCount=true"
+             "&showBreadCrumb=false&testAB=false&returnUrl=false")
+    d = json.loads(js("fetch(%s).then(r=>r.text())" % json.dumps(url)))
+    res = d.get("SearchResults") or []
+    rows += res
+    if len(res) < 47: break
+    time.sleep(0.4)
+```
+
+### Record shape (the useful bits)
+
+```
+UniqueId                      -> ad id (needed for the ad URL)
+FipePercent                   -> asking price as % of the FIPE table value  ← gold for "is it a deal"
+GoodDeal / HotDeal            -> site's own flags (GoodDeal=True ≈ FipePercent ≤ ~99)
+Prices.Price                  -> asking price (BRL)
+Specification.Title / Make.Value / Model.Value / Version.Value
+Specification.YearFabrication (str) / YearModel (float) / Odometer (float)
+Specification.BodyType        -> "Utilitário esportivo" | "Hatchback" | "Sedã" | "Picape" | ...
+Specification.VehicleAttributes[].Name -> "Único dono", "Garantia de fábrica", "Aceita troca", ...
+Specification.Auction (bool), Armored ("N"/"S"), Color.Primary
+Seller.City / State / AdType.Value ("Concessionária" | "Loja" | "Pessoa Física") / Id
+LongComment                   -> free text; dealers sometimes hide "price is entry + financing" here
+```
+
+Traps:
+- `marca1=suv` is *not* strict — hatches/sedans still come back. Filter on `Specification.BodyType`.
+- Dealer groups list the **same car in several cities** (same title/km/price, different `Seller.City`).
+  Dedupe on `(Title, YearFabrication, YearModel, Odometer, Price)`.
+- The radius search is straight-line: a 50 km radius from Teresópolis-RJ reached Niterói/São Gonçalo.
+
+## Ad URL pattern
+
+```
+https://www.webmotors.com.br/comprar/{make}/{model}/{version-slug}/4-portas/{yearFab}-{yearModel}/{UniqueId}
+```
+
+Slug rule that resolved 14/14 ads: lowercase, strip accents, **drop dots** (`1.2` → `12`), replace
+every other non-alphanumeric run with `-`. Example:
+`/comprar/chevrolet/tracker/12-turbo-flex-premier-automatico/4-portas/2023-2024/78502483`.
+A garbage version slug (e.g. `x`) redirects to a search page instead of the ad — the id alone is not enough.
+
+The ad page's `innerText` contains `Valor anunciado\nR$ 103.000` and, below it, the site's own
+average (`Webmotors R$ ...`) and `fipe R$ ...` figures.
+
+## Results page (if you must scrape the DOM)
+
+- `__NEXT_DATA__.props.pageProps.dehydratedState` holds the same records as the API.
+- Card text is fine for a quick `document.body.innerText` read; count is in
+  `/[\d.]+ anúncios encontrados/`.
+- `wait_for_load()` then ~3–5 s: the list hydrates after `readyState === "complete"`.


### PR DESCRIPTION
Two new agent-generated domain skills under `agent-workspace/domain-skills/`, written while researching used SUVs in Rio de Janeiro state.

**webmotors/search.md**
- `http_get`/curl get a PerimeterX 403 on every page and on the API; a same-origin `fetch()` from the attached tab passes.
- Exact shape of the internal `GET /api/search/car?url=...` call (the pretty SEO URL returns `SearchResults: null`), confirmed filter params, `displayPerPage=47`, pagination.
- Record fields worth knowing, especially `FipePercent` (asking price vs. FIPE table) and `Seller.AdType`.
- Ad URL pattern + the version-slug rule (drop dots) that resolved 14/14 ads; a bad slug redirects to search.
- Traps: `marca1=suv` is not strict, dealer groups duplicate cars across cities.

**olx/search.md**
- Search URL layout and query params (`rs`/`re`/`me`/`pe`/`sf`).
- `__NEXT_DATA__` is gone on the 2026 results page; ad links live on `rj.olx.com.br`; DOM extraction snippet that finds one card per ad.
- Lazy-list trap (scroll before extracting) and the sponsored blocks after `Próxima página`.

Field-tested 2026-08-27 from a real Chrome session via CDP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new domain skills under `agent-workspace/domain-skills/` for querying Webmotors and OLX, Brazil's largest car classifieds. Both sites now block plain HTTP clients (`http_get`/curl return 403), so both skills document CDP-based workflows that were field-tested 2026-08-27.

**New Features**
- Webmotors: bypasses PerimeterX with a same-origin `fetch()` from the attached tab to the internal `/api/search/car` endpoint; covers confirmed filter params, useful record fields (`FipePercent`), and the ad-URL slug rule (drop dots) that resolved 14/14 ads.
- OLX: covers the search URL layout with `rs`/`re`/`me`/`pe`/`sf` params, DOM extraction since `__NEXT_DATA__` was removed from results pages, and traps like lazy-loaded cards and sponsored blocks after pagination.

<sup>Written for commit b38f6b7dc2973761073df67d487bff149a719283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

