### PR TITLE
fix(admin): connectable BH_CHROME_PATH launch on display-less Linux

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -967,6 +967,42 @@ def _profile_directory_args(base):
     return [f"--profile-directory={last}"]
 
 
+def _display_less_linux(system):
+    """True on a Linux host with no way to show a browser window."""
+    return system == "Linux" and not (
+        os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+    )
+
+
+def _headless_server_launch(binary):
+    """Connectable launch command for a display-less Linux host.
+
+    A bare spawn on a server never opens a DevTools port or writes
+    ``DevToolsActivePort`` into a profile dir the daemon scans, so discovery
+    waits out its deadline and reports chrome-not-running even though a
+    working browser binary was configured. Launching headless with remote
+    debugging on the dedicated harness profile dir -- first entry in the
+    Linux ``PROFILES`` scan list -- lets the normal discovery loop attach
+    with no changes elsewhere, keeps harness launches out of real desktop
+    profiles, and sidesteps Chrome's refusal to open a DevTools port on a
+    browser's default data directory.
+    ``--remote-debugging-port=0`` avoids port collisions; the daemon reads
+    the ephemeral port back from ``DevToolsActivePort``.
+    """
+    profile = Path.home() / ".config" / "chrome-harness"
+    args = [
+        str(binary),
+        "--headless",
+        "--no-sandbox",
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+        "--remote-debugging-port=0",
+        f"--user-data-dir={profile}",
+        "about:blank",
+    ]
+    return args, profile
+
+
 def _launch_browser():
     """Prefers the browser whose profile already has perm box checked.
 
@@ -983,11 +1019,19 @@ def _launch_browser():
         base for base in PROFILES if base not in enabled and (base / "Local State").exists()
     ]
     system = platform.system()
+    headless_server = _display_less_linux(system)
     for key in ("BH_CHROME_PATH", "CHROME_PATH"):
         raw = (os.environ.get(key) or "").strip()
         if raw and Path(raw).expanduser().is_file():
             try:
                 binary = Path(raw).expanduser()
+                if headless_server:
+                    args, headless_profile = _headless_server_launch(binary)
+                    process = subprocess.Popen(
+                        args,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),
+                    )
+                    return process, headless_profile
                 process = subprocess.Popen(
                     [str(binary)],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **ipc.spawn_kwargs(),

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -48,6 +48,11 @@ _MAC_PROFILES = (
     "Library/Application Support/BraveSoftware/Brave-Browser",
 )
 _LINUX_PROFILES = (
+    # dedicated harness-launch profile: headless-server launches need an
+    # explicit non-default user-data-dir (Chrome refuses remote debugging on
+    # a browser's default data directory), and using a dedicated dir keeps
+    # harness launches out of real desktop profiles
+    ".config/chrome-harness",
     ".config/google-chrome",
     ".config/chromium",
     ".config/chromium-browser",

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -77,6 +77,7 @@ def test_explicit_chrome_path_retains_matching_profile_on_linux(monkeypatch, tmp
     other_key = "CHROME_PATH" if env_key == "BH_CHROME_PATH" else "BH_CHROME_PATH"
     monkeypatch.setenv(env_key, str(binary))
     monkeypatch.delenv(other_key, raising=False)
+    monkeypatch.setenv("DISPLAY", ":0")
     monkeypatch.setattr("browser_harness.daemon.PROFILES", [profile])
     monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [profile])
     monkeypatch.setattr("browser_harness.daemon._devtools_port_live", lambda _profile: False)
@@ -127,11 +128,69 @@ def test_explicit_unknown_browser_path_remains_unowned(monkeypatch, tmp_path):
 
     monkeypatch.setenv("BH_CHROME_PATH", str(binary))
     monkeypatch.delenv("CHROME_PATH", raising=False)
+    monkeypatch.setenv("DISPLAY", ":0")
     monkeypatch.setattr("browser_harness.daemon.PROFILES", [profile])
     monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [profile])
     monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: process)
 
     assert admin._launch_browser() == (process, None)
+
+
+def test_explicit_chrome_path_launches_connectable_on_displayless_linux(monkeypatch, tmp_path):
+    binary = tmp_path / "chrome-headless-shell"
+    binary.touch()
+    process = FakeProcess()
+    captured = []
+
+    def fake_popen(args, **_kwargs):
+        captured.append(args)
+        return process
+
+    monkeypatch.setenv("BH_CHROME_PATH", str(binary))
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setattr("browser_harness.daemon.PROFILES", [])
+    monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [])
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    launch = admin._launch_browser()
+
+    expected_profile = Path.home() / ".config" / "chrome-harness"
+    assert launch == (process, expected_profile)
+    args = captured[0]
+    assert args[0] == str(binary)
+    assert "--headless" in args
+    assert "--remote-debugging-port=0" in args
+    assert f"--user-data-dir={expected_profile}" in args
+
+
+@pytest.mark.parametrize("env_key, env_value", [("DISPLAY", ":0"), ("WAYLAND_DISPLAY", "wayland-0")])
+def test_explicit_chrome_path_stays_bare_when_linux_has_a_display(monkeypatch, tmp_path, env_key, env_value):
+    binary = tmp_path / "custom-browser"
+    binary.touch()
+    process = FakeProcess()
+    captured = []
+
+    def fake_popen(args, **_kwargs):
+        captured.append(args)
+        return process
+
+    monkeypatch.setenv("BH_CHROME_PATH", str(binary))
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setenv(env_key, env_value)
+    monkeypatch.setattr("browser_harness.daemon.PROFILES", [])
+    monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [])
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    launch = admin._launch_browser()
+
+    assert launch == (process, None)
+    assert captured[0] == [str(binary)]
 
 
 @pytest.mark.parametrize("value", ["0", "false", "NO", " off "])


### PR DESCRIPTION
## Problem

On a Linux server or container with no display, the harness reports `chrome-not-running: no supported browser is running and none could be launched` even when a working Chromium binary is explicitly configured via `BH_CHROME_PATH` / `CHROME_PATH`.

Two things compound:

1. `_launch_browser()` spawns the configured binary **bare** (no `--remote-debugging-port`, no `--user-data-dir`, no `--headless`).
2. On a display-less host that spawn never opens a DevTools port and never writes `DevToolsActivePort` into any profile dir the daemon scans, so `get_ws_url()` waits out its deadline and the recovery path gives up with "ask the user to open Chrome" — a dead end when there is no desktop.

Repro (Debian 13, Playwright `chrome-headless-shell` 151):

```
$ BH_CHROME_PATH=/path/to/chrome-headless-shell <any harness command>
browser-harness: chrome-not-running: no supported browser is running and none could be launched
```

Any agent runtime in a container (CI, VPS, devcontainer) hits this today.

## Solution

When launching via `BH_CHROME_PATH`/`CHROME_PATH` on Linux with no `DISPLAY`/`WAYLAND_DISPLAY`, spawn connectable instead of bare:

```
<binary> --headless --no-sandbox --disable-gpu --disable-dev-shm-usage \
  --remote-debugging-port=0 --user-data-dir=$HOME/.config/chrome-harness about:blank
```

- `~/.config/chrome-harness` is a dedicated profile dir, added to the front of `_LINUX_PROFILES`, so the existing discovery loop attaches with no changes elsewhere. A dedicated dir keeps harness launches out of real desktop profiles and sidesteps Chrome's refusal to open a DevTools port on a default data directory (same reasoning as #140, which proposed this dir for the desktop auto-launch path).
- `--remote-debugging-port=0` avoids collisions; the daemon already reads the ephemeral port back from `DevToolsActivePort`.
- Desktop behaviour is untouched: macOS, Windows, and Linux **with** a display keep the bare spawn so the user's real browser opens normally, and `_cleanup_unattached_browser_launch` semantics are preserved (the headless launch returns `(process, profile)` so a launch that never becomes reachable is cleaned up).

## Verification

- Live on a display-less Debian 13 box: the exact generated command writes `DevToolsActivePort`, and `/json/version` answers with a live `webSocketDebuggerUrl`; end-to-end harness calls then work first try.
- `pytest tests/` — 171 passed (3 new tests: connectable launch on display-less Linux, bare launch preserved when `DISPLAY` or `WAYLAND_DISPLAY` is set; existing launch tests pinned to a desktop env with `DISPLAY=:0`).

## Related

- #140 targets the *discovery fallback* on Linux **with** a display; this PR targets the *explicit env-var path* on Linux **without** one. Complementary, and both converge on a dedicated `~/.config/chrome-harness` profile dir.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `BH_CHROME_PATH` launches on display-less Linux so a configured Chromium binary is now connectable, instead of failing with `chrome-not-running`.

- Launches the binary headless with `--remote-debugging-port=0` on a dedicated `~/.config/chrome-harness` profile when no `DISPLAY` or `WAYLAND_DISPLAY` is set.
- Desktop launches (macOS, Windows, or Linux with a display) keep the bare spawn and are unaffected.

<sup>Written for commit ad3e5d67a7404500a064aa0f57624299eecad5b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

