### PR TITLE
Make fetch-use an optional cloud dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,12 @@ classifiers = [
 ]
 dependencies = [
     "cdp-use==1.4.5",
-    "fetch-use==0.4.0",
     "pillow==12.3.0",
     "websockets==15.0.1",
 ]
+
+[project.optional-dependencies]
+cloud = ["fetch-use==0.4.0"]
 
 [project.scripts]
 browser-harness = "browser_harness.run:main"

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,12 @@
+import tomllib
+from pathlib import Path
+
+
+def test_fetch_use_is_only_in_the_cloud_extra():
+    pyproject = tomllib.loads(
+        (Path(__file__).parents[2] / "pyproject.toml").read_text()
+    )
+    project = pyproject["project"]
+
+    assert "fetch-use==0.4.0" not in project["dependencies"]
+    assert project["optional-dependencies"]["cloud"] == ["fetch-use==0.4.0"]


### PR DESCRIPTION
## Summary

Closes #625.

`fetch-use` is only needed for the API-key-backed hosted fetch path. Keeping it in the core dependencies forces local browser harness users to install a cloud-only package even though the runtime already falls back to the standard library when that path is unused.

## Changes

- Remove `fetch-use` from the core dependencies.
- Add a `cloud` optional dependency containing the pinned `fetch-use==0.4.0` requirement.
- Add a regression test for the dependency declaration.

This preserves the existing hosted fetch behavior for users installing the `cloud` extra while making the base installation independent of it. No runtime code or local HTTP behavior changes.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest pytest -q tests/unit/test_packaging.py` — 1 passed.
- `uv run --with ruff ruff check pyproject.toml tests/unit/test_packaging.py` — passed.
- `uv run --with ruff ruff format --check tests/unit/test_packaging.py` — passed.
- `python -m compileall -q src tests/unit/test_packaging.py` — passed.
- `uv run --with build python -m build --wheel` — passed; wheel metadata contains `fetch-use==0.4.0; extra == "cloud"` only.
- `git diff --check` — passed.

## Remote verification

- Submitted from `mikemikimike:fix/625-optional-fetch-use` at commit `140603bf0c73ef63c18fda369338c3ff9662e01b`.
- Verified against `browser-use/browser-harness` with base `main`; the remote PR head matches the local commit.
- GitGuardian Security Checks and the repository skill review passed; the Cubic AI reviewer was still pending when this description was updated.

## Limitations

- The full unit suite was attempted on Windows: 128 passed, 3 failed, and 21 errored due to pre-existing POSIX-only `os.killpg` assertions, packaged-resource path assumptions, and pytest temporary-directory permissions. The new packaging test passed.
- Integration tests were not run because they require a live browser/daemon and are unrelated to this packaging-only change.
