### PR TITLE
Add WARC research extraction notes

### DIFF
--- a/domain-skills/warc/research.md
+++ b/domain-skills/warc/research.md
@@ -1,0 +1,46 @@
+# WARC — Research and PDF extraction
+
+`https://www.warc.com` is a subscription research database. Use an already-authenticated browser session and preserve the user's access boundaries. Do not redistribute downloaded subscription files.
+
+## Search
+
+WARC search accepts a plain query parameter:
+
+```text
+https://www.warc.com/en/search?q=share%20of%20search
+```
+
+Open promising result pages in the signed-in browser and extract the visible article metadata, population, effect size, design, and limitations. Treat award cases and vendor-authored reports as selected evidence unless a sampling frame or comparison design is disclosed.
+
+## Recover the underlying PDF from article viewers
+
+Some WARC report pages render only a preview or first page in the document viewer. After the viewer has loaded, inspect the page's performance resources from the article target:
+
+```python
+resources = js("""
+performance.getEntriesByType('resource')
+  .map(r => r.name)
+  .filter(u => u.includes('cdn.builder.io') && u.toLowerCase().includes('.pdf'))
+""", target_id=warc_target_id)
+```
+
+Observed PDF resource forms include:
+
+```text
+https://cdn.builder.io/o/assets/...pdf
+https://cdn.builder.io/api/v1/file/assets/...pdf
+```
+
+The exact asset path is page-specific. Discover it from the loaded page; never guess or reuse an asset URL from another report. Fetch it only through the authorized browser context or an authenticated request derived from that context.
+
+## Multi-tab reliability
+
+When many tabs are open, use a known WARC target ID for every JavaScript and CDP call. Global current-tab helpers can attach to the wrong target. Re-list targets after opening a new article and bind extraction to the matching WARC URL.
+
+## Evidence-quality checks
+
+- Record the claim-specific sample and uncertainty when available; a report-level database size is not a substitute.
+- Keep percentage points, relative percentages, ROI ratios, market-share effects, and revenue elasticities separate.
+- Do not turn WARC case-study outcomes into priors without a credible control or model specification.
+- Cite the public WARC article URL even when the detailed evidence came from its subscription PDF.
+


### PR DESCRIPTION
Documents authenticated WARC search, discovery of underlying Builder.io PDF resources from loaded article viewers, multi-tab target handling, and evidence-quality guardrails. No subscription content or credentials are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WARC research extraction notes so researchers can discover and pull PDF evidence from authenticated `warc.com` article viewers without violating access boundaries.

- Documents the search query format and the performance-resource technique to recover Builder.io PDF asset URLs.
- Specifies binding extraction to a known WARC target ID when multiple tabs are open.
- Adds evidence-quality guardrails: record claim-specific samples and uncertainty, keep metric types separate, and avoid using case-study outcomes as priors.
- Cites public article URLs and includes no subscription content or credentials.

<sup>Written for commit c049b47585d92a6d0dc0a5b537e2750b47a90a6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

