### PR TITLE
docs(yeastar): P-Series admin portal interaction traps

### DIFF
--- a/domain-skills/telnyx/portal.md
+++ b/domain-skills/telnyx/portal.md
@@ -1,0 +1,26 @@
+# Telnyx Customer Portal
+
+## URL patterns (hash-routed SPA)
+
+- My Numbers: `https://portal.telnyx.com/#/numbers/my-numbers`
+- Number editor: `#/numbers/my-numbers/<numeric-id>` (tabs: Settings, Messaging, Voice, Emergency Service)
+- SIP connections: `#/voice/connections`, editor `#/voice/connections/<id>`
+  (tabs: Configuration, Authentication and routing, Inbound, Outbound, Recording, Numbers, WebRTC)
+
+## Structure and quirks
+
+- The numbers table is NOT `<table>/<tr>` markup — row queries via `tr` return
+  nothing. Use coordinate clicks on the row's pencil icon (rightmost controls)
+  or navigate to the editor URL directly by id.
+- Numbers in "Port pending" status show a pencil, but clicking it does not
+  open the editor — number-level settings appear locked until the number is
+  Active.
+- Selected dropdown values (e.g. "Destination number format" on a SIP
+  connection's Inbound tab) are not in `body.innerText`; read the nearest
+  `input`/`[class*=singleValue]` value near the label instead.
+- Useful facts surfaced there: "Destination number format: E.164" means DIDs
+  arrive WITHOUT the plus (11-digit `1NPANXXXXXX`); "+E.164" is a separate
+  option. CNAM Listing toggle + Caller ID Name live on the number's Voice
+  tab; "Active Services" checklist on the Settings tab mirrors them.
+- Tables/lists render a few seconds after `wait_for_load()` reports done —
+  screenshot again before concluding a list is empty.

--- a/domain-skills/yeastar-pbx/portal.md
+++ b/domain-skills/yeastar-pbx/portal.md
@@ -1,0 +1,46 @@
+# Yeastar P-Series web portal (self-hosted PBX admin)
+
+Ant Design v3-era React SPA. Field-tested quirks that cost real debugging time:
+
+## Saving — the big trap
+
+- **JS-dispatched `.click()` on Save can silently discard the form**: the UI
+  returns to the list view with no error and no persistence. A real
+  coordinate click on the Save button saves and shows an "Operation
+  Succeeded" toast. Always verify persistence by reopening the record, not
+  by trusting navigation.
+- Most changes also need the orange **Apply** button (top bar) after Save.
+- Navigating away (or a daemon-restart page reload) discards unsaved form
+  state with no warning.
+
+## Inputs
+
+- **Native-setter value injection binds visually but not to the form
+  model** on many forms (masked inputs like DID patterns, emergency caller
+  ID). Use: focus + `element.select()` + CDP `Input.insertText` — or plain
+  clicks and typing. Three separate clicks do NOT select-all; they reposition
+  the caret and insertText appends.
+- Time pickers are antd-v3 3-column (`.ant-time-picker-panel` with `ul>li`
+  columns: hour/minute/AM-PM); typed text is rejected. Click the `li` cells;
+  values commit per-click. Close the panel by clicking a neutral area — the
+  panel swallows the next click otherwise.
+- Selects are `.ant-select`; options render into a detached
+  `.ant-select-dropdown`. A dropdown that won't open usually means a leftover
+  invisible `.ant-modal-wrap` overlay is eating clicks — check
+  `document.elementFromPoint`, click `.ant-modal-close`, retry.
+
+## Uploads
+
+- File dialogs can be bypassed: click the Upload button, then
+  `DOM.setFileInputFiles` on the revealed `input[type=file]`. Prompt/greeting
+  audio must be wav/mp3/gsm ≤8MB (PCM 8k 16-bit accepted).
+
+## Structure
+
+- Sessions idle out within minutes; expect the login page on return.
+- URL routes are path-based (e.g. `/call_control/inbound_routes`,
+  `/call_features/voicemail`, `/call_control/emergency_number`) and
+  deep-link fine after login.
+- List rows expose `[class*=ops-edit]` icons — DOM-clickable, unlike Save.
+- Inbound-route ordering is drag/arrow-only in the UI and impossible via the
+  OpenAPI; new routes append below the catch-all default.


### PR DESCRIPTION
Field-tested Yeastar P-Series portal quirks: JS-clicked Save silently discards forms (coordinate clicks save), native-setter input injection fails to bind to the form model, antd-v3 time-picker/select/dropdown handling, leftover modal masks eating clicks, CDP file-input upload bypass, and route/session behaviors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds field-tested portal interaction quirks for Telnyx and Yeastar P-Series so future browser-automation work skips the debugging traps these docs capture.

**Documentation**
- `domain-skills/telnyx/portal.md` covers the hash-routed SPA: non-table markup, locked port-pending editors, dropdown value reads, and delayed list rendering.
- `domain-skills/yeastar-pbx/portal.md` covers the `antd` v3 SPA: JS-clicked Save discarding forms, native-setter injection not binding, time-picker/select/modal-mask handling, CDP file-upload bypass, and idle-session behavior.

<sup>Written for commit 348b40d774099e805e6ab56cac2f786a1e274cfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

