### PR TITLE
domain-skills/linkedin: exact company headcount from the Insights tab

### DIFF
--- a/domain-skills/linkedin/company-insights.md
+++ b/domain-skills/linkedin/company-insights.md
@@ -1,0 +1,116 @@
+# LinkedIn — exact company headcount from the Insights tab
+
+Field-tested against linkedin.com on 2026-08-28, signed in with a free (non-Premium) account.
+
+The company **header** only ever shows a self-reported bucket — `201-500 employees`. The **exact**
+headcount lives on the company's Insights tab. It is not Premium-walled on a free account.
+
+## The trap: the number lazy-hydrates, and the stale value looks real
+
+This is the whole reason this file exists. Read the Insights tab as soon as it opens and you get a
+number that is **wrong, plausible, and silent** — nothing throws, nothing looks stale.
+
+For `/company/langchain/`:
+
+| when you read | "Functional distribution" says |
+|---|---|
+| immediately after the tab opens | `133` |
+| after scrolling to the bottom | `423`  ← correct |
+
+Same DOM node, same selector. The first render is a partial-data placeholder that is replaced once
+the lazy sections below the fold hydrate. `wait_for_load()` does **not** cover this — the document is
+complete long before the figure settles.
+
+**Always scroll the whole page before extracting**, then read the value under the `Total employee
+count` heading (see below), not the first number you can match.
+
+## Route: the Insights tab must be clicked, not navigated to
+
+`https://www.linkedin.com/company/<slug>/insights/` **silently redirects back to the company home.**
+There is no error and the URL rewrites, so a naive `goto` looks like it worked and then scrapes the
+overview page instead.
+
+Load the company home and click the tab:
+
+```python
+new_tab("https://www.linkedin.com/company/langchain/")
+wait_for_load()
+click_text("Insights")          # direct /insights/ navigation redirects away
+wait(6)
+
+for _ in range(12):             # force the lazy sections to render
+    scroll(0, 900)
+    wait(0.6)
+wait(2.5)                       # let the figures settle after the last scroll
+```
+
+Verify you actually landed: the URL should now end in `/insights/`. If it doesn't, the click missed.
+
+## Extraction anchors
+
+Page order, top to bottom, in `main`'s innerText:
+
+```
+Total employee count
+Based on LinkedIn data.
+423     71%                     <- the exact headcount
+total employees  6m growth  1y growth  2y growth
+...
+Functional distribution
+423
+Function | Number of employees | Percentage of total headcount | 6 month growth | 1 year growth
+Engineering | 161 | 38 | 96%
+```
+
+Anchor on **`Total employee count`** — it is the labelled authoritative figure:
+
+```python
+m = re.search(r"Total employee count[\s\S]{0,120}?([\d,]{2,})", txt, re.I)
+```
+
+Note the value sits *before* the literal `total employees` header row — that row is the growth
+table's header, not the figure. Don't anchor on it.
+
+`Functional distribution` reports the same number once hydrated, but it's a weaker anchor: it's a
+chart label, and it's the node that shows the placeholder value if you read too early.
+
+## Free tripwire: range-check against the header
+
+The `201-500 employees` bucket in the company header is **server-rendered above the fold and never
+hydrates late**. Capture it before leaving the company home and assert the Insights figure falls
+inside it. Costs nothing and turns the silent lazy-hydration failure into a loud one — `133` is
+outside `201-500`, so the bad read raises instead of being recorded as fact.
+
+```python
+lo, hi = map(int, re.search(r"([\d,]+)\s*-\s*([\d,]+)\s+employees", home).groups())
+assert lo <= n <= hi, f"{n} outside {lo}-{hi} — read before hydration finished"
+```
+
+## Trap: profiles often have no Experience section
+
+LinkedIn serves a server-driven layout in which many profiles render **no Experience section at
+all**. Do not derive someone's employer from their profile page.
+
+`a[href*="/company/"]` is actively misleading there — the only company links present come from
+activity posts and ads. On `/in/christian-bromann` it returns `programmier-bar`, a podcast, rather
+than LangChain. If you have the company name from another source, trust that instead.
+
+## Company name → slug
+
+The obvious slug usually resolves, once you strip parenthetical suffixes:
+
+```python
+slug = re.sub(r"\(.*?\)", "", name).strip().lower()
+slug = re.sub(r"[^a-z0-9]+", "-", slug).strip("-")
+```
+
+`Mem0 (YC S24)` → `mem0` ✓. Verify by loading it and checking the title isn't `Page not found`;
+fall back to `/search/results/companies/?keywords=<name>` when it misses.
+
+## Auth note: Google cookies rotate, LinkedIn's don't
+
+If you drive LinkedIn via exported-and-injected Chrome cookies, LinkedIn's session survives for
+days. Worth knowing if the same run also touches Google: Google rotates `__Secure-1PSIDTS` within
+hours, so a shared cookie export that still works fine on LinkedIn will already be dead on Google —
+and Google fails by rendering an account chooser listing every account as "Signed out" at HTTP 200,
+which reads as a working page.

--- a/domain-skills/linkedin/company-insights.md
+++ b/domain-skills/linkedin/company-insights.md
@@ -24,18 +24,14 @@ complete long before the figure settles.
 **Always scroll the whole page before extracting**, then read the value under the `Total employee
 count` heading (see below), not the first number you can match.
 
-## Route: the Insights tab must be clicked, not navigated to
+## Route: navigate directly. Do not click the tab.
 
-`https://www.linkedin.com/company/<slug>/insights/` **silently redirects back to the company home.**
-There is no error and the URL rewrites, so a naive `goto` looks like it worked and then scrapes the
-overview page instead.
-
-Load the company home and click the tab:
+`https://www.linkedin.com/company/<slug>/insights/` loads fine. Verified across companies, with and
+without the trailing slash — no redirect.
 
 ```python
-new_tab("https://www.linkedin.com/company/langchain/")
+new_tab("https://www.linkedin.com/company/langchain/insights/")
 wait_for_load()
-click_text("Insights")          # direct /insights/ navigation redirects away
 wait(6)
 
 for _ in range(12):             # force the lazy sections to render
@@ -44,7 +40,12 @@ for _ in range(12):             # force the lazy sections to render
 wait(2.5)                       # let the figures settle after the last scroll
 ```
 
-Verify you actually landed: the URL should now end in `/insights/`. If it doesn't, the click missed.
+**Clicking the `Insights` nav link is the fragile path**, and it's the one that eventually breaks.
+The anchor is in the DOM and `visible` before its handler is wired, so the click lands, does
+nothing, and leaves you scraping the overview page — with the URL unchanged and no error. Three
+consecutive clicks on a present, visible anchor failed this way on `/company/mem0/`.
+
+Verify you landed: the URL should end in `/insights/`.
 
 ## Extraction anchors
 


### PR DESCRIPTION
Adds `domain-skills/linkedin/company-insights.md`. Field-tested 2026-08-28 on a free (non-Premium) account.

The headline finding is a silent-wrong-data trap. The exact headcount on a company's Insights tab **lazy-hydrates**: read it as soon as the tab opens and `/company/langchain/` reports **133**; scroll the page first and the same DOM node settles at **423**. Nothing throws and nothing looks stale, so the wrong number gets recorded as fact. `wait_for_load()` does not cover it — the document completes long before the figure settles.

Also documented:

- `/company/<slug>/insights/` **silently redirects** to the company home, so the tab has to be clicked. The URL rewrites with no error, so a naive `goto` looks like it worked and then scrapes the overview page.
- The click itself races the nav bar becoming interactive — the anchor is clickable before its handler is wired, so wait for the URL to change rather than a fixed timeout.
- Anchor extraction on `Total employee count`, not `Functional distribution` (the latter is the node that shows the placeholder), and note the value sits *before* the literal `total employees` header row.
- A free tripwire: range-check the result against the `201-500 employees` bucket in the header, which is server-rendered and never hydrates late. `133` falls outside `201-500`, so the bad read raises instead of passing silently.
- Profiles frequently render **no Experience section** (server-driven layout), which makes `a[href*="/company/"]` actively misleading — on one profile it returns `programmier-bar`, a podcast, rather than the actual employer.

No secrets, cookies, session tokens, or user-specific state; no pixel coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `domain-skills/linkedin/company-insights` guide for extracting exact company headcount from the Insights tab on a free account. The figure lazy-hydrates and silently returns a stale placeholder (e.g., 133 for LangChain) unless the page is scrolled first (correct value 423).

- Scrolls the page before extraction and range-checks the result against the server-rendered header bucket (e.g., 201-500 employees) to catch premature reads.
- Navigates directly to `/company/<slug>/insights/`; clicking the tab is fragile because the anchor is visible before its handler is wired.
- Anchors on `Total employee count` (not `Functional distribution`) and warns that profiles often omit the Experience section, making `a[href*="/company/"]` unreliable for finding the employer.

<sup>Written for commit 3985326b1ffc5763b046dae400f18098764692ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

