### PR TITLE
domain-skills/google-sheets: autocomplete silently commits a value you never typed

### DIFF
--- a/domain-skills/google-sheets/writing-cells.md
+++ b/domain-skills/google-sheets/writing-cells.md
@@ -1,0 +1,68 @@
+# Google Sheets — typing values into cells without corrupting them
+
+Field-tested against docs.google.com/spreadsheets on 2026-08-29.
+
+## The trap: autocomplete silently commits a value you never typed
+
+Sheets autocompletes a **text** entry from other values already present in the same column. The
+suggested remainder is appended to the cell as *selected* text, and **`Tab` and `Enter` commit the
+suggestion, not what you typed.**
+
+Concretely: a column already contains `Mem0 (YC S24)`. You type `Mem0` into another cell in that
+column and press Tab. The cell ends up holding **`Mem0 (YC S24)`**.
+
+Nothing errors. The keystrokes all succeed, the write "works", and the wrong value is only visible
+if you read the sheet back. In a five-run series this corrupted exactly one cell per run while every
+run reported clean.
+
+## Fix: press Delete before committing
+
+```python
+type_text(value)
+press("Delete")      # discards any pending autocomplete suggestion
+press("Tab")
+```
+
+`Delete` removes the selected suggestion. When there is no suggestion it is a **no-op** — the caret
+sits at the end of the typed text with nothing after it — so it is safe to apply unconditionally
+rather than trying to detect when autocomplete fired.
+
+Only text triggers this. Numbers, URLs, and dates are unaffected, but applying `Delete` everywhere
+costs nothing and means you don't have to reason about which columns are at risk.
+
+## Always read the sheet back
+
+The failure mode above is invisible from the writing side, so verify from the reading side. The CSV
+export is the cheapest way and needs no extra auth beyond the session you already have:
+
+```
+https://docs.google.com/spreadsheets/d/<id>/export?format=csv&gid=<gid>
+```
+
+Diff it against what you intended to write, cell by cell, and raise on mismatch. A script that
+writes data should not be able to report success without checking the data — "no exception" is not
+"correct output".
+
+## Navigating to a cell: use the Name Box, not pixel clicks
+
+Clicking a grid cell by coordinate is fragile (scroll position, frozen rows, zoom). The Name Box is
+stable:
+
+```python
+click("#t-name-box")
+fill("#t-name-box", "A2")
+press("Enter")
+```
+
+Then type across the row with `Tab` between cells and `Enter` to end the row.
+
+## Auth note: Google session cookies rotate fast
+
+If you drive Sheets with exported-and-injected Chrome cookies, re-export them immediately before the
+run. Google rotates `__Secure-1PSIDTS` within hours. A stale export does **not** present as a login
+error — you land on the account chooser, which renders every account as "Signed out" while returning
+**HTTP 200**, so it reads as a working page. The failure surfaces much later as a bare `401` from
+the CSV export endpoint.
+
+Cookies for other sites in the same export (LinkedIn, X) stay valid for days, so "the export works"
+is not evidence that the Google half of it does.


### PR DESCRIPTION
Adds `domain-skills/google-sheets/writing-cells.md`. Field-tested 2026-08-29.

Sheets autocompletes a **text** cell entry from other values already in the same column, appending the remainder as *selected* text — so **`Tab` and `Enter` commit the suggestion, not what you typed.**

Typing `Mem0` into a column that already contains `Mem0 (YC S24)` leaves the cell holding `Mem0 (YC S24)`.

Nothing errors. Every keystroke succeeds and the write "works". I hit this in a five-run series where **every run reported clean while corrupting exactly one cell each time** — it was only caught by reading the sheet back afterwards.

Fix is one keystroke:

```python
type_text(value)
press("Delete")   # discards the pending suggestion; no-op when there isn't one
press("Tab")
```

`Delete` is safe to apply unconditionally, so you don't have to reason about which columns are at risk.

Also documented: verifying writes via the `/export?format=csv` endpoint, Name Box navigation instead of pixel clicks, and a note that Google rotates `__Secure-1PSIDTS` within hours — a stale cookie export fails by rendering the account chooser at HTTP 200 rather than by erroring, so it reads as a working page and only surfaces later as a bare 401.

No secrets, cookies, session tokens, or user-specific state; no pixel coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents safe Google Sheets cell writes: instead of letting `Tab` or `Enter` commit an autocomplete suggestion, press `Delete` before committing. This prevents silent text corruption that otherwise reports success.

- Recommends diffing the CSV export against intended values after each write.
- Uses the Name Box for stable cell navigation instead of pixel clicks.
- Notes that stale `__Secure-1PSIDTS` cookies can show an account chooser with HTTP 200 before the export later fails with 401.

<sup>Written for commit 6a8bb32d8fa37ac2648cf78064d8c263820c2965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

