### PR TITLE
Fix events.jsonl write crashing on lone surrogates in page titles

### DIFF
--- a/src/browser_harness/recorder.py
+++ b/src/browser_harness/recorder.py
@@ -287,7 +287,11 @@ def _capture(d, helper, args=(), kwargs=None, duration=None):
         event["frame"] = frame
     except Exception:
         pass
-    with (d / "events.jsonl").open("a", encoding="utf-8") as f:
+    # Page-controlled strings (document.title etc.) can carry lone surrogates
+    # in through CDP's \uDXXX escapes; they can't encode as UTF-8, and one
+    # would kill the whole trace. Replace with U+FFFD — same medicine run.py
+    # already gives stdout (#124).
+    with (d / "events.jsonl").open("a", encoding="utf-8", errors="replace") as f:
         f.write(json.dumps(event, ensure_ascii=False) + "\n")
 
 


### PR DESCRIPTION
A page that sets `document.title` to a lone surrogate (or any string carrying one through CDP's `returnByValue` \uDXXX escapes) kills the recording trace: `json.dumps(ensure_ascii=False)` + utf-8 write raises `UnicodeEncodeError`.

- In `observe()` the exception is swallowed, so **every event on that page is silently dropped** while frames keep accumulating — the run believes it is recorded.
- In `start_recording()`/`stop_recording()` the error escapes the agent-facing API.

Verified: a recording with `title = "\ud800booby"` persisted 0 of 3 events before the fix, 3 of 3 after; explicit `start_recording()` raised before, returns normally after. `pytest tests/unit`: 151 passed.

Open with `errors="replace"` — the same treatment `run.py` already gives stdout for this class of problem (#124). Valid text is unchanged; lone surrogates become U+FFFD and the trace survives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the recorder crashing on lone surrogates in page-controlled strings (e.g. `document.title`) by opening `events.jsonl` with `errors="replace"` so the trace survives and invalid characters become U+FFFD. Previously such pages silently dropped all events in `observe()` or raised an error in `start_recording()`/`stop_recording()`.

- Verified: a recording with `title = "\ud800booby"` persisted 0 of 3 events before the fix, 3 of 3 after; explicit `start_recording()` raised before, returns normally after.

<sup>Written for commit c5d207ce680022b8bf57372f8811246cc5f828d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

