### PR TITLE
daemon: make Runtime.enable opt-in (BH_ENABLE_RUNTIME=1) to stop bot-management sign-in blocks

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -194,6 +194,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.
 - Ask before leaving cloud browsers running; stop them with `stop_remote_daemon(name)` or `PATCH /browsers/{id} {"action":"stop"}`.
+- The daemon does not enable the CDP `Runtime` domain. `js()` works without it, and bot-management services treat an enabled Runtime domain as an attached debugger (sign-in pages behind them refuse the login). If you need `Runtime.*` events from `drain_events()` (console output, exceptions), set `BH_ENABLE_RUNTIME=1`.
 
 ## Domain Skills
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -385,6 +385,17 @@ class _PatientCDPClient(CDPClient):
         self._message_handler_task = asyncio.create_task(self._handle_messages())
 
 
+def default_cdp_domains():
+    """CDP domains enabled on every session the daemon attaches to.
+
+    Runtime is opt-in via BH_ENABLE_RUNTIME=1; see _enable_default_domains.
+    """
+    domains = ["Page", "DOM", "Network"]
+    if os.environ.get("BH_ENABLE_RUNTIME") == "1":
+        domains.insert(2, "Runtime")
+    return tuple(domains)
+
+
 class Daemon:
     def __init__(self):
         self.cdp = None
@@ -503,7 +514,7 @@ class Daemon:
             pass
 
     async def _enable_default_domains(self, session_id):
-        """Enable Page/DOM/Runtime/Network on a CDP session.
+        """Enable Page/DOM/Network (and optionally Runtime) on a CDP session.
 
         Used by both initial attach and set_session (called after switch_tab/
         new_tab). Without this, helpers that depend on Network.* events —
@@ -511,8 +522,16 @@ class Daemon:
         after a tab switch, because each fresh CDP session starts with all
         domains disabled.
 
-        Runs the four enables in parallel via gather so the worst-case time is
-        bounded by a single CDP round trip rather than four sequential ones —
+        Runtime is NOT enabled by default. Nothing in the harness consumes
+        Runtime events (Runtime.evaluate works without Runtime.enable), and
+        bot-management services fingerprint an enabled Runtime domain as an
+        attached debugger: sites behind them (GoDaddy sign-in, for one) refuse
+        to log in a tab where it is on while accepting the same input on a tab
+        where it is off. Set BH_ENABLE_RUNTIME=1 to opt back in, e.g. to
+        receive consoleAPICalled / exceptionThrown events via drain_events().
+
+        Runs the enables in parallel via gather so the worst-case time is
+        bounded by a single CDP round trip rather than several sequential ones —
         important on the set_session path, where the helper's IPC socket has
         a 5s read timeout.
         """
@@ -524,7 +543,7 @@ class Daemon:
                 )
             except Exception as e:
                 log(f"enable {d} on {session_id}: {e}")
-        await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
+        await asyncio.gather(*(enable_one(d) for d in default_cdp_domains()))
 
     def _record_session_replacement(self, stale_session, replacement_session):
         """Remember which recovered session still controls the same tab."""

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -74,12 +74,12 @@ def _fresh_daemon():
     return d
 
 
-def test_set_session_enables_all_four_default_domains_on_new_session():
+def test_set_session_enables_all_default_domains_on_new_session():
     """Regression: switch_tab() / new_tab() in helpers.py route through the
     `set_session` IPC, which previously only enabled Page on the new
     session. With Network disabled, wait_for_network_idle() silently stops
     receiving events after a tab switch. Initial attach enables all four
-    (Page, DOM, Runtime, Network); set_session must enable the same set."""
+    (Page, DOM, Network); set_session must enable the same set."""
     d = _fresh_daemon()
     new_session = "session-AFTER-switch"
 
@@ -93,8 +93,8 @@ def test_set_session_enables_all_four_default_domains_on_new_session():
         method for (method, _params, sid) in d.cdp.calls
         if sid == new_session and method.endswith(".enable")
     ]
-    assert set(enabled_on_new) == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}, (
-        f"set_session must enable Page/DOM/Runtime/Network on the new session "
+    assert set(enabled_on_new) == {"Page.enable", "DOM.enable", "Network.enable"}, (
+        f"set_session must enable Page/DOM/Network on the new session "
         f"(parity with initial attach). Got: {enabled_on_new}"
     )
     assert d.session == new_session
@@ -137,8 +137,26 @@ def test_enable_default_domains_swallows_errors_per_domain():
     attempted = [m for (m, _p, _s) in d.cdp.calls]
     assert "Page.enable" in attempted
     assert "DOM.enable" in attempted  # attempted, but raised
-    assert "Runtime.enable" in attempted
     assert "Network.enable" in attempted
+
+
+def test_runtime_domain_is_opt_in(monkeypatch):
+    """Runtime.enable is a well-known automation fingerprint (bot-management
+    services block sign-in on tabs where it is on) and nothing in the harness
+    consumes Runtime events, so it stays off unless BH_ENABLE_RUNTIME=1."""
+    monkeypatch.delenv("BH_ENABLE_RUNTIME", raising=False)
+    d = daemon.Daemon()
+    d.cdp = _FakeCDP()
+    asyncio.run(d._enable_default_domains("session-X"))
+    assert "Runtime.enable" not in [m for (m, _p, _s) in d.cdp.calls]
+
+    monkeypatch.setenv("BH_ENABLE_RUNTIME", "1")
+    d = daemon.Daemon()
+    d.cdp = _FakeCDP()
+    asyncio.run(d._enable_default_domains("session-Y"))
+    attempted = [m for (m, _p, _s) in d.cdp.calls]
+    assert attempted.count("Runtime.enable") == 1
+    assert {"Page.enable", "DOM.enable", "Network.enable"}.issubset(attempted)
 
 
 def test_set_session_disables_network_on_old_session_before_enabling_new():
@@ -240,18 +258,18 @@ def test_set_session_runs_disable_and_enables_in_parallel():
         return peak, d.cdp.calls
 
     peak, calls = asyncio.run(run())
-    assert peak == 5, (
-        f"set_session must run disable + 4 enables concurrently via gather "
-        f"(observed peak in-flight = {peak}; expected 5 = 1 disable on OLD + "
-        f"4 enables on NEW). Sequential await would peak at 1."
+    assert peak == 4, (
+        f"set_session must run disable + 3 enables concurrently via gather "
+        f"(observed peak in-flight = {peak}; expected 4 = 1 disable on OLD + "
+        f"3 enables on NEW). Sequential await would peak at 1."
     )
     # Sanity: the right calls were made.
     methods = sorted({m for (m, _p, _s) in calls})
     assert "Network.disable" in methods
-    assert {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}.issubset(methods)
+    assert {"Page.enable", "DOM.enable", "Network.enable"}.issubset(methods)
 
 
-def test_set_session_first_attach_runs_four_enables_in_parallel():
+def test_set_session_first_attach_runs_all_enables_in_parallel():
     """When there's no previous session, the disable path is skipped — only
     the four enables run, still in parallel."""
     class _ConcurrencyProbeCDP:
@@ -292,8 +310,8 @@ def test_set_session_first_attach_runs_four_enables_in_parallel():
         return peak
 
     peak = asyncio.run(run())
-    assert peak == 4, (
-        f"first set_session must run 4 enables concurrently "
+    assert peak == 3, (
+        f"first set_session must run 3 enables concurrently "
         f"(observed peak = {peak}). No Network.disable should fire."
     )
 
@@ -396,7 +414,7 @@ def test_named_daemon_creates_dedicated_tab(monkeypatch):
     create_calls = [p for (m, p, _s) in d.cdp.calls if m == "Target.createTarget"]
     assert create_calls == [{"url": "about:blank", "background": True}]
     enabled = {m for (m, _p, s) in d.cdp.calls if s == d.session and m.endswith(".enable")}
-    assert enabled == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
+    assert enabled == {"Page.enable", "DOM.enable", "Network.enable"}
 
 
 def test_default_daemon_still_attaches_first_page(monkeypatch):


### PR DESCRIPTION
## What

`Runtime.enable` is no longer sent on every CDP session the daemon attaches to. Page, DOM and Network are enabled as before. Runtime is enabled only when `BH_ENABLE_RUNTIME=1`.

## Why

Nothing in the harness consumes Runtime events. `Runtime.evaluate` (which `js()` uses) works without `Runtime.enable`, so the enable was pure overhead.

It is also a well-known automation fingerprint. Bot-management services treat an enabled Runtime domain as an attached debugger and refuse sign-in. Reproduced today on GoDaddy (sso.godaddy.com), same profile, same Chrome, same input events:

- tab attached by the daemon (Runtime enabled): "Your browser is a bit unusual..." and the login is refused
- tab driven over a private CDP session with no `.enable`: sign-in accepted, MFA prompt, then the signed-in domain portfolio drives normally

With this change the normal helpers load the signed-in GoDaddy pages without the block.

Anyone who wants `Runtime.consoleAPICalled` / `Runtime.exceptionThrown` from `drain_events()` can set `BH_ENABLE_RUNTIME=1`.

## Changes

- `daemon.py`: `default_cdp_domains()` returns `("Page", "DOM", "Network")`, plus `Runtime` when `BH_ENABLE_RUNTIME=1`; `_enable_default_domains` uses it. Docstring explains why.
- `tests/unit/test_daemon.py`: expectations updated to three default enables; new `test_runtime_domain_is_opt_in` covers both settings. All daemon tests pass (30).
- `SKILL.md`: one Gotchas line so agents know Runtime is off and how to turn it on.

## Context

I use browser-harness a lot and it ships as the browser layer of my own product, DevThrottle, so every one of my users hits this too. I recommend browser-harness everywhere. I used a coding agent to help develop and test this change; the diff is small and I have reviewed it. Happy to adjust the env-var name or make it a config preference if you prefer that over an environment variable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The daemon now enables CDP `Page`, `DOM`, and `Network` on every session, but only enables `Runtime` when `BH_ENABLE_RUNTIME=1`. This stops bot-management services from treating the tab as an attached debugger and blocking sign-in (e.g., GoDaddy).

- `Runtime.evaluate` still works without `Runtime.enable`, so `js()` is unaffected.
- To receive `Runtime.consoleAPICalled` and `Runtime.exceptionThrown` events via `drain_events()`, set `BH_ENABLE_RUNTIME=1`.
- Tests and `SKILL.md` updated to reflect the opt-in.

<sup>Written for commit 66d87efaeac992cdc3b04bbbc6cb9698e2a553f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

