### PR TITLE
fix: detach iframe CDP session after js(target_id=...) evaluation

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -498,6 +498,10 @@ def js(expression, target_id=None):
         if _is_illegal_return_error(e):
             return _runtime_evaluate(_wrap_js_function(expression), session_id=sid, await_promise=True)
         raise
+    finally:
+        if sid:
+            try: cdp("Target.detachFromTarget", sessionId=sid)
+            except Exception: pass
 
 
 _KC = {"Enter": 13, "Tab": 9, "Escape": 27, "Backspace": 8, " ": 32, "ArrowLeft": 37, "ArrowUp": 38, "ArrowRight": 39, "ArrowDown": 40}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, sys, time, urllib.request
+import base64, importlib.util, json, logging, math, os, sys, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -14,6 +14,7 @@ from . import paths
 CORE_DIR = Path(__file__).resolve().parent
 REPO_ROOT = CORE_DIR.parent.parent
 AGENT_WORKSPACE = paths.workspace_dir()
+_LOG = logging.getLogger(__name__)
 
 
 def _load_env():
@@ -501,7 +502,7 @@ def js(expression, target_id=None):
     finally:
         if sid:
             try: cdp("Target.detachFromTarget", sessionId=sid)
-            except Exception: pass
+            except Exception as e: _LOG.warning("js: failed to detach target session %s: %s", sid, e)
 
 
 _KC = {"Enter": 13, "Tab": 9, "Escape": 27, "Backspace": 8, " ": 32, "ArrowLeft": 37, "ArrowUp": 38, "ArrowRight": 39, "ArrowDown": 40}

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -466,3 +466,49 @@ def test_new_tab_reuses_an_empty_data_document(monkeypatch):
 
     assert helpers.new_tab("https://example.com") == "target-placeholder"
     assert calls == [("goto_url", "https://example.com")]
+
+
+# --- js ---
+
+def _js_cdp(calls, evaluate):
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": "S"}
+        if method == "Runtime.evaluate":
+            return evaluate
+        return {}
+    return fake_cdp
+
+
+def test_js_detaches_iframe_session_after_evaluate():
+    calls = []
+    with patch("browser_harness.helpers.cdp", side_effect=_js_cdp(calls, {"result": {"value": 1}})):
+        assert helpers.js("1", target_id="T") == 1
+
+    methods = [m for m, _ in calls]
+    assert ("Target.attachToTarget", {"targetId": "T", "flatten": True}) in calls
+    assert ("Target.detachFromTarget", {"sessionId": "S"}) in calls
+    assert calls[methods.index("Runtime.evaluate")][1]["session_id"] == "S"
+    assert methods.index("Target.detachFromTarget") > methods.index("Runtime.evaluate")
+
+
+def test_js_detaches_iframe_session_on_js_exception():
+    calls = []
+    failed = {
+        "result": {"type": "object", "subtype": "error", "description": "ReferenceError: x is not defined"},
+        "exceptionDetails": {"text": "Uncaught", "lineNumber": 0, "columnNumber": 0},
+    }
+    with patch("browser_harness.helpers.cdp", side_effect=_js_cdp(calls, failed)):
+        with pytest.raises(RuntimeError, match="ReferenceError"):
+            helpers.js("x", target_id="T")
+
+    assert ("Target.detachFromTarget", {"sessionId": "S"}) in calls
+
+
+def test_js_without_target_id_neither_attaches_nor_detaches():
+    calls = []
+    with patch("browser_harness.helpers.cdp", side_effect=_js_cdp(calls, {"result": {"value": 1}})):
+        assert helpers.js("1") == 1
+
+    assert [m for m, _ in calls] == ["Runtime.evaluate"]

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -506,6 +506,20 @@ def test_js_detaches_iframe_session_on_js_exception():
     assert ("Target.detachFromTarget", {"sessionId": "S"}) in calls
 
 
+def test_js_reports_detach_failure_without_masking_result(caplog):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        if method == "Target.detachFromTarget":
+            raise RuntimeError("detach failed")
+        return _js_cdp(calls, {"result": {"value": 1}})(method, **kwargs)
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        assert helpers.js("1", target_id="T") == 1
+
+    assert "failed to detach target session S: detach failed" in caplog.text
+
+
 def test_js_without_target_id_neither_attaches_nor_detaches():
     calls = []
     with patch("browser_harness.helpers.cdp", side_effect=_js_cdp(calls, {"result": {"value": 1}})):


### PR DESCRIPTION
## Problem
`js(expression, target_id=...)` attaches a flattened session to the target on every call and never detaches it, so each iframe evaluation leaks a CDP session for the life of the daemon's websocket.

## Fix
`helpers.js()`: detach in a `finally` (`Target.detachFromTarget`, `sessionId` as a CDP param — the daemon routes `Target.*` browser-level). The illegal-return retry reuses the same session, so one detach covers both attempts. A failed detach is logged at warning level and never masks the evaluation's result or exception.

## Notes
One extra CDP round trip per `js(..., target_id=...)` call. No API change.

## Tests
`tests/unit/test_helpers.py`: detach after success, after a JS exception, and on detach failure; no attach/detach without `target_id`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
