### PR TITLE
fix: report goto_url landing URL and raise on failed navigation

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -363,14 +363,15 @@ def new_tab(url="about:blank"):
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
     if url != "about:blank":
+        cur = None
         try:
-            cur = current_tab() or {}
+            cur = current_tab()
         except Exception:
-            cur = {}
-        cur_url = cur.get("url") or ""
+            pass
+        cur_url = (cur.get("url") or "") if isinstance(cur, dict) else None
         # Reuse attached tab when it's blank. A failed navigation must propagate;
         # retrying in a new target would leak the first tab and repeat the request.
-        if (
+        if cur_url is not None and (
             cur_url in ("", "about:blank", "data:text/html,")
             or cur_url.startswith("about:blank#")
             or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -364,18 +364,19 @@ def new_tab(url="about:blank"):
     # polls and wait_for_load() returns before navigation actually starts.
     if url != "about:blank":
         try:
-            cur = current_tab()
-            cur_url = cur.get("url") or ""
-            # Reuse attached tab when it's blank
-            if (
-                cur_url in ("", "about:blank", "data:text/html,")
-                or cur_url.startswith("about:blank#")
-                or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
-            ):
-                goto_url(url)
-                return cur.get("targetId") or cur.get("target_id")
+            cur = current_tab() or {}
         except Exception:
-            pass
+            cur = {}
+        cur_url = cur.get("url") or ""
+        # Reuse attached tab when it's blank. A failed navigation must propagate;
+        # retrying in a new target would leak the first tab and repeat the request.
+        if (
+            cur_url in ("", "about:blank", "data:text/html,")
+            or cur_url.startswith("about:blank#")
+            or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
+        ):
+            goto_url(url)
+            return cur.get("targetId") or cur.get("target_id")
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     switch_tab(tid)
     if url != "about:blank":

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -144,7 +144,14 @@ def _is_illegal_return_error(exc):
 
 # --- navigation / page ---
 def goto_url(url):
+    """Navigate the attached tab; returns {requested, landed, frameId, loaderId}.
+    Raises when Chrome reports the navigation failed — a download URL fails with
+    net::ERR_ABORTED, as in Puppeteer — or when it lands on an error page."""
     r = cdp("Page.navigate", url=url)
+    if err := r.get("errorText"): raise RuntimeError(f"goto_url: navigation to {url} failed: {err}")
+    landed = js("location.href")
+    if landed.startswith("chrome-error://"): raise RuntimeError(f"goto_url: navigation to {url} landed on an error page: {landed}")
+    r = {**r, "requested": url, "landed": landed}
     if os.environ.get("BH_DOMAIN_SKILLS") != "1":
         return r
     d = (AGENT_WORKSPACE / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0])

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -83,18 +83,42 @@ def test_goto_url_omits_domain_skills_by_default(tmp_path, monkeypatch):
     monkeypatch.delenv("BH_DOMAIN_SKILLS", raising=False)
     monkeypatch.setattr(helpers, "AGENT_WORKSPACE", tmp_path)
     _seed_skill(tmp_path)
-    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}):
+    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}), \
+         patch("browser_harness.helpers.js", return_value="https://www.example.com/"):
         result = helpers.goto_url("https://www.example.com/")
-    assert result == {"frameId": "f"}
+    assert result == {"frameId": "f", "requested": "https://www.example.com/", "landed": "https://www.example.com/"}
 
 
 def test_goto_url_includes_domain_skills_when_enabled(tmp_path, monkeypatch):
     monkeypatch.setenv("BH_DOMAIN_SKILLS", "1")
     monkeypatch.setattr(helpers, "AGENT_WORKSPACE", tmp_path)
     _seed_skill(tmp_path)
-    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}):
+    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}), \
+         patch("browser_harness.helpers.js", return_value="https://www.example.com/"):
         result = helpers.goto_url("https://www.example.com/")
-    assert result == {"frameId": "f", "domain_skills": ["scraping.md"]}
+    assert result == {"frameId": "f", "requested": "https://www.example.com/", "landed": "https://www.example.com/",
+                      "domain_skills": ["scraping.md"]}
+
+
+def test_goto_url_raises_when_chrome_reports_navigation_failed():
+    with patch("browser_harness.helpers.cdp", return_value={"errorText": "net::ERR_NAME_NOT_RESOLVED"}):
+        with pytest.raises(RuntimeError, match="net::ERR_NAME_NOT_RESOLVED"):
+            helpers.goto_url("https://nope.invalid/")
+
+
+def test_goto_url_raises_when_landing_on_error_page():
+    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}), \
+         patch("browser_harness.helpers.js", return_value="chrome-error://chromewebdata/"):
+        with pytest.raises(RuntimeError, match="error page"):
+            helpers.goto_url("https://www.example.com/")
+
+
+def test_goto_url_reports_where_a_redirect_landed():
+    with patch("browser_harness.helpers.cdp", return_value={"frameId": "f"}), \
+         patch("browser_harness.helpers.js", return_value="https://www.example.com/login"):
+        result = helpers.goto_url("https://www.example.com/account")
+    assert result["requested"] == "https://www.example.com/account"
+    assert result["landed"] == "https://www.example.com/login"
 
 
 def test_page_info_raises_clear_error_on_js_exception():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -490,3 +490,28 @@ def test_new_tab_reuses_an_empty_data_document(monkeypatch):
 
     assert helpers.new_tab("https://example.com") == "target-placeholder"
     assert calls == [("goto_url", "https://example.com")]
+
+
+def test_new_tab_does_not_retry_failed_navigation_in_a_second_tab(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        helpers,
+        "current_tab",
+        lambda: {"targetId": "target-placeholder", "url": "about:blank"},
+    )
+
+    def fail_navigation(url):
+        calls.append(("goto_url", url))
+        raise RuntimeError("navigation failed")
+
+    monkeypatch.setattr(helpers, "goto_url", fail_navigation)
+    monkeypatch.setattr(
+        helpers,
+        "cdp",
+        lambda method, **kwargs: calls.append((method, kwargs)) or {},
+    )
+
+    with pytest.raises(RuntimeError, match="navigation failed"):
+        helpers.new_tab("https://nope.invalid")
+
+    assert calls == [("goto_url", "https://nope.invalid")]

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -515,3 +515,26 @@ def test_new_tab_does_not_retry_failed_navigation_in_a_second_tab(monkeypatch):
         helpers.new_tab("https://nope.invalid")
 
     assert calls == [("goto_url", "https://nope.invalid")]
+
+
+def test_new_tab_creates_a_fresh_target_when_current_tab_is_unknown(monkeypatch):
+    calls = []
+
+    def current_tab_failed():
+        raise RuntimeError("not attached")
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        return {"targetId": "target-new"} if method == "Target.createTarget" else {}
+
+    monkeypatch.setattr(helpers, "current_tab", current_tab_failed)
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "switch_tab", lambda target: calls.append(("switch_tab", target)))
+    monkeypatch.setattr(helpers, "goto_url", lambda url: calls.append(("goto_url", url)))
+
+    assert helpers.new_tab("https://example.com") == "target-new"
+    assert calls == [
+        ("Target.createTarget", {"url": "about:blank", "background": True}),
+        ("switch_tab", "target-new"),
+        ("goto_url", "https://example.com"),
+    ]


### PR DESCRIPTION
## Problem
`goto_url()` returned `Page.navigate`'s raw result. A DNS error, refused connection or aborted request (including a download) came back as success while the tab showed `chrome-error://chromewebdata/`, and callers could not see where a redirect landed. `new_tab()` then retried a failed navigation in a second tab.

## Fix
- `goto_url()` raises `RuntimeError` when Chrome sets `errorText` or the committed URL is a `chrome-error://` page, and returns `{requested, landed, frameId, loaderId}` (`landed` = `location.href` after commit — `Page.navigate` resolves on commit or failure).
- `new_tab()`: a failed navigation on a reused blank tab propagates instead of falling through to a second tab; a failing `current_tab()` lookup creates a fresh target as before.

## Notes
Behaviour change: `goto_url` now raises on failed navigations (`new_tab` and MCP `browser_goto` inherit this); a download URL raises `net::ERR_ABORTED`, as in Puppeteer. Waiting for load stays a separate `wait_for_load()`. One extra round trip (`location.href`).

## Tests
`tests/unit/test_helpers.py`: error page, `errorText`, redirect landing, both `new_tab` paths. 156 passed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
