### PR TITLE
feat: type daemon error replies with a closed class set

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -391,9 +391,12 @@ def error_class(exc):
 
     Closed set of reply classes: session_stale, cdp_disconnected, cdp_error
     (CDP failures); unauthorized, not_attached, shutting_down, internal (daemon-side)."""
-    # cdp_use raises a CDP error response as RuntimeError({"code": .., "message": ..})
-    msg = str(exc.args[0].get("message", "")) if exc.args and isinstance(exc.args[0], dict) else str(exc)
-    if "Session with given id not found" in msg:
+    # cdp_use raises a CDP error response as RuntimeError({"code": .., "message": ..}).
+    # Chrome's stable session-not-found code is primary; keep the message match
+    # only for older/alternate clients that discard the structured payload.
+    payload = exc.args[0] if exc.args and isinstance(exc.args[0], dict) else {}
+    msg = str(payload.get("message", "")) if payload else str(exc)
+    if payload.get("code") == -32001 or "Session with given id not found" in msg:
         return "session_stale"
     # in-flight calls get ConnectionError when the socket closes; later sends raise websockets' ConnectionClosed
     if isinstance(exc, (ConnectionError, ConnectionClosed)) or "connection closed" in msg or "Client is not started" in msg:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -8,6 +8,7 @@ from . import _ipc as ipc
 from . import auth
 from . import paths
 from cdp_use.client import CDPClient
+from websockets.exceptions import ConnectionClosed
 
 
 def _load_env():
@@ -385,6 +386,24 @@ class _PatientCDPClient(CDPClient):
         self._message_handler_task = asyncio.create_task(self._handle_messages())
 
 
+def error_class(exc):
+    """Wire class of a failed CDP call.
+
+    Closed set of reply classes: session_stale, cdp_disconnected, cdp_error
+    (CDP failures); unauthorized, not_attached, shutting_down, internal (daemon-side)."""
+    # cdp_use raises a CDP error response as RuntimeError({"code": .., "message": ..})
+    msg = str(exc.args[0].get("message", "")) if exc.args and isinstance(exc.args[0], dict) else str(exc)
+    if "Session with given id not found" in msg:
+        return "session_stale"
+    # in-flight calls get ConnectionError when the socket closes; later sends raise websockets' ConnectionClosed
+    if isinstance(exc, (ConnectionError, ConnectionClosed)) or "connection closed" in msg or "Client is not started" in msg:
+        return "cdp_disconnected"
+    return "cdp_error"
+
+
+def _error(msg, cls): return {"error": msg, "class": cls}
+
+
 class Daemon:
     def __init__(self):
         self.cdp = None
@@ -617,7 +636,7 @@ class Daemon:
         # this check is a no-op there (AF_UNIX + chmod 600 is the boundary).
         expected = ipc.expected_token()
         if expected is not None and req.get("token") != expected:
-            return {"error": "unauthorized"}
+            return _error("unauthorized", "unauthorized")
         meta = req.get("meta")
         # Liveness probe — lets clients confirm the listener is actually this
         # daemon and not an unrelated process that reused our port post-crash.
@@ -634,19 +653,19 @@ class Daemon:
             # any Target.* method (browser-level call), and without a targetId
             # Chrome silently returns the *browser* target.
             if not self.target_id:
-                return {"error": "not_attached"}
+                return _error("not_attached", "not_attached")
             try:
                 info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
             except Exception:
-                return {"error": "cdp_disconnected"}
+                return _error("cdp_disconnected", "cdp_disconnected")
             return {"targetId": info.get("targetId"), "url": info.get("url", ""), "title": info.get("title", "")}
         if meta == "connection_status":
             if not self.target_id:
-                return {"error": "not_attached"}
+                return _error("not_attached", "not_attached")
             try:
                 info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
             except Exception:
-                return {"error": "cdp_disconnected"}
+                return _error("cdp_disconnected", "cdp_disconnected")
             page = None
             if is_real_page(info):
                 page = {
@@ -698,13 +717,13 @@ class Daemon:
             # cancel/drain existing handlers. In particular, a CDP replay that
             # never answers must not prevent Cloud cleanup from being attempted.
             if self._shutting_down:
-                return {"error": "shutdown already in progress"}
+                return _error("shutdown already in progress", "shutting_down")
             self._shutting_down = True
             if not await self._cancel_and_drain_recoveries():
                 # Preserve the daemon as a retryable cleanup authority. The
                 # strict caller will leave its endpoint and PID file intact.
                 self._shutting_down = False
-                return {"error": "stale-session recovery did not stop"}
+                return _error("stale-session recovery did not stop", "shutting_down")
             try:
                 stop_remote(strict=True)
             except Exception as e:
@@ -712,7 +731,7 @@ class Daemon:
                 # shutdown request can retry the billable-browser cleanup.
                 async with self._session_state_lock:
                     self._shutting_down = False
-                return {"error": str(e)}
+                return _error(str(e), "internal")
             self.stop.set()
             return {"ok": True}
 
@@ -725,26 +744,27 @@ class Daemon:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
             msg = str(e)
-            if "Session with given id not found" in msg and sid:
+            cls = error_class(e)
+            if cls == "session_stale" and sid:
                 # Explicit session callers asked for that exact session; do not
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):
-                    return {"error": msg}
+                    return _error(msg, cls)
                 recovery_task = self._begin_recovery()
                 if recovery_task is None:
-                    return {"error": "daemon is shutting down"}
+                    return _error("daemon is shutting down", "shutting_down")
                 try:
                     recovered_here = False
                     async with self._session_state_lock:
                         if self._shutting_down:
-                            return {"error": "daemon is shutting down"}
+                            return _error("daemon is shutting down", "shutting_down")
                         replacement_session = self._session_replacements.get(sid)
                         if replacement_session is None and sid == self.session:
                             log(f"stale session {sid}, re-attaching")
                             if not await self.attach_first_page(
                                 replaces_session=sid, enable_domains=False
                             ):
-                                return {"error": msg}
+                                return _error(msg, cls)
                             replacement_session = self._session_replacements.get(sid)
                             recovered_here = replacement_session is not None
                     if recovered_here:
@@ -758,10 +778,10 @@ class Daemon:
                                 method, params, session_id=replacement_session
                             )}
                         except Exception as retry_error:
-                            return {"error": str(retry_error)}
+                            return _error(str(retry_error), error_class(retry_error))
                 finally:
                     self._finish_recovery(recovery_task)
-            return {"error": msg}
+            return _error(msg, cls)
 
 
 async def serve(d):
@@ -775,7 +795,7 @@ async def serve(d):
         except Exception as e:
             log(f"conn: {e}")
             try:
-                writer.write((json.dumps({"error": str(e)}) + "\n").encode())
+                writer.write((json.dumps(_error(str(e), "internal")) + "\n").encode())
                 await writer.drain()
             except Exception:
                 pass

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -49,6 +49,13 @@ class _IPCResponseTimeout(TimeoutError):
     pass
 
 
+class DaemonError(RuntimeError):
+    """Daemon error reply. `cls` is its wire class (see daemon.error_class), "unknown" if absent."""
+    def __init__(self, msg, cls="unknown"):
+        super().__init__(msg)
+        self.cls = cls
+
+
 def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
     c, token = ipc.connect(NAME, timeout=IPC_CONNECT_TIMEOUT_SECONDS)
     try:
@@ -59,7 +66,7 @@ def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
             raise _IPCResponseTimeout from e
     finally:
         c.close()
-    if "error" in r: raise RuntimeError(r["error"])
+    if "error" in r: raise DaemonError(r["error"], r.get("class", "unknown"))
     return r
 
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+from websockets.exceptions import ConnectionClosedError
 
 from browser_harness import daemon
 
@@ -52,7 +53,7 @@ def test_shutdown_keeps_daemon_alive_when_cloud_stop_fails(monkeypatch):
 
     response = asyncio.run(d.handle({"meta": "shutdown"}))
 
-    assert response == {"error": "billing stop failed"}
+    assert response == {"error": "billing stop failed", "class": "internal"}
     assert d.stop.is_set() is False
 
 
@@ -343,7 +344,7 @@ def test_current_tab_meta_returns_not_attached_when_no_target_id():
 
     result = asyncio.run(d.handle({"meta": "current_tab"}))
 
-    assert result == {"error": "not_attached"}
+    assert result == {"error": "not_attached", "class": "not_attached"}
     # No CDP call should have been issued.
     assert d.cdp.calls == []
 
@@ -770,7 +771,22 @@ def test_explicit_stale_session_is_not_redirected():
         "session_id": "explicit-stale-session",
     }))
 
-    assert result == {"error": "Session with given id not found"}
+    assert result == {"error": "Session with given id not found", "class": "session_stale"}
     assert d.cdp.calls == [
         ("Runtime.evaluate", {"expression": "1"}, "explicit-stale-session")
     ]
+
+
+@pytest.mark.parametrize(
+    ("exc", "cls"),
+    [
+        (RuntimeError({"code": -32001, "message": "Session with given id not found."}), "session_stale"),
+        (ConnectionError("WebSocket connection closed"), "cdp_disconnected"),
+        (ConnectionClosedError(None, None), "cdp_disconnected"),
+        (RuntimeError("Client is not started. Call start() first"), "cdp_disconnected"),
+        (RuntimeError({"code": -32000, "message": "No node with given id found"}), "cdp_error"),
+        (RuntimeError({"code": -32000, "message": "Tracing is not started"}), "cdp_error"),
+    ],
+)
+def test_error_class_types_cdp_client_failures(exc, cls):
+    assert daemon.error_class(exc) == cls

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -780,7 +780,8 @@ def test_explicit_stale_session_is_not_redirected():
 @pytest.mark.parametrize(
     ("exc", "cls"),
     [
-        (RuntimeError({"code": -32001, "message": "Session with given id not found."}), "session_stale"),
+        (RuntimeError({"code": -32001, "message": "Target session expired"}), "session_stale"),
+        (RuntimeError("Session with given id not found."), "session_stale"),
         (ConnectionError("WebSocket connection closed"), "cdp_disconnected"),
         (ConnectionClosedError(None, None), "cdp_disconnected"),
         (RuntimeError("Client is not started. Call start() first"), "cdp_disconnected"),

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image
@@ -47,6 +47,20 @@ def test_send_keeps_connect_timeout_short_and_sets_response_budget():
 
     connect.assert_called_once_with(helpers.NAME, timeout=helpers.IPC_CONNECT_TIMEOUT_SECONDS)
     assert socket.timeouts == [60.0]
+
+
+def test_send_raises_daemon_error_carrying_wire_class():
+    def send(reply):
+        with patch("browser_harness.helpers.ipc.connect", return_value=(MagicMock(), None)), \
+             patch("browser_harness.helpers.ipc.request", return_value=reply):
+            with pytest.raises(RuntimeError) as info:
+                helpers._send({"meta": "ping"})
+        return info.value
+
+    e = send({"error": "x", "class": "session_stale"})
+    assert isinstance(e, helpers.DaemonError)
+    assert (str(e), e.cls) == ("x", "session_stale")
+    assert send({"error": "x"}).cls == "unknown"
 
 
 def test_screenshot_uses_long_response_timeout_without_forwarding_it_to_cdp(fake_png, tmp_path):


### PR DESCRIPTION
## Problem
Every daemon failure is `{"error": "<prose>"}` and `helpers._send` raises a bare `RuntimeError`, so reacting to a failure means substring-matching Chrome's text — the daemon itself does that inline to detect a stale session.

## Fix
- `daemon.error_class(exc)` types a CDP-client failure once, at the source: `session_stale` (CDP code `-32001`, message match as fallback), `cdp_disconnected` (`ConnectionError`, websockets `ConnectionClosed`, client not started), else `cdp_error`. Every error reply gains a `"class"` key next to the unchanged message: also `unauthorized`, `not_attached`, `shutting_down`, `internal`.
- `helpers.DaemonError(RuntimeError)` with `.cls`; `_send` raises it (`"unknown"` when an older daemon sends no class).

## Notes
Message texts are byte-identical, so existing `except RuntimeError` / `match=` keep working. Wire replies carry one extra key; `admin.py`, `run.py`, `mcp_server.py` untouched.

## Tests
`tests/unit/test_daemon.py`: class per failure kind (parametrized), updated whole-reply assertions. `tests/unit/test_helpers.py`: `_send` raises `DaemonError` with the wire class. 159 passed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
