### PR TITLE
feat: cap script stdout at 20k chars and spill the rest to a file

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,8 +26,8 @@ PY
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
 - Script stdout is capped at 20,000 chars; the overflow goes to a file whose
-  path is printed at the end. Write large results to a file from the script,
-  or set `BH_MAX_OUTPUT=0` to disable the cap.
+  path is printed when the cap is hit. Write large results to a file from the
+  script, or set `BH_MAX_OUTPUT=0` to disable the cap.
 - First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
   preserves the attached tab across separate CLI invocations, so do not call
   `new_tab()` again in every script.

--- a/SKILL.md
+++ b/SKILL.md
@@ -25,6 +25,9 @@ PY
 
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
+- Script stdout is capped at 20,000 chars; the overflow goes to a file whose
+  path is printed at the end. Write large results to a file from the script,
+  or set `BH_MAX_OUTPUT=0` to disable the cap.
 - First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
   preserves the attached tab across separate CLI invocations, so do not call
   `new_tab()` again in every script.

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -1,4 +1,4 @@
-import os, sys, time, urllib.request
+import os, sys, tempfile, time, urllib.request
 from io import StringIO
 
 # Windows default stdout/stderr encoding is cp1252
@@ -29,6 +29,7 @@ from .admin import (
     stop_remote_daemon,
     sync_local_profile,
 )
+from . import _ipc as ipc
 from . import auth, recorder, telemetry
 from .helpers import *
 
@@ -191,19 +192,34 @@ _MAX_OUTPUT_LENGTH = 20_000
 
 
 class _StreamTail:
-    """Pass-through stream wrapper that remembers the tail and total length."""
+    """Pass-through stream wrapper that remembers the tail and total length.
+    With `cap`, only that many chars reach the stream; the rest spills to a file."""
 
-    def __init__(self, wrapped, limit=500):
+    def __init__(self, wrapped, limit=500, cap=None):
         self._wrapped = wrapped
         self._limit = limit
+        self._cap = cap
+        self._spill = None
         self.tail = ""
         self.length = 0
 
     def write(self, text):
         text = str(text)
+        room = max(self._cap - self.length, 0) if self._cap is not None else len(text)
         self.length += len(text)
         self.tail = (self.tail + text)[-self._limit :]
+        if room < len(text):
+            if self._spill is None:
+                self._spill = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", errors="replace", prefix="output-", suffix=".txt", dir=ipc._TMP, delete=False)
+            self._spill.write(text[room:])
+            text = text[:room]
         return self._wrapped.write(text)
+
+    def finish(self):
+        if self._spill is None:
+            return
+        self._spill.close()
+        self._wrapped.write(f"\n[browser-harness] stdout truncated after {self._cap} chars; remaining {self.length - self._cap} chars saved to {self._spill.name}\n")
 
     def __getattr__(self, name):
         return getattr(self._wrapped, name)
@@ -245,7 +261,8 @@ def main():
     command = _telemetry_command(args)
     task = _read_task(args)
     stderr_tail = _StreamTail(sys.stderr)
-    stdout_tail = _StreamTail(sys.stdout, limit=_MAX_OUTPUT_LENGTH)
+    cap = int(os.environ.get("BH_MAX_OUTPUT") or _MAX_OUTPUT_LENGTH) or None
+    stdout_tail = _StreamTail(sys.stdout, limit=_MAX_OUTPUT_LENGTH, cap=cap if task else None)
     sys.stderr = stderr_tail
     sys.stdout = stdout_tail
     try:
@@ -284,6 +301,7 @@ def main():
     finally:
         sys.stderr = stderr_tail._wrapped
         sys.stdout = stdout_tail._wrapped
+        stdout_tail.finish()
     telemetry.capture_cli_event(
         action="completed",
         command=command,

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -205,6 +205,7 @@ class _StreamTail:
 
     def write(self, text):
         text = str(text)
+        accepted = len(text)
         room = max(self._cap - self.length, 0) if self._cap is not None else len(text)
         self.length += len(text)
         self.tail = (self.tail + text)[-self._limit :]
@@ -213,7 +214,8 @@ class _StreamTail:
                 self._spill = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", errors="replace", prefix="output-", suffix=".txt", dir=ipc._TMP, delete=False)
             self._spill.write(text[room:])
             text = text[:room]
-        return self._wrapped.write(text)
+        written = self._wrapped.write(text)
+        return None if written is None else written + accepted - len(text)
 
     def finish(self):
         if self._spill is None:
@@ -233,6 +235,21 @@ def _read_task(args):
     code = sys.stdin.read()
     sys.stdin = StringIO(code)
     return code
+
+
+def _stdout_cap(task):
+    if not task:
+        return None
+    value = os.environ.get("BH_MAX_OUTPUT")
+    if not value:
+        return _MAX_OUTPUT_LENGTH
+    try:
+        cap = int(value)
+    except ValueError:
+        raise SystemExit("BH_MAX_OUTPUT must be a non-negative integer") from None
+    if cap < 0:
+        raise SystemExit("BH_MAX_OUTPUT must be a non-negative integer")
+    return cap or None
 
 
 def _traced_steps():
@@ -261,8 +278,7 @@ def main():
     command = _telemetry_command(args)
     task = _read_task(args)
     stderr_tail = _StreamTail(sys.stderr)
-    cap = int(os.environ.get("BH_MAX_OUTPUT") or _MAX_OUTPUT_LENGTH) or None
-    stdout_tail = _StreamTail(sys.stdout, limit=_MAX_OUTPUT_LENGTH, cap=cap if task else None)
+    stdout_tail = _StreamTail(sys.stdout, limit=_MAX_OUTPUT_LENGTH, cap=_stdout_cap(task))
     sys.stderr = stderr_tail
     sys.stdout = stdout_tail
     try:

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -209,19 +209,22 @@ class _StreamTail:
         room = max(self._cap - self.length, 0) if self._cap is not None else len(text)
         self.length += len(text)
         self.tail = (self.tail + text)[-self._limit :]
-        if room < len(text):
+        visible, overflow = text[:room], text[room:]
+        written = self._wrapped.write(visible)
+        if overflow:
+            # Announce the spill now and flush every write: a script that dies hard
+            # (os._exit, SIGKILL) never reaches finish().
             if self._spill is None:
                 self._spill = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", errors="replace", prefix="output-", suffix=".txt", dir=ipc._TMP, delete=False)
-            self._spill.write(text[room:])
-            text = text[:room]
-        written = self._wrapped.write(text)
-        return None if written is None else written + accepted - len(text)
+                self._wrapped.write(f"\n[browser-harness] stdout truncated after {self._cap} chars; overflow is being saved to {self._spill.name}\n")
+                self._wrapped.flush()
+            self._spill.write(overflow)
+            self._spill.flush()
+        return None if written is None else written + accepted - len(visible)
 
     def finish(self):
-        if self._spill is None:
-            return
-        self._spill.close()
-        self._wrapped.write(f"\n[browser-harness] stdout truncated after {self._cap} chars; remaining {self.length - self._cap} chars saved to {self._spill.name}\n")
+        if self._spill is not None:
+            self._spill.close()
 
     def __getattr__(self, name):
         return getattr(self._wrapped, name)

--- a/src/browser_harness/video_render.py
+++ b/src/browser_harness/video_render.py
@@ -104,7 +104,7 @@ def _harness_command() -> list[str]:
 
 
 def run_harness(code: str, timeout: float = 60) -> dict:
-    env = {**os.environ, "BH_RECORD": "0"}
+    env = {**os.environ, "BH_RECORD": "0", "BH_MAX_OUTPUT": "0"}
     proc = subprocess.run(
         _harness_command(),
         input=code,

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -25,8 +25,8 @@ def test_stream_tail_cap_spills_overflow(monkeypatch, tmp_path):
     monkeypatch.setattr(run.ipc, "_TMP", tmp_path)
     out = StringIO()
     tail = run._StreamTail(out, cap=5)
-    tail.write("abc")
-    tail.write("defgh")
+    assert tail.write("abc") == 3
+    assert tail.write("defgh") == 5
     tail.finish()
 
     spill, = tmp_path.glob("output-*.txt")
@@ -77,6 +77,7 @@ def test_bh_max_output_zero_disables_cap(monkeypatch):
 
 def test_cap_applies_only_to_scripts(monkeypatch, tmp_path):
     monkeypatch.setattr(run.ipc, "_TMP", tmp_path)
+    monkeypatch.setenv("BH_MAX_OUTPUT", "not-an-integer")
     stdout = StringIO()
     with patch.object(sys, "argv", ["browser-harness", "--version"]), \
          patch("browser_harness.run._version", return_value="v" * 30000), \
@@ -85,6 +86,15 @@ def test_cap_applies_only_to_scripts(monkeypatch, tmp_path):
 
     assert stdout.getvalue() == "v" * 30000 + "\n"
     assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("value", ["not-an-integer", "-1"])
+def test_invalid_bh_max_output_is_rejected_for_scripts(monkeypatch, value):
+    monkeypatch.setenv("BH_MAX_OUTPUT", value)
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("sys.stdin", StringIO("print('unreachable')")), \
+         pytest.raises(SystemExit, match="BH_MAX_OUTPUT must be a non-negative integer"):
+        run.main()
 
 
 def test_require_existing_daemon_never_auto_starts(monkeypatch):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -30,7 +30,7 @@ def test_stream_tail_cap_spills_overflow(monkeypatch, tmp_path):
     tail.finish()
 
     spill, = tmp_path.glob("output-*.txt")
-    assert out.getvalue() == f"abcde\n[browser-harness] stdout truncated after 5 chars; remaining 3 chars saved to {spill}\n"
+    assert out.getvalue() == f"abcde\n[browser-harness] stdout truncated after 5 chars; overflow is being saved to {spill}\n"
     assert spill.read_text() == "fgh"
     assert tail.length == 8 and tail.tail == "abcdefgh"
 
@@ -58,7 +58,7 @@ def test_main_caps_stdout_and_spills_on_exit(monkeypatch, tmp_path):
         run.main()
 
     spill, = tmp_path.glob("output-*.txt")
-    assert stdout.getvalue() == "x" * 20000 + f"\n[browser-harness] stdout truncated after 20000 chars; remaining 10001 chars saved to {spill}\n"
+    assert stdout.getvalue() == "x" * 20000 + f"\n[browser-harness] stdout truncated after 20000 chars; overflow is being saved to {spill}\n"
     assert spill.read_text() == "x" * 10000 + "\n"
 
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -21,6 +21,72 @@ def test_stdin_executes_code():
     assert stdout.getvalue().strip() == "hello from stdin"
 
 
+def test_stream_tail_cap_spills_overflow(monkeypatch, tmp_path):
+    monkeypatch.setattr(run.ipc, "_TMP", tmp_path)
+    out = StringIO()
+    tail = run._StreamTail(out, cap=5)
+    tail.write("abc")
+    tail.write("defgh")
+    tail.finish()
+
+    spill, = tmp_path.glob("output-*.txt")
+    assert out.getvalue() == f"abcde\n[browser-harness] stdout truncated after 5 chars; remaining 3 chars saved to {spill}\n"
+    assert spill.read_text() == "fgh"
+    assert tail.length == 8 and tail.tail == "abcdefgh"
+
+
+def test_stream_tail_below_cap_passes_through(monkeypatch, tmp_path):
+    monkeypatch.setattr(run.ipc, "_TMP", tmp_path)
+    out = StringIO()
+    tail = run._StreamTail(out, cap=5)
+    tail.write("abcde")
+    tail.finish()
+
+    assert out.getvalue() == "abcde"
+    assert not list(tmp_path.iterdir())
+
+
+def test_main_caps_stdout_and_spills_on_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr(run.ipc, "_TMP", tmp_path)
+    stdout = StringIO()
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("sys.stdin", StringIO("print('x' * 30000); raise SystemExit(3)")), \
+         patch("sys.stdout", stdout), \
+         pytest.raises(SystemExit):
+        run.main()
+
+    spill, = tmp_path.glob("output-*.txt")
+    assert stdout.getvalue() == "x" * 20000 + f"\n[browser-harness] stdout truncated after 20000 chars; remaining 10001 chars saved to {spill}\n"
+    assert spill.read_text() == "x" * 10000 + "\n"
+
+
+def test_bh_max_output_zero_disables_cap(monkeypatch):
+    monkeypatch.setenv("BH_MAX_OUTPUT", "0")
+    stdout = StringIO()
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("sys.stdin", StringIO("print('x' * 30000)")), \
+         patch("sys.stdout", stdout):
+        run.main()
+
+    assert stdout.getvalue() == "x" * 30000 + "\n"
+
+
+def test_cap_applies_only_to_scripts(monkeypatch, tmp_path):
+    monkeypatch.setattr(run.ipc, "_TMP", tmp_path)
+    stdout = StringIO()
+    with patch.object(sys, "argv", ["browser-harness", "--version"]), \
+         patch("browser_harness.run._version", return_value="v" * 30000), \
+         patch("sys.stdout", stdout):
+        run.main()
+
+    assert stdout.getvalue() == "v" * 30000 + "\n"
+    assert not list(tmp_path.iterdir())
+
+
 def test_require_existing_daemon_never_auto_starts(monkeypatch):
     monkeypatch.setenv("BH_REQUIRE_EXISTING_DAEMON", "1")
     with patch.object(sys, "argv", ["browser-harness"]), \


### PR DESCRIPTION
## Problem
`run.py` wraps stdout in `_StreamTail` but only remembers a tail for telemetry; every byte still reaches the agent's context. One `print(js("document.body.innerText"))` dumps 100k+ chars, and the agent's tool layer then truncates it silently.

## Fix
- `_StreamTail(cap=...)`: text passes through until the cap; the first overflow writes a marker (`[browser-harness] stdout truncated after 20000 chars; overflow is being saved to <path>`) and the rest goes to `output-*.txt` under `ipc._TMP`, flushed per write so a hard exit loses nothing. `.tail`/`.length` still cover all text (telemetry unchanged).
- Cap applies to the script path only; `--version`, `skill`, `doctor --json` etc. are uncapped. `BH_MAX_OUTPUT` overrides it, `0` disables (for `> out.json`), invalid values exit with a message.
- `video_render.run_harness()` parses one JSON line from a harness subprocess, so it sets `BH_MAX_OUTPUT=0`.
- SKILL.md: one bullet.

## Notes
Covers `sys.stdout` writes (what `print()` uses); raw fd-1 / subprocess output is out of scope by design. Spill files are not cleaned up so the agent can read them.

## Tests
`tests/unit/test_run.py`: split at the cap, below the cap, `main()` on `SystemExit`, `BH_MAX_OUTPUT=0`, non-script command, invalid values. 158 passed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
