### PR TITLE
fix: pick select-all modifier by browser OS, not host OS

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -225,9 +225,11 @@ def fill_input(selector, text, clear_first=True, timeout=0.0):
         # select-all shortcut, leaving the field uncleared.
         mods = _select_all_modifier()
         select_all = {"key": "a", "code": "KeyA", "modifiers": mods,
-                      "windowsVirtualKeyCode": 65, "nativeVirtualKeyCode": 65}
+                      "windowsVirtualKeyCode": 65, "nativeVirtualKeyCode": 65,
+                      "commands": ["SelectAll"]}
         cdp("Input.dispatchKeyEvent", type="rawKeyDown", **select_all)
-        cdp("Input.dispatchKeyEvent", type="keyUp", **select_all)
+        cdp("Input.dispatchKeyEvent", type="keyUp",
+            **{k: v for k, v in select_all.items() if k != "commands"})
         press_key("Backspace")
     for ch in text:
         press_key(ch)

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, sys, time, urllib.request
+import base64, importlib.util, json, math, os, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -190,6 +190,15 @@ def click_at_xy(x, y, button="left", clicks=1):
 def type_text(text):
     cdp("Input.insertText", text=text)
 
+_SELECT_ALL_MODIFIER = None
+def _select_all_modifier():
+    """Select-all modifier by the browser's OS (not this process's): 4=Meta on macOS, else 2=Ctrl."""
+    global _SELECT_ALL_MODIFIER
+    if _SELECT_ALL_MODIFIER is None:
+        ua = cdp("Browser.getVersion").get("userAgent", "")
+        _SELECT_ALL_MODIFIER = 4 if "Mac OS X" in ua or "Macintosh" in ua else 2
+    return _SELECT_ALL_MODIFIER
+
 def fill_input(selector, text, clear_first=True, timeout=0.0):
     """Fill a framework-managed input (React controlled, Vue v-model, Ember tracked).
 
@@ -214,7 +223,7 @@ def fill_input(selector, text, clear_first=True, timeout=0.0):
         # `char` event for single-char keys. With Ctrl/Cmd held, that `char`
         # makes Chrome treat the input as a printable "a" instead of firing the
         # select-all shortcut, leaving the field uncleared.
-        mods = 4 if sys.platform == "darwin" else 2  # Cmd on macOS, Ctrl elsewhere
+        mods = _select_all_modifier()
         select_all = {"key": "a", "code": "KeyA", "modifiers": mods,
                       "windowsVirtualKeyCode": 65, "nativeVirtualKeyCode": 65}
         cdp("Input.dispatchKeyEvent", type="rawKeyDown", **select_all)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -185,6 +185,8 @@ def test_fill_input_clear_first_sends_select_all_then_backspace(monkeypatch):
     assert a_events, "expected an 'a' key event for select-all"
     assert all(e.get("modifiers") == 4 for e in a_events), \
         f"select-all 'a' must carry modifiers=4 for a macOS browser; got {[e.get('modifiers') for e in a_events]}"
+    assert a_events[0].get("commands") == ["SelectAll"]
+    assert "commands" not in a_events[-1]
 
     # Crucial: no `char` event for the "a" — emitting one makes Chrome treat
     # Cmd/Ctrl+A as a printable letter instead of a shortcut.

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -154,31 +154,37 @@ def test_fill_input_raises_when_element_not_found():
             helpers.fill_input("#missing", "hello")
 
 
-def test_fill_input_clear_first_sends_select_all_then_backspace():
-    import sys
+_MAC_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
+_LINUX_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
 
-    key_events = []
+
+def _fill_input_cdp_calls(monkeypatch, user_agent, texts=("x",)):
+    """fill_input(clear_first=True) each text against a browser with this user_agent; returns cdp calls."""
+    monkeypatch.setattr(helpers, "_SELECT_ALL_MODIFIER", None)
+    calls = []
 
     def fake_cdp(method, **kwargs):
-        if method == "Input.dispatchKeyEvent":
-            key_events.append(kwargs)
-        return {}
-
-    def fake_js(expr, **kwargs):
-        return True  # element found
+        calls.append((method, kwargs))
+        return {"userAgent": user_agent} if method == "Browser.getVersion" else {}
 
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
-         patch("browser_harness.helpers.js", side_effect=fake_js):
-        helpers.fill_input("#inp", "x", clear_first=True)
+         patch("browser_harness.helpers.js", return_value=True):  # element found
+        for text in texts:
+            helpers.fill_input("#inp", text, clear_first=True)
+    return calls
 
-    # The "a" must be dispatched with the platform-correct modifier (Meta=4 on
-    # macOS, Ctrl=2 elsewhere). Without the modifier, the field would never get
-    # selected — it would just receive a literal "a".
-    expected_mod = 4 if sys.platform == "darwin" else 2
+
+def test_fill_input_clear_first_sends_select_all_then_backspace(monkeypatch):
+    calls = _fill_input_cdp_calls(monkeypatch, _MAC_UA)
+    key_events = [kw for m, kw in calls if m == "Input.dispatchKeyEvent"]
+
+    # The "a" must carry the modifier of the browser's OS (Meta=4 on macOS,
+    # Ctrl=2 elsewhere), not this process's. Without the modifier, the field
+    # would never get selected — it would just receive a literal "a".
     a_events = [e for e in key_events if e.get("key") == "a"]
     assert a_events, "expected an 'a' key event for select-all"
-    assert all(e.get("modifiers") == expected_mod for e in a_events), \
-        f"select-all 'a' must carry modifiers={expected_mod}; got {[e.get('modifiers') for e in a_events]}"
+    assert all(e.get("modifiers") == 4 for e in a_events), \
+        f"select-all 'a' must carry modifiers=4 for a macOS browser; got {[e.get('modifiers') for e in a_events]}"
 
     # Crucial: no `char` event for the "a" — emitting one makes Chrome treat
     # Cmd/Ctrl+A as a printable letter instead of a shortcut.
@@ -188,6 +194,19 @@ def test_fill_input_clear_first_sends_select_all_then_backspace():
     # Backspace still fires (via press_key, which uses keyDown).
     keys_down = [e.get("key") for e in key_events if e.get("type") in ("keyDown", "rawKeyDown")]
     assert "Backspace" in keys_down
+
+
+def test_fill_input_clear_first_uses_ctrl_for_linux_browser(monkeypatch):
+    calls = _fill_input_cdp_calls(monkeypatch, _LINUX_UA)
+    a_events = [kw for m, kw in calls if m == "Input.dispatchKeyEvent" and kw.get("key") == "a"]
+    assert a_events, "expected an 'a' key event for select-all"
+    assert all(e.get("modifiers") == 2 for e in a_events), \
+        f"select-all 'a' must carry modifiers=2 for a Linux browser; got {[e.get('modifiers') for e in a_events]}"
+
+
+def test_fill_input_queries_browser_os_once(monkeypatch):
+    calls = _fill_input_cdp_calls(monkeypatch, _LINUX_UA, texts=("x", "y"))
+    assert [m for m, _ in calls].count("Browser.getVersion") == 1
 
 
 def test_fill_input_no_clear_skips_ctrl_a():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -165,7 +165,7 @@ def _fill_input_cdp_calls(monkeypatch, user_agent, texts=("x",)):
 
     def fake_cdp(method, **kwargs):
         calls.append((method, kwargs))
-        return {"userAgent": user_agent} if method == "Browser.getVersion" else {}
+        return {"userAgent": user_agent} if method == "Browser.getVersion" and user_agent is not None else {}
 
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
          patch("browser_harness.helpers.js", return_value=True):  # element found
@@ -204,6 +204,13 @@ def test_fill_input_clear_first_uses_ctrl_for_linux_browser(monkeypatch):
     assert a_events, "expected an 'a' key event for select-all"
     assert all(e.get("modifiers") == 2 for e in a_events), \
         f"select-all 'a' must carry modifiers=2 for a Linux browser; got {[e.get('modifiers') for e in a_events]}"
+
+
+def test_fill_input_clear_first_defaults_to_ctrl_without_a_user_agent(monkeypatch):
+    calls = _fill_input_cdp_calls(monkeypatch, None)
+    a_events = [kw for m, kw in calls if m == "Input.dispatchKeyEvent" and kw.get("key") == "a"]
+    assert a_events
+    assert all(e.get("modifiers") == 2 for e in a_events)
 
 
 def test_fill_input_queries_browser_os_once(monkeypatch):


### PR DESCRIPTION
## Problem
`fill_input(clear_first=True)` picked the select-all modifier from `sys.platform` — the OS of the process, not of the browser. Driving a Linux Chrome from a Mac sent Cmd+A, the field was never cleared, and the new text was appended.

## Fix
`_select_all_modifier()` reads the user agent from `Browser.getVersion` once per process: Meta on macOS, Ctrl otherwise (Ctrl when no UA is reported). The keydown also carries `commands: ["SelectAll"]`, so the editing command runs regardless of modifier mapping. Unused `sys` import dropped.

## Notes
One extra CDP round trip on the first clearing `fill_input` per process.

## Tests
`tests/unit/test_helpers.py`: macOS UA → 4, Linux UA → 2, missing UA → 2, `Browser.getVersion` queried once, `SelectAll` command on keydown only. 154 passed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
