### PR TITLE
feat: add set_value helper for one-round-trip field entry

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -114,6 +114,7 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 
 - Prefer to find elements with the accessibility tree, not screenshots: `cdp("Accessibility.getFullAXTree")["nodes"]` has every element's role, name, and `backendDOMNodeId` — filter in Python before printing (it is thousands of nodes). Coordinates: `q = cdp("DOM.getBoxModel", backendNodeId=n)["model"]["content"]; x, y = sum(q[0::2])/4, sum(q[1::2])/4` (viewport px, ready for `click_at_xy`; negative/oversized means scroll first).
 - Clicking: AX node -> box center -> `click_at_xy(x, y)` -> verify with a targeted `js(...)`/`page_info()` check.
+- Typing: `set_value(selector, text)` sets a field in one round trip (native setter + input/change events); use `fill_input(selector, text)` only for widgets that need real keystrokes (typeaheads, masks).
 - Fall back to raw HTML via `js(...)` only when the AX tree lacks the element (canvas, exotic widgets); screenshot when layout or imagery matters.
 - After navigation, call `wait_for_load()`.
 - If the current tab is stale or internal, call `ensure_real_tab()`.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -27,6 +27,7 @@ tools with a `browser_` prefix:
 - `browser_click`
 - `browser_type`
 - `browser_fill`
+- `browser_set_value`
 - `browser_press`
 - `browser_scroll`
 - `browser_screenshot`

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -41,6 +41,7 @@ from browser_harness.helpers import (
     page_info,
     press_key,
     scroll,
+    set_value,
     start_recording,
     stop_recording,
     switch_tab,
@@ -171,6 +172,12 @@ def browser_fill(selector: str, text: str, clear_first: bool = True):
     """Fill an input matched by `selector` with `text`."""
     fill_input(selector, text, clear_first=clear_first)
     return {"ok": True}
+
+
+@_tool
+def browser_set_value(selector: str, value: str):
+    """Set a field matched by `selector` to `value` in one round trip; returns the value read back."""
+    return {"value": set_value(selector, value)}
 
 
 @_tool

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -237,11 +237,12 @@ def set_value(selector, value):
     # e.focus() matters for the recorder, which masks password text by the active element's type.
     result = js(
         f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
-        f"if(!e)return null;e.focus();const v={json.dumps(value)};"
+        f"if(!e)return null;const v={json.dumps(value)};"
         f"const p=e instanceof HTMLTextAreaElement?HTMLTextAreaElement.prototype"
         f":e instanceof HTMLSelectElement?HTMLSelectElement.prototype:HTMLInputElement.prototype;"
         f"const s=Object.getOwnPropertyDescriptor(p,'value')?.set;"
         f"if(s)s.call(e,v);else e.value=v;"
+        f"e.focus();"
         f"e.dispatchEvent(new Event('input',{{bubbles:true}}));"
         f"e.dispatchEvent(new Event('change',{{bubbles:true}}));"
         f"return e.value;}})()"

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -229,6 +229,27 @@ def fill_input(selector, text, clear_first=True, timeout=0.0):
         f"e.dispatchEvent(new Event('change',{{bubbles:true}}));}})();"
     )
 
+def set_value(selector, value):
+    """Set an input/textarea/select value in one round trip via the native value setter
+    (so React/Vue see it) and fire input+change. Returns the value read back — a page may
+    normalise it (phone masks). Raises RuntimeError if the element is missing. Use
+    fill_input() for widgets that need real keystrokes (typeaheads, incremental masks)."""
+    # e.focus() matters for the recorder, which masks password text by the active element's type.
+    result = js(
+        f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
+        f"if(!e)return null;const v={json.dumps(value)};"
+        f"const p=e instanceof HTMLTextAreaElement?HTMLTextAreaElement.prototype"
+        f":e instanceof HTMLSelectElement?HTMLSelectElement.prototype:HTMLInputElement.prototype;"
+        f"const s=Object.getOwnPropertyDescriptor(p,'value')?.set;"
+        f"if(s)s.call(e,v);else e.value=v;e.focus();"
+        f"e.dispatchEvent(new Event('input',{{bubbles:true}}));"
+        f"e.dispatchEvent(new Event('change',{{bubbles:true}}));"
+        f"return e.value;}})()"
+    )
+    if result is None:
+        raise RuntimeError(f"set_value: element not found: {selector!r}")
+    return result
+
 _KEYS = {  # key → (windowsVirtualKeyCode, code, text)
     "Enter": (13, "Enter", "\r"), "Tab": (9, "Tab", "\t"), "Backspace": (8, "Backspace", ""),
     "Escape": (27, "Escape", ""), "Delete": (46, "Delete", ""), " ": (32, "Space", " "),

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -237,11 +237,11 @@ def set_value(selector, value):
     # e.focus() matters for the recorder, which masks password text by the active element's type.
     result = js(
         f"(()=>{{const e=document.querySelector({json.dumps(selector)});"
-        f"if(!e)return null;const v={json.dumps(value)};"
+        f"if(!e)return null;e.focus();const v={json.dumps(value)};"
         f"const p=e instanceof HTMLTextAreaElement?HTMLTextAreaElement.prototype"
         f":e instanceof HTMLSelectElement?HTMLSelectElement.prototype:HTMLInputElement.prototype;"
         f"const s=Object.getOwnPropertyDescriptor(p,'value')?.set;"
-        f"if(s)s.call(e,v);else e.value=v;e.focus();"
+        f"if(s)s.call(e,v);else e.value=v;"
         f"e.dispatchEvent(new Event('input',{{bubbles:true}}));"
         f"e.dispatchEvent(new Event('change',{{bubbles:true}}));"
         f"return e.value;}})()"

--- a/src/browser_harness/recorder.py
+++ b/src/browser_harness/recorder.py
@@ -29,7 +29,7 @@ from . import paths
 # capture_screenshot, ...) don't get frames — they'd bloat recordings of
 # inspection-heavy sessions without adding visual beats.
 ACTIONS = {
-    "goto_url", "click_at_xy", "type_text", "fill_input", "press_key",
+    "goto_url", "click_at_xy", "type_text", "fill_input", "set_value", "press_key",
     "scroll", "dispatch_key", "upload_file", "new_tab", "switch_tab",
     "close_tab", "ensure_real_tab",
     "wait", "wait_for_load", "wait_for_element", "wait_for_network_idle",
@@ -308,6 +308,9 @@ def _details(helper, args, kwargs, ctx):
     elif helper == "fill_input":
         d["selector"] = arg(0, "selector")
         d["text"] = _mask(arg(1, "text", ""), ctx)
+    elif helper == "set_value":
+        d["selector"] = arg(0, "selector")
+        d["text"] = _mask(arg(1, "value", ""), ctx)
     elif helper == "press_key":
         d["key"] = arg(0, "key")
     elif helper == "dispatch_key":

--- a/src/browser_harness/video.py
+++ b/src/browser_harness/video.py
@@ -87,7 +87,7 @@ EXPLANATION_KEYS = {
     "mistake",
     "correction",
 }
-TYPE_HELPERS = {"type_text", "fill", "fill_input"}
+TYPE_HELPERS = {"type_text", "fill", "fill_input", "set_value"}
 CLICK_HELPERS = {"click_at_xy"}
 REDACTION_KEYS = {"x", "y", "w", "h", "fill", "stroke", "radius", "pad"}
 VIEWPORT_TOLERANCE = 2

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -209,6 +209,33 @@ def test_fill_input_no_clear_skips_ctrl_a():
     assert "Backspace" not in keys_seen
 
 
+# --- set_value ---
+
+def test_set_value_sets_and_fires_events_in_one_call():
+    js_exprs = []
+
+    def fake_js(expr, **kwargs):
+        js_exprs.append(expr)
+        return "hello"
+
+    with patch("browser_harness.helpers.js", side_effect=fake_js):
+        assert helpers.set_value("#i", "hello") == "hello"
+
+    assert len(js_exprs) == 1
+    expr = js_exprs[0]
+    assert '"#i"' in expr and '"hello"' in expr
+    assert "input" in expr and "change" in expr
+
+
+def test_set_value_raises_when_element_not_found():
+    def fake_js(expr, **kwargs):
+        return None  # element not found
+
+    with patch("browser_harness.helpers.js", side_effect=fake_js):
+        with pytest.raises(RuntimeError, match="element not found"):
+            helpers.set_value("#missing", "hello")
+
+
 # --- wait_for_element ---
 
 def test_wait_for_element_returns_true_when_found_immediately():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -225,7 +225,7 @@ def test_set_value_sets_and_fires_events_in_one_call():
     expr = js_exprs[0]
     assert '"#i"' in expr and '"hello"' in expr
     assert "input" in expr and "change" in expr
-    assert expr.index("e.focus()") < expr.index("s.call(e,v)")
+    assert expr.index("s.call(e,v)") < expr.index("e.focus()") < expr.index("dispatchEvent")
 
 
 def test_set_value_raises_when_element_not_found():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -225,6 +225,7 @@ def test_set_value_sets_and_fires_events_in_one_call():
     expr = js_exprs[0]
     assert '"#i"' in expr and '"hello"' in expr
     assert "input" in expr and "change" in expr
+    assert expr.index("e.focus()") < expr.index("s.call(e,v)")
 
 
 def test_set_value_raises_when_element_not_found():


### PR DESCRIPTION
## Problem
`fill_input` types via CDP key events — three round trips per character, ~17 s for a 2,000-char field. Most inputs only need the value written through the native setter (so React/Vue/Angular notice) plus `input`/`change` events.

## Fix
`set_value(selector, value)`: one `js()` call — native `value` setter for input/textarea/select, then `focus()`, then bubbling `input` and `change`; returns the value read back (pages may normalise it); raises `RuntimeError` if the element is missing. Registered in `recorder.ACTIONS`, `video.TYPE_HELPERS`, MCP tool `browser_set_value`, one SKILL.md bullet pointing agents at it and keeping `fill_input` for typeaheads/masks.

## Notes
`focus()` after the set: the recorder masks password text by the active element, and a failed set (e.g. contenteditable → `Illegal invocation`) leaves focus untouched.

## Tests
`tests/unit/test_helpers.py`: one `js()` call with selector/value/events in the expected order; missing element raises. 153 passed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
