### PR TITLE
fix: give recorder frames the screenshot IPC timeout

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -56,7 +56,13 @@ def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
         try:
             r = ipc.request(c, token, req)
         except TimeoutError as e:
-            raise _IPCResponseTimeout from e
+            # Carry the detail on the exception itself. Raising the bare class
+            # left str(exc) empty, so every caller that reported the error had
+            # to rebuild the context by hand or print nothing useful.
+            label = req.get("method") or req.get("meta") or "request"
+            raise _IPCResponseTimeout(
+                f"{label} timed out after {response_timeout:g}s waiting for the daemon"
+            ) from e
     finally:
         c.close()
     if "error" in r: raise RuntimeError(r["error"])

--- a/src/browser_harness/recorder.py
+++ b/src/browser_harness/recorder.py
@@ -122,6 +122,8 @@ def stop_recording():
     _marker().unlink(missing_ok=True)
     frames = sum(1 for _ in Path(d).glob("*.jpg"))
     print(f"recording saved: {d} ({frames} frames)")
+    if not frames:
+        print(f"warning: no frames captured — see frame_error in {Path(d) / 'events.jsonl'}")
     return d
 
 
@@ -273,7 +275,15 @@ def _capture(d, helper, args=(), kwargs=None, duration=None):
         if k in event:
             event[k] = _scrub_url(event[k])
     try:
-        shot = helpers.cdp("Page.captureScreenshot", format="jpeg", quality=80)
+        # Same budget capture_screenshot() uses: a cloud screenshot routinely
+        # exceeds the 5s default IPC timeout, and every frame here would time
+        # out and be swallowed below, leaving a recording with no frames.
+        shot = helpers.cdp(
+            "Page.captureScreenshot",
+            _response_timeout=helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS,
+            format="jpeg",
+            quality=80,
+        )
         number = sum(1 for _ in d.glob("*.jpg")) + 1
         data = base64.b64decode(shot["data"])
         while True:
@@ -285,8 +295,11 @@ def _capture(d, helper, args=(), kwargs=None, duration=None):
             except FileExistsError:
                 number += 1
         event["frame"] = frame
-    except Exception:
-        pass
+    except Exception as e:
+        # A dropped frame must not break the run, but it must not vanish
+        # either — without this the only symptom is a recording that ends up
+        # with fewer frames than actions, and no way to tell why.
+        event["frame_error"] = f"{type(e).__name__}: {e}"[:200]
     with (d / "events.jsonl").open("a", encoding="utf-8") as f:
         f.write(json.dumps(event, ensure_ascii=False) + "\n")
 

--- a/src/browser_harness/recorder.py
+++ b/src/browser_harness/recorder.py
@@ -299,7 +299,9 @@ def _capture(d, helper, args=(), kwargs=None, duration=None):
         # A dropped frame must not break the run, but it must not vanish
         # either — without this the only symptom is a recording that ends up
         # with fewer frames than actions, and no way to tell why.
-        event["frame_error"] = f"{type(e).__name__}: {e}"[:200]
+        # `str(e) or ...` because an exception raised bare (no args) stringifies
+        # to "", which would record a useless "SomeError: " and defeat the point.
+        event["frame_error"] = f"{type(e).__name__}: {str(e) or 'no detail'}"[:200]
     with (d / "events.jsonl").open("a", encoding="utf-8") as f:
         f.write(json.dumps(event, ensure_ascii=False) + "\n")
 

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -1,0 +1,64 @@
+import base64
+import json
+
+from browser_harness import helpers, recorder
+
+
+class _FakeCDP:
+    """Stand-in for helpers.cdp that records its calls."""
+
+    def __init__(self, result=None, error=None):
+        self.calls = []
+        self._result = result
+        self._error = error
+
+    def __call__(self, method, **params):
+        self.calls.append((method, params))
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+def _screenshot_ok():
+    return _FakeCDP(result={"data": base64.b64encode(b"jpeg-bytes").decode()})
+
+
+def _events(directory):
+    lines = (directory / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines]
+
+
+def test_capture_uses_the_screenshot_ipc_timeout(tmp_path, monkeypatch):
+    """Frames must get the same budget capture_screenshot() uses.
+
+    On the default 5s IPC timeout every cloud screenshot times out, and the
+    handler in _capture swallows it — the recording keeps growing with no
+    frames in it.
+    """
+    cdp = _screenshot_ok()
+    monkeypatch.setattr(helpers, "cdp", cdp)
+    monkeypatch.setattr(helpers, "js", lambda expression: {})
+
+    recorder._capture(tmp_path, "click_at_xy", (10, 20), {})
+
+    method, params = cdp.calls[0]
+    assert method == "Page.captureScreenshot"
+    assert params["_response_timeout"] == helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS
+    assert params["_response_timeout"] > helpers.DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS
+
+    event = _events(tmp_path)[0]
+    assert event["frame"] == "0001.jpg"
+    assert (tmp_path / "0001.jpg").read_bytes() == b"jpeg-bytes"
+
+
+def test_dropped_frame_is_recorded_and_never_raises(tmp_path, monkeypatch):
+    """A failed screenshot stays non-fatal, but stops being invisible."""
+    monkeypatch.setattr(helpers, "cdp", _FakeCDP(error=TimeoutError("timed out")))
+    monkeypatch.setattr(helpers, "js", lambda expression: {})
+
+    recorder._capture(tmp_path, "click_at_xy", (10, 20), {})
+
+    event = _events(tmp_path)[0]
+    assert "frame" not in event
+    assert event["frame_error"].startswith("TimeoutError")
+    assert not list(tmp_path.glob("*.jpg"))

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -52,13 +52,45 @@ def test_capture_uses_the_screenshot_ipc_timeout(tmp_path, monkeypatch):
 
 
 def test_dropped_frame_is_recorded_and_never_raises(tmp_path, monkeypatch):
-    """A failed screenshot stays non-fatal, but stops being invisible."""
-    monkeypatch.setattr(helpers, "cdp", _FakeCDP(error=TimeoutError("timed out")))
+    """A failed screenshot stays non-fatal, but stops being invisible.
+
+    Drives the real IPC timeout rather than a hand-made TimeoutError: _send()
+    is what actually raises when a cloud screenshot overruns, and a stand-in
+    with a message of its own would hide an empty one on the real exception.
+    """
+
+    class _Socket:
+        def settimeout(self, _value):
+            pass
+
+        def close(self):
+            pass
+
+    def _timeout(_conn, _token, _req):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(helpers.ipc, "connect", lambda _name, timeout=None: (_Socket(), None))
+    monkeypatch.setattr(helpers.ipc, "request", _timeout)
     monkeypatch.setattr(helpers, "js", lambda expression: {})
 
     recorder._capture(tmp_path, "click_at_xy", (10, 20), {})
 
     event = _events(tmp_path)[0]
     assert "frame" not in event
-    assert event["frame_error"].startswith("TimeoutError")
     assert not list(tmp_path.glob("*.jpg"))
+
+    detail = event["frame_error"]
+    assert detail.startswith("_IPCResponseTimeout: ")
+    # The whole point of the key: it has to say what timed out, and for how long.
+    assert "Page.captureScreenshot" in detail
+    assert f"{helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS:g}s" in detail
+
+
+def test_frame_error_stays_useful_for_a_message_less_exception(tmp_path, monkeypatch):
+    """Any bare `raise SomeError` must not record a dangling 'SomeError: '."""
+    monkeypatch.setattr(helpers, "cdp", _FakeCDP(error=RuntimeError()))
+    monkeypatch.setattr(helpers, "js", lambda expression: {})
+
+    recorder._capture(tmp_path, "click_at_xy", (10, 20), {})
+
+    assert _events(tmp_path)[0]["frame_error"] == "RuntimeError: no detail"


### PR DESCRIPTION
Fixes #682.

## Problem

`helpers.py` defines two IPC read budgets, and says why:

```python
DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS = 5.0
# Cloud screenshots routinely take longer than ordinary CDP round trips. Keep
# their IPC socket alive within the caller's existing 90-second process budget.
SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS = 60.0
```

`capture_screenshot()` passes the 60s one. `recorder._capture()` issued its own raw call and fell back to the 5s default — the exact budget that constant exists to escape:

```python
shot = helpers.cdp("Page.captureScreenshot", format="jpeg", quality=80)
```

So on a cloud or remote daemon every frame timed out, and the bare `except Exception: pass` around the screenshot swallowed it. The recording still looked healthy — `events.jsonl` kept growing (just with no `frame` key), `stop_recording()` printed `(0 frames)`, `browser-harness recordings` listed it as the latest, and `make-video.md` then had nothing to compile.

That is the setup `SKILL.md` steers users toward for "headless servers, parallel sub-agents, or isolated work", and the one where they can't see the browser and are relying on the recording to know what happened.

## Fix

- **`recorder.py`** — pass `helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS` to the screenshot call, by name rather than as a literal `60`, so the two call sites can't drift apart again.
- **`recorder.py`** — the swallow also discarded *why* a frame was missing, so record it as `frame_error` on the event. Frame failures stay non-fatal (the module contract is that recording never breaks the run), but they're now visible in `events.jsonl`, and `stop_recording()` points at them when a recording ends up with no frames at all.
- **`tests/unit/test_recorder.py`** — new file. Covers that the screenshot is sent with the screenshot budget rather than the default, and that a failing screenshot records `frame_error` without raising.

`recorder.py:276` was the only call site that had this wrong — `helpers.py:264` is the other `Page.captureScreenshot` in the tree and it already passed the timeout, so no other caller needed touching.

## Verification

Windows 11, Python 3.11.9, `pip install -e .`

Both new tests fail against the unfixed `recorder.py` and pass with it:

```
$ git stash -- src/browser_harness/recorder.py && pytest tests/unit/test_recorder.py -q
FAILED tests/unit/test_recorder.py::test_capture_uses_the_screenshot_ipc_timeout
FAILED tests/unit/test_recorder.py::test_dropped_frame_is_recorded_and_never_raises
2 failed

$ git stash pop && pytest tests/unit/test_recorder.py -q
2 passed
```

Checked the plumbing end to end too, stubbing `helpers._send` to see what actually reaches the socket — the timeout lands on the IPC read, and `_response_timeout` is consumed by `cdp()` rather than being forwarded to Chrome as a CDP parameter:

```
IPC read timeout      : 60.0
params sent to Chrome : {'format': 'jpeg', 'quality': 80}
_response_timeout leaked to CDP wire? False
```

Full suite goes from `9 failed, 159 passed` to `9 failed, 161 passed` — the two new tests, nothing regressed. The 9 pre-existing failures are unrelated: 8 POSIX-only scaffolding in `test_admin.py` (#680) and `test_skill.py` (#678, fixed in #693).

## Note for reviewers

I could not exercise a real cloud daemon, so the >5s timing itself is reproduced by asserting the timeout that reaches the IPC layer rather than by a slow socket. If someone has a cloud browser handy, `start_recording()` → a few actions → `stop_recording()` should now report a non-zero frame count where it previously reported `0 frames`.

`frame_error` is a new optional key in `events.jsonl`. Nothing in `video.py` or `video_render.py` reads unknown keys, so existing recordings and the video pipeline are unaffected, but flagging it in case the format is treated as a contract elsewhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #682. `recorder._capture()` sent `Page.captureScreenshot` with the default 5s IPC timeout, so on cloud or remote daemons every frame timed out and the `except Exception: pass` swallowed it — recordings looked healthy but ended with zero frames and no visible cause. Screenshots now use the same 60s timeout as `capture_screenshot()`, and failed frames are recorded as `frame_error` in `events.jsonl` instead of disappearing.

**Notes**
- `_IPCResponseTimeout` now carries the method and elapsed budget in its message (e.g. `Page.captureScreenshot timed out after 60s waiting for the daemon`); previously `str(exc)` was empty, so `frame_error` would have recorded nothing useful.
- `stop_recording()` prints a warning pointing at `frame_error` when no frames were captured.
- The timeout is passed by the shared constant so the two call sites can't drift apart.
- A failed frame still doesn't break the run; it's just no longer invisible.
- `frame_error` is an optional key; the video pipeline ignores unknown keys, so existing recordings are unaffected.
- Adds `tests/unit/test_recorder.py` covering the timeout, the `frame_error` detail, and message-less exceptions.

<sup>Written for commit 1ab4169e30b95076cbe6fa21a745ab09269c5bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

