### PR TITLE
fix: decode http_get() with the encoding the response declares

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, sys, time, urllib.request
+import base64, codecs, importlib.util, json, math, os, re, sys, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -521,8 +521,48 @@ def upload_file(selector, path):
     if not nid: raise RuntimeError(f"no element for {selector}")
     cdp("DOM.setFileInputFiles", files=[path] if isinstance(path, str) else list(path), nodeId=nid)
 
+# Charset from an HTML <meta> tag, in either of the two spellings the HTML spec
+# allows. Only the head of the document is scanned, which is where both must appear.
+_META_CHARSET = re.compile(
+    rb"""<meta[^>]+?charset\s*=\s*["']?\s*([a-zA-Z0-9_\-:.]+)""",
+    re.IGNORECASE,
+)
+_META_PRESCAN_BYTES = 2048
+
+
+def _response_encoding(data, response_headers):
+    """Encoding a response's bytes are actually in.
+
+    Resolution order follows the HTML spec: a BOM wins outright, then the
+    Content-Type charset, then a <meta charset> in the head, then UTF-8. Skipping
+    the last two would leave the common case — a legacy page that declares gbk or
+    shift_jis in markup and says nothing in its headers — silently mojibaked.
+    """
+    if data.startswith(codecs.BOM_UTF8):
+        return "utf-8-sig"
+    if data.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
+        return "utf-16"
+    declared = response_headers.get_content_charset() if response_headers else None
+    if not declared:
+        match = _META_CHARSET.search(data[:_META_PRESCAN_BYTES])
+        if match:
+            declared = match.group(1).decode("ascii", errors="replace")
+    if not declared:
+        return "utf-8"
+    try:  # a bogus or misspelled charset must not take the whole fetch down
+        codecs.lookup(declared)
+    except LookupError:
+        return "utf-8"
+    return declared
+
+
 def http_get(url, headers=None, timeout=20.0):
     """Pure HTTP — no browser. Use for static pages / APIs. Wrap in ThreadPoolExecutor for bulk.
+
+    Decoded using the encoding the response declares (BOM, Content-Type charset,
+    then <meta charset>), falling back to UTF-8. Undecodable bytes become U+FFFD
+    rather than raising — a page with a few replacement characters is more useful
+    than a traceback.
 
     When BROWSER_USE_API_KEY is set, routes through the fetch-use proxy (handles bot
     detection, residential proxies, retries). Falls back to local urllib otherwise."""
@@ -538,7 +578,7 @@ def http_get(url, headers=None, timeout=20.0):
     with urllib.request.urlopen(urllib.request.Request(url, headers=h), timeout=timeout) as r:
         data = r.read()
         if r.headers.get("Content-Encoding") == "gzip": data = gzip.decompress(data)
-        return data.decode()
+        return data.decode(_response_encoding(data, r.headers), errors="replace")
 
 
 # Imported at the bottom so recorder's own `from . import helpers` sees a

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -543,7 +543,12 @@ def _response_encoding(data, response_headers):
     if data.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
         return "utf-16"
     declared = response_headers.get_content_charset() if response_headers else None
-    if not declared:
+    media_type = response_headers.get_content_type() if response_headers else None
+    if not declared and (
+        not response_headers
+        or response_headers.get("Content-Type") is None
+        or media_type in ("text/html", "application/xhtml+xml")
+    ):
         match = _META_CHARSET.search(data[:_META_PRESCAN_BYTES])
         if match:
             declared = match.group(1).decode("ascii", errors="replace")

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -540,6 +540,8 @@ def _response_encoding(data, response_headers):
     """
     if data.startswith(codecs.BOM_UTF8):
         return "utf-8-sig"
+    if data.startswith((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE)):
+        return "utf-32"
     if data.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)):
         return "utf-16"
     declared = response_headers.get_content_charset() if response_headers else None

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,3 +1,6 @@
+import codecs
+import email.message
+import gzip
 import os
 import tempfile
 import time
@@ -466,3 +469,72 @@ def test_new_tab_reuses_an_empty_data_document(monkeypatch):
 
     assert helpers.new_tab("https://example.com") == "target-placeholder"
     assert calls == [("goto_url", "https://example.com")]
+
+
+# --- http_get charset handling ---
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urlopen() yields as a context manager."""
+
+    def __init__(self, body, content_type=None, content_encoding=None):
+        self._body = body
+        self.headers = email.message.Message()
+        if content_type:
+            self.headers["Content-Type"] = content_type
+        if content_encoding:
+            self.headers["Content-Encoding"] = content_encoding
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+def _fetch(body, content_type=None, content_encoding=None):
+    response = _FakeResponse(body, content_type, content_encoding)
+    with patch.dict(os.environ, {}, clear=False), \
+         patch("browser_harness.helpers.urllib.request.urlopen", return_value=response):
+        os.environ.pop("BROWSER_USE_API_KEY", None)
+        return helpers.http_get("https://example.test/")
+
+
+def test_http_get_honours_the_content_type_charset():
+    body = "café".encode("windows-1252")
+    assert _fetch(body, content_type="text/html; charset=windows-1252") == "café"
+
+
+def test_http_get_falls_back_to_the_meta_charset():
+    """The header-less legacy page is the case that actually breaks in the wild."""
+    body = "<html><head><meta charset=\"gbk\"></head><body>中文</body></html>".encode("gbk")
+    assert "中文" in _fetch(body, content_type="text/html")
+
+
+def test_http_get_strips_a_utf8_bom():
+    body = codecs.BOM_UTF8 + "hello".encode("utf-8")
+    assert _fetch(body) == "hello"
+
+
+def test_http_get_defaults_to_utf8_without_any_declaration():
+    assert _fetch("héllo".encode("utf-8")) == "héllo"
+
+
+def test_http_get_ignores_an_unknown_charset():
+    body = "plain".encode("utf-8")
+    assert _fetch(body, content_type="text/html; charset=totally-not-a-codec") == "plain"
+
+
+def test_http_get_replaces_undecodable_bytes_instead_of_raising():
+    """A mislabelled page must not take the whole fetch down."""
+    body = b"ok \xe9\xff nope"
+    assert _fetch(body, content_type="text/html; charset=utf-8") == "ok \ufffd\ufffd nope"
+
+
+def test_http_get_decodes_after_gunzip():
+    body = gzip.compress("café".encode("windows-1252"))
+    result = _fetch(body, content_type="text/html; charset=windows-1252", content_encoding="gzip")
+    assert result == "café"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -495,6 +495,13 @@ class _FakeResponse:
         return False
 
 
+def _headers(content_type=None):
+    headers = email.message.Message()
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers
+
+
 def _fetch(body, content_type=None, content_encoding=None):
     response = _FakeResponse(body, content_type, content_encoding)
     with patch.dict(os.environ, {}, clear=False), \
@@ -517,6 +524,48 @@ def test_http_get_falls_back_to_the_meta_charset():
 def test_http_get_strips_a_utf8_bom():
     body = codecs.BOM_UTF8 + "hello".encode("utf-8")
     assert _fetch(body) == "hello"
+
+
+_BOM_TEXT = "héllo 中文"
+
+
+@pytest.mark.parametrize(
+    "bom, encoding",
+    [
+        (codecs.BOM_UTF16_LE, "utf-16-le"),
+        (codecs.BOM_UTF16_BE, "utf-16-be"),
+        (codecs.BOM_UTF32_LE, "utf-32-le"),
+        (codecs.BOM_UTF32_BE, "utf-32-be"),
+    ],
+    ids=["utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be"],
+)
+def test_http_get_decodes_every_utf_bom(bom, encoding):
+    """A BOM wins outright, so these decode with no charset declared anywhere."""
+    assert _fetch(bom + _BOM_TEXT.encode(encoding)) == _BOM_TEXT
+
+
+def test_utf32_bom_is_checked_before_utf16():
+    """Pins the branch order in _response_encoding().
+
+    BOM_UTF32_LE (\xff\xfe\x00\x00) starts with BOM_UTF16_LE (\xff\xfe), so a
+    UTF-16 check placed first swallows every UTF-32LE document and decodes it
+    as UTF-16 -- no exception, just silently wrong text. The big-endian BOMs do
+    not overlap, so LE is the only ordering that matters.
+    """
+    assert codecs.BOM_UTF32_LE.startswith(codecs.BOM_UTF16_LE)
+    assert not codecs.BOM_UTF32_BE.startswith(codecs.BOM_UTF16_BE)
+
+    body = codecs.BOM_UTF32_LE + _BOM_TEXT.encode("utf-32-le")
+    assert helpers._response_encoding(body, _headers()) == "utf-32"
+    # What the reordered version would have produced, spelled out.
+    assert body.decode("utf-16", errors="replace") != _BOM_TEXT
+
+
+def test_utf16_document_is_not_mistaken_for_utf32():
+    """The reverse direction: a UTF-16LE body must not trip the UTF-32 branch."""
+    body = codecs.BOM_UTF16_LE + _BOM_TEXT.encode("utf-16-le")
+    assert not body.startswith(codecs.BOM_UTF32_LE)
+    assert helpers._response_encoding(body, _headers()) == "utf-16"
 
 
 def test_http_get_defaults_to_utf8_without_any_declaration():


### PR DESCRIPTION
Fixes #683.

## Problem

`http_get()` ended in a bare `data.decode()` — UTF-8, strict. The response's own `Content-Type: ...; charset=` was sitting on `r.headers` and was never consulted:

```python
data = r.read()
if r.headers.get("Content-Encoding") == "gzip": data = gzip.decompress(data)
return data.decode()
```

So any page served as windows-1252, gbk, shift_jis or euc-kr — still common on regional news, government and older corporate sites — raised straight out of the caller's script:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 3
```

No fallback, and nothing in the error naming the charset. `SKILL.md` points at this helper specifically so agents *don't* launch a browser for a page a plain fetch can read, so the likely recovery from an unexplained traceback is the browser it exists to avoid.

## Fix

Resolve the encoding the way the HTML spec does, in `_response_encoding()`:

1. **BOM** — wins outright (`utf-8-sig` strips it rather than leaving a stray `\ufeff` that breaks JSON parsing and string comparisons).
2. **`Content-Type` charset** — via `headers.get_content_charset()`.
3. **`<meta charset>` prescan** of the first 2 KB, covering both spellings the spec allows.
4. **UTF-8** otherwise.

A charset no codec matches falls back to UTF-8 instead of raising, and the decode uses `errors="replace"` so a mislabelled page yields a few U+FFFD rather than killing the fetch.

**On the meta step** — the issue suggested a header-only fix, and I went past it deliberately. A legacy page that declares `gbk` in markup and says nothing in its headers is the common real-world shape, and header-only would have turned that crash into silent mojibake rather than fixing it. That is the second failure mode the issue lists, so a one-line header fix would only have covered half of it.

This also settles an inconsistency the issue notes: the `fetch_use` branch above returns `.text`, which is already charset-aware, so `http_get()` previously behaved differently depending on whether `BROWSER_USE_API_KEY` happened to be set.

## Verification

Windows 11, Python 3.11.9, `pip install -e .`

Seven new tests in `test_helpers.py`. Five fail against the unfixed helper, reproducing the reported error exactly; the other two are the already-correct paths, guarding the new code against regressing them:

```
$ git stash -- src/browser_harness/helpers.py && pytest tests/unit/test_helpers.py -k http_get -q
E  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 3: unexpected end of data
FAILED  test_http_get_honours_the_content_type_charset
FAILED  test_http_get_falls_back_to_the_meta_charset
FAILED  test_http_get_strips_a_utf8_bom
FAILED  test_http_get_replaces_undecodable_bytes_instead_of_raising
FAILED  test_http_get_decodes_after_gunzip
5 failed, 2 passed

$ git stash pop && pytest tests/unit/test_helpers.py -k http_get -q
7 passed
```

Checked the resolution table directly, including the false-positive case that worried me — a `charset=` appearing inside an unrelated `content` attribute:

```
utf-8       <- <meta charset="utf-8">
utf-8       <- <meta charset=utf-8>
gbk         <- <meta http-equiv="Content-Type" content="text/html; charset=gbk">
Shift_JIS   <- <META CHARSET='Shift_JIS'>
euc-kr      <- <meta charset="euc-kr">
utf-8       <- <meta name="description" content="about charset=bogus stuff">   # rejected by codecs.lookup
utf-8       <- <html>no meta</html>
utf-8       <- <meta charset="gbk">  with header charset=utf-8                 # header wins
```

Full suite: `9 failed, 159 passed` → `9 failed, 166 passed`. The 9 are pre-existing and unrelated — 8 POSIX-only scaffolding in `test_admin.py` (#680) and `test_skill.py` (#678, fixed in #693).

## Notes for reviewers

- The meta prescan is 2 KB rather than the spec's 1 KB, which is more generous and costs nothing since the body is already in memory.
- A bogus `charset=` inside an unrelated attribute can only ever match when there is no header charset, and any value that isn't a real codec falls back to UTF-8 — so the worst case is the behaviour you have today.
- `_response_encoding` runs *after* gunzip, so it prescans the real document rather than compressed bytes. `test_http_get_decodes_after_gunzip` pins that ordering.
- The `fetch_use` branch is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #683 by making `http_get()` decode responses using the encoding the response declares — BOM (UTF-8/16/32), `Content-Type` charset, `<meta charset>` prescan, then UTF-8 — instead of always assuming strict UTF-8. Also decodes with `errors="replace"` so mislabelled pages return replacement characters rather than raising.

- Handles legacy pages that declare charset only in `<meta>` (the common case) and falls back to UTF-8 for unknown charsets.
- Adds tests covering each resolution step, the fallback, replace behaviour, gunzip decoding order, and all UTF BOMs — including a pin on the UTF-32LE-before-UTF-16LE branch order that prevents silent corruption.

<sup>Written for commit 0361d33a445c39be30e7ffe53d6610c9df4af872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

