### PR TITLE
fix: don't assume uv when updating a wheel install

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1194,6 +1194,29 @@ def _prompt_yes(question, default_yes=True, yes=False):
     return ans.startswith("y")
 
 
+def _pip_available():
+    import importlib.util
+
+    return importlib.util.find_spec("pip") is not None
+
+
+def _pypi_upgrade_command():
+    """Command that can upgrade a wheel install, or None when nothing can.
+
+    install.md documents `uv tool install`, so uv stays the first choice when it
+    is on PATH. It is not always there — browser-harness is a normal PyPI
+    package and pip and pipx install it just as well — so fall back to pip
+    against the interpreter that is actually running us.
+    """
+    import shutil
+
+    if shutil.which("uv"):
+        return ["uv", "tool", "upgrade", "browser-harness"]
+    if _pip_available():
+        return [sys.executable, "-m", "pip", "install", "--upgrade", "browser-harness"]
+    return None
+
+
 def run_update(yes=False):
     """Pull the latest version and (after prompt) restart the daemon so it picks up changed code.
 
@@ -1227,8 +1250,33 @@ def run_update(yes=False):
         if r.returncode != 0:
             return r.returncode
     elif mode == "pypi":
-        tool_upgrade = subprocess.run(["uv", "tool", "upgrade", "browser-harness"])
+        command = _pypi_upgrade_command()
+        if command is None:
+            print(
+                "can't auto-update: neither uv nor pip is available. Install uv "
+                "(https://docs.astral.sh/uv/) or reinstall browser-harness with pip.",
+                file=sys.stderr,
+            )
+            return 1
+        printable = " ".join(command)
+        try:
+            tool_upgrade = subprocess.run(command)
+        except OSError as e:
+            # shutil.which() said the binary was there; PATH can still be stale,
+            # or the file can be unexecutable. Never surface this as a traceback.
+            print(f"could not run `{printable}`: {e}", file=sys.stderr)
+            return 1
         if tool_upgrade.returncode != 0:
+            print(f"upgrade failed: `{printable}`", file=sys.stderr)
+            if command[0] == "uv":
+                # uv tool upgrade only manages packages from `uv tool install`,
+                # so this is the expected failure for a pip install on a box
+                # that happens to have uv.
+                print(
+                    "if you installed browser-harness with pip, upgrade with:\n"
+                    f"  {sys.executable} -m pip install --upgrade browser-harness",
+                    file=sys.stderr,
+                )
             return tool_upgrade.returncode
     else:
         print("unknown install mode; can't auto-update.", file=sys.stderr)

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1200,21 +1200,51 @@ def _pip_available():
     return importlib.util.find_spec("pip") is not None
 
 
-def _pypi_upgrade_command():
-    """Command that can upgrade a wheel install, or None when nothing can.
+def _pypi_upgrade_commands():
+    """Upgrade candidates for a wheel install, best first. Empty when none apply.
 
-    install.md documents `uv tool install`, so uv stays the first choice when it
-    is on PATH. It is not always there — browser-harness is a normal PyPI
-    package and pip and pipx install it just as well — so fall back to pip
-    against the interpreter that is actually running us.
+    uv leads whenever it is on PATH, because install.md documents
+    `uv tool install`. pip follows rather than replacing it: `uv tool upgrade`
+    only manages what `uv tool install` put there, so on a pip or pipx install
+    it fails with "`browser-harness` is not installed" — having uv on PATH must
+    not be the end of the road for those users.
+
+    pip is only offered when this interpreter actually has it, which is what
+    keeps the retry away from a uv-managed install: uv builds its tool venvs
+    without pip, so inside one there is nothing to retry with and uv's own
+    failure stands.
     """
     import shutil
 
+    commands = []
     if shutil.which("uv"):
-        return ["uv", "tool", "upgrade", "browser-harness"]
+        commands.append(["uv", "tool", "upgrade", "browser-harness"])
     if _pip_available():
-        return [sys.executable, "-m", "pip", "install", "--upgrade", "browser-harness"]
-    return None
+        commands.append([sys.executable, "-m", "pip", "install", "--upgrade", "browser-harness"])
+    return commands
+
+
+def _run_upgrade(commands):
+    """Run upgrade candidates until one succeeds. 0 on success, else the last failure."""
+    last = 1
+    for index, command in enumerate(commands):
+        printable = " ".join(command)
+        try:
+            last = subprocess.run(command).returncode
+        except OSError as e:
+            # shutil.which() said the binary was there; PATH can still be stale,
+            # or the file can be unexecutable. Treat it like any other failure:
+            # report it, then try the next candidate. Never let it surface as a
+            # traceback.
+            print(f"could not run `{printable}`: {e}", file=sys.stderr)
+            last = 1
+        else:
+            if last == 0:
+                return 0
+            print(f"upgrade failed: `{printable}`", file=sys.stderr)
+        if index + 1 < len(commands):
+            print(f"retrying with `{' '.join(commands[index + 1])}`", file=sys.stderr)
+    return last
 
 
 def run_update(yes=False):
@@ -1250,34 +1280,17 @@ def run_update(yes=False):
         if r.returncode != 0:
             return r.returncode
     elif mode == "pypi":
-        command = _pypi_upgrade_command()
-        if command is None:
+        commands = _pypi_upgrade_commands()
+        if not commands:
             print(
                 "can't auto-update: neither uv nor pip is available. Install uv "
                 "(https://docs.astral.sh/uv/) or reinstall browser-harness with pip.",
                 file=sys.stderr,
             )
             return 1
-        printable = " ".join(command)
-        try:
-            tool_upgrade = subprocess.run(command)
-        except OSError as e:
-            # shutil.which() said the binary was there; PATH can still be stale,
-            # or the file can be unexecutable. Never surface this as a traceback.
-            print(f"could not run `{printable}`: {e}", file=sys.stderr)
-            return 1
-        if tool_upgrade.returncode != 0:
-            print(f"upgrade failed: `{printable}`", file=sys.stderr)
-            if command[0] == "uv":
-                # uv tool upgrade only manages packages from `uv tool install`,
-                # so this is the expected failure for a pip install on a box
-                # that happens to have uv.
-                print(
-                    "if you installed browser-harness with pip, upgrade with:\n"
-                    f"  {sys.executable} -m pip install --upgrade browser-harness",
-                    file=sys.stderr,
-                )
-            return tool_upgrade.returncode
+        failure = _run_upgrade(commands)
+        if failure != 0:
+            return failure
     else:
         print("unknown install mode; can't auto-update.", file=sys.stderr)
         return 1

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1225,7 +1225,14 @@ def _pypi_upgrade_commands():
 
 
 def _run_upgrade(commands):
-    """Run upgrade candidates until one succeeds. 0 on success, else the last failure."""
+    """Run upgrade candidates until one succeeds. 0 on success, else the last failure.
+
+    A candidate falling over while others remain is not the upgrade failing, so
+    it reads as a retry note. uv declining a pip install is the expected route
+    to the pip candidate, and calling that "upgrade failed" on a run that then
+    succeeds and exits 0 just teaches readers to distrust the output. Only the
+    last candidate gets to call itself an error.
+    """
     last = 1
     for index, command in enumerate(commands):
         printable = " ".join(command)
@@ -1233,17 +1240,17 @@ def _run_upgrade(commands):
             last = subprocess.run(command).returncode
         except OSError as e:
             # shutil.which() said the binary was there; PATH can still be stale,
-            # or the file can be unexecutable. Treat it like any other failure:
-            # report it, then try the next candidate. Never let it surface as a
-            # traceback.
-            print(f"could not run `{printable}`: {e}", file=sys.stderr)
-            last = 1
+            # or the file can be unexecutable. Never let it surface as a traceback.
+            problem, last = f"could not run `{printable}` ({e})", 1
         else:
             if last == 0:
                 return 0
-            print(f"upgrade failed: `{printable}`", file=sys.stderr)
-        if index + 1 < len(commands):
-            print(f"retrying with `{' '.join(commands[index + 1])}`", file=sys.stderr)
+            problem = f"`{printable}` could not upgrade this install"
+        remaining = commands[index + 1:]
+        if remaining:
+            print(f"{problem}; retrying with `{' '.join(remaining[0])}`", file=sys.stderr)
+        else:
+            print(f"upgrade failed: {problem}", file=sys.stderr)
     return last
 
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -958,7 +958,10 @@ def test_run_update_retries_with_pip_when_uv_does_not_manage_this_install(monkey
     assert ran == [UV, [admin.sys.executable, *PIP]]
 
     err = capsys.readouterr().err
-    assert "upgrade failed: `uv tool upgrade browser-harness`" in err
+    # The run succeeded, so nothing here may read as a failure: uv declining a
+    # pip install is the expected route to the pip candidate.
+    assert "upgrade failed" not in err
+    assert "`uv tool upgrade browser-harness` could not upgrade this install" in err
     assert "retrying with" in err
 
 
@@ -970,7 +973,10 @@ def test_run_update_retries_with_pip_when_the_uv_path_entry_is_stale(monkeypatch
 
     assert admin.run_update(yes=True) == 0
     assert ran == [UV, [admin.sys.executable, *PIP]]
-    assert "could not run `uv tool upgrade browser-harness`" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "could not run `uv tool upgrade browser-harness`" in err
+    assert "retrying with" in err
+    assert "upgrade failed" not in err
 
 
 def test_run_update_stops_at_uv_when_it_succeeds(monkeypatch):
@@ -993,22 +999,28 @@ def test_run_update_uses_pip_when_uv_is_missing(monkeypatch, capsys):
     assert "update complete." in capsys.readouterr().out
 
 
-def test_run_update_returns_the_last_failure_when_every_candidate_fails(monkeypatch):
+def test_run_update_returns_the_last_failure_when_every_candidate_fails(monkeypatch, capsys):
     _stub_update_preamble(monkeypatch)
     _available(monkeypatch, uv=True, pip=True)
     ran = _record_runs(monkeypatch, {"uv": 2, "pip": 3})
 
     assert admin.run_update(yes=True) == 3
     assert len(ran) == 2
+    # Only the final candidate gets to call itself an error.
+    err = capsys.readouterr().err
+    assert err.count("upgrade failed") == 1
+    assert "upgrade failed: `uv" not in err
 
 
-def test_run_update_keeps_uv_failure_when_there_is_no_pip_to_retry(monkeypatch):
+def test_run_update_keeps_uv_failure_when_there_is_no_pip_to_retry(monkeypatch, capsys):
     _stub_update_preamble(monkeypatch)
     _available(monkeypatch, uv=True, pip=False)
     ran = _record_runs(monkeypatch, {"uv": 2})
 
     assert admin.run_update(yes=True) == 2
     assert ran == [UV]
+    # Last candidate, nothing left to try: this one really is a failure.
+    assert "upgrade failed" in capsys.readouterr().err
 
 
 def test_run_update_reports_missing_upgrader_instead_of_crashing(monkeypatch, capsys):

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -886,3 +886,95 @@ def test_process_start_time_returns_none_for_invalid_pid():
         )
     # 2**31 - 1 is the largest pid_t; in practice no live process at that PID.
     assert admin._process_start_time((1 << 31) - 1) is None
+
+
+# --- run_update: PyPI installs are not always uv installs (#688) ---
+
+
+def _stub_update_preamble(monkeypatch, mode="pypi"):
+    """Get run_update() to the install-mode branch and stop before the daemon."""
+    monkeypatch.setattr(admin, "check_for_update", lambda: ("0.1.9", "0.1.10", True))
+    monkeypatch.setattr(admin, "_install_mode", lambda: mode)
+    monkeypatch.setattr(admin, "_cache_read", lambda: {})
+    monkeypatch.setattr(admin, "_cache_write", lambda _data: None)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: False)
+
+
+def test_pypi_upgrade_prefers_uv_when_present(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
+    assert admin._pypi_upgrade_command() == ["uv", "tool", "upgrade", "browser-harness"]
+
+
+def test_pypi_upgrade_falls_back_to_pip_without_uv(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(admin, "_pip_available", lambda: True)
+    command = admin._pypi_upgrade_command()
+    assert command[1:] == ["-m", "pip", "install", "--upgrade", "browser-harness"]
+    assert command[0] == admin.sys.executable
+
+
+def test_pypi_upgrade_is_none_without_uv_or_pip(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(admin, "_pip_available", lambda: False)
+    assert admin._pypi_upgrade_command() is None
+
+
+def test_run_update_uses_pip_when_uv_is_missing(monkeypatch, capsys):
+    """The reported crash: `uv` absent made subprocess.run raise FileNotFoundError."""
+    _stub_update_preamble(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(admin, "_pip_available", lambda: True)
+    ran = []
+
+    def fake_run(command, *_args, **_kwargs):
+        ran.append(command)
+        if command[:2] == ["uv", "tool"]:
+            raise FileNotFoundError(2, "The system cannot find the file specified")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr(admin.subprocess, "run", fake_run)
+
+    assert admin.run_update(yes=True) == 0
+    assert ran == [
+        [admin.sys.executable, "-m", "pip", "install", "--upgrade", "browser-harness"]
+    ]
+    assert "update complete." in capsys.readouterr().out
+
+
+def test_run_update_reports_missing_upgrader_instead_of_crashing(monkeypatch, capsys):
+    _stub_update_preamble(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    monkeypatch.setattr(admin, "_pip_available", lambda: False)
+
+    assert admin.run_update(yes=True) == 1
+    assert "neither uv nor pip is available" in capsys.readouterr().err
+
+
+def test_run_update_survives_a_stale_path_entry(monkeypatch, capsys):
+    """which() can resolve a binary that is gone or unexecutable by the time we run it."""
+    _stub_update_preamble(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
+
+    def fake_run(_command, *_args, **_kwargs):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(admin.subprocess, "run", fake_run)
+
+    assert admin.run_update(yes=True) == 1
+    err = capsys.readouterr().err
+    assert "could not run `uv tool upgrade browser-harness`" in err
+    assert "Permission denied" in err
+
+
+def test_run_update_points_pip_users_at_pip_when_uv_upgrade_fails(monkeypatch, capsys):
+    """`uv tool upgrade` cannot upgrade a pip install, so say so."""
+    _stub_update_preamble(monkeypatch)
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
+    monkeypatch.setattr(
+        admin.subprocess, "run", lambda *_a, **_k: type("R", (), {"returncode": 2})()
+    )
+
+    assert admin.run_update(yes=True) == 2
+    err = capsys.readouterr().err
+    assert "upgrade failed" in err
+    assert "-m pip install --upgrade browser-harness" in err

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -891,6 +891,15 @@ def test_process_start_time_returns_none_for_invalid_pid():
 # --- run_update: PyPI installs are not always uv installs (#688) ---
 
 
+UV = ["uv", "tool", "upgrade", "browser-harness"]
+PIP = ["-m", "pip", "install", "--upgrade", "browser-harness"]
+
+
+def _available(monkeypatch, *, uv, pip):
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if (uv and cmd == "uv") else None)
+    monkeypatch.setattr(admin, "_pip_available", lambda: pip)
+
+
 def _stub_update_preamble(monkeypatch, mode="pypi"):
     """Get run_update() to the install-mode branch and stop before the daemon."""
     monkeypatch.setattr(admin, "check_for_update", lambda: ("0.1.9", "0.1.10", True))
@@ -900,81 +909,111 @@ def _stub_update_preamble(monkeypatch, mode="pypi"):
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
 
 
-def test_pypi_upgrade_prefers_uv_when_present(monkeypatch):
-    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
-    assert admin._pypi_upgrade_command() == ["uv", "tool", "upgrade", "browser-harness"]
-
-
-def test_pypi_upgrade_falls_back_to_pip_without_uv(monkeypatch):
-    monkeypatch.setattr("shutil.which", lambda _cmd: None)
-    monkeypatch.setattr(admin, "_pip_available", lambda: True)
-    command = admin._pypi_upgrade_command()
-    assert command[1:] == ["-m", "pip", "install", "--upgrade", "browser-harness"]
-    assert command[0] == admin.sys.executable
-
-
-def test_pypi_upgrade_is_none_without_uv_or_pip(monkeypatch):
-    monkeypatch.setattr("shutil.which", lambda _cmd: None)
-    monkeypatch.setattr(admin, "_pip_available", lambda: False)
-    assert admin._pypi_upgrade_command() is None
-
-
-def test_run_update_uses_pip_when_uv_is_missing(monkeypatch, capsys):
-    """The reported crash: `uv` absent made subprocess.run raise FileNotFoundError."""
-    _stub_update_preamble(monkeypatch)
-    monkeypatch.setattr("shutil.which", lambda _cmd: None)
-    monkeypatch.setattr(admin, "_pip_available", lambda: True)
+def _record_runs(monkeypatch, outcomes):
+    """Stub subprocess.run; `outcomes` maps command[0]-ish to a code or an exception."""
     ran = []
 
     def fake_run(command, *_args, **_kwargs):
         ran.append(command)
-        if command[:2] == ["uv", "tool"]:
-            raise FileNotFoundError(2, "The system cannot find the file specified")
-        return type("R", (), {"returncode": 0})()
+        key = "uv" if command[:2] == ["uv", "tool"] else "pip"
+        outcome = outcomes[key]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return type("R", (), {"returncode": outcome})()
 
     monkeypatch.setattr(admin.subprocess, "run", fake_run)
+    return ran
+
+
+def test_upgrade_candidates_put_uv_first_then_pip(monkeypatch):
+    _available(monkeypatch, uv=True, pip=True)
+    commands = admin._pypi_upgrade_commands()
+    assert commands[0] == UV
+    assert commands[1] == [admin.sys.executable, *PIP]
+
+
+def test_upgrade_candidates_are_pip_only_without_uv(monkeypatch):
+    _available(monkeypatch, uv=False, pip=True)
+    assert admin._pypi_upgrade_commands() == [[admin.sys.executable, *PIP]]
+
+
+def test_upgrade_candidates_are_uv_only_without_pip(monkeypatch):
+    """Inside a uv tool venv there is no pip, so uv's failure has to stand."""
+    _available(monkeypatch, uv=True, pip=False)
+    assert admin._pypi_upgrade_commands() == [UV]
+
+
+def test_upgrade_candidates_empty_without_uv_or_pip(monkeypatch):
+    _available(monkeypatch, uv=False, pip=False)
+    assert admin._pypi_upgrade_commands() == []
+
+
+def test_run_update_retries_with_pip_when_uv_does_not_manage_this_install(monkeypatch, capsys):
+    """`uv tool upgrade` cannot upgrade a pip install, so pip has to actually run."""
+    _stub_update_preamble(monkeypatch)
+    _available(monkeypatch, uv=True, pip=True)
+    ran = _record_runs(monkeypatch, {"uv": 2, "pip": 0})
 
     assert admin.run_update(yes=True) == 0
-    assert ran == [
-        [admin.sys.executable, "-m", "pip", "install", "--upgrade", "browser-harness"]
-    ]
+    assert ran == [UV, [admin.sys.executable, *PIP]]
+
+    err = capsys.readouterr().err
+    assert "upgrade failed: `uv tool upgrade browser-harness`" in err
+    assert "retrying with" in err
+
+
+def test_run_update_retries_with_pip_when_the_uv_path_entry_is_stale(monkeypatch, capsys):
+    """which() can resolve a binary that is gone or unexecutable by spawn time."""
+    _stub_update_preamble(monkeypatch)
+    _available(monkeypatch, uv=True, pip=True)
+    ran = _record_runs(monkeypatch, {"uv": OSError(13, "Permission denied"), "pip": 0})
+
+    assert admin.run_update(yes=True) == 0
+    assert ran == [UV, [admin.sys.executable, *PIP]]
+    assert "could not run `uv tool upgrade browser-harness`" in capsys.readouterr().err
+
+
+def test_run_update_stops_at_uv_when_it_succeeds(monkeypatch):
+    _stub_update_preamble(monkeypatch)
+    _available(monkeypatch, uv=True, pip=True)
+    ran = _record_runs(monkeypatch, {"uv": 0, "pip": 0})
+
+    assert admin.run_update(yes=True) == 0
+    assert ran == [UV], "pip must not run after uv succeeds"
+
+
+def test_run_update_uses_pip_when_uv_is_missing(monkeypatch, capsys):
+    """The originally reported crash: uv absent made subprocess.run raise."""
+    _stub_update_preamble(monkeypatch)
+    _available(monkeypatch, uv=False, pip=True)
+    ran = _record_runs(monkeypatch, {"pip": 0})
+
+    assert admin.run_update(yes=True) == 0
+    assert ran == [[admin.sys.executable, *PIP]]
     assert "update complete." in capsys.readouterr().out
+
+
+def test_run_update_returns_the_last_failure_when_every_candidate_fails(monkeypatch):
+    _stub_update_preamble(monkeypatch)
+    _available(monkeypatch, uv=True, pip=True)
+    ran = _record_runs(monkeypatch, {"uv": 2, "pip": 3})
+
+    assert admin.run_update(yes=True) == 3
+    assert len(ran) == 2
+
+
+def test_run_update_keeps_uv_failure_when_there_is_no_pip_to_retry(monkeypatch):
+    _stub_update_preamble(monkeypatch)
+    _available(monkeypatch, uv=True, pip=False)
+    ran = _record_runs(monkeypatch, {"uv": 2})
+
+    assert admin.run_update(yes=True) == 2
+    assert ran == [UV]
 
 
 def test_run_update_reports_missing_upgrader_instead_of_crashing(monkeypatch, capsys):
     _stub_update_preamble(monkeypatch)
-    monkeypatch.setattr("shutil.which", lambda _cmd: None)
-    monkeypatch.setattr(admin, "_pip_available", lambda: False)
+    _available(monkeypatch, uv=False, pip=False)
 
     assert admin.run_update(yes=True) == 1
     assert "neither uv nor pip is available" in capsys.readouterr().err
-
-
-def test_run_update_survives_a_stale_path_entry(monkeypatch, capsys):
-    """which() can resolve a binary that is gone or unexecutable by the time we run it."""
-    _stub_update_preamble(monkeypatch)
-    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
-
-    def fake_run(_command, *_args, **_kwargs):
-        raise OSError(13, "Permission denied")
-
-    monkeypatch.setattr(admin.subprocess, "run", fake_run)
-
-    assert admin.run_update(yes=True) == 1
-    err = capsys.readouterr().err
-    assert "could not run `uv tool upgrade browser-harness`" in err
-    assert "Permission denied" in err
-
-
-def test_run_update_points_pip_users_at_pip_when_uv_upgrade_fails(monkeypatch, capsys):
-    """`uv tool upgrade` cannot upgrade a pip install, so say so."""
-    _stub_update_preamble(monkeypatch)
-    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/uv" if cmd == "uv" else None)
-    monkeypatch.setattr(
-        admin.subprocess, "run", lambda *_a, **_k: type("R", (), {"returncode": 2})()
-    )
-
-    assert admin.run_update(yes=True) == 2
-    err = capsys.readouterr().err
-    assert "upgrade failed" in err
-    assert "-m pip install --upgrade browser-harness" in err


### PR DESCRIPTION
Fixes #688.

## Problem

`run_update()`'s `pypi` branch shelled out to `uv` unconditionally:

```python
elif mode == "pypi":
    tool_upgrade = subprocess.run(["uv", "tool", "upgrade", "browser-harness"])
```

No `shutil.which()` guard — grepping the package, `"uv"` appears on exactly that one line, while the neighbouring `profile-use` calls in the same module *do* check before shelling out. And `_install_mode()` returns `"pypi"` for any non-git install that reports a version, which covers every `pip install browser-harness` and `pipx install browser-harness`.

So a user without uv, running the command the tool told them to run, got a traceback. `print_update_banner()` nags daily with `browser-harness --update -y`, and `HELP` advertises that same flag as *the agent path* — so an agent following it hit an unhandled exception with nothing to act on.

## Fix

Pick the upgrader instead of assuming one. uv stays the first choice when it's on PATH, since `install.md` documents `uv tool install` as the blessed route; otherwise fall back to pip against the interpreter actually running us. When neither exists, say so and return 1.

Two smaller failure paths get handled while here:

- **`subprocess.run` wrapped in `try/except OSError`.** `which()` can resolve a binary that is gone or unexecutable by the time we spawn it. That must not surface as a traceback either.
- **A pip install on a box that happens to have uv.** `uv tool upgrade` only manages packages from `uv tool install`, so this case fails with `` `browser-harness` is not installed; run `uv tool install browser-harness` `` — accurate from uv's point of view, useless from the user's. It's now followed by the pip command that will actually work.

That second case is not hypothetical; it's what this checkout does. Forcing the `pypi` branch here (uv present, not a uv-tool install) gives exactly that dead end:

```
$ browser-harness --update -y
updating browser-harness: 0.1.9 -> 0.1.10
error: Failed to upgrade browser-harness
  Caused by: `browser-harness` is not installed; run `uv tool install browser-harness` to install
```

## Verification

Windows 11, Python 3.11.9, `pip install -e .`

The reported crash, reproduced by actually removing uv from `PATH` rather than by stubbing — `subprocess` resolves the binary itself, so monkeypatching `shutil.which` does **not** reproduce it:

```
$ PATH=C:\Windows\System32 python -c "...run_update(yes=True)"     # unfixed
  File "subprocess.py", line 1538, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args, ...)
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

Same scenario on this branch:

```
updating browser-harness: 0.1.9 -> 0.1.10
update complete.
returned: 0
ran     : python.exe ['-m', 'pip', 'install', '--upgrade', 'browser-harness']
```

Seven new tests — the three command-selection branches, the reported crash, the no-upgrader path, a stale PATH entry, and the pip hint on uv failure. All seven fail on `main` and pass here.

Full suite: `9 failed, 159 passed` → `9 failed, 166 passed`. The 9 are pre-existing and unrelated — 8 POSIX-only scaffolding in `test_admin.py` (#680) and `test_skill.py` (#678, fixed in #693).

## Notes for reviewers

- **Detection vs. fallback.** I considered sniffing whether this interpreter lives in a uv tools environment (`uv-receipt.toml`, or `uv`/`tools` path components) to pick the right command outright. I left it out: it depends on uv's on-disk layout, which isn't a stable public contract, and the actionable error message covers the same case without betting on internals. Happy to add it if you'd rather have the automatic route.
- **pipx** installs land on the pip branch. pipx venvs ship pip, so `python -m pip install --upgrade` works there; I didn't add a separate `pipx upgrade` branch since nothing in the repo documents pipx.
- The `git` branch is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #688: `run_update()` no longer assumes `uv` is installed when upgrading a PyPI install, so `pip`- or `pipx`-installed users no longer hit a traceback on the daily `--update -y` banner. It tries `uv` first when on PATH, then falls back to `pip` on the running interpreter when uv is missing or cannot upgrade the install.

**Bug Fixes**
- Prints an actionable error and returns 1 when neither `uv` nor `pip` is available.
- Catches `OSError` from `subprocess.run` so a stale PATH entry falls through to the next candidate instead of crashing.
- When `uv tool upgrade` fails on a pip-installed package, retries with `python -m pip install --upgrade`; a uv-managed install has no pip in its venv, so uv's failure still stands there.
- Intermediate candidates report "could not upgrade...; retrying with..." and only the final failure is called "upgrade failed", so a run that succeeds never prints error language.

<sup>Written for commit 5338c317e719a9f4f0125f9ae1a56b4fa578020f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

