### PR TITLE
fix: stop doctor reporting FAIL for browsers the daemon drives

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -898,16 +898,24 @@ def print_update_banner(out=None):
 
 
 def _chrome_running():
-    """Cross-platform best-effort check for a running Chromium-based browser."""
+    """Cross-platform best-effort check for a running Chromium-based browser.
+
+    Shares its process names with daemon.supported_browser_running(). They used
+    to be two hand-maintained lists, and doctor's had drifted: it was missing
+    Brave on both platforms and Chromium on Windows, so users of browsers the
+    harness happily drives were told to "start chrome/edge".
+    """
     import platform, subprocess
+    from .daemon import BROWSER_PROCESSES_POSIX, BROWSER_PROCESSES_WINDOWS
+
     system = platform.system()
     try:
         if system == "Windows":
             out = subprocess.check_output(["tasklist"], text=True, errors="replace", timeout=5)
-            names = ("chrome.exe", "msedge.exe", "helium.exe")
+            names = BROWSER_PROCESSES_WINDOWS
         else:
             out = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, errors="replace", timeout=5)
-            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "helium")
+            names = BROWSER_PROCESSES_POSIX
         return any(n.lower() in out.lower() for n in names)
     except Exception:
         return False
@@ -1102,9 +1110,14 @@ def run_doctor():
     import platform, sys
     cur = _version()
     mode = _install_mode()
-    chrome = _chrome_running()
     daemon = daemon_alive()
     connections = browser_connections()
+    # A live CDP connection proves a browser is running, and proves it better
+    # than a process-name match: it covers the browsers the name probe cannot
+    # safely spot (Arc, Dia, Comet) and a Chrome launched from an unusual path.
+    # Without this, doctor could print a FAIL directly above the attached page
+    # it had just listed. run_doctor_json() already scores browser_ready first.
+    chrome = _chrome_running() or bool(connections)
     try:
         auth_state = auth.auth_status()
     except (auth.AuthError, OSError) as e:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1105,6 +1105,21 @@ def _open_chrome_inspect_once():
         pass
 
 
+def _browser_running(live_connection):
+    """Is a browser running? A live CDP connection settles it on its own.
+
+    Better evidence than a process-name match: it covers the browsers the name
+    probe cannot safely spot (Arc, Dia and Comet have profile dirs but names too
+    common to substring-match — "arc" matches "searchd") and a Chrome launched
+    from an unusual path. Without it, `--doctor` could print a FAIL directly
+    above the attached page it had just listed.
+
+    Shared by both doctor surfaces so `--doctor` and `doctor --json` cannot
+    disagree about what "chrome running" means on the same machine.
+    """
+    return _chrome_running() or bool(live_connection)
+
+
 def run_doctor():
     """Read-only diagnostics. Exit 0 iff everything looks healthy."""
     import platform, sys
@@ -1112,12 +1127,7 @@ def run_doctor():
     mode = _install_mode()
     daemon = daemon_alive()
     connections = browser_connections()
-    # A live CDP connection proves a browser is running, and proves it better
-    # than a process-name match: it covers the browsers the name probe cannot
-    # safely spot (Arc, Dia, Comet) and a Chrome launched from an unusual path.
-    # Without this, doctor could print a FAIL directly above the attached page
-    # it had just listed. run_doctor_json() already scores browser_ready first.
-    chrome = _chrome_running() or bool(connections)
+    chrome = _browser_running(connections)
     try:
         auth_state = auth.auth_status()
     except (auth.AuthError, OSError) as e:
@@ -1173,9 +1183,12 @@ def run_doctor_json(require_existing_daemon=False):
     connection; it never starts, repairs, or discovers another daemon.
     """
     strict = bool(require_existing_daemon)
-    chrome = None if strict else _chrome_running()
     browser_ready = daemon_browser_ready(NAME)
     daemon = browser_ready or daemon_alive(NAME)
+    # Same rule the text doctor uses; browser_ready is this surface's live
+    # connection. Strict mode still reports None — it deliberately probes
+    # nothing but the named daemon.
+    chrome = None if strict else _browser_running(browser_ready)
     healthy = (daemon and browser_ready) if strict else (browser_ready or (chrome and daemon))
     report = {
         "schema_version": 1,

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1117,7 +1117,7 @@ def _browser_running(live_connection):
     Shared by both doctor surfaces so `--doctor` and `doctor --json` cannot
     disagree about what "chrome running" means on the same machine.
     """
-    return _chrome_running() or bool(live_connection)
+    return bool(live_connection) or _chrome_running()
 
 
 def run_doctor():

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -167,6 +167,20 @@ def browser_running_for_profile(base):
         return True  # pid exists but belongs to another user
 
 
+# Process names for the Chromium-family browsers whose profiles PROFILES scans.
+# Matched as case-insensitive substrings, so "chrome" also covers "Google Chrome"
+# and "chromium" covers "chromium-browser".
+#
+# Arc, Dia and Comet have entries in _MAC_PROFILES but are deliberately absent
+# here: their names are too short or too common to substring-match safely — "dia"
+# alone matches any process with "media" in its name. On macOS they are detected
+# via SingletonLock below, and run_doctor() falls back to a live CDP connection.
+BROWSER_PROCESSES_WINDOWS = ("chrome.exe", "msedge.exe", "chromium.exe", "brave.exe", "helium.exe")
+BROWSER_PROCESSES_POSIX = (
+    "Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "brave", "helium",
+)
+
+
 def supported_browser_running():
     """Is any browser whose profile we scan actually running?"""
     if platform.system() == "Windows":
@@ -176,7 +190,7 @@ def supported_browser_running():
             out = subprocess.check_output(["tasklist"], text=True, errors="replace", timeout=5).lower()
         except Exception:
             return True  # can't tell — assume running so recovery stays on the popup/toggle path
-        return any(n in out for n in ("chrome.exe", "msedge.exe", "chromium.exe", "brave.exe", "helium.exe"))
+        return any(n in out for n in BROWSER_PROCESSES_WINDOWS)
     return any(browser_running_for_profile(base) for base in PROFILES)
 
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -886,3 +886,87 @@ def test_process_start_time_returns_none_for_invalid_pid():
         )
     # 2**31 - 1 is the largest pid_t; in practice no live process at that PID.
     assert admin._process_start_time((1 << 31) - 1) is None
+
+
+# --- doctor browser detection matches the daemon's (#686) ---
+
+
+def _fake_process_list(monkeypatch, system, output):
+    monkeypatch.setattr("platform.system", lambda: system)
+    monkeypatch.setattr(
+        "subprocess.check_output", lambda *_args, **_kwargs: output
+    )
+
+
+@pytest.mark.parametrize(
+    "system, output",
+    [
+        # No chrome.exe in any of these: the browser under test has to be what
+        # trips the check, or the old list would pass for the wrong reason.
+        ("Windows", "explorer.exe  1234 Console\nbrave.exe  5678 Console\n"),
+        ("Linux", "systemd\nbrave-browser\n"),
+        ("Darwin", "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser\n"),
+    ],
+    ids=["windows", "linux", "darwin"],
+)
+def test_chrome_running_detects_brave(monkeypatch, system, output):
+    """Brave has a profile dir on all three platforms and the daemon drives it."""
+    _fake_process_list(monkeypatch, system, output)
+    assert admin._chrome_running() is True
+
+
+def test_chrome_running_detects_chromium_on_windows(monkeypatch):
+    _fake_process_list(monkeypatch, "Windows", "chromium.exe  1234 Console\n")
+    assert admin._chrome_running() is True
+
+
+def test_chrome_running_is_false_with_no_browser(monkeypatch):
+    _fake_process_list(monkeypatch, "Windows", "explorer.exe  1234 Console\n")
+    assert admin._chrome_running() is False
+
+
+def test_doctor_and_daemon_agree_on_windows_process_names(monkeypatch):
+    """The two lists drifted once; keep them the same list.
+
+    daemon.supported_browser_running() knew about Chromium and Brave while
+    doctor's copy did not, so doctor told those users to "start chrome/edge".
+    """
+    from browser_harness import daemon
+
+    for name in daemon.BROWSER_PROCESSES_WINDOWS:
+        _fake_process_list(monkeypatch, "Windows", f"{name}  1234 Console\n")
+        assert admin._chrome_running() is True, f"doctor missed {name}"
+
+
+def _doctor_env(monkeypatch, chrome_running, connections):
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.10")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "pypi")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: chrome_running)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "browser_connections", lambda: connections)
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.10")
+    monkeypatch.setattr(admin, "_doctor_probe_chrome_binary_for_snap", lambda: (None, None))
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+
+def test_doctor_trusts_a_live_connection_over_the_name_probe(monkeypatch, capsys):
+    """Arc/Dia/Comet can't be substring-matched safely, so the connection decides."""
+    _doctor_env(
+        monkeypatch,
+        chrome_running=False,
+        connections=[{"name": "default", "page": {"title": "Example", "url": "https://example.com"}}],
+    )
+
+    assert admin.run_doctor() == 0
+
+    out = capsys.readouterr().out
+    assert "[FAIL] chrome running" not in out
+    assert "[ok  ] chrome running" in out
+
+
+def test_doctor_still_fails_with_no_browser_and_no_connection(monkeypatch, capsys):
+    _doctor_env(monkeypatch, chrome_running=False, connections=[])
+
+    assert admin.run_doctor() == 1
+    assert "[FAIL] chrome running" in capsys.readouterr().out

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,3 +1,4 @@
+import json
 import signal
 from pathlib import Path
 
@@ -970,3 +971,74 @@ def test_doctor_still_fails_with_no_browser_and_no_connection(monkeypatch, capsy
 
     assert admin.run_doctor() == 1
     assert "[FAIL] chrome running" in capsys.readouterr().out
+
+
+def _doctor_json_env(monkeypatch, chrome_running, browser_ready):
+    monkeypatch.setattr(admin, "_chrome_running", lambda: chrome_running)
+    monkeypatch.setattr(admin, "daemon_browser_ready", lambda _name: browser_ready)
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.10")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "pypi")
+
+
+def test_doctor_json_counts_a_live_connection_as_chrome_running(monkeypatch, capsys):
+    """Both doctor surfaces must mean the same thing by "chrome running".
+
+    run_doctor() treats a live CDP connection as proof; without the same rule
+    here, the same machine reported `[ok  ] chrome running` in text and
+    `"chrome_running": false` in JSON.
+    """
+    _doctor_json_env(monkeypatch, chrome_running=False, browser_ready=True)
+
+    assert admin.run_doctor_json() == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["chrome_running"] is True
+    assert report["healthy"] is True
+
+
+def test_doctor_json_reports_no_browser_without_a_connection(monkeypatch, capsys):
+    _doctor_json_env(monkeypatch, chrome_running=False, browser_ready=False)
+
+    assert admin.run_doctor_json() == 1
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["chrome_running"] is False
+    assert report["healthy"] is False
+
+
+def test_doctor_json_strict_still_reports_no_browser_probe(monkeypatch, capsys):
+    """Strict mode probes only the named daemon, so chrome_running stays null."""
+    _doctor_json_env(monkeypatch, chrome_running=False, browser_ready=True)
+    monkeypatch.setattr(
+        admin, "_chrome_running", lambda: pytest.fail("strict mode must not probe processes")
+    )
+
+    assert admin.run_doctor_json(require_existing_daemon=True) == 0
+
+    assert json.loads(capsys.readouterr().out)["chrome_running"] is None
+
+
+def test_both_doctor_surfaces_agree_on_the_same_machine(monkeypatch, capsys):
+    """The contradiction this guards: text says ok, JSON says false."""
+    monkeypatch.setattr(admin, "_chrome_running", lambda: False)
+    monkeypatch.setattr(admin, "daemon_alive", lambda *_a: True)
+    monkeypatch.setattr(admin, "daemon_browser_ready", lambda _name: True)
+    monkeypatch.setattr(
+        admin, "browser_connections",
+        lambda: [{"name": "default", "page": {"title": "T", "url": "https://example.com"}}],
+    )
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.10")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "pypi")
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.10")
+    monkeypatch.setattr(admin, "_doctor_probe_chrome_binary_for_snap", lambda: (None, None))
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+
+    admin.run_doctor()
+    text_ok = "[ok  ] chrome running" in capsys.readouterr().out
+
+    admin.run_doctor_json()
+    json_ok = json.loads(capsys.readouterr().out)["chrome_running"]
+
+    assert text_ok is json_ok is True


### PR DESCRIPTION
Fixes #686.

## Problem

Two hand-maintained lists answer the same question — "is a supported browser running?" — and doctor's copy had drifted:

| | list |
|---|---|
| `daemon.supported_browser_running()` | `chrome.exe` `msedge.exe` `chromium.exe` `brave.exe` `helium.exe` |
| `admin._chrome_running()` (Windows) | `chrome.exe` `msedge.exe` — — `helium.exe` |
| `admin._chrome_running()` (POSIX) | `chrome` `chromium` `Microsoft Edge` `msedge` — `helium` |

Brave is missing from both of doctor's lists, Chromium from its Windows one. Yet Brave has a profile entry in all three of `_MAC_PROFILES`, `_LINUX_PROFILES` and `_WINDOWS_PROFILES`, and a launch spec in `_BROWSER_LAUNCH` — the harness discovers a Brave profile, attaches to it over CDP and drives it. Doctor then prints:

```
  [FAIL] chrome running — start chrome/edge
  [ok  ] daemon alive
  [ok  ] active browser connections — 1
```

and exits 1, because `run_doctor()` gates its exit code on that check. `SKILL.md` and `install.md` both send agents to `--doctor` when something looks wrong, so the agent gets a false failure telling it to start a browser that is already attached — with the very next line contradicting it.

## Fix

**One list.** Moved the process names to `daemon.py` as `BROWSER_PROCESSES_WINDOWS` / `BROWSER_PROCESSES_POSIX`, read from both call sites, so they cannot drift apart again. Brave and Chromium come along for free.

**A live CDP connection satisfies the check.** It is strictly better evidence than a process-name match, and it covers what the names cannot. Arc, Dia and Comet have `_MAC_PROFILES` entries but are genuinely unsafe to substring-match:

```
'dia'   -> matches 'mediaremoted', 'com.apple.MediaRemote', 'diagnosticd'
'arc'   -> matches 'searchd', 'arcd'
'comet' -> matches 'Comet Helper'
```

Listing them would make doctor claim a browser is running on any idle Mac, so they stay out. macOS already finds them via `SingletonLock` in the daemon, and doctor now falls back to the connection — which is also why I did **not** simply make `_chrome_running()` call `supported_browser_running()`: that function's POSIX branch checks `SingletonLock` in the standard profile dirs only, so it would report False for a dedicated automation Chrome started with a custom `--user-data-dir` under `BU_CDP_URL`, which `ps` currently catches.

`run_doctor_json()` already scored `browser_ready` ahead of the name probe (`browser_ready or (chrome and daemon)`). `run_doctor()` now agrees with it.

## Verification

Windows 11, Python 3.11.9, `pip install -e .`

Nine new tests; six fail on `main`:

```
FAILED test_chrome_running_detects_brave[windows]
FAILED test_chrome_running_detects_brave[linux]
FAILED test_chrome_running_detects_brave[darwin]
FAILED test_chrome_running_detects_chromium_on_windows
FAILED test_doctor_and_daemon_agree_on_windows_process_names
FAILED test_doctor_trusts_a_live_connection_over_the_name_probe
6 failed, 3 passed
```

The 3 that pass both ways are the negative guards — no browser, and no-browser-plus-no-connection still fails — there to stop the fix from turning doctor into something that always reports OK.

One note on how those were built: my first Windows fixture listed `brave.exe` *alongside* `chrome.exe`, so it passed against the unfixed code for the wrong reason. The fixtures now contain only the browser under test (`explorer.exe` as filler), which is what moved `[windows]` from passing to failing on `main`.

`test_doctor_and_daemon_agree_on_windows_process_names` iterates `daemon.BROWSER_PROCESSES_WINDOWS` and asserts doctor detects each one, so the sharing is pinned behaviourally rather than by identity — re-introducing a separate literal list in `admin.py` fails it.

Full suite: `9 failed, 159 passed` → `9 failed, 167 passed`. The 9 are pre-existing and unrelated (#680, #678).

## Note for reviewers

The POSIX detection methods still differ by design — the daemon checks `SingletonLock` per profile dir (precise, and what its recovery logic needs), doctor greps `ps` (broad, and what a diagnostic wants). Only the name lists are shared. Worth a look on a real Brave/Linux box; everything here was verified on Windows with stubbed process output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #686 so `--doctor` and `doctor --json` trust the daemon's browser process list and treat a live CDP connection as proof a browser is running.

- Moves the browser process names to `daemon.py` (`BROWSER_PROCESSES_WINDOWS` / `BROWSER_PROCESSES_POSIX`) and reads them from both call sites, so they cannot drift apart.
- Lets a live CDP connection satisfy the check before the name probe, covering Arc, Dia, and Comet without unsafe name matching.
- `--doctor` and `doctor --json` now exit 0 for these cases; strict JSON mode still reports `null` for `chrome_running`.

<sup>Written for commit 1d1c67245d61c795ebf4b5cd6a8613f2adb1e471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

