### PR TITLE
fix: send real physical key codes for printable characters

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -265,7 +265,7 @@ def _printable_key(char):
     """
     unshifted = _SHIFTED_CHARS.get(char, char)
     needs_shift = char in _SHIFTED_CHARS or char.isupper()
-    if "a" <= unshifted.lower() <= "z":
+    if unshifted.isascii() and "a" <= unshifted.lower() <= "z":
         return f"Key{unshifted.upper()}", ord(unshifted.upper()), needs_shift
     if unshifted.isdigit() and unshifted.isascii():
         return f"Digit{unshifted}", ord(unshifted), needs_shift

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -237,11 +237,67 @@ _KEYS = {  # key → (windowsVirtualKeyCode, code, text)
     "Home": (36, "Home", ""), "End": (35, "End", ""),
     "PageUp": (33, "PageUp", ""), "PageDown": (34, "PageDown", ""),
 }
+# US-layout physical keys for printable ASCII punctuation: char → (code, virtual key).
+# `code` names the physical key, so it is layout-independent and never the
+# character itself; the virtual key code is the Win32 VK_OEM_* value, which is
+# unrelated to ord(char) for everything except A-Z and 0-9.
+_PUNCTUATION_KEYS = {
+    "`": ("Backquote", 192), "-": ("Minus", 189), "=": ("Equal", 187),
+    "[": ("BracketLeft", 219), "]": ("BracketRight", 221), "\\": ("Backslash", 220),
+    ";": ("Semicolon", 186), "'": ("Quote", 222), ",": ("Comma", 188),
+    ".": ("Period", 190), "/": ("Slash", 191),
+}
+# Characters a US layout only produces with Shift held, mapped to the unshifted
+# character that shares their physical key.
+_SHIFTED_CHARS = {
+    "~": "`", "!": "1", "@": "2", "#": "3", "$": "4", "%": "5", "^": "6",
+    "&": "7", "*": "8", "(": "9", ")": "0", "_": "-", "+": "=",
+    "{": "[", "}": "]", "|": "\\", ":": ";", '"': "'", "<": ",", ">": ".", "?": "/",
+}
+
+
+def _printable_key(char):
+    """(code, virtual key, needs_shift) for one printable ASCII char on a US layout.
+
+    None when the character has no US physical key — accented letters, CJK,
+    emoji. Those still insert from the char event's text, and inventing a
+    keyboard key for them would just be a different wrong answer.
+    """
+    unshifted = _SHIFTED_CHARS.get(char, char)
+    needs_shift = char in _SHIFTED_CHARS or char.isupper()
+    if "a" <= unshifted.lower() <= "z":
+        return f"Key{unshifted.upper()}", ord(unshifted.upper()), needs_shift
+    if unshifted.isdigit() and unshifted.isascii():
+        return f"Digit{unshifted}", ord(unshifted), needs_shift
+    if unshifted in _PUNCTUATION_KEYS:
+        code, vk = _PUNCTUATION_KEYS[unshifted]
+        return code, vk, needs_shift
+    return None
+
+
 def press_key(key, modifiers=0):
     """Modifiers bitfield: 1=Alt, 2=Ctrl, 4=Meta(Cmd), 8=Shift.
-    Special keys (Enter, Tab, Arrow*, Backspace, etc.) carry their virtual key codes
-    so listeners checking e.keyCode / e.key all fire."""
-    vk, code, text = _KEYS.get(key, (ord(key[0]) if len(key) == 1 else 0, key, key if len(key) == 1 else ""))
+
+    Named keys (Enter, Tab, Arrow*, Backspace, ...) and printable characters alike
+    carry the physical `code` and virtual key code a real US keyboard sends, so
+    listeners reading e.key, e.code and e.keyCode all agree. A character that
+    needs Shift on that layout (uppercase, !@#$...) sets the Shift modifier too,
+    unless the caller is already composing a shortcut with Alt/Ctrl/Meta — there,
+    the caller's intent wins over the physical truth.
+    """
+    if key in _KEYS:
+        vk, code, text = _KEYS[key]
+    elif len(key) == 1:
+        text = key
+        resolved = _printable_key(key)
+        if resolved:
+            code, vk, needs_shift = resolved
+            if needs_shift and not modifiers & (1 | 2 | 4):
+                modifiers |= 8
+        else:
+            code, vk = "", 0
+    else:
+        vk, code, text = 0, key, ""
     base = {"key": key, "code": code, "modifiers": modifiers, "windowsVirtualKeyCode": vk, "nativeVirtualKeyCode": vk}
     shortcut_modifiers = modifiers & (1 | 2 | 4)  # Alt/Ctrl/Meta turn single keys into shortcuts.
     printable_char = len(key) == 1 and bool(text) and not shortcut_modifiers

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -466,3 +466,116 @@ def test_new_tab_reuses_an_empty_data_document(monkeypatch):
 
     assert helpers.new_tab("https://example.com") == "target-placeholder"
     assert calls == [("goto_url", "https://example.com")]
+
+
+# --- press_key physical key identity (#685) ---
+
+
+def _key_events(key, modifiers=0):
+    events = []
+
+    def fake_cdp(method, **kwargs):
+        if method == "Input.dispatchKeyEvent":
+            events.append(kwargs)
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        helpers.press_key(key, modifiers)
+    return events
+
+
+@pytest.mark.parametrize(
+    "char, code, vk, shift",
+    [
+        ("a", "KeyA", 65, False),
+        ("A", "KeyA", 65, True),
+        ("z", "KeyZ", 90, False),
+        ("1", "Digit1", 49, False),
+        ("!", "Digit1", 49, True),
+        ("0", "Digit0", 48, False),
+        (")", "Digit0", 48, True),
+        ("/", "Slash", 191, False),
+        ("?", "Slash", 191, True),
+        (";", "Semicolon", 186, False),
+        (":", "Semicolon", 186, True),
+        ("-", "Minus", 189, False),
+        ("_", "Minus", 189, True),
+        ("`", "Backquote", 192, False),
+        ("~", "Backquote", 192, True),
+        ("\\", "Backslash", 220, False),
+        ("|", "Backslash", 220, True),
+        ("'", "Quote", 222, False),
+        ('"', "Quote", 222, True),
+        (" ", "Space", 32, False),
+    ],
+)
+def test_press_key_sends_the_physical_key_a_real_keyboard_would(char, code, vk, shift):
+    """`code` is the physical key, never the character; the VK is not ord(char).
+
+    ord() only coincides for A-Z and 0-9 -- "a" is VK 65 not 97, and "/" is
+    VK 191 not 47 -- so anything reading e.code or e.keyCode saw values no
+    keyboard can produce.
+    """
+    events = _key_events(char)
+    down = events[0]
+
+    assert down["key"] == char
+    assert down["code"] == code
+    assert down["windowsVirtualKeyCode"] == vk
+    assert down["nativeVirtualKeyCode"] == vk
+    assert bool(down["modifiers"] & 8) is shift
+    # The character still reaches the page via the char event.
+    assert [e for e in events if e["type"] == "char"][0]["text"] == char
+
+
+@pytest.mark.parametrize("char", ["\u00e9", "\u4e2d", "\U0001F600"])
+def test_press_key_claims_no_physical_key_for_non_us_characters(char):
+    """No US key produces these, so report none rather than a fabricated one."""
+    events = _key_events(char)
+    down = events[0]
+
+    assert down["code"] == ""
+    assert down["windowsVirtualKeyCode"] == 0
+    assert [e for e in events if e["type"] == "char"][0]["text"] == char
+
+
+@pytest.mark.parametrize("modifiers", [1, 2, 4])
+def test_press_key_does_not_add_shift_to_a_shortcut(modifiers):
+    """press_key("A", modifiers=2) means Ctrl+A, not Ctrl+Shift+A.
+
+    Auto-shifting uppercase is right when typing text, but here the caller is
+    composing a shortcut and their intent has to win.
+    """
+    events = _key_events("A", modifiers)
+
+    assert all(e["modifiers"] == modifiers for e in events)
+    assert not any(e["type"] == "char" for e in events)
+
+
+@pytest.mark.parametrize(
+    "key, code, vk",
+    [("Enter", "Enter", 13), ("Backspace", "Backspace", 8),
+     ("ArrowLeft", "ArrowLeft", 37), ("Tab", "Tab", 9), ("Escape", "Escape", 27)],
+)
+def test_press_key_leaves_named_keys_alone(key, code, vk):
+    down = _key_events(key)[0]
+    assert (down["code"], down["windowsVirtualKeyCode"]) == (code, vk)
+    assert down["modifiers"] == 0
+
+
+def test_fill_input_types_each_character_as_a_real_key():
+    """fill_input() exists to emit real key events, so its codes must be real."""
+    events = []
+
+    def fake_cdp(method, **kwargs):
+        if method == "Input.dispatchKeyEvent":
+            events.append(kwargs)
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.js", side_effect=lambda *_a, **_k: True):
+        helpers.fill_input("#inp", "Hi!", clear_first=False)
+
+    typed = [(e["key"], e["code"], e["windowsVirtualKeyCode"], bool(e["modifiers"] & 8))
+             for e in events if e["type"] == "keyDown"]
+    assert typed == [("H", "KeyH", 72, True), ("i", "KeyI", 73, False), ("!", "Digit1", 49, True)]


### PR DESCRIPTION
Fixes #685.

## Problem

`press_key()` derived both `code` and the virtual key code from the character itself for anything outside the `_KEYS` table:

```python
vk, code, text = _KEYS.get(key, (ord(key[0]) if len(key) == 1 else 0, key, ...))
```

Both are wrong for every printable character:

| call | sent | a real keyboard sends |
|---|---|---|
| `press_key("a")` | `code="a"`, `keyCode=97` | `code="KeyA"`, `keyCode=65` |
| `press_key("A")` | `code="A"`, `keyCode=65`, no Shift | `code="KeyA"`, `keyCode=65`, **Shift** |
| `press_key("1")` | `code="1"` | `code="Digit1"` |
| `press_key("/")` | `code="/"`, `keyCode=47` | `code="Slash"`, `keyCode=191` |

`code` names the *physical key* and is layout-independent, so it is never the character — the values sent were ones no keyboard can produce. And `ord()` only coincides with the virtual key code for A-Z and 0-9: lowercase letters are off by 32, punctuation is unrelated.

This matters because `fill_input()` types every character through `press_key()`, and `fill_input()` exists precisely because `type_text()`'s `Input.insertText` bypasses framework listeners. The helper whose whole job is emitting real key events was emitting malformed ones.

The text still landed — the `char` event carries it — so what broke is anything reading the key identity: hotkey handlers on `e.code`, input masks filtering on `e.keyCode`, capitalisation checks on `e.shiftKey`. Those fail per-character, so some input lands and some is rejected, which is the hardest shape for an agent to diagnose from a screenshot.

## Fix

A US-layout table: letters → `KeyX`, digits → `DigitN`, punctuation → its `VK_OEM_*` code, and the shifted characters (`!@#$`, uppercase) mapped back to the physical key they share, with the Shift modifier set.

**Two deliberate limits**, both of which I'd want a reviewer to weigh in on:

- **Shift is not added when the caller already passed Alt/Ctrl/Meta.** `press_key("A", modifiers=2)` stays Ctrl+A rather than becoming Ctrl+Shift+A. Physically the shortcut *does* need Shift, but the caller's intent wins over that. Without this carve-out the change would silently alter existing shortcut calls.
- **Characters with no US key** (accented, CJK, emoji) now report `code=""` and `keyCode=0` rather than a fabricated `ord()`. They still insert from the char event's text; claiming a physical key for them is just a different wrong answer. This goes slightly beyond the issue, which only covered ASCII.

## Verification

Windows 11, Python 3.11.9, `pip install -e .`

Probed the emitted events across the character space before writing assertions:

```
'a'   -> code='KeyA'        vk= 65        char='a'
'A'   -> code='KeyA'        vk= 65 SHIFT  char='A'
'!'   -> code='Digit1'      vk= 49 SHIFT  char='!'
'/'   -> code='Slash'       vk=191        char='/'
'?'   -> code='Slash'       vk=191 SHIFT  char='?'
'|'   -> code='Backslash'   vk=220 SHIFT  char='|'
' '   -> code='Space'       vk= 32        char=' '

Ctrl+a  -> code='KeyA' vk=65 shift=False char_event=False keydown_text='a'
Ctrl+A  -> code='KeyA' vk=65 shift=False char_event=False keydown_text='A'   # not Ctrl+Shift+A
Enter   -> code='Enter' vk=13 keydown_text='\r'                              # unchanged
```

32 new tests; **23 fail on `main`**. The 13 that pass both ways are the guards: `Space` (already correct, it was in `_KEYS`), the five named keys, the three shortcut cases, and the four pre-existing `fill_input` tests — there to prove the change doesn't disturb what already worked.

`test_fill_input_types_each_character_as_a_real_key` pins the end-to-end path:

```python
assert typed == [("H", "KeyH", 72, True), ("i", "KeyI", 73, False), ("!", "Digit1", 49, True)]
```

Full suite: `9 failed, 159 passed` → `9 failed, 191 passed`. The 9 are pre-existing and unrelated (#680, #678).

## Note for reviewers

The table is US-layout, which the harness already assumes elsewhere, and it's a table rather than arithmetic so a non-US layout can be added later without unpicking anything. Worth confirming against a real page — everything here was verified against the dispatched CDP payloads, not a live browser, so the assertion is "we now send what a US keyboard sends", not "site X now works".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`press_key()` now sends the physical key code and virtual key code a real US keyboard would produce for printable characters, so listeners checking `e.code`, `e.keyCode`, or `e.shiftKey` see consistent, valid values. Previously it derived both from the character itself (e.g., `press_key("a")` sent `code="a"` and `keyCode=97`, and `press_key("A")` lost the Shift modifier); this also fixes `fill_input()`, which types every character through `press_key()`.

**Bug Fixes**

- Maps letters, digits, and punctuation to their US-layout `Key*`/`Digit*` codes and `VK_OEM_*` virtual key codes, with Shift added for uppercase and shifted characters (`!@#$` etc.).
- Does not add Shift when the caller already passed Alt/Ctrl/Meta, so `press_key("A", modifiers=2)` stays Ctrl+A.
- Reports `code=""` and `keyCode=0` for characters without a US key (accented, CJK, emoji); the character still inserts via the char event.
- Adds 32 tests covering the character table, non-ASCII input, shortcut modifiers, and the end-to-end `fill_input()` path.

<sup>Written for commit fccd4dcf6c01ab3aedaa93a973cf40c921f9d976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

