### PR TITLE
refactor: load .env files once, from paths

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -104,25 +104,7 @@ def _process_start_time(pid):
     return None
 
 
-def _load_env():
-    repo_root = Path(__file__).resolve().parents[2]
-    workspace = paths.workspace_dir()
-    for p in (repo_root / ".env", workspace / ".env"):
-        if not p.exists():
-            continue
-        _load_env_file(p)
-
-
-def _load_env_file(p):
-    for line in p.read_text(encoding="utf-8-sig", errors="replace").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
-
-
-_load_env()
+paths.load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 BU_API = "https://api.browser-use.com/api/v3"

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -10,25 +10,7 @@ from . import paths
 from cdp_use.client import CDPClient
 
 
-def _load_env():
-    repo_root = Path(__file__).resolve().parents[2]
-    workspace = paths.workspace_dir()
-    for p in (repo_root / ".env", workspace / ".env"):
-        if not p.exists():
-            continue
-        _load_env_file(p)
-
-
-def _load_env_file(p):
-    for line in p.read_text(encoding="utf-8-sig", errors="replace").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
-
-
-_load_env()
+paths.load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 SOCK = ipc.sock_addr(NAME)

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -16,24 +16,7 @@ REPO_ROOT = CORE_DIR.parent.parent
 AGENT_WORKSPACE = paths.workspace_dir()
 
 
-def _load_env():
-    paths = [REPO_ROOT / ".env", AGENT_WORKSPACE / ".env"]
-    for p in paths:
-        if not p.exists():
-            continue
-        _load_env_file(p)
-
-
-def _load_env_file(p):
-    for line in p.read_text(encoding="utf-8-sig", errors="replace").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
-
-
-_load_env()
+paths.load_env()
 
 NAME = os.environ.get("BU_NAME", "default")
 SOCK = ipc.sock_addr(NAME)

--- a/src/browser_harness/paths.py
+++ b/src/browser_harness/paths.py
@@ -47,3 +47,16 @@ def tmp_dir() -> Path:
 def workspace_dir() -> Path:
     raw = os.environ.get("BH_AGENT_WORKSPACE")
     return ensure_private_dir(Path(raw).expanduser().resolve() if raw else home_dir() / "agent-workspace")
+
+
+def load_env(*files: Path) -> None:
+    """Seed os.environ from the repo's .env, then the workspace's .env; set variables win."""
+    for p in files or (Path(__file__).resolve().parents[2] / ".env", workspace_dir() / ".env"):
+        if not p.exists():
+            continue
+        for line in p.read_text(encoding="utf-8-sig", errors="replace").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,16 +1,15 @@
+import os
+
 from browser_harness import paths
 
 
 def test_load_env_seeds_missing_variables_only(tmp_path, monkeypatch):
-    monkeypatch.setenv("BH_TEST_SET", "kept")
-    monkeypatch.delenv("BH_TEST_NEW", raising=False)
-    monkeypatch.delenv("BH_TEST_QUOTED", raising=False)
+    env = {"BH_TEST_SET": "kept"}
+    monkeypatch.setattr(os, "environ", env)
     (tmp_path / ".env").write_text(
         "# comment\n\nBH_TEST_SET=overridden\nBH_TEST_NEW = fresh\nBH_TEST_QUOTED='q'\nnot a pair\n"
     )
 
     paths.load_env(tmp_path / ".env", tmp_path / "missing.env")
 
-    assert paths.os.environ["BH_TEST_SET"] == "kept"
-    assert paths.os.environ["BH_TEST_NEW"] == "fresh"
-    assert paths.os.environ["BH_TEST_QUOTED"] == "q"
+    assert env == {"BH_TEST_SET": "kept", "BH_TEST_NEW": "fresh", "BH_TEST_QUOTED": "q"}

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,16 @@
+from browser_harness import paths
+
+
+def test_load_env_seeds_missing_variables_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("BH_TEST_SET", "kept")
+    monkeypatch.delenv("BH_TEST_NEW", raising=False)
+    monkeypatch.delenv("BH_TEST_QUOTED", raising=False)
+    (tmp_path / ".env").write_text(
+        "# comment\n\nBH_TEST_SET=overridden\nBH_TEST_NEW = fresh\nBH_TEST_QUOTED='q'\nnot a pair\n"
+    )
+
+    paths.load_env(tmp_path / ".env", tmp_path / "missing.env")
+
+    assert paths.os.environ["BH_TEST_SET"] == "kept"
+    assert paths.os.environ["BH_TEST_NEW"] == "fresh"
+    assert paths.os.environ["BH_TEST_QUOTED"] == "q"


### PR DESCRIPTION
`helpers.py`, `daemon.py` and `admin.py` each carried an identical private `_load_env`/`_load_env_file` pair. Moved once into `paths.load_env()` (repo `.env`, then workspace `.env`; set variables win — same order and rule as before) and called from the three modules at import. Net −40 lines, no behaviour change.

Tests: `tests/unit/test_paths.py` covers skipped comments/blanks/non-pairs, quote stripping, no override of set variables, missing file ignored. 152 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
