### PR TITLE
docs: let agents choose faster long-text input

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -118,7 +118,7 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - After navigation, call `wait_for_load()`.
 - If the current tab is stale or internal, call `ensure_real_tab()`.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
-- For long plain `input` or `textarea` values, prefer one `js(...)` call that uses the element prototype's native value setter and dispatches bubbling `input` and `change` events; keep `fill_input` for masked fields, typeaheads, and controls that must react to each keystroke.
+- When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -118,6 +118,7 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - After navigation, call `wait_for_load()`.
 - If the current tab is stale or internal, call `ensure_real_tab()`.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
+- For long plain `input` or `textarea` values, prefer one `js(...)` call that uses the element prototype's native value setter and dispatches bubbling `input` and `change` events; keep `fill_input` for masked fields, typeaheads, and controls that must react to each keystroke.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
 


### PR DESCRIPTION
## Why

`fill_input()` emits several CDP events per character; the contributor measured about 17 seconds for 2,000 characters. That evidence does not justify a new public helper.

## Change

Add one method-neutral skill line: when text is unusually long, avoid slow per-character typing, choose a faster input method suited to the page, and verify the exact value afterward.

The agent chooses the method. This PR adds no helper, MCP tool, or runtime behavior.

## Verification

- `uv run --with pytest pytest tests/unit/test_skill.py -q`
- `git diff --check`

This is a one-line alternative to the seven-file helper in #699. It does not modify the contributor branch.