### PR TITLE
fix: make the MCP server installable from PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Use your local browser for logged-in, personal work. When you want many browsers
 
 ## MCP server
 
-`mcp_server.py` exposes the browser control helpers as MCP tools over stdio,
-so any MCP client (Claude Code, Devin, Cursor, etc.) can drive the browser
-without writing a second CDP layer. See [docs/MCP.md](docs/MCP.md) for setup and
-client configuration.
+`browser-harness-mcp` exposes the browser control helpers as MCP tools over
+stdio, so any MCP client (Claude Code, Devin, Cursor, etc.) can drive the
+browser without writing a second CDP layer. See [docs/MCP.md](docs/MCP.md) for
+setup and client configuration.
 
 ## Contributing
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,15 +1,15 @@
 # Browser Harness MCP Server
 
-The MCP server in `mcp_server.py` exposes `browser_harness.helpers` as MCP tools.
+The `browser-harness-mcp` command exposes `browser_harness.helpers` as MCP tools.
 It reuses the existing helper layer — no second CDP implementation and no changes
 inside `src/browser_harness/`.
 
 ## Start
 
-From the repo root:
+From any directory:
 
 ```bash
-uv run --extra mcp python -m mcp_server
+uvx --from 'browser-harness[mcp]' browser-harness-mcp
 ```
 
 The server speaks MCP stdio and connects to the same local Chrome CDP endpoint
@@ -57,20 +57,18 @@ server process keeps running.
 
 ## Client configuration
 
-Replace `<path-to-repo>` with your checkout path.
-
 ### Claude Code
 
 ```bash
 claude mcp add browser-harness \
-  uv --directory <path-to-repo> run --extra mcp python -m mcp_server
+  uvx --from 'browser-harness[mcp]' browser-harness-mcp
 ```
 
 ### Devin
 
 ```bash
 devin mcp add -s project browser-harness -- \
-  uv --directory <path-to-repo> run --extra mcp python -m mcp_server
+  uvx --from 'browser-harness[mcp]' browser-harness-mcp
 ```
 
 ### Cursor / OpenClaw / other MCP clients
@@ -79,16 +77,11 @@ devin mcp add -s project browser-harness -- \
 {
   "mcpServers": {
     "browser-harness": {
-      "command": "uv",
+      "command": "uvx",
       "args": [
-        "--directory",
-        "<path-to-repo>",
-        "run",
-        "--extra",
-        "mcp",
-        "python",
-        "-m",
-        "mcp_server"
+        "--from",
+        "browser-harness[mcp]",
+        "browser-harness-mcp"
       ]
     }
   }
@@ -99,5 +92,8 @@ devin mcp add -s project browser-harness -- \
 
 ```bash
 npx @modelcontextprotocol/inspector \
-  uv --directory <path-to-repo> run --extra mcp python -m mcp_server
+  uvx --from 'browser-harness[mcp]' browser-harness-mcp
 ```
+
+From a repository checkout, `uv run --extra mcp browser-harness-mcp` runs the
+same packaged entry point against the current source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ mcp = ["mcp>=2.0.0,<3"]
 
 [project.scripts]
 browser-harness = "browser_harness.run:main"
+browser-harness-mcp = "mcp_server:main"
 
 [project.urls]
 Homepage = "https://github.com/browser-use/browser-harness"
@@ -41,6 +42,7 @@ Issues = "https://github.com/browser-use/browser-harness/issues"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+py-modules = ["mcp_server"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ mcp = ["mcp>=2.0.0,<3"]
 
 [project.scripts]
 browser-harness = "browser_harness.run:main"
-browser-harness-mcp = "mcp_server:main"
+browser-harness-mcp = "browser_harness.mcp_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/browser-use/browser-harness"

--- a/src/browser_harness/mcp_cli.py
+++ b/src/browser_harness/mcp_cli.py
@@ -1,0 +1,16 @@
+"""Console entry point for the optional Browser Harness MCP server."""
+
+
+def main() -> None:
+    """Run the MCP server, or explain how to install its optional dependency."""
+    try:
+        from mcp_server import main as run_server
+    except ModuleNotFoundError as exc:
+        if exc.name == "mcp" or (exc.name and exc.name.startswith("mcp.")):
+            raise SystemExit(
+                "browser-harness-mcp requires MCP support. "
+                "Install it with: pip install 'browser-harness[mcp]'"
+            ) from None
+        raise
+
+    run_server()

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -290,5 +290,10 @@ def browser_stop_recording():
     return {"recording_dir": stop_recording()}
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run the Browser Harness MCP server over stdio."""
     SERVER.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -21,15 +21,15 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
-from PIL import Image
 from mcp.server import MCPServer
+from PIL import Image
 
 from browser_harness.admin import ensure_daemon
 from browser_harness.helpers import (
     capture_screenshot,
+    cdp,
     click_at_xy,
     close_tab,
-    cdp,
     current_tab,
     ensure_real_tab,
     fill_input,
@@ -128,7 +128,7 @@ def _tool(fn):
             with _stderr_stdout():
                 result = fn(*args, **kwargs)
             return _dump(result)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 -- MCP tools must serialize arbitrary browser failures.
             return _dump({"error": str(exc)})
 
     return SERVER.tool(name=fn.__name__, description=fn.__doc__ or "")(wrapper)
@@ -259,7 +259,7 @@ def browser_js(expression: str, target_id: str | None = None):
 
 
 @_tool
-def browser_cdp(method: str, params: dict = {}):
+def browser_cdp(method: str, params: dict | None = None):
     """Call a raw Chrome DevTools Protocol method. `params` are passed as kwargs."""
     return cdp(method, **(params or {}))
 

--- a/tests/unit/test_mcp_cli.py
+++ b/tests/unit/test_mcp_cli.py
@@ -1,0 +1,21 @@
+"""Tests for the optional MCP console entry point."""
+
+import builtins
+
+import pytest
+
+from browser_harness import mcp_cli
+
+
+def test_main_explains_missing_mcp_extra(monkeypatch):
+    real_import = builtins.__import__
+
+    def import_without_mcp(name, *args, **kwargs):
+        if name == "mcp_server":
+            raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_mcp)
+
+    with pytest.raises(SystemExit, match=r"pip install 'browser-harness\[mcp\]'"):
+        mcp_cli.main()


### PR DESCRIPTION
## Summary

The MCP server merged in #601 lives at the repository root, so it is absent from the published wheel and every client still needs a local checkout. Package the module, add a `browser-harness-mcp` entry point, and update setup examples to run from any directory.

## Proof

Before: the built wheel did not contain `mcp_server.py`; `python -m mcp_server` failed after installing it.

After:
- built wheel contains `mcp_server.py`
- `browser-harness-mcp = mcp_server:main` is present in wheel entry points
- isolated wheel import succeeds and exposes all 23 tools
- the entry point starts and exits cleanly on stdio EOF
- 190 unit tests pass
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Packages the MCP server in the PyPI wheel and adds a `browser-harness-mcp` command, so MCP clients can run it from any directory instead of requiring a repository checkout.

- Updates README, docs, client configurations, and inspector examples to use `uvx --from 'browser-harness[mcp]' browser-harness-mcp`.
- Shows an install hint when the optional MCP dependency is missing.
- Keeps `uv run --extra mcp browser-harness-mcp` available for running the packaged entry point from a checkout.

<sup>Written for commit fad70f6fe15ecd527fd97ca986528710a0ca567b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

