### PR TITLE
fix: clean up owned tabs and cap browser growth

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -150,6 +150,15 @@ captured. Never reenact a completed task. For a video, follow
 If sub-agents are available, they may handle post-production from the exact
 recording path while the main agent returns the task result.
 
+## Tab Lifecycle
+
+- Tabs created by `new_tab()` are closed automatically when the CLI invocation ends, including after an error.
+- If `new_tab()` reuses an existing blank page, that page is restored to `about:blank` instead of being closed.
+- To keep new tabs for a later invocation, call `keep_opened_tabs()` or set `BH_KEEP_TABS=1`. The later workflow is responsible for closing them explicitly.
+- Preservation applies to tabs created by the invocation. A pre-existing blank tab borrowed by `new_tab()` is still restored to `about:blank`.
+- Existing tabs and tabs opened by another process are never automatically closed.
+- Popups and pages opened indirectly with `window.open()` or `target=_blank` are not process-owned and are left open.
+
 ## Interaction Skills
 
 If you get stuck on a browser mechanic, check https://github.com/browser-use/browser-harness/tree/main/interaction-skills.

--- a/SKILL.md
+++ b/SKILL.md
@@ -25,9 +25,9 @@ PY
 
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
-- First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
-  preserves the attached tab across separate CLI invocations, so do not call
-  `new_tab()` again in every script.
+- First navigation for an invocation is `new_tab(url)`, not `goto_url(url)`.
+  Tabs created or borrowed by that invocation are cleaned up when it exits;
+  call `keep_opened_tabs()` only when a later invocation must reuse them.
 - Keep one working tab per task/site. Before opening another, inspect
   `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
   tab. Do not leave duplicate tabs on the same URL or close tabs you did not
@@ -154,8 +154,7 @@ recording path while the main agent returns the task result.
 
 - Tabs created by `new_tab()` are closed automatically when the CLI invocation ends, including after an error.
 - If `new_tab()` reuses an existing blank page, that page is restored to `about:blank` instead of being closed.
-- To keep new tabs for a later invocation, call `keep_opened_tabs()` or set `BH_KEEP_TABS=1`. The later workflow is responsible for closing them explicitly.
-- Preservation applies to tabs created by the invocation. A pre-existing blank tab borrowed by `new_tab()` is still restored to `about:blank`.
+- To keep new or borrowed tabs for a later invocation, call `keep_opened_tabs()` or set `BH_KEEP_TABS=1`. The later workflow is responsible for closing them explicitly.
 - Existing tabs and tabs opened by another process are never automatically closed.
 - Popups and pages opened indirectly with `window.open()` or `target=_blank` are not process-owned and are left open.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -155,8 +155,9 @@ recording path while the main agent returns the task result.
 - Tabs created by `new_tab()` are closed automatically when the CLI invocation ends, including after an error.
 - If `new_tab()` reuses an existing blank page, that page is restored to `about:blank` instead of being closed.
 - To keep new or borrowed tabs for a later invocation, call `keep_opened_tabs()` or set `BH_KEEP_TABS=1`. The later workflow is responsible for closing them explicitly.
-- Existing tabs and tabs opened by another process are never automatically closed.
-- Popups and pages opened indirectly with `window.open()` or `target=_blank` are not process-owned and are left open.
+- `new_tab()` also enforces a browser-wide 15-tab ceiling by closing the oldest work tabs. Set `BH_MAX_TABS` to another positive limit or `0` to disable this backstop.
+- Existing tabs and tabs opened by another process are not touched by ownership cleanup, but the browser-wide ceiling can evict them once they are among the oldest work tabs.
+- Popups and pages opened indirectly with `window.open()` or `target=_blank` are not process-owned and are left open unless the browser-wide ceiling evicts them.
 
 ## Interaction Skills
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -225,6 +225,19 @@ def _ws_from_devtools_active_port(http_url: str) -> str | None:
     return None
 
 
+def http_endpoint_from_ws(ws_url):
+    """Return the DevTools HTTP base for the local browser connection."""
+    if REMOTE_ID or not ws_url:
+        return None
+    parsed = urlparse(ws_url)
+    if not parsed.hostname:
+        return None
+    scheme = "https" if parsed.scheme == "wss" else "http"
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{scheme}://{host}{port}"
+
+
 def get_ws_url():
     if url := os.environ.get("BU_CDP_WS"):
         return url
@@ -388,6 +401,7 @@ class _PatientCDPClient(CDPClient):
 class Daemon:
     def __init__(self):
         self.cdp = None
+        self.ws_url = None
         self.session = None
         self.target_id = None
         self.dedicated_target_id = None
@@ -577,6 +591,7 @@ class Daemon:
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
+        self.ws_url = url
         log(f"connecting to {_safe_connection_label(url)}")
         self.cdp = _PatientCDPClient(url) if BROWSER_KIND == "local" else CDPClient(url)
         if BROWSER_KIND == "local":
@@ -628,6 +643,8 @@ class Daemon:
             out = list(self.events); self.events.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
+        if meta == "http_endpoint":
+            return {"endpoint": http_endpoint_from_ws(self.ws_url)}
         if meta == "current_tab":
             # Resolve the attached page's target info server-side. Helpers can't
             # send Target.getTargetInfo themselves: daemon strips session_id for

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -446,6 +446,59 @@ def switch_tab(target, activate=False):
     _mark_tab()
     return sid
 
+
+DEFAULT_MAX_TABS = 15
+_TAB_CAP_SKIP = (
+    "chrome://",
+    "chrome-untrusted://",
+    "edge://",
+    "devtools://",
+    "chrome-extension://",
+)
+
+
+def _reap_tabs(keep_id):
+    """Keep automation browsers bounded by closing their oldest work tabs."""
+    global _RETURN_TAB_ID
+    try:
+        max_tabs = int(os.environ.get("BH_MAX_TABS", str(DEFAULT_MAX_TABS)))
+    except ValueError:
+        max_tabs = DEFAULT_MAX_TABS
+    if max_tabs <= 0:
+        return
+
+    try:
+        endpoint = _send({"meta": "http_endpoint"}).get("endpoint")
+        if not endpoint:
+            return
+        with urllib.request.urlopen(f"{endpoint.rstrip('/')}/json/list", timeout=2) as response:
+            pages = [
+                target
+                for target in json.loads(response.read())
+                if target.get("type") == "page"
+                and not target.get("url", "").startswith(_TAB_CAP_SKIP)
+            ]
+    except Exception:
+        return
+
+    excess = len(pages) - max_tabs
+    if excess <= 0:
+        return
+    for target in reversed(pages):
+        target_id = target.get("id")
+        if excess <= 0:
+            break
+        if not target_id or target_id == keep_id:
+            continue
+        if _close_target_with_retry(target_id) is not None:
+            continue
+        _OPENED_TABS.discard(target_id)
+        _REUSED_BLANK_TABS.pop(target_id, None)
+        if _RETURN_TAB_ID == target_id:
+            _RETURN_TAB_ID = None
+        excess -= 1
+
+
 def new_tab(url="about:blank"):
     global _RETURN_TAB_ID
     # Always create blank, then goto: passing url to createTarget races with
@@ -464,6 +517,7 @@ def new_tab(url="about:blank"):
             ):
                 target_id = cur.get("targetId") or cur.get("target_id")
                 _REUSED_BLANK_TABS.setdefault(target_id, _blank_restore_url(cur_url))
+                _reap_tabs(target_id)
                 goto_url(url)
                 return target_id
     except Exception:
@@ -475,6 +529,7 @@ def new_tab(url="about:blank"):
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     _OPENED_TABS.add(tid)
     switch_tab(tid)
+    _reap_tabs(tid)
     if url != "about:blank":
         goto_url(url)
     return tid

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -357,6 +357,7 @@ def capture_screenshot(path=None, full=False, max_dim=None):
 _OPENED_TABS = set()
 _REUSED_BLANK_TABS = {}
 _KEEP_OPENED_TABS = False
+_RETURN_TAB_ID = None
 
 
 def _is_agent_startup_placeholder(title, url):
@@ -430,13 +431,15 @@ def switch_tab(target, activate=False):
     return sid
 
 def new_tab(url="about:blank"):
+    global _RETURN_TAB_ID
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    if url != "about:blank":
-        try:
-            cur = current_tab()
-            cur_url = cur.get("url") or ""
+    cur = None
+    try:
+        cur = current_tab()
+        cur_url = cur.get("url") or ""
+        if url != "about:blank":
             # Reuse attached tab when it's blank
             if (
                 cur_url in ("", "about:blank", "data:text/html,")
@@ -447,8 +450,12 @@ def new_tab(url="about:blank"):
                 _REUSED_BLANK_TABS.setdefault(target_id, cur_url or "about:blank")
                 goto_url(url)
                 return target_id
-        except Exception:
-            pass
+    except Exception:
+        pass
+    if cur:
+        current_id = cur.get("targetId") or cur.get("target_id")
+        if current_id and current_id not in _OPENED_TABS and _RETURN_TAB_ID is None:
+            _RETURN_TAB_ID = current_id
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     _OPENED_TABS.add(tid)
     switch_tab(tid)
@@ -493,6 +500,15 @@ def _move_to_keeper(target_ids):
     if current_id not in target_ids:
         return set(), []
 
+    if _RETURN_TAB_ID and _RETURN_TAB_ID not in target_ids:
+        try:
+            switch_tab(_RETURN_TAB_ID)
+            return set(), []
+        except Exception:
+            # The original tab may have been closed while the task was running.
+            # Fall back to a fresh neutral target before closing the owned one.
+            pass
+
     keeper_id = None
     try:
         keeper_id = cdp("Target.createTarget", url="about:blank")["targetId"]
@@ -523,6 +539,7 @@ def _cleanup_error_message(failures):
 
 def close_opened_tabs(force=False):
     """Close created tabs and restore blank tabs reused by this CLI process."""
+    global _RETURN_TAB_ID
     if _KEEP_OPENED_TABS and not force:
         # Keeping means hands off every tab this invocation touched, not just
         # ones it created via Target.createTarget. new_tab() usually reuses
@@ -533,6 +550,7 @@ def close_opened_tabs(force=False):
         # common case a caller relies on it for.
         _OPENED_TABS.clear()
         _REUSED_BLANK_TABS.clear()
+        _RETURN_TAB_ID = None
         return []
 
     _, failures = _restore_reused_blank_tabs()
@@ -541,6 +559,7 @@ def close_opened_tabs(force=False):
     if not target_ids:
         if failures:
             raise RuntimeError(_cleanup_error_message(failures))
+        _RETURN_TAB_ID = None
         return []
 
     protected_ids, handoff_failures = _move_to_keeper(target_ids)
@@ -577,6 +596,7 @@ def close_opened_tabs(force=False):
             time.sleep(0.05)
     if failures:
         raise RuntimeError(_cleanup_error_message(failures))
+    _RETURN_TAB_ID = None
     return closed
 
 def close_tab(target=None):

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -532,11 +532,24 @@ def _move_to_keeper(target_ids):
         # The keeper becomes the daemon's neutral anchor. It is intentionally
         # not owned by this invocation and can be reused by the next new_tab().
     except Exception as exc:
-        # switch_tab() can fail after the daemon accepted set_session. Closing
-        # the keeper here could therefore strand it on a dead target. Leave the
-        # neutral page open and keep the current owned target as a second safe
-        # anchor; unrelated owned targets can still be cleaned up.
-        return {current_id}, [("keeper handoff", exc)]
+        failures = [("keeper handoff", exc)]
+        # switch_tab() can fail after the daemon accepted set_session. Read the
+        # daemon's acknowledged target before deciding whether the keeper is
+        # safe to close; ambiguity fails closed and leaves the neutral page.
+        keeper_attached = None
+        if keeper_id:
+            try:
+                keeper_attached = current_tab()["targetId"] == keeper_id
+            except Exception:
+                pass
+        if keeper_id and keeper_attached is False:
+            try:
+                result = cdp("Target.closeTarget", targetId=keeper_id)
+                if not result.get("success", True):
+                    raise RuntimeError("Target.closeTarget returned false")
+            except Exception as close_exc:
+                failures.append((keeper_id, close_exc))
+        return {current_id}, failures
     return set(), []
 
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -360,6 +360,22 @@ _KEEP_OPENED_TABS = False
 _RETURN_TAB_ID = None
 
 
+def _reset_tab_ownership():
+    """Reset process-local ownership before and after one CLI invocation."""
+    global _KEEP_OPENED_TABS, _RETURN_TAB_ID
+    _OPENED_TABS.clear()
+    _REUSED_BLANK_TABS.clear()
+    _KEEP_OPENED_TABS = False
+    _RETURN_TAB_ID = None
+
+
+def _blank_restore_url(url):
+    url = str(url or "")
+    if url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab")):
+        return "about:blank"
+    return url or "about:blank"
+
+
 def _is_agent_startup_placeholder(title, url):
     url = str(url or "")
     return str(title or "").startswith("Starting agent ") and (
@@ -447,7 +463,7 @@ def new_tab(url="about:blank"):
                 or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
             ):
                 target_id = cur.get("targetId") or cur.get("target_id")
-                _REUSED_BLANK_TABS.setdefault(target_id, cur_url or "about:blank")
+                _REUSED_BLANK_TABS.setdefault(target_id, _blank_restore_url(cur_url))
                 goto_url(url)
                 return target_id
     except Exception:
@@ -516,19 +532,11 @@ def _move_to_keeper(target_ids):
         # The keeper becomes the daemon's neutral anchor. It is intentionally
         # not owned by this invocation and can be reused by the next new_tab().
     except Exception as exc:
-        failures = [("keeper handoff", exc)]
-        if keeper_id:
-            try:
-                result = cdp("Target.closeTarget", targetId=keeper_id)
-                if not result.get("success", True):
-                    raise RuntimeError("Target.closeTarget returned false")
-            except Exception as close_exc:
-                # Retain ownership so a later invocation can retry cleanup.
-                _OPENED_TABS.add(keeper_id)
-                failures.append((keeper_id, close_exc))
-        # Keeping one page is better than leaving the daemon attached to a dead
-        # target. Other owned tabs can still be cleaned up safely.
-        return {current_id}, failures
+        # switch_tab() can fail after the daemon accepted set_session. Closing
+        # the keeper here could therefore strand it on a dead target. Leave the
+        # neutral page open and keep the current owned target as a second safe
+        # anchor; unrelated owned targets can still be cleaned up.
+        return {current_id}, [("keeper handoff", exc)]
     return set(), []
 
 
@@ -602,10 +610,17 @@ def close_opened_tabs(force=False):
 def close_tab(target=None):
     """Close a tab. If `target` is omitted, closes the currently attached tab.
     Accepts a raw targetId string or a dict from list_tabs()/current_tab()."""
+    global _RETURN_TAB_ID
     target_id = _target_id(target)
     if target_id is None:
         target_id = current_tab()["targetId"]
-    cdp("Target.closeTarget", targetId=target_id)
+    result = cdp("Target.closeTarget", targetId=target_id)
+    if not result.get("success", True):
+        raise RuntimeError("Target.closeTarget returned false")
+    _OPENED_TABS.discard(target_id)
+    _REUSED_BLANK_TABS.pop(target_id, None)
+    if _RETURN_TAB_ID == target_id:
+        _RETURN_TAB_ID = None
 
 
 def ensure_real_tab():

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -354,6 +354,11 @@ def capture_screenshot(path=None, full=False, max_dim=None):
 
 
 # --- tabs ---
+_OPENED_TABS = set()
+_REUSED_BLANK_TABS = {}
+_KEEP_OPENED_TABS = False
+
+
 def _is_agent_startup_placeholder(title, url):
     url = str(url or "")
     return str(title or "").startswith("Starting agent ") and (
@@ -438,15 +443,137 @@ def new_tab(url="about:blank"):
                 or cur_url.startswith("about:blank#")
                 or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
             ):
+                target_id = cur.get("targetId") or cur.get("target_id")
+                _REUSED_BLANK_TABS.setdefault(target_id, cur_url or "about:blank")
                 goto_url(url)
-                return cur.get("targetId") or cur.get("target_id")
+                return target_id
         except Exception:
             pass
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
+    _OPENED_TABS.add(tid)
     switch_tab(tid)
     if url != "about:blank":
         goto_url(url)
     return tid
+
+
+def opened_tabs():
+    """Return target IDs created by new_tab() in this CLI process."""
+    return list(_OPENED_TABS)
+
+
+def keep_opened_tabs(keep=True):
+    """Opt out of automatic cleanup for tabs owned by this CLI process."""
+    global _KEEP_OPENED_TABS
+    _KEEP_OPENED_TABS = keep
+
+
+def _restore_reused_blank_tabs():
+    restored = []
+    failures = []
+    for target_id, original_url in list(_REUSED_BLANK_TABS.items()):
+        try:
+            switch_tab(target_id)
+            goto_url(original_url or "about:blank")
+            restored.append(target_id)
+            _REUSED_BLANK_TABS.pop(target_id, None)
+        except Exception as exc:
+            failures.append((target_id, exc))
+    return restored, failures
+
+
+def _move_to_keeper(target_ids):
+    """Move off an owned target before it closes; return protected IDs and failures."""
+    try:
+        current_id = current_tab()["targetId"]
+    except Exception as exc:
+        # Without the active target ID, any owned target could be the daemon's
+        # current session. Fail closed instead of risking a stale attachment.
+        return set(target_ids), [("current target", exc)]
+    if current_id not in target_ids:
+        return set(), []
+
+    keeper_id = None
+    try:
+        keeper_id = cdp("Target.createTarget", url="about:blank")["targetId"]
+        switch_tab(keeper_id)
+        # The keeper becomes the daemon's neutral anchor. It is intentionally
+        # not owned by this invocation and can be reused by the next new_tab().
+    except Exception as exc:
+        failures = [("keeper handoff", exc)]
+        if keeper_id:
+            try:
+                result = cdp("Target.closeTarget", targetId=keeper_id)
+                if not result.get("success", True):
+                    raise RuntimeError("Target.closeTarget returned false")
+            except Exception as close_exc:
+                # Retain ownership so a later invocation can retry cleanup.
+                _OPENED_TABS.add(keeper_id)
+                failures.append((keeper_id, close_exc))
+        # Keeping one page is better than leaving the daemon attached to a dead
+        # target. Other owned tabs can still be cleaned up safely.
+        return {current_id}, failures
+    return set(), []
+
+
+def _cleanup_error_message(failures):
+    details = ", ".join(f"{target}: {error}" for target, error in failures)
+    return f"tab cleanup incomplete ({details})"
+
+
+def close_opened_tabs(force=False):
+    """Close created tabs and restore blank tabs reused by this CLI process."""
+    _, failures = _restore_reused_blank_tabs()
+
+    if _KEEP_OPENED_TABS and not force:
+        # Keeping a tab releases it from this invocation's ownership. Otherwise
+        # an embedder calling main() again would close it on the next run.
+        _OPENED_TABS.clear()
+        if failures:
+            raise RuntimeError(_cleanup_error_message(failures))
+        return []
+
+    target_ids = set(_OPENED_TABS)
+    if not target_ids:
+        if failures:
+            raise RuntimeError(_cleanup_error_message(failures))
+        return []
+
+    protected_ids, handoff_failures = _move_to_keeper(target_ids)
+    failures.extend(handoff_failures)
+    target_ids.difference_update(protected_ids)
+
+    closed = []
+    for target_id in list(target_ids):
+        last_error = None
+        for _ in range(2):
+            try:
+                result = cdp("Target.closeTarget", targetId=target_id)
+                if result.get("success", True):
+                    closed.append(target_id)
+                    last_error = None
+                    break
+                last_error = RuntimeError("Target.closeTarget returned false")
+            except Exception as exc:
+                last_error = exc
+        if last_error is None:
+            _OPENED_TABS.discard(target_id)
+        else:
+            failures.append((target_id, last_error))
+
+    if closed:
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            try:
+                remaining = {tab["targetId"] for tab in list_tabs(include_chrome=True)}
+            except Exception:
+                break
+            if not remaining.intersection(closed):
+                break
+            time.sleep(0.05)
+    if failures:
+        raise RuntimeError(_cleanup_error_message(failures))
+    return closed
 
 def close_tab(target=None):
     """Close a tab. If `target` is omitted, closes the currently attached tab.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -543,12 +543,9 @@ def _move_to_keeper(target_ids):
             except Exception:
                 pass
         if keeper_id and keeper_attached is False:
-            try:
-                result = cdp("Target.closeTarget", targetId=keeper_id)
-                if not result.get("success", True):
-                    raise RuntimeError("Target.closeTarget returned false")
-            except Exception as close_exc:
-                failures.append((keeper_id, close_exc))
+            close_error = _close_target_with_retry(keeper_id)
+            if close_error is not None:
+                failures.append((keeper_id, close_error))
         return {current_id}, failures
     return set(), []
 
@@ -556,6 +553,19 @@ def _move_to_keeper(target_ids):
 def _cleanup_error_message(failures):
     details = ", ".join(f"{target}: {error}" for target, error in failures)
     return f"tab cleanup incomplete ({details})"
+
+
+def _close_target_with_retry(target_id):
+    last_error = None
+    for _ in range(2):
+        try:
+            result = cdp("Target.closeTarget", targetId=target_id)
+            if result.get("success", True):
+                return None
+            last_error = RuntimeError("Target.closeTarget returned false")
+        except Exception as exc:
+            last_error = exc
+    return last_error
 
 
 def close_opened_tabs(force=False):
@@ -589,18 +599,9 @@ def close_opened_tabs(force=False):
 
     closed = []
     for target_id in list(target_ids):
-        last_error = None
-        for _ in range(2):
-            try:
-                result = cdp("Target.closeTarget", targetId=target_id)
-                if result.get("success", True):
-                    closed.append(target_id)
-                    last_error = None
-                    break
-                last_error = RuntimeError("Target.closeTarget returned false")
-            except Exception as exc:
-                last_error = exc
+        last_error = _close_target_with_retry(target_id)
         if last_error is None:
+            closed.append(target_id)
             _OPENED_TABS.discard(target_id)
         else:
             failures.append((target_id, last_error))

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -523,15 +523,19 @@ def _cleanup_error_message(failures):
 
 def close_opened_tabs(force=False):
     """Close created tabs and restore blank tabs reused by this CLI process."""
-    _, failures = _restore_reused_blank_tabs()
-
     if _KEEP_OPENED_TABS and not force:
-        # Keeping a tab releases it from this invocation's ownership. Otherwise
-        # an embedder calling main() again would close it on the next run.
+        # Keeping means hands off every tab this invocation touched, not just
+        # ones it created via Target.createTarget. new_tab() usually reuses
+        # the current blank tab instead of creating a new one (the daemon is
+        # commonly parked on a blank keeper between invocations), so most
+        # "kept" tabs in practice are reused-blank ones. Restoring them to
+        # blank here would silently defeat keep_opened_tabs() for exactly the
+        # common case a caller relies on it for.
         _OPENED_TABS.clear()
-        if failures:
-            raise RuntimeError(_cleanup_error_message(failures))
+        _REUSED_BLANK_TABS.clear()
         return []
+
+    _, failures = _restore_reused_blank_tabs()
 
     target_ids = set(_OPENED_TABS)
     if not target_ids:

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -408,8 +408,10 @@ def _run(args):
     task_failed = False
     try:
         exec(code, globals())
-    except BaseException:
-        task_failed = True
+    except BaseException as exc:
+        task_failed = not (
+            isinstance(exc, SystemExit) and exc.code in (None, 0)
+        )
         raise
     finally:
         keep_tabs = os.environ.get("BH_KEEP_TABS", "").lower()

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -30,6 +30,7 @@ from .admin import (
     sync_local_profile,
 )
 from . import auth, recorder, telemetry
+from . import helpers as helper_module
 from .helpers import *
 
 HELP = """Browser Harness
@@ -403,7 +404,21 @@ def _run(args):
             print(f"browser-harness: {e}", file=sys.stderr)
             sys.exit(1)
     _install_helper_trace()
-    exec(code, globals())
+    try:
+        exec(code, globals())
+    finally:
+        keep_tabs = os.environ.get("BH_KEEP_TABS", "").lower()
+        try:
+            if keep_tabs in {"1", "true", "yes"}:
+                helper_module.keep_opened_tabs()
+            helper_module.close_opened_tabs()
+        except Exception as exc:
+            # Cleanup must never replace the browser task's result or exception.
+            print(f"Warning: automatic tab cleanup failed: {exc}", file=sys.stderr)
+        finally:
+            # main() can be exercised repeatedly in one Python process by tests
+            # and embedders, so keep the opt-out scoped to one invocation.
+            helper_module.keep_opened_tabs(False)
 
 
 if __name__ == "__main__":

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -404,21 +404,27 @@ def _run(args):
             print(f"browser-harness: {e}", file=sys.stderr)
             sys.exit(1)
     _install_helper_trace()
+    helper_module._reset_tab_ownership()
+    task_failed = False
     try:
         exec(code, globals())
+    except BaseException:
+        task_failed = True
+        raise
     finally:
         keep_tabs = os.environ.get("BH_KEEP_TABS", "").lower()
         try:
             if keep_tabs in {"1", "true", "yes"}:
                 helper_module.keep_opened_tabs()
             helper_module.close_opened_tabs()
-        except Exception as exc:
-            # Cleanup must never replace the browser task's result or exception.
-            print(f"Warning: automatic tab cleanup failed: {exc}", file=sys.stderr)
+        except BaseException as exc:
+            if task_failed:
+                # Preserve the task's original error when cleanup also fails.
+                print(f"Warning: automatic tab cleanup failed: {exc}", file=sys.stderr)
+            else:
+                raise
         finally:
-            # main() can be exercised repeatedly in one Python process by tests
-            # and embedders, so keep the opt-out scoped to one invocation.
-            helper_module.keep_opened_tabs(False)
+            helper_module._reset_tab_ownership()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -21,6 +21,21 @@ def test_safe_connection_label_removes_credentials_paths_and_queries(url, label)
     assert daemon._safe_connection_label(url) == label
 
 
+def test_http_endpoint_is_derived_from_the_connected_local_browser(monkeypatch):
+    monkeypatch.setattr(daemon, "REMOTE_ID", "")
+    assert daemon.http_endpoint_from_ws(
+        "ws://127.0.0.1:18792/devtools/browser/id?token=secret"
+    ) == "http://127.0.0.1:18792"
+    assert daemon.http_endpoint_from_ws(
+        "wss://[::1]:9222/devtools/browser/id"
+    ) == "https://[::1]:9222"
+
+
+def test_remote_browser_does_not_expose_a_local_http_endpoint(monkeypatch):
+    monkeypatch.setattr(daemon, "REMOTE_ID", "browser-1")
+    assert daemon.http_endpoint_from_ws("wss://provider.example/session/id") is None
+
+
 def test_remote_stop_retries_and_succeeds(monkeypatch):
     attempts = []
     monkeypatch.setattr(daemon, "REMOTE_ID", "browser-1")

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -7,6 +7,17 @@ import pytest
 from browser_harness import run
 
 
+@pytest.fixture(autouse=True)
+def reset_tab_ownership():
+    run.helper_module._OPENED_TABS.clear()
+    run.helper_module._REUSED_BLANK_TABS.clear()
+    run.helper_module.keep_opened_tabs(False)
+    yield
+    run.helper_module._OPENED_TABS.clear()
+    run.helper_module._REUSED_BLANK_TABS.clear()
+    run.helper_module.keep_opened_tabs(False)
+
+
 def test_stdin_executes_code():
     stdout = StringIO()
     fake_stdin = StringIO("print('hello from stdin')")
@@ -32,6 +43,126 @@ def test_require_existing_daemon_never_auto_starts(monkeypatch):
 
     mock_require.assert_called_once_with()
     mock_ensure.assert_not_called()
+
+
+def test_stdin_closes_owned_tabs_after_success():
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("browser_harness.run.helper_module.close_opened_tabs") as cleanup, \
+         patch("sys.stdin", StringIO("x = 1")):
+        run.main()
+
+    cleanup.assert_called_once_with()
+
+
+def test_stdin_closes_owned_tabs_after_error():
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("browser_harness.run.helper_module.close_opened_tabs") as cleanup, \
+         patch("sys.stdin", StringIO("raise RuntimeError('boom')")), \
+         pytest.raises(RuntimeError, match="boom"):
+        run.main()
+
+    cleanup.assert_called_once_with()
+
+
+def test_cleanup_failure_does_not_mask_task_error():
+    stderr = StringIO()
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch(
+             "browser_harness.run.helper_module.close_opened_tabs",
+             side_effect=RuntimeError("cleanup failed"),
+         ), \
+         patch("sys.stdin", StringIO("raise RuntimeError('task failed')")), \
+         patch("sys.stderr", stderr), \
+         pytest.raises(RuntimeError, match="task failed"):
+        run.main()
+
+    assert "automatic tab cleanup failed: cleanup failed" in stderr.getvalue()
+
+
+def test_real_cleanup_runs_after_task_error():
+    closed = []
+
+    def fake_cdp(method, **kwargs):
+        if method == "Target.closeTarget":
+            closed.append(kwargs["targetId"])
+        return {"success": True}
+
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch.object(run.helper_module, "_OPENED_TABS", {"owned"}), \
+         patch.object(run.helper_module, "_REUSED_BLANK_TABS", {}), \
+         patch.object(run.helper_module, "_KEEP_OPENED_TABS", False), \
+         patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.list_tabs", return_value=[]), \
+         patch("sys.stdin", StringIO("raise RuntimeError('task failed')")), \
+         pytest.raises(RuntimeError, match="task failed"):
+        run.main()
+
+    assert closed == ["owned"]
+
+
+def test_keep_opened_tabs_is_scoped_to_one_main_invocation():
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("sys.stdin", StringIO("keep_opened_tabs()")):
+        run.main()
+
+    assert run.helper_module._KEEP_OPENED_TABS is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "YES"])
+def test_bh_keep_tabs_skips_automatic_cleanup(monkeypatch, value):
+    monkeypatch.setenv("BH_KEEP_TABS", value)
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("browser_harness.run.helper_module.keep_opened_tabs") as keep, \
+         patch("browser_harness.run.helper_module.close_opened_tabs") as cleanup, \
+         patch("sys.stdin", StringIO("x = 1")):
+        run.main()
+
+    keep.assert_any_call()
+    keep.assert_called_with(False)
+    cleanup.assert_called_once_with()
+
+
+def test_cloud_admin_code_still_runs_tab_finalizer():
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("browser_harness.run.start_remote_daemon"), \
+         patch("browser_harness.run.helper_module.close_opened_tabs") as cleanup, \
+         patch("sys.stdin", StringIO("start_remote_daemon('profile')")):
+        run.main()
+
+    cleanup.assert_called_once_with()
+
+
+def test_bh_keep_tabs_releases_owned_tabs_and_restores_borrowed_blank(monkeypatch):
+    monkeypatch.setenv("BH_KEEP_TABS", "1")
+    run.helper_module._OPENED_TABS.add("created")
+    run.helper_module._REUSED_BLANK_TABS["blank"] = "about:blank"
+
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("browser_harness.helpers.switch_tab") as switch, \
+         patch("browser_harness.helpers.goto_url") as restore, \
+         patch("sys.stdin", StringIO("x = 1")):
+        run.main()
+
+    switch.assert_called_once_with("blank")
+    restore.assert_called_once_with("about:blank")
+    assert run.helper_module.opened_tabs() == []
+    assert run.helper_module._REUSED_BLANK_TABS == {}
 
 
 def test_c_flag_is_rejected():

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -137,6 +137,19 @@ def test_cleanup_baseexception_propagates_after_success():
         run.main()
 
 
+def test_cleanup_failure_overrides_successful_system_exit():
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch(
+             "browser_harness.run.helper_module.close_opened_tabs",
+             side_effect=RuntimeError("cleanup failed"),
+         ), \
+         patch("sys.stdin", StringIO("raise SystemExit(0)")), \
+         pytest.raises(RuntimeError, match="cleanup failed"):
+        run.main()
+
+
 def test_real_cleanup_runs_after_task_error():
     closed = []
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -146,7 +146,10 @@ def test_cloud_admin_code_still_runs_tab_finalizer():
     cleanup.assert_called_once_with()
 
 
-def test_bh_keep_tabs_releases_owned_tabs_and_restores_borrowed_blank(monkeypatch):
+def test_bh_keep_tabs_releases_owned_and_borrowed_blank_tabs_untouched(monkeypatch):
+    # Regression: BH_KEEP_TABS must protect reused-blank tabs too, since
+    # new_tab() usually reuses the current blank tab instead of creating a
+    # new one, so most "kept" tabs in practice go through that path.
     monkeypatch.setenv("BH_KEEP_TABS", "1")
     run.helper_module._OPENED_TABS.add("created")
     run.helper_module._REUSED_BLANK_TABS["blank"] = "about:blank"
@@ -159,8 +162,8 @@ def test_bh_keep_tabs_releases_owned_tabs_and_restores_borrowed_blank(monkeypatc
          patch("sys.stdin", StringIO("x = 1")):
         run.main()
 
-    switch.assert_called_once_with("blank")
-    restore.assert_called_once_with("about:blank")
+    switch.assert_not_called()
+    restore.assert_not_called()
     assert run.helper_module.opened_tabs() == []
     assert run.helper_module._REUSED_BLANK_TABS == {}
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -34,6 +34,20 @@ def test_stdin_executes_code():
     assert stdout.getvalue().strip() == "hello from stdin"
 
 
+def test_stdin_resets_stale_tab_ownership_before_exec():
+    run.helper_module._OPENED_TABS.add("stale")
+    stdout = StringIO()
+
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch("sys.stdin", StringIO("print(opened_tabs())")), \
+         patch("sys.stdout", stdout):
+        run.main()
+
+    assert stdout.getvalue().strip() == "[]"
+
+
 def test_require_existing_daemon_never_auto_starts(monkeypatch):
     monkeypatch.setenv("BH_REQUIRE_EXISTING_DAEMON", "1")
     with patch.object(sys, "argv", ["browser-harness"]), \
@@ -87,6 +101,42 @@ def test_cleanup_failure_does_not_mask_task_error():
     assert "automatic tab cleanup failed: cleanup failed" in stderr.getvalue()
 
 
+def test_cleanup_baseexception_does_not_mask_task_error():
+    class CleanupAbort(BaseException):
+        pass
+
+    stderr = StringIO()
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch(
+             "browser_harness.run.helper_module.close_opened_tabs",
+             side_effect=CleanupAbort("cleanup aborted"),
+         ), \
+         patch("sys.stdin", StringIO("raise RuntimeError('task failed')")), \
+         patch("sys.stderr", stderr), \
+         pytest.raises(RuntimeError, match="task failed"):
+        run.main()
+
+    assert "automatic tab cleanup failed: cleanup aborted" in stderr.getvalue()
+
+
+def test_cleanup_baseexception_propagates_after_success():
+    class CleanupAbort(BaseException):
+        pass
+
+    with patch.object(sys, "argv", ["browser-harness"]), \
+         patch("browser_harness.run.ensure_daemon"), \
+         patch("browser_harness.run.print_update_banner"), \
+         patch(
+             "browser_harness.run.helper_module.close_opened_tabs",
+             side_effect=CleanupAbort("cleanup aborted"),
+         ), \
+         patch("sys.stdin", StringIO("x = 1")), \
+         pytest.raises(CleanupAbort, match="cleanup aborted"):
+        run.main()
+
+
 def test_real_cleanup_runs_after_task_error():
     closed = []
 
@@ -98,13 +148,10 @@ def test_real_cleanup_runs_after_task_error():
     with patch.object(sys, "argv", ["browser-harness"]), \
          patch("browser_harness.run.ensure_daemon"), \
          patch("browser_harness.run.print_update_banner"), \
-         patch.object(run.helper_module, "_OPENED_TABS", {"owned"}), \
-         patch.object(run.helper_module, "_REUSED_BLANK_TABS", {}), \
-         patch.object(run.helper_module, "_KEEP_OPENED_TABS", False), \
          patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
          patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
          patch("browser_harness.helpers.list_tabs", return_value=[]), \
-         patch("sys.stdin", StringIO("raise RuntimeError('task failed')")), \
+         patch("sys.stdin", StringIO("helper_module._OPENED_TABS.add('owned'); raise RuntimeError('task failed')")), \
          pytest.raises(RuntimeError, match="task failed"):
         run.main()
 
@@ -132,8 +179,7 @@ def test_bh_keep_tabs_skips_automatic_cleanup(monkeypatch, value):
          patch("sys.stdin", StringIO("x = 1")):
         run.main()
 
-    keep.assert_any_call()
-    keep.assert_called_with(False)
+    keep.assert_called_once_with()
     cleanup.assert_called_once_with()
 
 
@@ -153,15 +199,16 @@ def test_bh_keep_tabs_releases_owned_and_borrowed_blank_tabs_untouched(monkeypat
     # new_tab() usually reuses the current blank tab instead of creating a
     # new one, so most "kept" tabs in practice go through that path.
     monkeypatch.setenv("BH_KEEP_TABS", "1")
-    run.helper_module._OPENED_TABS.add("created")
-    run.helper_module._REUSED_BLANK_TABS["blank"] = "about:blank"
 
     with patch.object(sys, "argv", ["browser-harness"]), \
          patch("browser_harness.run.ensure_daemon"), \
          patch("browser_harness.run.print_update_banner"), \
          patch("browser_harness.helpers.switch_tab") as switch, \
          patch("browser_harness.helpers.goto_url") as restore, \
-         patch("sys.stdin", StringIO("x = 1")):
+         patch("sys.stdin", StringIO(
+             "helper_module._OPENED_TABS.add('created'); "
+             "helper_module._REUSED_BLANK_TABS['blank'] = 'about:blank'"
+         )):
         run.main()
 
     switch.assert_not_called()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -11,10 +11,12 @@ from browser_harness import run
 def reset_tab_ownership():
     run.helper_module._OPENED_TABS.clear()
     run.helper_module._REUSED_BLANK_TABS.clear()
+    run.helper_module._RETURN_TAB_ID = None
     run.helper_module.keep_opened_tabs(False)
     yield
     run.helper_module._OPENED_TABS.clear()
     run.helper_module._REUSED_BLANK_TABS.clear()
+    run.helper_module._RETURN_TAB_ID = None
     run.helper_module.keep_opened_tabs(False)
 
 

--- a/tests/unit/test_tab_cleanup.py
+++ b/tests/unit/test_tab_cleanup.py
@@ -1,0 +1,216 @@
+from unittest.mock import patch
+
+import pytest
+
+from browser_harness import helpers
+
+
+@pytest.fixture(autouse=True)
+def reset_tab_ownership():
+    helpers._OPENED_TABS.clear()
+    helpers._REUSED_BLANK_TABS.clear()
+    helpers.keep_opened_tabs(False)
+    yield
+    helpers._OPENED_TABS.clear()
+    helpers._REUSED_BLANK_TABS.clear()
+    helpers.keep_opened_tabs(False)
+
+
+def test_new_tab_tracks_only_targets_it_creates():
+    def fake_cdp(method, **kwargs):
+        if method == "Target.createTarget":
+            return {"targetId": "created"}
+        return {}
+
+    with patch("browser_harness.helpers.current_tab", side_effect=RuntimeError("no tab")), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.switch_tab"), \
+         patch("browser_harness.helpers.goto_url"):
+        assert helpers.new_tab("https://example.com") == "created"
+
+    assert helpers.opened_tabs() == ["created"]
+
+
+def test_reused_blank_tab_is_restored_instead_of_closed():
+    with patch("browser_harness.helpers.current_tab", return_value={
+        "targetId": "blank", "target_id": "blank", "url": "about:blank", "title": ""
+    }), patch("browser_harness.helpers.goto_url"):
+        assert helpers.new_tab("https://example.com") == "blank"
+
+    assert helpers.opened_tabs() == []
+
+    with patch("browser_harness.helpers.switch_tab") as switch, \
+         patch("browser_harness.helpers.goto_url") as restore, \
+         patch("browser_harness.helpers.cdp") as cdp:
+        assert helpers.close_opened_tabs() == []
+
+    switch.assert_called_once_with("blank")
+    restore.assert_called_once_with("about:blank")
+    assert not any(call.args[0] == "Target.closeTarget" for call in cdp.call_args_list)
+
+
+def test_cleanup_closes_only_owned_tabs_and_uses_fresh_keeper():
+    helpers._OPENED_TABS.update({"owned-a", "owned-b"})
+    events = []
+
+    def fake_cdp(method, **kwargs):
+        events.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "created"}
+        return {"success": True}
+
+    def fake_switch(target):
+        events.append(("switch", {"targetId": target}))
+
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "owned-b"}), \
+         patch("browser_harness.helpers.switch_tab", side_effect=fake_switch), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        closed = helpers.close_opened_tabs()
+
+    assert set(closed) == {"owned-a", "owned-b"}
+    assert events[:2] == [
+        ("Target.createTarget", {"url": "about:blank"}),
+        ("switch", {"targetId": "created"}),
+    ]
+    close_ids = {
+        kwargs["targetId"] for method, kwargs in events if method == "Target.closeTarget"
+    }
+    assert close_ids == {"owned-a", "owned-b"}
+    assert helpers.opened_tabs() == []
+
+
+def test_cleanup_creates_keeper_before_closing_only_remaining_tab():
+    helpers._OPENED_TABS.add("owned")
+    events = []
+
+    def fake_cdp(method, **kwargs):
+        events.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "keeper"}
+        return {"success": True}
+
+    def fake_switch(target):
+        events.append(("switch", {"targetId": target}))
+
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "owned"}), \
+         patch("browser_harness.helpers.switch_tab", side_effect=fake_switch), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        assert helpers.close_opened_tabs() == ["owned"]
+
+    assert events[:3] == [
+        ("Target.createTarget", {"url": "about:blank"}),
+        ("switch", {"targetId": "keeper"}),
+        ("Target.closeTarget", {"targetId": "owned"}),
+    ]
+
+
+def test_cleanup_keeps_current_tab_if_safe_session_handoff_fails():
+    helpers._OPENED_TABS.update({"current", "other"})
+
+    def fake_cdp(method, **kwargs):
+        if method == "Target.createTarget":
+            return {"targetId": "keeper"}
+        return {"success": True}
+
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "current"}), \
+         patch("browser_harness.helpers.switch_tab", side_effect=RuntimeError("attach failed")), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp) as cdp, \
+         pytest.raises(RuntimeError, match="keeper handoff"):
+        helpers.close_opened_tabs()
+
+    closed = [
+        call.kwargs["targetId"] for call in cdp.call_args_list
+        if call.args[0] == "Target.closeTarget"
+    ]
+    assert closed == ["keeper", "other"]
+    assert "current" in helpers.opened_tabs()
+
+
+def test_keep_opened_tabs_requires_force_to_clean_up():
+    helpers._OPENED_TABS.add("owned")
+    helpers.keep_opened_tabs()
+
+    with patch("browser_harness.helpers.cdp") as cdp:
+        assert helpers.close_opened_tabs() == []
+        cdp.assert_not_called()
+    assert helpers.opened_tabs() == []
+
+    helpers._OPENED_TABS.add("owned")
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
+         patch("browser_harness.helpers.cdp", return_value={"success": True}), \
+         patch("browser_harness.helpers.list_tabs", return_value=[]):
+        assert helpers.close_opened_tabs(force=True) == ["owned"]
+
+
+def test_keep_opened_tabs_still_restores_reused_blank():
+    helpers._OPENED_TABS.add("created")
+    helpers._REUSED_BLANK_TABS["blank"] = "about:blank"
+    helpers.keep_opened_tabs()
+
+    with patch("browser_harness.helpers.switch_tab") as switch, \
+         patch("browser_harness.helpers.goto_url") as restore:
+        assert helpers.close_opened_tabs() == []
+
+    switch.assert_called_once_with("blank")
+    restore.assert_called_once_with("about:blank")
+    assert helpers.opened_tabs() == []
+    assert helpers._REUSED_BLANK_TABS == {}
+
+
+def test_restore_failure_is_reported_and_retained_for_retry():
+    helpers._REUSED_BLANK_TABS["blank"] = "about:blank"
+
+    with patch("browser_harness.helpers.switch_tab", side_effect=RuntimeError("attach failed")), \
+         pytest.raises(RuntimeError, match="blank: attach failed"):
+        helpers.close_opened_tabs()
+
+    assert helpers._REUSED_BLANK_TABS == {"blank": "about:blank"}
+
+
+def test_unknown_current_target_fails_closed():
+    helpers._OPENED_TABS.update({"owned-a", "owned-b"})
+
+    with patch("browser_harness.helpers.current_tab", side_effect=RuntimeError("unknown")), \
+         patch("browser_harness.helpers.cdp") as cdp, \
+         pytest.raises(RuntimeError, match="current target: unknown"):
+        helpers.close_opened_tabs()
+
+    cdp.assert_not_called()
+    assert set(helpers.opened_tabs()) == {"owned-a", "owned-b"}
+
+
+def test_failed_close_is_retried_and_retained():
+    helpers._OPENED_TABS.add("owned")
+
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
+         patch("browser_harness.helpers.cdp", side_effect=RuntimeError("close failed")) as cdp, \
+         pytest.raises(RuntimeError, match="owned: close failed"):
+        helpers.close_opened_tabs()
+
+    assert cdp.call_count == 2
+    assert helpers.opened_tabs() == ["owned"]
+
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
+         patch("browser_harness.helpers.cdp", return_value={"success": True}), \
+         patch("browser_harness.helpers.list_tabs", return_value=[]):
+        assert helpers.close_opened_tabs() == ["owned"]
+    assert helpers.opened_tabs() == []
+
+
+def test_failed_keeper_cleanup_is_retained_for_retry():
+    helpers._OPENED_TABS.update({"current", "other"})
+
+    def fake_cdp(method, **kwargs):
+        if method == "Target.createTarget":
+            return {"targetId": "keeper"}
+        if method == "Target.closeTarget" and kwargs["targetId"] == "keeper":
+            raise RuntimeError("keeper close failed")
+        return {"success": True}
+
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "current"}), \
+         patch("browser_harness.helpers.switch_tab", side_effect=RuntimeError("attach failed")), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         pytest.raises(RuntimeError, match="keeper: keeper close failed"):
+        helpers.close_opened_tabs()
+
+    assert set(helpers.opened_tabs()) == {"current", "keeper"}

--- a/tests/unit/test_tab_cleanup.py
+++ b/tests/unit/test_tab_cleanup.py
@@ -142,7 +142,11 @@ def test_keep_opened_tabs_requires_force_to_clean_up():
         assert helpers.close_opened_tabs(force=True) == ["owned"]
 
 
-def test_keep_opened_tabs_still_restores_reused_blank():
+def test_keep_opened_tabs_does_not_restore_reused_blank():
+    # Regression: new_tab() usually reuses the current blank tab instead of
+    # creating a new one, so most "kept" tabs in practice are reused-blank
+    # ones. keep_opened_tabs() must protect those too, or it silently fails
+    # for the common single-tab case a caller relies on it for.
     helpers._OPENED_TABS.add("created")
     helpers._REUSED_BLANK_TABS["blank"] = "about:blank"
     helpers.keep_opened_tabs()
@@ -151,9 +155,25 @@ def test_keep_opened_tabs_still_restores_reused_blank():
          patch("browser_harness.helpers.goto_url") as restore:
         assert helpers.close_opened_tabs() == []
 
+    switch.assert_not_called()
+    restore.assert_not_called()
+    assert helpers.opened_tabs() == []
+    assert helpers._REUSED_BLANK_TABS == {}
+
+
+def test_keep_opened_tabs_force_still_restores_reused_blank():
+    helpers._REUSED_BLANK_TABS["blank"] = "about:blank"
+    helpers.keep_opened_tabs()
+
+    with patch("browser_harness.helpers.switch_tab") as switch, \
+         patch("browser_harness.helpers.goto_url") as restore, \
+         patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
+         patch("browser_harness.helpers.cdp", return_value={"success": True}), \
+         patch("browser_harness.helpers.list_tabs", return_value=[]):
+        assert helpers.close_opened_tabs(force=True) == []
+
     switch.assert_called_once_with("blank")
     restore.assert_called_once_with("about:blank")
-    assert helpers.opened_tabs() == []
     assert helpers._REUSED_BLANK_TABS == {}
 
 

--- a/tests/unit/test_tab_cleanup.py
+++ b/tests/unit/test_tab_cleanup.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -31,6 +32,50 @@ def test_new_tab_tracks_only_targets_it_creates():
         assert helpers.new_tab("https://example.com") == "created"
 
     assert helpers.opened_tabs() == ["created"]
+
+
+def test_tab_cap_defaults_to_fifteen_and_closes_oldest_while_preserving_current(monkeypatch):
+    monkeypatch.delenv("BH_MAX_TABS", raising=False)
+    helpers._OPENED_TABS.add("tab-1")
+    helpers._REUSED_BLANK_TABS["tab-2"] = "about:blank"
+    helpers._RETURN_TAB_ID = "tab-1"
+    pages = [
+        {"id": f"tab-{index}", "type": "page", "url": f"https://example.com/{index}"}
+        for index in reversed(range(17))
+    ]
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = json.dumps(pages).encode()
+
+    with patch("browser_harness.helpers._send", return_value={"endpoint": "http://127.0.0.1:9222"}), \
+         patch("browser_harness.helpers.urllib.request.urlopen", return_value=response), \
+         patch("browser_harness.helpers.cdp", return_value={"success": True}) as cdp:
+        helpers._reap_tabs("tab-0")
+
+    closed = [
+        call.kwargs["targetId"] for call in cdp.call_args_list
+        if call.args[0] == "Target.closeTarget"
+    ]
+    assert closed == ["tab-1", "tab-2"]
+    assert helpers.opened_tabs() == []
+    assert helpers._REUSED_BLANK_TABS == {}
+    assert helpers._RETURN_TAB_ID is None
+
+
+def test_zero_tab_cap_disables_reaping(monkeypatch):
+    monkeypatch.setenv("BH_MAX_TABS", "0")
+    with patch("browser_harness.helpers._send") as send:
+        helpers._reap_tabs("current")
+    send.assert_not_called()
+
+
+def test_reused_blank_tab_still_enforces_global_tab_cap():
+    with patch("browser_harness.helpers.current_tab", return_value={
+        "targetId": "blank", "target_id": "blank", "url": "about:blank", "title": ""
+    }), patch("browser_harness.helpers.goto_url"), \
+         patch("browser_harness.helpers._reap_tabs") as reap:
+        assert helpers.new_tab("https://example.com") == "blank"
+
+    reap.assert_called_once_with("blank")
 
 
 def test_new_tab_remembers_preexisting_return_tab():

--- a/tests/unit/test_tab_cleanup.py
+++ b/tests/unit/test_tab_cleanup.py
@@ -186,8 +186,8 @@ def test_cleanup_keeps_current_tab_if_safe_session_handoff_fails():
         call.kwargs["targetId"] for call in cdp.call_args_list
         if call.args[0] == "Target.closeTarget"
     ]
-    assert closed == ["other"]
-    assert "current" in helpers.opened_tabs()
+    assert closed == ["keeper", "other"]
+    assert helpers.opened_tabs() == ["current"]
 
 
 def test_close_tab_releases_explicitly_closed_owned_target():
@@ -276,7 +276,7 @@ def test_unknown_current_target_fails_closed():
     assert set(helpers.opened_tabs()) == {"owned-a", "owned-b"}
 
 
-def test_failed_close_is_retried_and_retained():
+def test_failed_close_is_retried_and_reported():
     helpers._OPENED_TABS.add("owned")
 
     with patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
@@ -287,12 +287,6 @@ def test_failed_close_is_retried_and_retained():
     assert cdp.call_count == 2
     assert helpers.opened_tabs() == ["owned"]
 
-    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "survivor"}), \
-         patch("browser_harness.helpers.cdp", return_value={"success": True}), \
-         patch("browser_harness.helpers.list_tabs", return_value=[]):
-        assert helpers.close_opened_tabs() == ["owned"]
-    assert helpers.opened_tabs() == []
-
 
 def test_failed_keeper_handoff_never_closes_ambiguous_keeper():
     helpers._OPENED_TABS.update({"current", "other"})
@@ -302,7 +296,10 @@ def test_failed_keeper_handoff_never_closes_ambiguous_keeper():
             return {"targetId": "keeper"}
         return {"success": True}
 
-    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "current"}), \
+    with patch(
+        "browser_harness.helpers.current_tab",
+        side_effect=[{"targetId": "current"}, RuntimeError("unknown handoff")],
+    ), \
          patch("browser_harness.helpers.switch_tab", side_effect=RuntimeError("attach failed")), \
          patch("browser_harness.helpers.cdp", side_effect=fake_cdp) as cdp, \
          pytest.raises(RuntimeError, match="keeper handoff"):

--- a/tests/unit/test_tab_cleanup.py
+++ b/tests/unit/test_tab_cleanup.py
@@ -67,6 +67,25 @@ def test_reused_blank_tab_is_restored_instead_of_closed():
     assert not any(call.args[0] == "Target.closeTarget" for call in cdp.call_args_list)
 
 
+@pytest.mark.parametrize(
+    "internal_url",
+    ["chrome://newtab/", "chrome://new-tab-page/", "edge://newtab/", "about:newtab"],
+)
+def test_reused_internal_new_tab_restores_to_about_blank(internal_url):
+    with patch("browser_harness.helpers.current_tab", return_value={
+        "targetId": "blank", "target_id": "blank", "url": internal_url, "title": "New Tab"
+    }), patch("browser_harness.helpers.goto_url"):
+        assert helpers.new_tab("https://example.com") == "blank"
+
+    assert helpers._REUSED_BLANK_TABS == {"blank": "about:blank"}
+
+    with patch("browser_harness.helpers.switch_tab"), \
+         patch("browser_harness.helpers.goto_url") as restore:
+        helpers.close_opened_tabs()
+
+    restore.assert_called_once_with("about:blank")
+
+
 def test_cleanup_closes_only_owned_tabs_and_uses_fresh_keeper():
     helpers._OPENED_TABS.update({"owned-a", "owned-b"})
     events = []
@@ -167,8 +186,21 @@ def test_cleanup_keeps_current_tab_if_safe_session_handoff_fails():
         call.kwargs["targetId"] for call in cdp.call_args_list
         if call.args[0] == "Target.closeTarget"
     ]
-    assert closed == ["keeper", "other"]
+    assert closed == ["other"]
     assert "current" in helpers.opened_tabs()
+
+
+def test_close_tab_releases_explicitly_closed_owned_target():
+    helpers._OPENED_TABS.add("owned")
+    helpers._REUSED_BLANK_TABS["owned"] = "about:blank"
+    helpers._RETURN_TAB_ID = "owned"
+
+    with patch("browser_harness.helpers.cdp", return_value={"success": True}):
+        helpers.close_tab("owned")
+
+    assert helpers.opened_tabs() == []
+    assert helpers._REUSED_BLANK_TABS == {}
+    assert helpers._RETURN_TAB_ID is None
 
 
 def test_keep_opened_tabs_requires_force_to_clean_up():
@@ -262,20 +294,23 @@ def test_failed_close_is_retried_and_retained():
     assert helpers.opened_tabs() == []
 
 
-def test_failed_keeper_cleanup_is_retained_for_retry():
+def test_failed_keeper_handoff_never_closes_ambiguous_keeper():
     helpers._OPENED_TABS.update({"current", "other"})
 
     def fake_cdp(method, **kwargs):
         if method == "Target.createTarget":
             return {"targetId": "keeper"}
-        if method == "Target.closeTarget" and kwargs["targetId"] == "keeper":
-            raise RuntimeError("keeper close failed")
         return {"success": True}
 
     with patch("browser_harness.helpers.current_tab", return_value={"targetId": "current"}), \
          patch("browser_harness.helpers.switch_tab", side_effect=RuntimeError("attach failed")), \
-         patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
-         pytest.raises(RuntimeError, match="keeper: keeper close failed"):
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp) as cdp, \
+         pytest.raises(RuntimeError, match="keeper handoff"):
         helpers.close_opened_tabs()
 
-    assert set(helpers.opened_tabs()) == {"current", "keeper"}
+    closed = [
+        call.kwargs["targetId"] for call in cdp.call_args_list
+        if call.args[0] == "Target.closeTarget"
+    ]
+    assert closed == ["other"]
+    assert helpers.opened_tabs() == ["current"]

--- a/tests/unit/test_tab_cleanup.py
+++ b/tests/unit/test_tab_cleanup.py
@@ -170,10 +170,15 @@ def test_cleanup_creates_keeper_before_closing_only_remaining_tab():
 
 def test_cleanup_keeps_current_tab_if_safe_session_handoff_fails():
     helpers._OPENED_TABS.update({"current", "other"})
+    attempts = {"keeper": 0}
 
     def fake_cdp(method, **kwargs):
         if method == "Target.createTarget":
             return {"targetId": "keeper"}
+        if method == "Target.closeTarget" and kwargs["targetId"] == "keeper":
+            attempts["keeper"] += 1
+            if attempts["keeper"] == 1:
+                raise RuntimeError("transient close failure")
         return {"success": True}
 
     with patch("browser_harness.helpers.current_tab", return_value={"targetId": "current"}), \
@@ -186,7 +191,7 @@ def test_cleanup_keeps_current_tab_if_safe_session_handoff_fails():
         call.kwargs["targetId"] for call in cdp.call_args_list
         if call.args[0] == "Target.closeTarget"
     ]
-    assert closed == ["keeper", "other"]
+    assert closed == ["keeper", "keeper", "other"]
     assert helpers.opened_tabs() == ["current"]
 
 

--- a/tests/unit/test_tab_cleanup.py
+++ b/tests/unit/test_tab_cleanup.py
@@ -9,10 +9,12 @@ from browser_harness import helpers
 def reset_tab_ownership():
     helpers._OPENED_TABS.clear()
     helpers._REUSED_BLANK_TABS.clear()
+    helpers._RETURN_TAB_ID = None
     helpers.keep_opened_tabs(False)
     yield
     helpers._OPENED_TABS.clear()
     helpers._REUSED_BLANK_TABS.clear()
+    helpers._RETURN_TAB_ID = None
     helpers.keep_opened_tabs(False)
 
 
@@ -29,6 +31,22 @@ def test_new_tab_tracks_only_targets_it_creates():
         assert helpers.new_tab("https://example.com") == "created"
 
     assert helpers.opened_tabs() == ["created"]
+
+
+def test_new_tab_remembers_preexisting_return_tab():
+    def fake_cdp(method, **kwargs):
+        if method == "Target.createTarget":
+            return {"targetId": "created"}
+        return {}
+
+    with patch("browser_harness.helpers.current_tab", return_value={
+        "targetId": "baseline", "target_id": "baseline", "url": "https://example.test", "title": "baseline"
+    }), patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.switch_tab"), \
+         patch("browser_harness.helpers.goto_url"):
+        assert helpers.new_tab("https://example.com") == "created"
+
+    assert helpers._RETURN_TAB_ID == "baseline"
 
 
 def test_reused_blank_tab_is_restored_instead_of_closed():
@@ -77,6 +95,33 @@ def test_cleanup_closes_only_owned_tabs_and_uses_fresh_keeper():
     }
     assert close_ids == {"owned-a", "owned-b"}
     assert helpers.opened_tabs() == []
+
+
+def test_cleanup_returns_to_preexisting_tab_instead_of_creating_keeper():
+    helpers._OPENED_TABS.add("owned")
+    helpers._RETURN_TAB_ID = "baseline"
+    events = []
+
+    def fake_cdp(method, **kwargs):
+        events.append((method, kwargs))
+        if method == "Target.createTarget":
+            raise AssertionError("must reuse the pre-existing return tab")
+        return {"success": True}
+
+    def fake_switch(target):
+        events.append(("switch", {"targetId": target}))
+
+    with patch("browser_harness.helpers.current_tab", return_value={"targetId": "owned"}), \
+         patch("browser_harness.helpers.switch_tab", side_effect=fake_switch), \
+         patch("browser_harness.helpers.cdp", side_effect=fake_cdp), \
+         patch("browser_harness.helpers.list_tabs", return_value=[]):
+        assert helpers.close_opened_tabs() == ["owned"]
+
+    assert events == [
+        ("switch", {"targetId": "baseline"}),
+        ("Target.closeTarget", {"targetId": "owned"}),
+    ]
+    assert helpers._RETURN_TAB_ID is None
 
 
 def test_cleanup_creates_keeper_before_closing_only_remaining_tab():


### PR DESCRIPTION
## What changes

- Tracks tabs created or borrowed by each CLI invocation and cleans them up on success or failure.
- Preserves unrelated tabs during ownership cleanup and supports explicit keep-open behavior.
- Adds the browser-wide backstop from #520, refreshed for the ownership model: `new_tab()` keeps at most 15 work tabs by default, preserves the current target, skips browser UI pages, and supports `BH_MAX_TABS=0` to disable.
- Enforces the cap even when `new_tab()` reuses an existing blank tab.

This keeps normal cleanup precise while preventing missed, popup, or abandoned tabs from growing without bound. The cap is part of this PR rather than a separate patch.

## Verification

- Unit suite: 230 passed.
- Isolated Brave/CDP smoke: 17 work tabs settled at 15; invocation cleanup left one neutral tab.

Tab-ceiling implementation is based on #520 by @daniel771277.
