### PR TITLE
Add battlefy domain skill: organizer tournament-creation flow

### DIFF
--- a/agent-workspace/domain-skills/battlefy/create-tournament.md
+++ b/agent-workspace/domain-skills/battlefy/create-tournament.md
@@ -1,0 +1,40 @@
+# Battlefy — create a tournament (organizer flow)
+
+Verified 2026-09-01 by creating a live Fortnite 5v5 double-elim tournament end-to-end.
+
+## URL patterns
+
+- Organizer hub: sidebar "Organize Tournaments" on battlefy.com → org list. Orgs at `/{org-slug}`.
+- Create wizard: `battlefy.com/create-tournament?orgSlug={org-slug}` (game picker) → `battlefy.com/create-tournament-wizard?selectedItem={setup|brackets|streams|publish}&selectedTab=...`. The wizard is an Angular SPA; the draft tournament is created server-side only after Setup completes (it then appears in the org sidebar).
+- Admin (after creation): `/{org-slug}/{tournament-slug}/{tournamentId}/admin?selectedItem=...`
+- Public page: `/{org-slug}/{tournament-slug}/{tournamentId}/info` — shows "Registration Open", "Join as Team".
+
+## Wizard flow (Setup → Brackets → Streams → Publish)
+
+Setup has three tabs: Basics, Info, Settings. **The tab links at the top do nothing until you advance with the bottom-right "Next" button** — Next validates the current tab and moves you forward; don't fight the tab links.
+
+- **Basics**: game (preselected from picker), tournament name, start date, start time.
+  - ⚠️ Date field is **DD/MM/YYYY** (label says so, easy to misread as US format). Sept 5 2026 = `05/09/2026`. Time defaults to 7:00 PM, timezone shown next to the field (EDT for US-East accounts).
+- **Info**: "How will your players contact you?" — **required before Next**, red "Contact details are required" otherwise. Dropdown: Discord/Facebook/Twitter/Email/Curse/Teamspeak/IRC/Twitch/Custom. Picking Discord reveals a "non-expiring Discord invite link" textbox. About/Rules/Prizes/Schedule expanders are optional.
+  - Next can race form updates — if you get the "fill out all required elements" toast with visibly filled fields, just click Next again.
+- **Settings**: Region, Platform (Fortnite offers Cross Platform), Tournament Format: `1v1` / `Pre-Made Teams` / `Free Agent Draft` / `Pre-Mades & Free Agents`. Selecting Pre-Made Teams reveals a players-per-team number input (defaults to 5). Also: check-in toggle, score reporting (default Admins & Players), participant limit (default Unlimited).
+
+## Brackets
+
+"Create an Elimination Bracket" expander → name, start date/time (inherited), Single/Double Elimination radio, bracket size (# of teams; unused slots become byes).
+
+- Fortnite elimination brackets default to **Aggregate** scoring (points across N games). For classic series play switch Scoring Format to **"Best Of" Scoring** — this reveals **per-round Best of 1/3/5/7/9/11 dropdowns** for every round: Winners R1–Rn, Losers R1–R(2n-2), Grand Finals Round 1 and Round 2 (the bracket-reset match), plus a "Best of for all rounds" master dropdown.
+- ⚠️ Clicking **Save** after changing scoring format pops a "Reset And Update Bracket" confirm — resets the bracket and unseeds teams. Harmless pre-registration; destructive after seeding.
+
+## Publish
+
+Draft/Published and Private/Public segmented toggles + optional Join Codes.
+
+- ⚠️ These toggles are **non-semantic** (`div.label.right` etc.) — invisible to the accessibility tree and unreliable for coordinate clicks. DOM click works: find leaf element whose `textContent.trim() === 'Published'` (or `'Public'`) and `.click()` it.
+- Publishing pops a confirm modal ("players will be able to register… no longer able to edit fields that affect registration") → Publish. Then Finish → "Success!" modal.
+- Invite link lives at Share → Invite Players in the admin sidebar (`.../info` URL with copy button).
+
+## Traps
+
+- Battlefy accounts: creation requires login; organizer actions live under an **organization** (create one via "+ New Organization" if the account has none).
+- The wizard keeps unsaved SPA state — don't reload mid-wizard before the tournament shows in the org sidebar.


### PR DESCRIPTION
Adds `agent-workspace/domain-skills/battlefy/create-tournament.md` — the organizer-side tournament creation flow, field-tested end-to-end (created a live Fortnite 5v5 double-elim tournament).

Covers:
- URL patterns for the create wizard, admin panel, and public info page
- Wizard order (Setup: Basics/Info/Settings → Brackets → Streams → Publish) and why the top tab links are inert until Next
- DD/MM/YYYY date-field trap
- Required player-contact step and its race with Next
- `Pre-Made Teams` format revealing the players-per-team input
- Per-round Best-of dropdowns hidden behind switching scoring format from Fortnite's Aggregate default to "Best Of" Scoring, and the bracket-reset confirm on save
- Publish screen's non-semantic Draft/Published + Private/Public toggles (invisible to the a11y tree; DOM `.click()` on the text leaf works)

No coordinates, no user-specific state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Battlefy domain skill for the organizer tournament-creation flow, verified end-to-end by creating a live Fortnite 5v5 double-elim tournament.

- Covers URL patterns for the create wizard, admin panel, and public info page.
- Documents the Setup → Brackets → Streams → Publish wizard order and the inert top tab links.
- Records the DD/MM/YYYY date-field trap, the required player-contact step, and its race with Next.
- Explains that Pre-Made Teams reveals the players-per-team input and Best Of Scoring enables per-round Best-of dropdowns, plus the bracket-reset dialog on save.
- Flags the publish Draft/Published and Private/Public toggles as non-semantic, requiring DOM `.click()` on the text leaf.
- Contains no coordinates or user-specific state.

<sup>Written for commit 544de952407bd00bc6e7a901e59384e9c2a934b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

