### PR TITLE
fix: guard uv upgrade path when uv is missing

### DIFF
--- a/docs/plans/2026-09-01-2115-fix-update-uv-missing-plan.md
+++ b/docs/plans/2026-09-01-2115-fix-update-uv-missing-plan.md
@@ -1,0 +1,84 @@
+---
+title: Fix --update crash when uv is missing - Plan
+type: fix
+date: 2026-09-01
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+## Goal Capsule
+
+- **Objective:** `browser-harness --update` exits with a clear, actionable error message when the package was installed from PyPI and `uv` is not on PATH, instead of crashing with `FileNotFoundError`.
+- **Means:** Detect `uv` availability before invoking it and report the missing prerequisite (KTD1).
+- **Stop conditions:** The update path reports the missing-uv case cleanly, existing update paths keep working, and the unit suite passes.
+
+## Product Contract
+
+### Summary
+
+`run_update()` in `src/browser_harness/admin.py` upgrades a PyPI-installed `browser-harness` by shelling out to `uv tool upgrade browser-harness` with no availability check. On a machine without `uv`, `subprocess.run` raises `FileNotFoundError`, which escapes as a traceback. The fix adds a `shutil.which("uv")` guard that prints an actionable message and returns a non-zero exit code.
+
+### Problem Frame
+
+The PyPI install path already has an "unknown install mode" error branch, but the `pypi` branch assumes `uv` exists. `uv` is the recommended install tool but not universal — users may have used `pip` or `pipx`. The crash is a poor UX regression for those users.
+
+### Requirements
+
+- R1. When install mode is `pypi` and `uv` is not on PATH, `--update` prints a clear error telling the user `uv` is required to auto-update, and exits non-zero.
+- R2. When install mode is `pypi` and `uv` is present, `--update` keeps the existing `uv tool upgrade browser-harness` behavior.
+- R3. The `git` and `unknown` install-mode paths are unchanged.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Use `shutil.which("uv")` to detect `uv` before the `pypi` upgrade branch. Rationale: `shutil.which` is the existing convention in this file (used at `admin.py:748, 773, 1021`), and it is dependency-free.
+
+### Assumptions
+
+- A. A user on the `pypi` path without `uv` is expected to upgrade via `pip`/`pipx`/their package manager manually; `--update` only needs to say so.
+
+### Sequencing
+
+- U1 is the only unit; no dependencies.
+
+### Deferred to Follow-Up Work
+
+- The uv-present-but-not-uv-managed case: a pip/pipx-installed package on a machine where `uv` happens to be on PATH still gets uv's raw "not installed via uv" error from `uv tool upgrade`. Out of scope for this fix (R2 preserves existing behavior), but the same population the Problem Frame names would benefit from an actionable error there too.
+
+## Implementation Units
+
+### U1. Guard the uv upgrade path in run_update
+
+- **Goal:** `--update` fails cleanly with an actionable message when `uv` is absent, and behaves identically when `uv` is present.
+- **Requirements:** R1, R2, R3
+- **Files:**
+  - `src/browser_harness/admin.py`
+  - `tests/unit/test_admin.py`
+- **Approach:**
+  1. In the `elif mode == "pypi":` branch of `run_update()`, before the `subprocess.run(["uv", ...])` call, check `shutil.which("uv")`.
+  2. When `uv` is missing, print an error to stderr naming the missing prerequisite and pointing at the manual upgrade route for the tool the user installed with (`pip install --upgrade browser-harness`, `pipx upgrade browser-harness`, or their package manager), then `return 1`.
+  3. Keep the existing `subprocess.run` call in the `uv`-present case.
+- **Patterns to follow:** The `shutil.which` guard pattern at `admin.py:748` and `admin.py:773`; the stderr + non-zero exit convention in the `git status failed` branch at `admin.py:1219-1221`.
+- **Test scenarios:**
+  - Happy path: `run_update` with `_install_mode()` returning `"pypi"`, `shutil.which("uv")` returning a path, and a mocked `subprocess.run` returning returncode 0 → exits 0, calls `subprocess.run` with `["uv", "tool", "upgrade", "browser-harness"]`.
+  - Error path: `_install_mode()` returns `"pypi"` and `shutil.which("uv")` returns `None` → exits 1, prints a message containing `uv` to stderr, and never calls `subprocess.run`.
+  - Regression: `_install_mode()` returns `"git"` → the uv guard is not hit; existing git-path behavior is preserved.
+  - Regression: `_install_mode()` returns `"unknown"` → existing "unknown install mode" error branch is preserved.
+  - Hermeticity: every `run_update` test mocks `check_for_update()` and `daemon_alive()`/`_prompt_yes` so no test hits PyPI over the network or restarts a live daemon — matching the existing suite convention at `tests/unit/test_admin.py` (network is treated as a failure).
+- **Verification:** `uv run --with pytest python -m pytest tests/unit/test_admin.py -q` passes, including the new scenarios; the full unit suite still passes.
+
+## Verification Contract
+
+- Run `uv run --with pytest python -m pytest tests/unit -q` from the repo root. All tests pass.
+- No live browser or network is required.
+
+## Definition of Done
+
+- The `pypi`-mode missing-`uv` case produces a clear stderr message and exit code 1, with no `FileNotFoundError` traceback.
+- The `pypi`-mode `uv`-present case still runs `uv tool upgrade browser-harness`.
+- New unit tests cover the missing-uv and uv-present branches.
+- The full unit suite passes.
+- Cleanup: no dead-end code or stray files remain in the diff.

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1227,6 +1227,16 @@ def run_update(yes=False):
         if r.returncode != 0:
             return r.returncode
     elif mode == "pypi":
+        import shutil
+        if not shutil.which("uv"):
+            print(
+                "browser-harness --update needs uv, which is not on PATH. "
+                "Upgrade manually with the tool you installed it with "
+                "(pip install --upgrade browser-harness, pipx upgrade browser-harness, "
+                "or your system package manager).",
+                file=sys.stderr,
+            )
+            return 1
         tool_upgrade = subprocess.run(["uv", "tool", "upgrade", "browser-harness"])
         if tool_upgrade.returncode != 0:
             return tool_upgrade.returncode

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -886,3 +886,84 @@ def test_process_start_time_returns_none_for_invalid_pid():
         )
     # 2**31 - 1 is the largest pid_t; in practice no live process at that PID.
     assert admin._process_start_time((1 << 31) - 1) is None
+
+
+def _run_update_hermetic(monkeypatch, *, install_mode, which_result, subprocess_result):
+    """Drive run_update with network and daemon-restart surfaces mocked out."""
+    called = []
+
+    monkeypatch.setattr(admin, "check_for_update", lambda: ("0.1.0", "0.2.0", True))
+    monkeypatch.setattr(admin, "_install_mode", lambda: install_mode)
+    monkeypatch.setattr("shutil.which", lambda _cmd: which_result)
+
+    def fake_subprocess_run(argv, *args, **kwargs):
+        called.append(argv)
+        # Git-mode calls (status preflight and pull) read .returncode; the
+        # status preflight also reads captured .stdout/.stderr.
+        if "capture_output" in kwargs or argv[0] == "git":
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        return subprocess_result
+
+    monkeypatch.setattr("subprocess.run", fake_subprocess_run)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: False)
+    return called
+
+
+def test_run_update_pypi_missing_uv_prints_error_and_exits_nonzero(monkeypatch, capsys):
+    """A PyPI install with no `uv` on PATH must fail cleanly instead of a
+    FileNotFoundError traceback, and must never invoke subprocess.run."""
+    called = _run_update_hermetic(
+        monkeypatch,
+        install_mode="pypi",
+        which_result=None,
+        subprocess_result=None,
+    )
+
+    assert admin.run_update() == 1
+    assert called == [], "must not shell out to uv when uv is missing"
+    err = capsys.readouterr().err
+    assert "uv" in err
+    assert "pip" in err or "pipx" in err or "package manager" in err
+
+
+def test_run_update_pypi_with_uv_runs_uv_tool_upgrade(monkeypatch):
+    """A PyPI install with `uv` on PATH keeps the existing upgrade behavior."""
+    called = _run_update_hermetic(
+        monkeypatch,
+        install_mode="pypi",
+        which_result="/usr/local/bin/uv",
+        subprocess_result=type("R", (), {"returncode": 0})(),
+    )
+
+    assert admin.run_update() == 0
+    assert called == [["uv", "tool", "upgrade", "browser-harness"]]
+
+
+def test_run_update_git_mode_skips_uv_guard(monkeypatch):
+    """The git install-mode path is untouched by the uv guard."""
+    called = _run_update_hermetic(
+        monkeypatch,
+        install_mode="git",
+        which_result=None,
+        subprocess_result=None,
+    )
+
+    # git mode runs `git status --porcelain` then `git pull --ff-only`.
+    assert admin.run_update() == 0
+    assert called and called[0] == ["git", "-C", str(admin._repo_dir()), "status", "--porcelain"]
+    assert all(argv[0] == "git" for argv in called)
+
+
+def test_run_update_unknown_mode_keeps_error_branch(monkeypatch, capsys):
+    """The unknown install-mode error branch is preserved."""
+    called = _run_update_hermetic(
+        monkeypatch,
+        install_mode="unknown",
+        which_result=None,
+        subprocess_result=None,
+    )
+
+    assert admin.run_update() == 1
+    assert called == [], "unknown mode must not shell out"
+    assert "unknown install mode" in capsys.readouterr().err
+

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -889,12 +889,15 @@ def test_process_start_time_returns_none_for_invalid_pid():
 
 
 def _run_update_hermetic(monkeypatch, *, install_mode, which_result, subprocess_result):
-    """Drive run_update with network and daemon-restart surfaces mocked out."""
+    """Drive run_update with network, cache, and daemon-restart surfaces mocked out."""
     called = []
 
     monkeypatch.setattr(admin, "check_for_update", lambda: ("0.1.0", "0.2.0", True))
     monkeypatch.setattr(admin, "_install_mode", lambda: install_mode)
     monkeypatch.setattr("shutil.which", lambda _cmd: which_result)
+    # The success tail clears the version-cache banner; keep it off the real config dir.
+    monkeypatch.setattr(admin, "_cache_read", lambda: {})
+    monkeypatch.setattr(admin, "_cache_write", lambda _data: None)
 
     def fake_subprocess_run(argv, *args, **kwargs):
         called.append(argv)
@@ -948,7 +951,7 @@ def test_run_update_git_mode_skips_uv_guard(monkeypatch):
         subprocess_result=None,
     )
 
-    # git mode runs `git status --porcelain` then `git pull --ff-only`.
+    # git mode shells out only to git, never to uv.
     assert admin.run_update() == 0
     assert called and called[0] == ["git", "-C", str(admin._repo_dir()), "status", "--porcelain"]
     assert all(argv[0] == "git" for argv in called)


### PR DESCRIPTION
`browser-harness --update` on a PyPI install no longer crashes with a `FileNotFoundError` traceback when `uv` is not on PATH. It now prints an actionable stderr message naming the manual upgrade routes (pip, pipx, or the system package manager) and exits 1, so agents and users get a clear path instead of an opaque crash.

The `uv`-present upgrade path and the git/unknown install-mode branches are unchanged. New hermetic unit tests cover the missing-uv, uv-present, git-mode, and unknown-mode branches (network, cache, and daemon-restart surfaces mocked).

Fixes #688


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `browser-harness --update` crashing with a `FileNotFoundError` traceback when a PyPI install lacks `uv` on PATH. The command now prints an actionable stderr message with manual upgrade options and exits 1.

- The uv-present, git, and unknown install-mode branches are unchanged.
- New hermetic unit tests cover the missing-uv, uv-present, git, and unknown branches.

Fixes #688.

<sup>Written for commit d3e2acc48d45588bd09159732fb6c920c85cce87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

