### PR TITLE
domain-skills: add Neptune Cigar promotion checks

### DIFF
--- a/domain-skills/neptunecigar/site.md
+++ b/domain-skills/neptunecigar/site.md
@@ -1,0 +1,16 @@
+# Neptune Cigar
+
+## Promotions and coupon detection
+
+- Do not rely on homepage body text, search snippets, or product-list extraction alone. Take a screenshot of the rendered homepage/header and cart because active promotions can appear as a small coupon badge beside the cart.
+- The active coupon badge is exposed at `#couponContent` / `#couponCode`. The coupon code is in `data-value`; the rendered text includes the percentage and expiration. Example shape: `<div id="couponCode" data-value="CODE"><span class="classValue">21%</span> ...`.
+- Coupon state is session/cart dependent, so inspect the rendered badge after opening the site and again after adding an item.
+
+## Product and cart verification
+
+- Product variants use `button.pr_ddBtn` with IDs such as `btn<variantId>` and an inline `addToCart(this, <variantId>)` handler.
+- The shopping cart route is `/shopping-cart`. Eligible products show a cash coupon line in totals. Restricted products are explicitly labeled `Excluded From Coupon` on their cart row.
+- During percentage promotions, restricted products may receive `BONUS POINTS` instead of cash savings. Report bonus Smoke Rings separately from the cash-discount calculation.
+- Gift-with-purchase items can be inserted automatically and appear as additional cart items at $0.
+- Before testing, record the existing cart. Remove only test items and verify the original cart state afterward. Cart item detail IDs appear in trash handlers such as `RemoveItem('<detailId>')`; the underlying service is `NeptuneWebServices.UpdateShoppingCart(detailId, '0', callback)`.
+


### PR DESCRIPTION
Adds a Neptune Cigar domain skill covering visual coupon detection, session-applied promotion badges, restricted-brand bonus-point handling, gift-with-purchase cart behavior, and reversible cart verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Neptune Cigar domain skill so automated checks can detect active coupons and verify cart behavior accurately.

**New Features**
- Records the rendered coupon badge selectors and session-dependent coupon state.
- Documents product variant buttons, cart route, restricted-brand bonus-point handling, and gift-with-purchase items.
- Requires recording the original cart before testing and verifying it after removing test items.

<sup>Written for commit 4c14131beb99af8e54719d8123a1b623b2e7eb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

