### PR TITLE
fix: correct MCP tool signatures in mcp_server

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -213,7 +213,7 @@ def browser_current_tab():
 
 @_tool
 def browser_switch_tab(target: str):
-    """Switch to tab by `targetId` or URL substring. Returns the sessionId."""
+    """Switch to a tab by its `targetId`. Returns the sessionId."""
     return {"sessionId": switch_tab(target)}
 
 
@@ -259,7 +259,7 @@ def browser_js(expression: str, target_id: str | None = None):
 
 
 @_tool
-def browser_cdp(method: str, params: dict = {}):
+def browser_cdp(method: str, params: dict | None = None):
     """Call a raw Chrome DevTools Protocol method. `params` are passed as kwargs."""
     return cdp(method, **(params or {}))
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,34 @@
+"""Tests for the MCP server tool wrappers in mcp_server.py.
+
+Importing mcp_server requires the optional `mcp` extra; run the unit suite
+with `uv run --extra mcp --with pytest python -m pytest tests/unit -q`.
+"""
+import inspect
+
+import mcp_server
+
+
+def test_browser_switch_tab_docstring_does_not_advertise_url_substring():
+    """The tool description must match what switch_tab() actually does:
+    switching by targetId only, with no URL-substring matching."""
+    doc = mcp_server.browser_switch_tab.__doc__ or ""
+    assert "URL substring" not in doc
+    assert "targetId" in doc
+
+
+def test_browser_cdp_uses_none_default_for_params():
+    """browser_cdp must not use a mutable default for `params`."""
+    sig = inspect.signature(mcp_server.browser_cdp)
+    assert sig.parameters["params"].default is None
+
+
+def test_browser_cdp_params_none_matches_omitted(monkeypatch):
+    """browser_cdp(method, params=None) must behave identically to
+    browser_cdp(method) — both unpack to an empty kwargs dict."""
+    captured = []
+    monkeypatch.setattr(mcp_server, "cdp", lambda method, **kwargs: captured.append((method, kwargs)) or {})
+
+    mcp_server.browser_cdp("Page.navigate")
+    mcp_server.browser_cdp("Page.navigate", params=None)
+
+    assert captured == [("Page.navigate", {}), ("Page.navigate", {})]

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2,10 +2,14 @@
 
 Importing mcp_server requires the optional `mcp` extra; run the unit suite
 with `uv run --extra mcp --with pytest python -m pytest tests/unit -q`.
+Without the extra, these tests are skipped (importorskip below) so the rest
+of the suite still collects.
 """
 import inspect
 
-import mcp_server
+import pytest
+
+mcp_server = pytest.importorskip("mcp_server")
 
 
 def test_browser_switch_tab_docstring_does_not_advertise_url_substring():
@@ -26,9 +30,21 @@ def test_browser_cdp_params_none_matches_omitted(monkeypatch):
     """browser_cdp(method, params=None) must behave identically to
     browser_cdp(method) — both unpack to an empty kwargs dict."""
     captured = []
+    monkeypatch.setattr(mcp_server, "ensure_daemon", lambda: None)
     monkeypatch.setattr(mcp_server, "cdp", lambda method, **kwargs: captured.append((method, kwargs)) or {})
 
     mcp_server.browser_cdp("Page.navigate")
     mcp_server.browser_cdp("Page.navigate", params=None)
 
     assert captured == [("Page.navigate", {}), ("Page.navigate", {})]
+
+
+def test_browser_cdp_params_dict_is_forwarded(monkeypatch):
+    """browser_cdp(method, params={...}) must forward the params as kwargs."""
+    captured = []
+    monkeypatch.setattr(mcp_server, "ensure_daemon", lambda: None)
+    monkeypatch.setattr(mcp_server, "cdp", lambda method, **kwargs: captured.append((method, kwargs)) or {})
+
+    mcp_server.browser_cdp("Page.navigate", params={"url": "https://example.test"})
+
+    assert captured == [("Page.navigate", {"url": "https://example.test"})]


### PR DESCRIPTION
The MCP server's `browser_switch_tab` tool advertised URL-substring matching that `switch_tab()` does not implement — the target is passed straight to `Target.attachToTarget`, so a URL-substring call failed with an opaque CDP error. The tool description (which is the schema models see) now correctly states it switches by `targetId` only; callers needing URL-based selection can resolve a targetId via `browser_list_tabs()` first.

`browser_cdp` no longer uses a mutable default (`params: dict = {}` -> `params: dict | None = None`), matching the file's existing convention and removing a latent footgun; behavior with omitted params is unchanged.

Adds `tests/unit/test_mcp_server.py` covering both fixes, including a hermetic params-forwarding check (the MCP tests require the optional `mcp` extra and skip cleanly without it).

Fixes #690


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two defects in the MCP server: `browser_switch_tab` no longer claims to match URL substrings (it only switches by `targetId`), and `browser_cdp` no longer uses a mutable default for `params`. Closes #690.

- `browser_switch_tab`'s tool description now says it switches by `targetId` only; callers needing URL-based selection should resolve a target first via `browser_list_tabs()`.
- `browser_cdp`'s `params` argument defaults to `None` instead of `{}`; behavior when omitted is unchanged.
- Adds `tests/unit/test_mcp_server.py` covering both fixes; tests require the optional `mcp` extra and skip cleanly without it.

<sup>Written for commit c6585edf922d0a6b0b71e20be152ea3664993e8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

