### PR TITLE
fix(helpers): release the iframe session js(target_id=...) attaches

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -571,6 +571,12 @@ def js(expression, target_id=None):
         if _is_illegal_return_error(e):
             return _runtime_evaluate(_wrap_js_function(expression), session_id=sid, await_promise=True)
         raise
+    finally:
+        # Each iframe call attaches a fresh session; release it so polling loops
+        # do not accumulate one live session (and one event stream) per call.
+        if sid:
+            try: cdp("Target.detachFromTarget", sessionId=sid)
+            except Exception: pass
 
 
 _KC = {"Enter": 13, "Tab": 9, "Escape": 27, "Backspace": 8, " ": 32, "ArrowLeft": 37, "ArrowUp": 38, "ArrowRight": 39, "ArrowDown": 40}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -566,17 +566,37 @@ def js(expression, target_id=None):
     """
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"] if target_id else None
     try:
+        result = _js_evaluate(expression, sid)
+    except BaseException:
+        # Keep the evaluation error; a detach failure here must not replace it.
+        if sid:
+            try: _detach_iframe_session(sid)
+            except Exception: pass
+        raise
+    if sid:
+        _detach_iframe_session(sid)
+    return result
+
+
+def _js_evaluate(expression, sid):
+    try:
         return _runtime_evaluate(expression, session_id=sid, await_promise=True)
     except RuntimeError as e:
         if _is_illegal_return_error(e):
             return _runtime_evaluate(_wrap_js_function(expression), session_id=sid, await_promise=True)
         raise
-    finally:
-        # Each iframe call attaches a fresh session; release it so polling loops
-        # do not accumulate one live session (and one event stream) per call.
-        if sid:
-            try: cdp("Target.detachFromTarget", sessionId=sid)
-            except Exception: pass
+
+
+def _detach_iframe_session(sid):
+    """Release the session js(target_id=...) attached so polling loops do not
+    accumulate one live session (and one event stream) per call. A session that
+    Chrome already dropped (iframe navigated or closed) is not a leak."""
+    try:
+        cdp("Target.detachFromTarget", sessionId=sid)
+    except Exception as e:
+        if "session" in str(e).lower():
+            return
+        raise
 
 
 _KC = {"Enter": 13, "Tab": 9, "Escape": 27, "Backspace": 8, " ": 32, "ArrowLeft": 37, "ArrowUp": 38, "ArrowRight": 39, "ArrowDown": 40}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -570,8 +570,10 @@ def js(expression, target_id=None):
     except BaseException:
         # Keep the evaluation error; a detach failure here must not replace it.
         if sid:
-            try: _detach_iframe_session(sid)
-            except Exception: pass
+            try:
+                _detach_iframe_session(sid)
+            except BaseException:
+                pass
         raise
     if sid:
         _detach_iframe_session(sid)
@@ -594,7 +596,8 @@ def _detach_iframe_session(sid):
     try:
         cdp("Target.detachFromTarget", sessionId=sid)
     except Exception as e:
-        if "session" in str(e).lower():
+        message = str(e).lower()
+        if "no session with given id" in message or "session with given id not found" in message:
             return
         raise
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -693,9 +693,9 @@ def test_js_surfaces_an_unexpected_detach_failure_after_success():
             return {"sessionId": "sess-1"}
         if method == "Runtime.evaluate":
             return {"result": {"type": "number", "value": 7}}
-        raise RuntimeError("daemon unreachable")
+        raise RuntimeError("session broker unreachable")
 
-    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), pytest.raises(RuntimeError, match="daemon unreachable"):
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), pytest.raises(RuntimeError, match="session broker unreachable"):
         helpers.js("7", target_id="iframe-target")
 
 
@@ -708,4 +708,18 @@ def test_js_keeps_the_evaluation_error_when_detach_also_fails():
         raise RuntimeError("daemon unreachable")
 
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), pytest.raises(RuntimeError, match="evaluation failed"):
+        helpers.js("7", target_id="iframe-target")
+
+
+def test_js_keeps_base_exception_from_evaluation_when_detach_also_raises():
+    def fake_cdp(method, **kwargs):
+        if method == "Target.attachToTarget":
+            return {"sessionId": "sess-1"}
+        if method == "Runtime.evaluate":
+            raise KeyboardInterrupt("evaluation interrupted")
+        raise KeyboardInterrupt("detach interrupted")
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), pytest.raises(
+        KeyboardInterrupt, match="evaluation interrupted"
+    ):
         helpers.js("7", target_id="iframe-target")

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -609,7 +609,7 @@ def test_fill_input_types_each_character_as_a_real_key():
     assert typed == [("H", "KeyH", 72, True), ("i", "KeyI", 73, False), ("!", "Digit1", 49, True)]
 
 
-def _js_session_calls(expression, target_id, evaluate=None):
+def _js_session_calls(expression, target_id, evaluate=None, detach=None):
     calls = []
 
     def fake_cdp(method, **kwargs):
@@ -620,6 +620,8 @@ def _js_session_calls(expression, target_id, evaluate=None):
             if evaluate:
                 return evaluate(kwargs)
             return {"result": {"type": "number", "value": 1}}
+        if method == "Target.detachFromTarget" and detach:
+            return detach(kwargs)
         return {}
 
     with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
@@ -664,3 +666,46 @@ def test_js_with_target_reuses_one_session_across_the_return_retry():
     calls = _js_session_calls("return 1", "iframe-target", evaluate=evaluate)
     assert seen == ["sess-1", "sess-1"]
     assert [m for m, _ in calls].count("Target.detachFromTarget") == 1
+
+
+def test_js_ignores_detach_of_a_session_chrome_already_dropped():
+    def gone(_kwargs):
+        raise RuntimeError("CDP error: No session with given id")
+
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append(method)
+        if method == "Target.attachToTarget":
+            return {"sessionId": "sess-1"}
+        if method == "Runtime.evaluate":
+            return {"result": {"type": "number", "value": 7}}
+        return gone(kwargs)
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        assert helpers.js("7", target_id="iframe-target") == 7
+    assert calls[-1] == "Target.detachFromTarget"
+
+
+def test_js_surfaces_an_unexpected_detach_failure_after_success():
+    def fake_cdp(method, **kwargs):
+        if method == "Target.attachToTarget":
+            return {"sessionId": "sess-1"}
+        if method == "Runtime.evaluate":
+            return {"result": {"type": "number", "value": 7}}
+        raise RuntimeError("daemon unreachable")
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), pytest.raises(RuntimeError, match="daemon unreachable"):
+        helpers.js("7", target_id="iframe-target")
+
+
+def test_js_keeps_the_evaluation_error_when_detach_also_fails():
+    def fake_cdp(method, **kwargs):
+        if method == "Target.attachToTarget":
+            return {"sessionId": "sess-1"}
+        if method == "Runtime.evaluate":
+            raise RuntimeError("evaluation failed")
+        raise RuntimeError("daemon unreachable")
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp), pytest.raises(RuntimeError, match="evaluation failed"):
+        helpers.js("7", target_id="iframe-target")

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -607,3 +607,60 @@ def test_fill_input_types_each_character_as_a_real_key():
     typed = [(e["key"], e["code"], e["windowsVirtualKeyCode"], bool(e["modifiers"] & 8))
              for e in events if e["type"] == "keyDown"]
     assert typed == [("H", "KeyH", 72, True), ("i", "KeyI", 73, False), ("!", "Digit1", 49, True)]
+
+
+def _js_session_calls(expression, target_id, evaluate=None):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"sess-{len(calls)}"}
+        if method == "Runtime.evaluate":
+            if evaluate:
+                return evaluate(kwargs)
+            return {"result": {"type": "number", "value": 1}}
+        return {}
+
+    with patch("browser_harness.helpers.cdp", side_effect=fake_cdp):
+        try:
+            helpers.js(expression, target_id=target_id)
+        except RuntimeError:
+            pass
+    return calls
+
+
+def test_js_with_target_detaches_the_session_it_attached():
+    calls = _js_session_calls("1", "iframe-target")
+    attached = [k["targetId"] for m, k in calls if m == "Target.attachToTarget"]
+    detached = [k["sessionId"] for m, k in calls if m == "Target.detachFromTarget"]
+    assert attached == ["iframe-target"]
+    assert detached == ["sess-1"], f"js(target_id=...) must release its session; calls: {calls}"
+    assert [m for m, _ in calls][-1] == "Target.detachFromTarget"
+
+
+def test_js_without_target_never_attaches_or_detaches():
+    calls = _js_session_calls("1", None)
+    assert [m for m, _ in calls] == ["Runtime.evaluate"]
+
+
+def test_js_with_target_detaches_even_when_evaluation_fails():
+    def boom(_kwargs):
+        raise RuntimeError("evaluation failed")
+
+    calls = _js_session_calls("1", "iframe-target", evaluate=boom)
+    assert [m for m, _ in calls] == ["Target.attachToTarget", "Runtime.evaluate", "Target.detachFromTarget"]
+
+
+def test_js_with_target_reuses_one_session_across_the_return_retry():
+    seen = []
+
+    def evaluate(kwargs):
+        seen.append(kwargs["session_id"])
+        if len(seen) == 1:
+            raise RuntimeError("SyntaxError: Illegal return statement")
+        return {"result": {"type": "number", "value": 1}}
+
+    calls = _js_session_calls("return 1", "iframe-target", evaluate=evaluate)
+    assert seen == ["sess-1", "sess-1"]
+    assert [m for m, _ in calls].count("Target.detachFromTarget") == 1


### PR DESCRIPTION
## What

`js(expression, target_id=...)` attaches a fresh CDP session to the iframe target on every call and never sends `Target.detachFromTarget`. This releases the session in a `finally`, on the success path, the illegal-`return` retry path, and the error path.

## Why

The documented cross-origin iframe workflow (`iframe_target()` + `js(..., target_id=tid)`) is naturally a poll loop. Each iteration leaked one live session for the lifetime of the daemon, and each session carries its own copy of the enabled-domain event stream into the daemon's shared event buffer, so long loops could also evict the events `wait_for_network_idle()` reads.

`Target.detachFromTarget` is a browser-level call that takes `sessionId` as a parameter, so it passes through the daemon's `Target.*` session stripping unchanged.

## Tests

- `test_js_with_target_detaches_the_session_it_attached`
- `test_js_without_target_never_attaches_or_detaches`
- `test_js_with_target_detaches_even_when_evaluation_fails`
- `test_js_with_target_reuses_one_session_across_the_return_retry`

Red on `main` (3 failed), green on this branch (194 passed).

Fixes #684

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the CDP session `js(..., target_id=...)` attaches to iframe targets on every call — previously each call attached a fresh session and never sent `Target.detachFromTarget`. The session is now released on the success path, the illegal-`return` retry path, and the error path, with the evaluation error kept when detach also fails. Detaching a session Chrome already dropped is ignored, while unexpected detach failures after success are surfaced.

- Prevents the documented `iframe_target()` + `js()` polling loop from leaking one live session and its event stream into the daemon's shared event buffer per iteration.
- Adds unit tests for attach/detach on success, evaluation failure, retry reuse, the no-target path, already-dropped sessions, and unexpected detach failures.

Fixes #684.

<sup>Written for commit 835529d95bbd9967ccb3ff333dc65346257c2067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

