### PR TITLE
domain-skills: add TCCigar promotion checks

### DIFF
--- a/domain-skills/tccigar/site.md
+++ b/domain-skills/tccigar/site.md
@@ -1,0 +1,16 @@
+# Treasure Coast Cigars (TCCigar.com)
+
+## Promotion discovery
+
+- Always screenshot the rendered homepage from scroll position zero. Major promotions can be presented only as hero-image text and may be absent from fetched HTML and `document.body.innerText`.
+- Read the hero visually for the code, dates, and fine-print exclusions, then verify the code against exact products in the cart.
+- Free shipping is advertised for orders of $76 or more.
+
+## Shopify product and cart APIs
+
+- Collection inventory is available at `/collections/<handle>/products.json?limit=250`; useful handles include `padron-cigars` and `arturo-fuente`.
+- Apply a discount through `/discount/<CODE>?redirect=/cart`, then inspect the rendered cart total.
+- Product variants use 14-digit Shopify IDs that exceed JavaScript's safe integer range. Pass variant IDs as strings to `/cart/change.js`; a numeric ID may be rounded and rejected.
+- `/cart/add.js` can return `discounted_price` while also retaining an undiscounted `final_price`; trust the rendered cart total or `/cart.js` discount allocations for the applied total.
+- Record the initial cart, add only test variants, and remove those exact variants afterward.
+


### PR DESCRIPTION
Adds TCCigar.com guidance for image-only hero promotions, Shopify collection/cart endpoints, large variant-ID handling, and reversible discount verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TCCigar.com domain guidance so promotion checks handle image-only hero banners and Shopify API quirks.

- Documented that major promotions may appear only as hero-image text and require a visual screenshot from scroll position zero.
- Captured Shopify collection, discount, and cart endpoints, including passing 14-digit variant IDs as strings.

<sup>Written for commit b63d3c24d0f4e3a68678546257d9f75bb91d48bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

