### PR TITLE
domain-skills: Clutch directory parser + Maven category URLs

### DIFF
--- a/domain-skills/annas-archive/search.md
+++ b/domain-skills/annas-archive/search.md
@@ -20,34 +20,53 @@ through the fast-download API outside the browser.
   interstitial is up; poll until it clears, then extract. After the first
   clearance the cookie persists for the session and later searches don't
   re-challenge.
-- **Result extraction**: every hit is an `<a href="/md5/<hex>">` wrapping the
-  whole result card. Dedupe by md5 (each card can contain nested anchors).
-  `a.innerText` carries title, publisher, authors and a meta line like
-  `English [en], .pdf, 🚀/lgli/zlib, 12.3MB, 📘 Book (non-fiction)` — enough
-  to pick an edition without opening the detail page.
+- **Result extraction (live DOM)**: target the *title* anchor
+  `a.js-vim-focus[href^="/md5/"]` and take `a.closest('div.pt-3')` as the
+  card — its innerText carries file path, title, authors, publisher and a
+  meta line like `English [en] · PDF · 12.3MB · 📘 Book (non-fiction)`,
+  enough to pick an edition without opening the detail page.
 
 ```python
 EXTRACT = """
 (() => {
   const seen = new Set(); const res = [];
-  for (const a of document.querySelectorAll('a[href^="/md5/"]')) {
+  for (const a of document.querySelectorAll('a.js-vim-focus[href^="/md5/"]')) {
     const md5 = a.getAttribute('href').split('/md5/')[1].split(/[/?]/)[0];
     if (seen.has(md5)) continue;
     seen.add(md5);
-    const t = a.innerText.replace(/\\s+/g,' ').trim();
-    if (t.length > 10) res.push({md5, text: t.slice(0,350)});
-    if (res.length >= 6) break;
+    const card = a.closest('div.pt-3') || a.parentElement;
+    res.push({md5, text: card.innerText.replace(/\\s+/g,' ').trim().slice(0,400)});
+    if (res.length >= 8) break;
   }
-  return JSON.stringify(res);
+  return JSON.stringify({res, none: document.body.innerText.includes('No files found')});
 })()
 """
 ```
 
-Sequential search cadence ~10-15s per query including challenge/nav waits is
-sustained fine over 60+ queries in one tab.
+- **Static-HTML parsing** (if you fetch the page body some other way): result
+  cards may sit inside HTML comments (lazy-render trick) — strip
+  `<!--`/`-->` first, then split on `<div class="flex pt-3 pb-3 border-b`.
+  Each card's *first* md5 anchor is an **empty cover-image link**; the title
+  is in a later anchor. Don't dedupe-by-first-anchor or you keep the textless
+  cover link.
+
+Sequential navigation cadence ~10-15s per query including challenge/nav waits
+is sustained fine over 100+ queries in one tab.
 
 ## Traps
 
+- **Cookie snapshots go stale fast.** Exporting the `__ddg*`/`aa_ddg_check`
+  cookies for plain-HTTP reuse works for ~40-60 requests, then DDoS-Guard
+  starts 302-loops and connection resets (`__ddg8_`/`__ddg10_` rotate
+  per-request in the browser; a static copy ages out). Parallel workers make
+  it die faster. `fetch()` from inside the page gets challenged the same way
+  at speed — it receives the interstitial HTML but *cannot solve it* (only
+  navigation can). For bulk work, paced real navigation is the only route
+  that survives.
+- **Recent-downloads marquee poisons naive extraction.** The page top has a
+  `.js-recent-downloads-scroll` strip full of `/md5/` links to random books.
+  A generic `a[href^="/md5/"]` sweep on the live DOM returns those first.
+  Use `a.js-vim-focus` (result-title anchors only).
 - **Fuzzy fallback**: when nothing matches, AA silently pads the page with
   unrelated "partial match" cards — the presence of hits does NOT mean the
   work exists. Judge every hit's text against the query; expect pure junk for

--- a/domain-skills/annas-archive/search.md
+++ b/domain-skills/annas-archive/search.md
@@ -1,0 +1,61 @@
+# Anna's Archive — search via browser (WAF bypass)
+
+## Why the browser at all
+
+As of 2026-08, AA `/search` is behind DDoS-Guard on every mirror: `.gl`,
+`.pk`, `.gd` return 403 to plain HTTP clients; `.li` serves a JS-fingerprint
+interstitial (and for fresh browser profiles has redirected to an ad-parking
+page — avoid `.li`). No member search API exists: the member key only works
+for `dyn/api/fast_download.json` by md5; bulk search means the ES/MariaDB
+dumps. So title→md5 resolution goes through a real browser; downloads then go
+through the fast-download API outside the browser.
+
+## What works
+
+- **Mirror**: use `https://annas-archive.gl/search?q=<query>`. A real Chrome
+  clears the DDoS-Guard challenge automatically in ~1-3s (no CAPTCHA, just JS
+  fingerprinting). A throwaway `--user-data-dir` Chrome instance passes fine —
+  no login or cookies needed for search.
+- **Challenge detection**: `document.title` contains `DDoS-Guard` while the
+  interstitial is up; poll until it clears, then extract. After the first
+  clearance the cookie persists for the session and later searches don't
+  re-challenge.
+- **Result extraction**: every hit is an `<a href="/md5/<hex>">` wrapping the
+  whole result card. Dedupe by md5 (each card can contain nested anchors).
+  `a.innerText` carries title, publisher, authors and a meta line like
+  `English [en], .pdf, 🚀/lgli/zlib, 12.3MB, 📘 Book (non-fiction)` — enough
+  to pick an edition without opening the detail page.
+
+```python
+EXTRACT = """
+(() => {
+  const seen = new Set(); const res = [];
+  for (const a of document.querySelectorAll('a[href^="/md5/"]')) {
+    const md5 = a.getAttribute('href').split('/md5/')[1].split(/[/?]/)[0];
+    if (seen.has(md5)) continue;
+    seen.add(md5);
+    const t = a.innerText.replace(/\\s+/g,' ').trim();
+    if (t.length > 10) res.push({md5, text: t.slice(0,350)});
+    if (res.length >= 6) break;
+  }
+  return JSON.stringify(res);
+})()
+"""
+```
+
+Sequential search cadence ~10-15s per query including challenge/nav waits is
+sustained fine over 60+ queries in one tab.
+
+## Traps
+
+- **Fuzzy fallback**: when nothing matches, AA silently pads the page with
+  unrelated "partial match" cards — the presence of hits does NOT mean the
+  work exists. Judge every hit's text against the query; expect pure junk for
+  rare scholarly titles.
+- **Search drops diacritics/translator names**: query author-surname + short
+  title; adding a translator often zeroes an otherwise-good match.
+- **`.li` ad-parking redirect**: a fresh profile navigating to
+  `annas-archive.li` can land on `ron.mamma.com` spam instead of AA.
+- **Dead links**: `Invalid domain_index or path_index` from the fast-download
+  API is permanent for that md5 — resolve an alternate md5/edition rather
+  than retrying.

--- a/domain-skills/astro-seek/chart-output.md
+++ b/domain-skills/astro-seek/chart-output.md
@@ -1,0 +1,252 @@
+# Astro-Seek — Chart Output
+
+Charts on astro-seek are **server-rendered bitmaps**, not SVG. Every results page embeds several `<img>` tags pointing at chart URLs whose query strings carry the entire computed dataset (planet positions, house cusps, retrograde flags). You can either download the image as-is or parse the query string for typed numeric data without scraping the HTML tables.
+
+**Bitmap format is not always PNG despite the `.png` extension.** Verified as of 2026-04-19:
+
+| Chart type | Actual file format | Signature |
+|---|---|---|
+| `horoscope-chart4def-700__radix_*` (birth chart) | GIF87a | `47 49 46 38` |
+| `horoscope-chart1snew-700__radix_*` (asteroids) | PNG | `89 50 4e 47` |
+| `horoscope-chart1-700__radix_*` (sidereal + house-systems-calculator) | PNG | `89 50 4e 47` |
+| `horoscope-chart6-700__radix_comparision_*` (house-systems comparison wheel) | PNG | `89 50 4e 47` |
+| `horoscope-chart4def-700__composite_*` (composite) | PNG | `89 50 4e 47` |
+| `horoscope-synastry-chart{N}-700__transits_*` (transit bi-wheel) | PNG | `89 50 4e 47` |
+| `horoscope-synastry-chart23-700__{d1}_p_{d2}` (synastry — no TYPE) | PNG | `89 50 4e 47` |
+| `horoscope-synastry-chart20-700__progressions_*` (progressed) | PNG | `89 50 4e 47` |
+
+Don't hardcode a PNG signature check — the extension lies. `file` on the byte stream, or just trust the `Content-Type`. Only birth-chart radix is GIF; every other tool tested so far is PNG.
+
+**Chart URLs require a `User-Agent` header.** A bare `urllib.request.urlopen(url)` returns **HTTP 403 Forbidden**. `http_get` in the harness works because it sets `User-Agent: Mozilla/5.0`. When downloading outside `http_get`, set the header yourself.
+
+## No SVG anywhere
+
+`document.querySelectorAll('svg').length === 0` on every tool tested. Don't waste time looking for inline SVG.
+
+## Chart URL anatomy
+
+There are **two base paths** on the CDN — single-wheel tools and bi-wheel/relationship tools use different prefixes:
+
+```
+Single wheel:  https://horoscopes.astro-seek.com/horoscope-chart{STYLE}-{SIZE}__{TYPE}_{date}.png?{payload}
+Bi-wheel:      https://horoscopes.astro-seek.com/horoscope-synastry-chart{N}-{SIZE}__{TYPE}_{d1}_a_{d2}.png?{payload}
+Bi-wheel (synastry special case — no TYPE):
+               https://horoscopes.astro-seek.com/horoscope-synastry-chart{N}-{SIZE}__{d1}_p_{d2}.png?{payload}
+```
+
+Live filenames verified in the DOM:
+
+```
+horoscope-chart4def-700__radix_1-1-1990_12-00.png                           # birth chart
+horoscope-chart1-700__radix_1-1-1990_12-00.png                              # sidereal (primary)
+horoscope-chart1snew-700__radix_1-1-1990_12-00.png                          # asteroids (primary)
+horoscope-chart4def-700__composite_1-1-1990_12-00_a_15-6-1992_18-30.png     # composite (primary, single wheel)
+horoscope-synastry-chart20-700__transits_1-1-1990_12-0_a_19-4-2026_12-0.png # transit bi-wheel
+horoscope-synastry-chart24-700__transits_..._a_..._.png                     # transit, style 24
+horoscope-synastry-chart5-700__transits_..._a_..._.png                      # transit, style 5 (whole)
+horoscope-synastry-chart23-700__1-1-1990_12-00_p_15-6-1992_18-30.png        # synastry (primary) — no TYPE, _p_ separator
+horoscope-synastry-chart20-700__progressions_1-1-1990_12-00_a_19-4-2026.png # progressions (primary) — note: no time on d2
+horoscope-synastry-chart24-700__secondary-progressions_..._a_..._.png       # progressions, style 24 — hyphenated TYPE
+horoscope-chart6-700__radix_comparision_1-1-1990_12-00.png                  # house-systems-calculator comparison wheel — TYPE is Czech-misspelled "comparision" (missing 's'); carries BOTH cusp sets via dum_1..12 + dum_1_alter..12_alter
+```
+
+Notes:
+- The bi-wheel uses `horoscope-synastry-chart{NUMBER}-...`, NOT `horoscope-chart{STYLE}-...`.
+- TYPE tokens are **English plural**: `transits`, `progressions` (NOT `tranzit` / `progres`); the composite TYPE is `composite` (not `composit`); `secondary-progressions` has a literal hyphen.
+- The transit-chart results page has multiple bi-wheel styles (chart5 / chart20 / chart24) co-existing.
+- **Synastry is the odd one out**: its primary filename has *no* TYPE token and uses `_p_` as the date separator. Don't match with a universal `{TYPE}_{d1}_a_{d2}` regex.
+- Some bi-wheel filenames drop the time on the second date (progressed chart20: `_a_19-4-2026`), while others keep it (progressed chart24: `_a_19-4-2026_12-00`). Parse the filename by splitting on `_a_` / `_p_` rather than assuming a fixed `D-M-YYYY_HH-MM` shape on both sides.
+
+Multiple `<img>` tags coexist on a single results page. **`naturalWidth === 700` alone is NOT unique** — both `chart4def-700` and `chart4zone3-700` load at 700×700 when scrolled into view. Filter by style token AND size:
+
+```python
+# Birth chart (primary default-style wheel)
+js("""
+JSON.stringify(Array.from(document.querySelectorAll('img'))
+  .filter(i => /horoscope-chart4def-700__radix_/.test(i.src)
+            && !/minor_aspects|astroseek/.test(i.src)
+            && i.naturalWidth === 700)
+  .map(i => i.src))
+""")
+
+# Transit bi-wheel (primary colored-aspects style)
+js("""
+JSON.stringify(Array.from(document.querySelectorAll('img'))
+  .filter(i => /horoscope-synastry-chart20-700__transits_/.test(i.src)
+            && i.naturalWidth === 700)
+  .map(i => i.src))
+""")
+```
+
+Lazy `<img loading="lazy">` tags report `naturalWidth === 0` until scrolled into view. When scraping `http_get` HTML (no layout), filter by the URL regex alone — naturalWidth is a browser-only signal.
+
+### `src=` attributes contain literal newlines
+
+Astro-seek breaks its chart `src` URLs across multiple lines inside the HTML:
+
+```html
+<img src="https://horoscopes.astro-seek.com/horoscope-chart4def-700__radix_1-1-1990_12-00.png?
+fortune_asp=1&vertex_asp=1&chiron_asp=1&…
+```
+
+A naive `[^"\s]+` regex stops at the first newline and returns a truncated URL. Use `[^"]+` and strip whitespace:
+
+```python
+m = re.search(r'src="(https://horoscopes\.astro-seek\.com/horoscope-chart4def-700__radix_[^"]+)"', html, re.S)
+chart_url = re.sub(r'\s+', '', m.group(1)) if m else None
+```
+
+### Style tokens (single-wheel tools only)
+
+| `STYLE` | Visual / used by |
+|---|---|
+| `4def` | Default modern, white background, colored aspect lines. **Birth chart + composite primary**. |
+| `4zone3` | Astro-Seek branded, dark background, colored planet glyphs. Watermark variant. |
+| `3` | Classic line style. Simpler, older look. |
+| `4` | Alternate seen on sidereal + composite. |
+| `1` | **Sidereal + house-systems-calculator primary**. `chart1-700__radix_…`. |
+| `6` | **House-systems comparison wheel** (unique to house-systems-calculator). `chart6-700__radix_comparision_…`. |
+| `1snew` | **Asteroids primary**. `chart1snew-700__radix_…`. Variant `8snew` is the watermark counterpart. |
+
+STYLE is tool-dependent. The birth chart regex `chart4def-700__radix_` misses every tool in the bottom half of the table. When you probe a new tool, list all `/horoscope-chart[a-z0-9]+-\d+__/` matches in the DOM and pick whichever is the 700×700 non-watermark.
+
+For bi-wheel tools the `{N}` is a numeric style id. Seen: `5`, `20`, `23`, `24`, `27`. Defaults vary by tool:
+
+| Tool | Bi-wheel default |
+|---|---|
+| Transit | `chart20` |
+| Synastry | **`chart23`** (not chart20 — styles 20/24/5 don't appear at all) |
+| Progressions | `chart20` (plus `chart24` as `secondary-progressions`) |
+| Composite (bi-wheel overlay) | `synastry-chart1-700__composite_transits_…` |
+
+### `TYPE` tokens
+
+| `TYPE` | Chart | Base path |
+|---|---|---|
+| `radix` | Single natal wheel (birth chart, asteroids, sidereal, traditional, house-systems-calculator, …) | `horoscope-chart` |
+| `radix_comparision` | House-systems comparison wheel overlaying two cusp systems (unique to house-systems-calculator). **Note the Czech-origin misspelling: "comparision" has no `s`.** Query carries `dum_1..12` + `dum_1_alter..12_alter` + `vstyl=` visual-style param. | `horoscope-chart` |
+| `composite` | Composite (single wheel from two charts) — note the `e`, NOT `composit` | `horoscope-chart` |
+| `transits` | Bi-wheel — natal inner, transit outer | `horoscope-synastry-chart` |
+| *(none)* | **Synastry — bi-wheel with Person A inner, Person B outer.** Filename is `__{d1}_p_{d2}.png` with no TYPE token. | `horoscope-synastry-chart` |
+| `progressions` | Primary progressed bi-wheel (natal + progressed date). Plural, NOT `progres`. | `horoscope-synastry-chart` |
+| `secondary-progressions` | Alternate progressed bi-wheel on the same page (chart24 style). Literal hyphen. | `horoscope-synastry-chart` |
+| `composite_transits` | Bi-wheel overlaying composite + current transits, rendered on the composite tool page. | `horoscope-synastry-chart` |
+
+The `_minor_aspects` infix and `gif=1` query mean an animated/minor-aspects variant — usually a duplicate of the static chart for the customize tab; ignore it. An `astroseek` infix is a watermark variant; also ignore.
+
+**There is no universal TYPE-aware regex.** Each tool has its own combination of `{base_path, style, TYPE}`. Start by listing what's in the DOM:
+
+```python
+# list distinct base paths + TYPE tokens on a new tool's results page
+js("""JSON.stringify(Array.from(new Set(
+  Array.from(document.querySelectorAll('img'))
+    .map(i => i.src.match(/\\/horoscope-[^?]+/))
+    .filter(m => m).map(m => m[0].replace(/_\\d+-\\d+-\\d+.*$/,'_<date>'))
+)))""")
+```
+
+Filename date is `D-M-YYYY_HH-MM` (no leading zeros on D/M, leading zeros on H-MM, e.g. `1-1-1990_12-00`).
+
+## Downloading the chart bitmap
+
+The chart URL is plain HTTP, no cookie required — **but a `User-Agent` header is**. Default Python UA (`Python-urllib/…`) returns `HTTP 403 Forbidden`. Set `Mozilla/5.0` or anything browser-like:
+
+```python
+import urllib.request
+src = "https://horoscopes.astro-seek.com/horoscope-chart4def-700__radix_1-1-1990_12-00.png?p_slunce=280.8&…"
+req = urllib.request.Request(src, headers={"User-Agent": "Mozilla/5.0"})
+data = urllib.request.urlopen(req, timeout=20).read()
+open("/tmp/chart.gif", "wb").write(data)   # Signature depends on chart type (see table at top)
+```
+
+`http_get` returns text and will mangle binary bytes — use `urllib.request` directly for binary downloads, or extract just the URL with `js` and curl from outside the harness.
+
+## Reading data out of the chart query string
+
+The chart URL's query encodes the entire chart dataset as floats. Parsing it is more reliable than scraping the HTML tables, because there are no `&deg;`/`&rsquo;` entities to deal with and angles are already decimal degrees.
+
+| Param | Meaning |
+|---|---|
+| `p_slunce` | Sun longitude (deg, ecliptic) |
+| `p_luna` | Moon |
+| `p_merkur` | Mercury |
+| `p_venuse` | Venus |
+| `p_mars` | Mars |
+| `p_jupiter` | Jupiter |
+| `p_saturn` | Saturn |
+| `p_uran` | Uranus |
+| `p_neptun` | Neptune |
+| `p_pluto` | Pluto |
+| `p_uzel` | North Node |
+| `p_lilith` | Lilith (Black Moon) |
+| `p_chiron` | Chiron |
+| `p_fortune` | Part of Fortune |
+| `p_spirit` | Part of Spirit |
+| `p_vertex` | Vertex |
+| `dum_1` … `dum_12` | House cusps 1–12 (deg) |
+| `dum_1_new`, `dum_10_new` | ASC and MC (rounded copies of dum_1 / dum_10) |
+| `r_<planet>=ANO` | Retrograde flag — Czech `ANO` ("yes"). Absence == direct. |
+| `tolerance` | Aspect orb tolerance setting (echoed from form) |
+| `tolerance_paral` | Parallels orb (deg) |
+| `nocache` | Cache-buster, ignore. |
+| `gif=1` | Animated minor-aspects variant flag. |
+
+Czech-to-English glossary you'll need:
+- `slunce`=Sun, `luna`=Moon, `merkur`=Mercury, `venuse`=Venus, `mars`=Mars, `jupiter`=Jupiter, `saturn`=Saturn, `uran`=Uranus, `neptun`=Neptune, `pluto`=Pluto.
+- `uzel`=Node, `lilith`=Lilith, `chiron`=Chiron, `fortune`=Part of Fortune, `spirit`=Part of Spirit, `vertex`=Vertex.
+- `dum`=house, `radix`=natal, `tranzit`=transit, `synastrie`=synastry, `composit`=composite.
+- `ANO`=yes (used for retrograde flags), `NE`=no.
+
+For bi-wheel charts (`transits`, synastry, `progressions`), the query string contains both subjects' planets. **The prefix convention is tool-dependent, not style-dependent** — don't assume chart20 means `p_*` everywhere.
+
+| Tool + chart style | Inner wheel | Outer wheel |
+|---|---|---|
+| Transit `synastry-chart20` (colored-aspects) | `p_slunce`, `p_luna`, … | `p_p_slunce`, `p_p_luna`, … (double-p) |
+| Transit `synastry-chart24` (classic) | `planeta_slunce`, `planeta_luna`, … | `planeta_partner_slunce`, `planeta_partner_luna`, … |
+| Transit `synastry-chart5` (whole-sign-style) | `planeta_slunce`, … | `planeta_partner_slunce`, … |
+| Synastry `synastry-chart23` (primary) | `p_slunce`, … (plus extras `p_juzel`, `p_bstesti`, `p_bspirit`, `p_spirit`) | `p_p_slunce`, … |
+| **Progressed `synastry-chart20`** (same style id, different tool!) | `planeta_slunce`, … | `planeta_partner_slunce`, … |
+| Composite bi-wheel `synastry-chart1__composite_transits_` | `planeta_slunce`, … | `planeta_partner_slunce`, … |
+
+Retrograde flags on the outer wheel use `r_partner_<planet>=ANO` (e.g. `r_partner_uzel=ANO`). House cusps on the outer wheel use `dum_partner_1`, `dum_partner_10`, etc. The same outer-wheel `_partner_` convention holds across every bi-wheel tool regardless of prefix choice on the inner wheel.
+
+## Tools with no chart bitmap
+
+Search/calendar tools do **not** emit any `horoscope-chart*` or `horoscope-synastry-chart*` image — the results page is a table of dated events. Confirmed: `/calculate-ephemeris-search-engine/` has zero chart tags. Don't hunt for chart URLs on these tools — scrape the rows instead.
+
+## Capturing chart variants
+
+Each rendering option (house system, sidereal/tropical, asteroid toggles, etc.) is a query param on the form URL. Build the URL for each variant, `http_get` to scrape data, and download the chart `<img>` for the screenshot. Remember: `[^"]+` (not `[^"\s]+`) to handle embedded newlines in the `src` attribute, and a `User-Agent` on the download:
+
+```python
+CHART_RE = re.compile(
+    r'src="(https://horoscopes\.astro-seek\.com/horoscope-chart4def-700__radix_'
+    r'(?!minor_aspects|astroseek)[^"]+)"',
+    re.S,
+)
+
+def fetch(u):
+    req = urllib.request.Request(u, headers={"User-Agent": "Mozilla/5.0"})
+    return urllib.request.urlopen(req, timeout=20).read()
+
+for variant in [{"house_system": "placidus"}, {"house_system": "koch"}, {"house_system": "whole_horizon"}]:
+    url = build_results_url({**common_params, **variant})
+    html = http_get(url)
+    chart_src = re.sub(r'\s+', '', CHART_RE.search(html).group(1))
+    open(f"chart-{variant['house_system']}.gif", "wb").write(fetch(chart_src))
+```
+
+## Tabs on the results page
+
+Six tabs share the same DOM, all server-rendered up front (so they're scrapeable from a single `http_get`):
+
+| Tab anchor | Content |
+|---|---|
+| `#tab1` | Chart wheel + birth-data summary (default visible) |
+| `#tab2` | Customize / download options |
+| `#tab3` | Horoscope Shape Characteristics — **placeholder only on initial load**, populated lazily via `id="radix_graf_3"` highslide gallery click |
+| `#tab4` | Aspectarian — full list of aspects |
+| `#tab5` | Technical positions table (Ecliptic, Equatorial, Horizontal coords) |
+| `#tab6` | Dominant planets analysis |
+
+Tab 3's content is the only lazy-loaded part. If you need it, click the tab in a real browser and wait for the image gallery to populate. Tabs 1, 2, 4, 5, 6 are present in the initial HTML response — `http_get` is sufficient.

--- a/domain-skills/astro-seek/chart-output.md
+++ b/domain-skills/astro-seek/chart-output.md
@@ -250,3 +250,70 @@ Six tabs share the same DOM, all server-rendered up front (so they're scrapeable
 | `#tab6` | Dominant planets analysis |
 
 Tab 3's content is the only lazy-loaded part. If you need it, click the tab in a real browser and wait for the image gallery to populate. Tabs 1, 2, 4, 5, 6 are present in the initial HTML response — `http_get` is sufficient.
+
+## Some tools ship real SVG, not a bitmap (2026-08-11)
+
+**"No SVG anywhere" is no longer universal.** The 90° dial
+(`/90-degree-dial-uranian-astrology-online-calculator` →
+`/calculate-90-degree-dial/`) renders its chart as an interactive **SVG
+document in an `<object>`**, not an `<img>`:
+
+```html
+<object id="svg_horoskop" type="image/svg+xml"
+        data="https://horoscopes.astro-seek.com/horoscope-chart8uranian7-700__radix_21-10-2002_14-40.svg?...">
+```
+
+Consequences:
+
+- **Every `<img>`-based recipe finds nothing on these pages.** `querySelectorAll('img')`
+  returns only chrome (logo, flags, icons); `document.querySelectorAll('svg').length`
+  is also **0** at the top level, because the SVG lives in the object's own
+  document. Check for `object[type="image/svg+xml"]` before concluding a tool
+  is chart-less.
+- **The vector source is same-origin readable** — far better than screenshotting:
+
+  ```python
+  src = js("""(function(){var o=document.querySelector('#svg_horoskop');
+    return o.contentDocument ? new XMLSerializer().serializeToString(o.contentDocument.documentElement) : null;})()""")
+  ```
+
+  ~300 KB for the dial, with an embedded woff2 astro font (`AstroFontPhysis`),
+  a `<style>` block of semantic classes (`line-zodiac-main`, `planet-guide-line`,
+  `planet-marker-outer`, `strip-line-thick`) and inline `<script>` for the
+  rotatable pointer. Class names make the geometry directly measurable.
+- **The `data` URL's query string carries the full computed payload**, same as
+  bitmap charts (`planeta_*`, `dum_*`, `r_*=ANO`), plus dial extras:
+  `dial_cislo`, `planeta_tnp*` (the eight Uranian TNPs), `planeta_fortune`,
+  `planeta_vertex`, and precomputed midpoints (`planeta_asc_mc`,
+  `planeta_slunce_luna`, …).
+- Style token is `chart8uranian7-700` and the extension is a genuine **`.svg`**.
+
+### Capturing one as a reference image
+
+Ads are injected *over* the figure, and hiding them reflows the page — so hide
+first, then re-read the rect, or the clip lands on stale coordinates:
+
+```python
+js("document.querySelectorAll('iframe,ins,[id*=google],[class*=adsbygoogle]').forEach(e=>e.style.display='none')")
+r = json.loads(js("""(function(){var b=document.querySelector('#svg_horoskop').getBoundingClientRect();
+  return JSON.stringify({x:b.x,y:b.y+scrollY,w:b.width,h:b.height});})()"""))
+shot = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=True,
+           clip={"x":r["x"],"y":r["y"],"width":r["w"],"height":r["h"],"scale":2})
+```
+
+`Page.captureScreenshot`'s `clip` is in **page** coordinates (document origin),
+not viewport coordinates — pass `y + scrollY`, and don't assume a fresh
+`window.scrollTo` moved what you think it moved.
+
+## 90° dial form fields
+
+`document.forms[0]` (action `/calculate-90-degree-dial/`); single-subject, so
+the city input is `#city`. Beyond the usual `narozeni_*` set (**no
+`narozeni_sekunda` on this tool**):
+
+| Field | Values |
+|---|---|
+| `dial_cislo` | dial modulus — `90` (default), `45`, `22.5`, `30`, `36`, `40`, `51.428`, `60`, `72`, `120`, `135`, `144`, `150`, `180`, `360`, `3`, `6`, `7.5`, `9`, `12`, `15` |
+| `orb` | `0.05`–`4` (default `1`) |
+| `hid_uranian_check` / `hid_midpointy_check` / `hid_asteroidy_check` | `on` — TNPs / midpoints / asteroids; uranian + midpoints default **on** |
+| `planeta_midpoint1_leva` / `_prava` | the two bodies of the highlighted midpoint pair |

--- a/domain-skills/astro-seek/custom-chart-generators.md
+++ b/domain-skills/astro-seek/custom-chart-generators.md
@@ -1,0 +1,93 @@
+# Astro-Seek — Custom Chart Generators (bi / tri / quadri-wheel)
+
+A family of tools that **take pasted planet positions instead of birth data**.
+Because you supply the positions, these are the way to render *your own* data in
+astro-seek's house style — useful for like-for-like visual comparison rather
+than benchmarking their ephemeris.
+
+Reachable only from `/advanced-astrology-chart-tools-tables` (the "Astro Tools"
+page); they are **not** in the main nav and not linked from the tool index, so
+a nav crawl will miss them.
+
+| Tool | Form URL |
+|---|---|
+| Bi-wheel layout customizer | `/bi-wheel-chart-customizer` |
+| Custom bi-wheel generator | `/custom-synastry-chart-generator` |
+| Custom **tri**-wheel generator | `/tri-wheel-chart-astrology-calculator` |
+| Custom **quadri**-wheel generator | `/quadri-wheel-chart-astrology-calculator` |
+
+Results URL: `/calculate-tri-wheel-chart-astrology-calculator/#chart_generated`
+(same shape for the others). GET, so the result is a permalink.
+
+## Field map (tri-wheel; bi/quadri follow with fewer/more letters)
+
+| Field | Meaning |
+|---|---|
+| `pozice_import_a` / `_b` / `_c` | **textarea** — planet positions, one per line. `a` = inner wheel, `b` = middle, `c` = outer |
+| `slovo_chart_a` / `_b` / `_c` | free-text label printed in the chart's corner caption |
+| `house_layout` | 0 = aligned outer houses, else non-aligned |
+| `barva_planet` | planet colour scheme |
+| `barva_stupne` | degree-text colour |
+| `partner_domy` | whose houses to draw |
+| `markers_hide` | show/hide markers |
+| `grey`, `barva_invert` | greyscale / invert |
+| `generate_chart` | **the submit button — required** (see gotcha) |
+
+### Position line format
+
+```
+Sun,Aries,21°55'
+Jupiter,Sagittarius,19°43',R
+```
+
+`Name,Sign,DEG°MM'` with an optional `,R` for retrograde. Sign names are English
+and full ("Sagittarius", not "Sag"). **Cap: 10 objects per wheel** — an 11th
+line is silently dropped, so send the ten majors and leave nodes/Chiron out.
+
+## Gotchas
+
+**`form.submit()` renders nothing.** The submit input is
+`input[name=generate_chart]`, and the backend keys chart generation off that
+parameter. Calling `document.forms[0].submit()` sends every field *except* the
+button's own name/value, so you land on the results URL with your data in the
+query string, the textareas correctly repopulated, and **no chart** — which
+looks like a silent failure rather than a missing param. Click the element
+instead:
+
+```python
+js("document.querySelector('input[name=generate_chart]').click()")
+```
+
+The same trap applies to any astro-seek form whose submit input carries a name.
+
+**The output image is `chart35custom`, 800×800 — not 700.** Every other chart on
+the site is 700px, so a `naturalWidth===700` filter (the usual idiom, see
+`chart-output.md`) finds nothing here:
+
+```
+horoscope-synastry-chart35custom-700__tri_wheel_astroseek_customized_chart_.png?bdata=1&…
+```
+
+Note the filename still says `-700` while the rendered bitmap is 800 — filter on
+the `chart35custom` token, or on `naturalWidth > 300`, not on an exact size.
+
+**Fetching the PNG needs the page's own session.** A bare `http_get` of
+`horoscopes.astro-seek.com` returns **403** (Cloudflare). Fetch in-page and hand
+the bytes back as base64:
+
+```python
+b64 = js("""(async()=>{const i=[...document.querySelectorAll('img')].find(i=>i.naturalWidth===800);
+const r=await fetch(i.src.replace(/\\s+/g,''));const b=await r.arrayBuffer();
+let s='';const u=new Uint8Array(b);for(let k=0;k<u.length;k++)s+=String.fromCharCode(u[k]);return btoa(s);})()""")
+open("out.png","wb").write(base64.b64decode(b64))
+```
+
+The `.replace(/\s+/g,'')` is required — astro-seek breaks long chart `src` URLs
+across lines inside the HTML (see `gotchas.md`).
+
+## Wheel identity in the output
+
+The generator prints the three `slovo_chart_*` labels as corner captions
+(`#1: Inner Wheel / <label>` top-left, `#2: Middle Wheel` bottom-left,
+`#3: Outer Wheel` bottom-right) rather than an in-figure legend. Worth knowing
+if you are scraping which ring is which.

--- a/domain-skills/astro-seek/forms.md
+++ b/domain-skills/astro-seek/forms.md
@@ -1,0 +1,210 @@
+# Astro-Seek — Forms & City Autocomplete
+
+Every tool form on `horoscopes.astro-seek.com` is a `<form method="get">`. **Default path: drive the form in a browser like a human would.** The form's jQuery autocomplete quietly handles the lat/lon/tzid fields for you, and field names and option values stay in sync with whatever the site changes. URL construction is still supported as a fast path for bulk scraping (see "Fast path" at the bottom).
+
+## Default: drive the form (one tool run, ~10–15 s)
+
+```python
+import time, json
+
+# 1. Open the tool's form page in a new tab (not goto — goto clobbers the user's tab).
+new_tab("https://horoscopes.astro-seek.com/birth-chart-horoscope-online")
+wait_for_load()
+time.sleep(1.5)  # let jQuery + autocomplete JS attach
+
+# 2. Set every <select>/<input> via jQuery so .change() fires. Zero-pad H/M/S.
+js("""(function() {
+  jQuery('[name=narozeni_den]').val('1').change();
+  jQuery('[name=narozeni_mesic]').val('1').change();
+  jQuery('[name=narozeni_rok]').val('1990').change();
+  jQuery('[name=narozeni_hodina]').val('12').change();   // "12", "00"..."23"
+  jQuery('[name=narozeni_minuta]').val('00').change();   // "00"..."59"  NOT "0"
+  jQuery('[name=narozeni_sekunda]').val('00').change();
+  jQuery('[name=house_system]').val('placidus').change();
+  return 'set';
+})()""")
+
+# 3. Coordinate-click the city input (bypasses password-manager focus overlays),
+#    then type + wait for autocomplete + commit with ArrowDown + Enter.
+rect = js("""(function(){
+  var el = document.querySelector('#city');
+  el.scrollIntoView({block:'center'});
+  var r = el.getBoundingClientRect();
+  return JSON.stringify({x: r.x + r.width/2, y: r.y + r.height/2});
+})()""")
+r = json.loads(rect)
+click(r["x"], r["y"])
+time.sleep(0.3)
+js("document.querySelector('#city').value='';")
+type_text("London")              # insertText, NOT per-char press_key (see gotchas)
+time.sleep(1.8)                   # 300ms debounce + live API call
+press_key("ArrowDown")
+press_key("Enter")
+time.sleep(0.6)
+
+# 4. Verify the autocomplete committed — tzid_id + sirka_* + delka_* are now populated
+#    in hidden fields. If tzid_id is empty, the dropdown never opened; retry click + type.
+assert js("document.querySelector('[name=narozeni_tzid_id]').value"), "autocomplete didn't commit"
+
+# 5. Submit. Use the form directly — bypasses any stale click handlers.
+#    Most tools have exactly one user-facing form so forms[0] is right.
+#    Exception: aspect-search has 4 forms; forms[0] is a timezone sub-form, forms[1] is the real search.
+#    When in doubt, check `document.forms[N].action` to pick the right N.
+js("document.forms[0].submit()")
+wait_for_load()
+time.sleep(1.2)
+
+# 6. Materialise lazy chart imgs before querying them.
+js("window.scrollTo(0, document.body.scrollHeight);")
+time.sleep(1.0)
+js("window.scrollTo(0, 0);")
+
+# 7. Read the primary chart URL out of the DOM (see chart-output.md for the filter regex).
+chart = json.loads(js("""
+  JSON.stringify(Array.from(document.querySelectorAll('img'))
+    .filter(i => /horoscope-chart4def-700__radix_/.test(i.src)
+              && !/minor_aspects|astroseek/.test(i.src))
+    .map(i => i.src.replace(/\\s+/g, '')))
+"""))[0]
+```
+
+**Why this is the default:** the form-driven path mirrors what a human does — the autocomplete populates `narozeni_sirka_stupne/_minuty/_smer` and `narozeni_delka_stupne/_minuty/_smer` automatically. The URL-built path silently defaults to **lat 0°, lon 0° at the equator** when those six fields are omitted, which masks house-system bugs (all quadrant systems agree at the equator).
+
+### Multi-subject tools (synastry, transit, composite, progressions)
+
+Same recipe twice, with prefixes. The transit form has `#muz_city` (Person A / natal) and `#zena_city` (Person B / transit date); fields use `muz_narozeni_*` and `zena_narozeni_*` prefixes. Set each subject's selects, coordinate-click each city input separately, type + commit each autocomplete, then submit once.
+
+```python
+# Person A (natal)
+js("jQuery('[name=muz_narozeni_rok]').val('1990').change(); ...")
+click_city("#muz_city", "London")
+# Person B (transit date / partner)
+js("jQuery('[name=zena_narozeni_rok]').val('2026').change(); ...")
+click_city("#zena_city", "New York")
+js("document.forms[0].submit()")
+```
+
+**Per-tool city-input differences** — confirm with `document.querySelector('#<id>')` on a new tool:
+
+| Tool | `#muz_city` | `#zena_city` | `#tranzity_city` |
+|---|---|---|---|
+| Birth chart, asteroids, sidereal, traditional | — (`#city`) | — | — |
+| Transit, synastry | ✓ | ✓ | — |
+| Composite | ✓ | ✓ | ✓ (transit date for the bi-wheel overlay; can be left blank) |
+| Secondary progressions | ✓ | **none — progression date reuses the natal location; set `zena_narozeni_den/mesic/rok/hodina/minuta` only** | — |
+
+Tools without a city input for a given subject don't need any autocomplete call for that side. Just set the date selects via jQuery and submit.
+
+### Extended-settings panel
+
+`<div id="toggle_prvky_url">` (and friends like `toggle_adjust_coordinates`) start with `display: none`. To set values there, either click the trigger (a `<strong>` with text like "Extended settings" / "+") to expand, **or** set them via `jQuery('[name=foo]').val(...).change()` directly — the inputs are in the form regardless of visibility.
+
+## City autocomplete API (the only private API)
+
+Two endpoints, both on `horoscopes.astro-seek.com`:
+
+| Endpoint | Returns |
+|---|---|
+| `GET /api_gmaps3.php?term=<query>` (`minLength=3`) | JSON array of suggestions: `[{value, label, id}, …]`. `value` is the display string, `label` adds coordinates, `id` is the place id for the next call. |
+| `GET /api_gmaps3.php?place_id=<id>` | JSON object with the city's lat/lon and timezone id: `{mesto, stat_kratky, podstat, podstat_kratky, sirka_stupne, sirka_minuty, sirka_smer, delka_stupne, delka_minuty, delka_smer, tzid_id}` |
+
+The `id` from the first call is **not** the `tzid_id` — you must make the second call to get the timezone. When you drive the form, the jQuery select handler makes both calls and populates the hidden fields for you; you only need to hit the API directly when URL-building.
+
+`sirka_smer` (latitude direction): `"0"` = North, `"1"` = South.
+`delka_smer` (longitude direction): `"0"` = East, `"1"` = West.
+
+Autocomplete is jQuery UI with `delay: 300` and `minLength: 3`. Dropdown is `ul.ui-autocomplete.ui-front`; items are `li.ui-menu-item > a.ui-menu-item-wrapper`. The `<ul>`'s id (`#ui-id-1`/`#ui-id-2`/…) increments across interactions — match by class, not id.
+
+## Mechanics reference
+
+### Setting `<select>` values
+
+`document.querySelector('[name=narozeni_rok]').value = '1990'` **often does not stick** — the form submits with the default. Use jQuery:
+
+```js
+jQuery('[name=narozeni_rok]').val('1990').change();
+```
+
+Option-value quirks that cost debugging time:
+
+| Field | Option-value format |
+|---|---|
+| `narozeni_den` | `"1"`, `"2"`, … `"31"` (unpadded) |
+| `narozeni_mesic` | `"1"`, `"2"`, … `"12"` (unpadded) |
+| `narozeni_rok` | `"1800"`, `"1801"`, … `"2099"`; also `"before1800"` |
+| `narozeni_hodina` | `"00"`, `"01"`, … `"23"` (**zero-padded**) |
+| `narozeni_minuta` | `"00"`, `"01"`, … `"59"` (**zero-padded**) |
+| `narozeni_sekunda` | `"00"`, `"01"`, … `"59"` (**zero-padded**). **Not universal** — some tools (e.g. house-systems-calculator) omit the seconds select entirely. Check for the element before setting it. |
+
+Passing `"0"` for minute via jQuery silently leaves the select unchanged and the field never reaches the submitted URL. Zero-pad HMS values.
+
+### City field id is `#city`, not `#narozeni_city`
+
+The `name` is `narozeni_city`; the `id` is bare `#city`. Multi-subject forms use `#muz_city` / `#zena_city`.
+
+### Browser-extension overlays break programmatic focus
+
+If `type_text` after a `.focus()` doesn't cause the dropdown to open (`ul.ui-autocomplete` never appears, `tzid_id` stays empty), a password-manager extension (1Password, LastPass, Bitwarden) is overlaying the input and swallowing programmatic focus. **Coordinate-click the input first** — it lands a real focus event that the overlay can't intercept. Verify: `document.activeElement.id === 'city'` after the click.
+
+### Year out of 1800–2099
+
+The year `<select>` only covers 1800–2099. For out-of-range values, the form exposes a manual text input `narozeni_year_of_birth_input` (toggled by `narozeni_year_of_birth_select`). For form-driving, set the select to the relevant sentinel + write the text input. For URL-building, pass the year directly in `narozeni_rok` — the server accepts any numeric value.
+
+### `press_key` doubles characters in text inputs
+
+CDP's `Input.dispatchKeyEvent` fires both `keyDown` (with `text`) and a `char` event. For `<input>`/`<textarea>`, each inserts the character — `for ch in "London": press_key(ch)` produces `LLoonnddoonn`. Use `type_text("London")` (CDP `Input.insertText`); it inserts once and still fires `input` events the autocomplete listens to. Reserve `press_key` for Arrow keys, Enter, Escape, Tab.
+
+### Submit
+
+`js("document.forms[0].submit()")` bypasses any click handlers. There is no CSRF token; `send_calculation=1` is the only "was really submitted" marker and jQuery adds it automatically on submit.
+
+**Don't assume `forms[0]` is the tool's primary form.** Most tools have one user-facing form, but a few — aspect-search-engine is the known case — wrap unrelated widgets (timezone picker, current-planets, planetary-ingresses) in additional `<form>`s that appear *before* the real search form. `document.forms[0]` on aspect-search is the timezone sub-form; the real search is `document.forms[1]`. When a new tool's submit produces the form page again instead of results, list `document.forms` and read each one's `.action` to find the right index.
+
+### Form action often ends in `#tabs_redraw`
+
+Browsers strip fragments from outgoing GET requests; form-driving won't trip on this. Only strip it manually if you're passing the action URL into a Python HTTP library.
+
+## Fast path: `http_get` the results URL directly (bulk scraping)
+
+When you need **the same tool repeated across many inputs** (e.g. 500 birth charts for calibration), skip the browser and build the URL yourself. You pay a documentation tax — every field name plus the lat/lon hidden fields — but you get parallel `http_get` + `ThreadPoolExecutor` with no browser in the loop.
+
+```python
+import urllib.parse, json
+
+# 1. Resolve the city — two calls, second one returns tzid + lat/lon
+sug = json.loads(http_get("https://horoscopes.astro-seek.com/api_gmaps3.php?term=" + urllib.parse.quote("London")))
+place_id = sug[0]["id"]                         # API id, NOT the tzid
+city = json.loads(http_get("https://horoscopes.astro-seek.com/api_gmaps3.php?place_id=" + place_id))
+# city = {"mesto":"London","stat_kratky":"GB","podstat":"England","podstat_kratky":"",
+#         "sirka_stupne":"51","sirka_minuty":"31","sirka_smer":"0",
+#         "delka_stupne":"0","delka_minuty":"8","delka_smer":"1","tzid_id":"345"}
+
+# 2. Build the results URL. MUST include the six sirka_/delka_ hidden fields —
+#    omitting them silently computes the chart at lat 0°/lon 0° (equator).
+params = {
+  "send_calculation": "1", "input_natal": "1",
+  "narozeni_den": "1", "narozeni_mesic": "1", "narozeni_rok": "1990",
+  "narozeni_hodina": "12", "narozeni_minuta": "0", "narozeni_sekunda": "0",
+  "narozeni_city": sug[0]["value"],             # "London, UK, England"
+  "narozeni_mesto_hidden": city["mesto"],
+  "narozeni_stat_hidden": city["stat_kratky"],
+  "narozeni_podstat_hidden": city["podstat"],
+  "narozeni_tzid_id": city["tzid_id"],
+  # The six fields form-driving sets for you via the autocomplete select handler:
+  "narozeni_sirka_stupne": str(city["sirka_stupne"]),
+  "narozeni_sirka_minuty": str(city["sirka_minuty"]),
+  "narozeni_sirka_smer": str(city["sirka_smer"]),
+  "narozeni_delka_stupne": str(city["delka_stupne"]),
+  "narozeni_delka_minuty": str(city["delka_minuty"]),
+  "narozeni_delka_smer": str(city["delka_smer"]),
+  "house_system": "placidus",
+}
+url = "https://horoscopes.astro-seek.com/calculate-birth-chart-horoscope-online/?" + urllib.parse.urlencode(params)
+html = http_get(url)
+```
+
+The page is fully server-rendered — all planet positions, house cusps, aspect tables, copy-paste blocks, and chart `<img>` URLs appear in that response. No cookies, no CSRF, no rate-limit observed. Parse with the techniques in `scraping.md` and `chart-output.md`.
+
+**Parity:** URL-built and form-driven paths produce byte-identical chart URLs (verified across `p_slunce`, `p_luna`, `p_merkur`, `p_mars`, `dum_1_new`, `dum_10_new`). Once you have the field list right, the two paths are interchangeable for one-shot fetches.
+
+**500 on refetch trap:** long form-driven URLs (≥ ~700 chars with every hidden field) sometimes 500 when `http_get`'d back without a browser session. If you need to refetch, use your trimmed URL-built version, not the browser's `location.href`.

--- a/domain-skills/astro-seek/gotchas.md
+++ b/domain-skills/astro-seek/gotchas.md
@@ -1,0 +1,174 @@
+# Astro-Seek — Gotchas
+
+Field-tested traps. The site is stable and quirk-light, but these will burn time if you don't know.
+
+## Czech field names everywhere
+
+The compute backend was originally Czech. **Most form field names are Czech**, with no English aliases. You can't rename them — the server reads exactly:
+
+- `narozeni_den/mesic/rok/hodina/minuta/sekunda` (birth day/month/year/hour/minute/second)
+- `narozeni_city/mesto/stat/podstat` (city/town/state/region)
+- `narozeni_sirka/delka` (latitude/longitude)
+- `dum_1` … `dum_12` (house cusps)
+- `p_slunce/luna/merkur/venuse/…` (planet positions)
+- `r_<planet>=ANO` (retrograde — `ANO` is Czech "yes"; absence == direct)
+- `muz_` / `zena_` prefixes (man/woman) on relationship/transit forms — opaque keys, not gender markers
+
+Glossary lives in `chart-output.md`. Keep it open while scraping.
+
+## `?lang=en` does almost nothing
+
+The `horoscopes.astro-seek.com` subdomain is English-only; the param is a no-op there. The marketing-side translations live on host-prefixed subdomains (`pt.`, `de.`, etc.) with separate content, not parameter switches. Don't waste time toggling `?lang=`.
+
+## Forms are GET — but prefer driving them anyway
+
+A results URL is a complete permalink, so URL construction *is* possible. But the form's jQuery autocomplete silently writes six lat/lon hidden fields (`narozeni_sirka_stupne/_minuty/_smer` + `narozeni_delka_*`) that the default path has to remember to include. Miss them and the server computes at **lat 0°, lon 0°** — all quadrant house systems collapse to equal-house at the equator, which masks bugs without raising an error. Default path: drive the form. Fast path (bulk scraping): build the URL, and include the six sirka/delka fields. See `forms.md`.
+
+## City autocomplete needs two API calls
+
+The dropdown's API returns suggestions with an `id`, but that `id` is the place id, **not** the timezone id. You must make a second call: `GET /api_gmaps3.php?place_id=<id>` to get `tzid_id`, lat/lon, and country. When you drive the form, the jQuery select handler makes both calls and populates every hidden field; you only touch the API directly on the URL-building fast path. See `forms.md`.
+
+## Hour/minute/second `<select>` option values are zero-padded; day/month are not
+
+`jQuery('[name=narozeni_minuta]').val('0').change()` silently fails because the option value is `"00"`. Same for `narozeni_hodina` and `narozeni_sekunda`. `narozeni_den` and `narozeni_mesic` are `"1".."12"` / `"1".."31"` (unpadded). For URL-building the server accepts either form; for form-driving you must match the option value exactly or the field is omitted from the submitted URL.
+
+## Chart bitmap caching is tool-dependent
+
+The **birth-chart radix** (`chart4def-700__radix_*.gif`) is cached by filename — all three house-system variants (placidus / koch / whole_horizon) return byte-identical bytes. The filename only encodes date + time (`radix_1-1-1990_12-00`), so the server serves the same cached bitmap regardless of cusp or tropical/sidereal settings. For regression-testing the birth-chart tool, diff the URL query string (`dum_*`, `p_*`, `r_*`), not the image bytes.
+
+**Every other tool tested re-renders per query.** Verified as of 2026-04-19:
+
+| Tool | Primary chart | Cache behaviour |
+|---|---|---|
+| Birth chart | `chart4def-700__radix_` | filename-only cache (md5 identical across house-system variants) |
+| Asteroids | `chart1snew-700__radix_` | cusps re-render bitmap; planet-sort-order does NOT |
+| Sidereal | `chart1-700__radix_` | ayanamsa re-renders bitmap (server emits `nocache=21` in the URL) |
+| Synastry | `synastry-chart23-700__…_p_…` | cusps + `hide_aspects` re-render |
+| Composite | `chart4def-700__composite_` | cusps re-render (`metoda_vypoctu` did NOT change bytes in one test) |
+| Progressions | `synastry-chart20-700__progressions_` | cusps + `hide_aspects` re-render |
+
+Safer rule: always diff the query string for semantic changes, and md5 the bytes only when you specifically want to test that the bitmap reflects them. Don't rely on the cached-filename shortcut outside the birth chart.
+
+## Form-driven submit URLs can exceed server-handleable length
+
+After `document.forms[0].submit()`, `location.href` is a ~750-char URL echoing every form field including empty hidden ones. Re-fetching that URL through `http_get` can return **HTTP 500** while a shorter URL-built variant with the same semantic inputs returns 200. If you need the results page twice, cache the browser's rendered HTML or rebuild with the trimmed field set.
+
+## `press_key` doubles characters in text inputs
+
+Harness footgun: the harness's `press_key("a")` sends both a `keyDown` (with `text`) and a `char` event via CDP. Listening sites get the character once, but `<input>` and `<textarea>` insert it twice. Result: typing "London" via `for ch in "London": press_key(ch)` produces `LLoonnddoonn`.
+
+**Fix:** use `type_text("London")` (CDP `Input.insertText`) for free-form text. It inserts once and still fires the `input` event jQuery autocomplete listens to. Reserve `press_key` for special keys (Arrow*, Enter, Escape, Tab).
+
+## Degree glyphs are Unicode `'` (U+2019), not ASCII `'`
+
+Tables and copy-paste blocks render arcminutes as U+2019 RIGHT SINGLE QUOTATION MARK and arcseconds as two of them. HTML entity is `&rsquo;`. ASCII apostrophe regexes will silently miss every value. See `scraping.md`.
+
+## Tables have no id and no class
+
+`<table>`s in the result page are bare. Locate by header content (e.g. "Planet | Sign | Degree | House | Motion"), not ordinal — astro-seek inserts ad/info rows that shift table indices.
+
+## Tab 3 is the only lazy-loaded tab
+
+Tabs 1, 2, 4, 5, 6 are all in the initial HTML. Tab 3 (Horoscope Shape Characteristics) is a `<div>` placeholder that loads a highslide image gallery on click. Skip it for `http_get`; only drive a browser if you specifically need the shape PNG.
+
+## Multiple chart `<img>` tags coexist
+
+Every results page has 3–8 `<img>` tags pointing at different style/size variants of the chart. `naturalWidth === 700` on its own is **not unique** — several chart styles load at 700×700 when scrolled into view. Filter by the style token AND the size (and exclude `minor_aspects` / `astroseek` infixes). The correct style token is **tool-specific**:
+
+| Tool | Primary style token to match |
+|---|---|
+| Birth chart | `chart4def-700__radix_` |
+| Asteroids | `chart1snew-700__radix_` (NOT `chart4def-700`) |
+| Sidereal | `chart1-700__radix_` (NOT `chart4def-700`) |
+| Composite | `chart4def-700__composite_` (single wheel) |
+| Synastry | `synastry-chart23-700__` (with `_p_` separator; NO TYPE token) |
+| Transit | `synastry-chart20-700__transits_` |
+| Progressions | `synastry-chart20-700__progressions_` |
+
+Example for the birth chart:
+
+```js
+img.src.match(/horoscope-chart4def-700__radix_/) &&
+  !img.src.match(/minor_aspects|astroseek/) &&
+  img.naturalWidth === 700
+```
+
+The `4def` style is the default modern look; `4zone3` is the watermark variant; `3` is the classic style. Bi-wheel tools (transit, synastry, progressions) use the `horoscope-synastry-chart…` base path — see `chart-output.md` for the full style-and-TYPE inventory.
+
+## `src=` attributes contain literal newlines
+
+Astro-seek breaks long chart URLs across multiple lines inside `<img src="…">`. A naive `[^"\s]+` regex truncates the URL at the first newline. Use `[^"]+` and then `re.sub(r'\s+', '', url)` to strip the whitespace.
+
+## `.png` extension lies — birth-chart radix is GIF
+
+Birth-chart radix files (`horoscope-chart4def-700__radix_*.png`) are actually GIF87a (signature `47 49 46 38`). Every other tool tested (transit, synastry, composite, progressions, asteroids, sidereal) returns real PNG (`89 50 4e 47`) despite the same `.png` extension. Don't hardcode a PNG signature check — only the birth chart is the GIF-in-PNG-clothing case. See `chart-output.md`.
+
+## Chart download needs a User-Agent
+
+Plain `urllib.request.urlopen(chart_url)` returns **HTTP 403**. Set `User-Agent: Mozilla/5.0` on the request. `http_get` already does this; external curl/wget does it by default; bare urllib does not. Cookies, referer, and auth are still not required.
+
+## Transit-chart results have a surprising primary image
+
+The `/calculate-transit-chart/?…` page headlines an **annual-transits-in-natal** graph (`horoscope-chart8annual-700__annual_transits_in_natal_chart_…`) plus a natal radix. The actual **transit bi-wheel** is rendered further down the page under the `horoscope-synastry-chart{N}-700__transits_…` path. Don't assume the first 700×700 image is what you asked for.
+
+## Search / calendar tools have no chart image
+
+Ephemeris search, transit-calendar, and similar tools emit zero `horoscope-chart*` tags on the results page. The payload is table rows. Don't waste time hunting for chart URLs on these — scrape `<tr>` directly.
+
+## Transit-chart result tables skip the birth-chart header
+
+`Planet | Sign | Degree | House | Motion` is a **birth-chart-only** header. Transit results lay out the data differently (grouped by natal/transit side). Test your header regex per tool before assuming the pattern in `scraping.md` is universal.
+
+## Single-subject city input id is `#city`, not `#narozeni_city`
+
+The `name` attribute is `narozeni_city`, but the `id` is bare `#city`. `forms.md` has the full id mapping across tool shapes. Multi-subject forms use `#muz_city` / `#zena_city`. Composite adds a third `#tranzity_city` for the transit overlay. Secondary progressions has only `#muz_city` — the progression date reuses the natal location and exposes no `#zena_city`.
+
+## Browser-extension overlays break programmatic focus
+
+If `type_text` after `.focus()` doesn't trigger the city autocomplete (dropdown never appears, `tzid_id` stays empty), the likely culprit is a password-manager extension (1Password, LastPass, Bitwarden) overlaying the text input and swallowing programmatic focus. **Coordinate-click the input first** to land a real focus event, then `type_text`. See `forms.md` "Browser-extension overlays".
+
+## Filename date format is Czech-locale
+
+Chart PNG filenames embed the date as `D-M-YYYY_HH-MM` — no leading zeros on D and M (Czech locale), leading zeros on H and MM. `1-1-1990_12-00.png` not `01-01-1990_12-00.png`.
+
+## Year out of 1800–2099
+
+The year `<select>` only covers 1800–2099. Out-of-range values switch to a manual text input (`narozeni_year_of_birth_input`). For URL submission, just pass any year directly in `narozeni_rok` — the server accepts it without the select-vs-input dance.
+
+## No cookie banner, no captcha, no auth wall
+
+Confirmed clean session. A `PHPSESSID` cookie is set on first visit but isn't required for any read or compute call. No rate limiting observed.
+
+## `#tabs_redraw` fragment in form action
+
+Form `action` URLs sometimes end with `#tabs_redraw` (a JS scroll anchor). Browsers strip fragments from outgoing GET requests; some HTTP libs don't. Strip it before passing to `http_get` to avoid an unnecessary 30x or oddity.
+
+## Tools at unexpected URLs
+
+The "obvious" URL isn't always real — `synastry-chart-online-calculator` works, but `free-synastry-chart-online-calculator-relationship-astrology` 404s. When unsure, find the link from `https://horoscopes.astro-seek.com/` or `https://www.astro-seek.com/` instead of guessing.
+
+Confirmed-wrong guesses to avoid (all 404):
+
+- `/aspect-search-calculator` → real URL is `/astrology-aspects-online-search-engine`
+- `/progressed-chart-astrology-online` → real URL is `/astrology-secondary-progressions-directions-chart`
+- `/transit-calendar` → real URL is `/personal-transit-calendar-monthly-astrology-transits` (there is no bare `/transit-calendar`)
+
+## `document.forms[0]` is not always the tool's real form
+
+Most tools expose a single user-facing form so `forms[0]` is right. Aspect-search-engine is the known exception: the page has 4 forms (timezone picker + search + current-planets + ingresses). `forms[0]` is the timezone sub-form and submitting it keeps you on the intro page. The real search is **`document.forms[1]`**. When a new tool's submit returns the form page again instead of results, enumerate `document.forms` and check `.action` on each.
+
+## Progressed-chart filename has two inconsistent date formats on one page
+
+The secondary-progressions results page renders both `synastry-chart20-700__progressions_` and `synastry-chart24-700__secondary-progressions_` bi-wheels. The chart20 filename drops the time on the second date (`…_a_19-4-2026.png`) while the chart24 filename keeps it (`…_a_19-4-2026_12-00.png`). Parse the date block by splitting on `_a_` (or `_p_` for synastry) rather than regexing for a fixed `D-M-YYYY_HH-MM` shape on both sides.
+
+## Astro-seek's `r_<planet>=ANO` retrograde flags aren't always ephemerally correct
+
+Verified: astro-seek emits `r_venuse=ANO` in the chart URL for 1990-01-01 noon London, but Venus was **direct** at that moment. Treat the `r_<planet>` flags in chart query strings as display hints mirroring astro-seek's rendering, not as ground truth for regression-testing your own retrograde detection. Compute retrograde status yourself from the planet's longitudinal speed (via Swiss Ephemeris) rather than trusting the URL parameter.
+
+## Sidereal tool defaults to `whole`-sign houses, not placidus
+
+The `<select name=house_system>` on `/sidereal-astrology-chart-calculator` defaults to `whole` (the Vedic convention), not `placidus` like the other tools. If you don't explicitly set `house_system` the submitted URL will carry `house_system=whole`. Don't assume placidus is universal.
+
+## Aspect-search uses Czech aspect keys + abbreviated months
+
+`kalendar_aspekt` takes Czech values (`konjunkce`, `sextil`, `kvadratura`, `trigon`, `opozice`, `minor`, `hard`, `konjunkce_opozice`), and the result-row format uses **3-letter English month abbreviations** (`Jan`, `Feb`, `Sep`) with a completely different shape from the ephemeris search tool. Don't reuse the ephemeris row regex. See `scraping.md`.

--- a/domain-skills/astro-seek/gotchas.md
+++ b/domain-skills/astro-seek/gotchas.md
@@ -161,9 +161,9 @@ Most tools expose a single user-facing form so `forms[0]` is right. Aspect-searc
 
 The secondary-progressions results page renders both `synastry-chart20-700__progressions_` and `synastry-chart24-700__secondary-progressions_` bi-wheels. The chart20 filename drops the time on the second date (`…_a_19-4-2026.png`) while the chart24 filename keeps it (`…_a_19-4-2026_12-00.png`). Parse the date block by splitting on `_a_` (or `_p_` for synastry) rather than regexing for a fixed `D-M-YYYY_HH-MM` shape on both sides.
 
-## Astro-seek's `r_<planet>=ANO` retrograde flags aren't always ephemerally correct
+## Astro-seek's `r_<planet>=ANO` retrograde flags ARE ephemerally correct (2026-08 correction)
 
-Verified: astro-seek emits `r_venuse=ANO` in the chart URL for 1990-01-01 noon London, but Venus was **direct** at that moment. Treat the `r_<planet>` flags in chart query strings as display hints mirroring astro-seek's rendering, not as ground truth for regression-testing your own retrograde detection. Compute retrograde status yourself from the planet's longitudinal speed (via Swiss Ephemeris) rather than trusting the URL parameter.
+**Correction (2026-08-06):** this file previously claimed `r_venuse=ANO` for 1990-01-01 noon London was wrong ("Venus was direct"). That claim was itself the error — Venus was retrograde Dec 29 1989 – Feb 8 1990; astro-seek's flag, Swiss Ephemeris speed sign, and the page's own coordinate-table speeds all agree. Benchmarks against the `r_<planet>` payload flags have since matched Swiss Ephemeris across natal, transit, progressed, and return charts with zero discrepancies. Trust the flags.
 
 ## Sidereal tool defaults to `whole`-sign houses, not placidus
 
@@ -172,3 +172,40 @@ The `<select name=house_system>` on `/sidereal-astrology-chart-calculator` defau
 ## Aspect-search uses Czech aspect keys + abbreviated months
 
 `kalendar_aspekt` takes Czech values (`konjunkce`, `sextil`, `kvadratura`, `trigon`, `opozice`, `minor`, `hard`, `konjunkce_opozice`), and the result-row format uses **3-letter English month abbreviations** (`Jan`, `Feb`, `Sep`) with a completely different shape from the ephemeris search tool. Don't reuse the ephemeris row regex. See `scraping.md`.
+
+## 2026-08 updates (benchmark campaign, 14 cloud sessions)
+
+- **Cloudflare now challenges plain HTTP.** Every non-browser request (curl,
+  `http_get`) to `horoscopes.astro-seek.com` gets `403 cf-mitigated: challenge`
+  ("Just a moment…"). The April-era bulk-HTTP fast path is dead. Browser Use
+  cloud browsers (stealth + residential proxy) were never challenged across 14
+  sessions. In-page bulk capture still works: submit the form, then dump
+  `document.documentElement.outerHTML` and parse offline.
+- **Ephemeris-search row format changed.** Visible rows are now just
+  `YYYY, Mon DD (display chart)`; the full 13-body noon-UT ephemeris (with R/st
+  flags) moved into each row's `onmouseover` tooltip. The row regex documented
+  in scraping.md no longer matches the visible text — parse the tooltip HTML.
+  Results are day-granular noon-UT snapshots (an ingress after noon lands on
+  the following day's row).
+- **House-systems form URL moved.** `/house-systems-astrology-calculator-comparison`
+  now 404s; live page is `/astrology-house-systems-calculator` (19 systems,
+  no seconds select).
+- **There is no tools index page.** `/astrology-tools-online` 404s — discover
+  tools from the homepage `#calculations` section and footer nav.
+- **Timezone handling is correct and tz-aware.** Transit/mansion/return pages
+  apply historical DST (e.g. 2026-04-19 12:00 London = 11:00 UT, banner says
+  BST). Payload decimals are TRUNCATED, not rounded — compare with one-sided
+  tolerance 10^(−decimals).
+- **Best-precision sources per page family:** birth chart tab-5 coordinate
+  table (arcseconds); progressions payload `luna_denni_00/_24` (11 decimals);
+  sidereal payload `aya_posun` (12-decimal ayanamsa); retrograde calendar
+  "shadow" links (station longitudes to arcseconds); ZR results' plain-text
+  export tabs (cleanest structured export on the whole site).
+- **Aspect-search extras:** `kalendar_aspekt` also accepts `trioktil` (135°)
+  and `kvinkunx` (150°) beyond the documented keys. Sign/aspect in result rows
+  live ONLY in `img alt` attributes; degrees use plain ASCII (no U+2019) unlike
+  chart pages.
+- **Cloud-browser death mode:** a Browser Use browser can die mid-session
+  (daemon websocket keepalive timeout; v4 API still says "active" but `cdpUrl`
+  is null and `/json/version` 503s). Stop it via PATCH and provision a fresh
+  browser — no in-place recovery.

--- a/domain-skills/astro-seek/pages-2026-08.md
+++ b/domain-skills/astro-seek/pages-2026-08.md
@@ -1,0 +1,97 @@
+# Astro-Seek — Page Maps from the 2026-08 Benchmark Campaign
+
+Condensed maps for tools first driven during the Astrolabi benchmark campaign
+(2026-08-06/07). Fixture used throughout: 1990-01-01 12:00 London. Full parsed
+reference JSONs live in the Astrolabi repo under `docs/benchmarks/astro-seek/`.
+
+## Returns
+
+- Solar return: dedicated form; `zena_` prefix = "City for Solar return"; the
+  return is computed AT that location. Results page has NO copy blocks and NO
+  cusp table — SR angles exist ONLY in the chart-URL payload (`dum_*`). The SR
+  moment is solved to the second but displayed to the minute; the seconds hide
+  in the "open as standalone chart" link's query params. Bi-wheel TYPE token
+  `__solarni_` with `_rok_YYYY` filename suffix; SR side under
+  `planeta_partner_*` / `dum_partner_*`.
+- Lunar/planet returns: `/lunar-return-revolution` is the generic
+  planet-returns calculator preset to `planeta_navrat=luna`. Form takes a YEAR
+  only and lists ALL returns of that year (13 lunar) to the minute, LOCAL time.
+  `planeta_navrat` also offers `soliluna`/`slunceluna` combined returns. The
+  natal side omits the seconds select here.
+
+## Harmonics / Antiscia / Draconic / Sidereal
+
+- Harmonic: `/harmonics-astrology-harmonic-horoscope-chart-calculator` →
+  `/calculate-harmonic-chart/`. `select[name=harmonic]` 1–360, page DEFAULT 9.
+  No house select — harmonic wheel is whole-sign from harmonic ASC = natal
+  ASC × N mod 360 exactly. Single-wheel chart URLs reuse the `draconic_chart`
+  TYPE token (misleading); bi-wheel `synastry-chart8-700__harmonic_natal` with
+  empty date slots. Natal side of the bi-wheel payload carries ~10-decimal
+  longitudes.
+- Antiscia: NOT standalone — the "Antiscia Calculator" form posts to
+  `/calculate-traditional-chart/` with `aktivni_tab=5&tradicni=1`. house_system
+  DEFAULTS to whole_horizon. Axis fixed solstitial; contra shown in the same
+  13-row table; the `__antiscia.png`/`__antiscia_contra.png` payloads carry all
+  points (display table covers traditional points only). Formulas verified:
+  antiscia = (180 − L) mod 360, contra = (360 − L) mod 360.
+- Draconic: `/draconic-chart-astrology-calculator`. Default MEAN node
+  (`true_uzel` checkbox unchecked); houses node-shifted too; payload pins
+  `planeta_uzel=0`; no Vertex.
+- Sidereal: default `house_system=whole_horizon` (value is NOT `whole` as
+  previously documented) and Lahiri ayanamsa; payload `aya_posun` gives the
+  ayanamsa to 12 decimals — best precision on the site. This session emitted
+  `chart4-700` + size-less `chart1` tokens (not the documented `chart1-700`).
+
+## Moon calendar subdomain (`mooncalendar.astro-seek.com`)
+
+Pure direct-GET pages — no forms, no location, everything UT by default (header
+tooltip confirms). One engine serves three calendars via `voc=` + filter params
+(`/calculate-moon-void-of-course/` with `voc=5&kalendar_planeta_1=slunce_lunacni&kalendar_aspekt=minor`
+= lunation cycle). Month calendar prints exact times only for New/Full; quarter
+times live on the lunation-cycle page. No illumination % anywhere. Eclipse rows
+in the year list are separate rows minutes apart from their paired lunation.
+VoC begin-row sign/degree is display-rounded (a "Vir 00°00'" begin actually
+perfected in late Leo).
+
+## Timelord suite (Traditional Astrology nav; all dedicated calculators)
+
+- Profections: `/annual-profections-astrology-calculator` — whole-sign,
+  30°/year; also monthly/daily variants which default to SOLAR-RETURN anchoring
+  (`solar_profekce=1`), 1-day-per-sign key for daily. Includes a non-classical
+  "Lord of the Orb" planetary-hour column.
+- Zodiacal releasing: `/zodiacal-releasing-astrology-calculator` — default lot
+  FORTUNE. Results embed plain-text export tabs (L1/L2, L1/L3, L1/L4) with
+  MM/DD/YYYY dates, 3-letter signs, and pLB/LB/Cu./Co. markers — the cleanest
+  structured export surface on the whole site. Uses 360-day Valens years
+  (verified: matches Valens Anthology IV.9).
+- Vimshottari dashas: `/vimshottari-dasha-vedic-astrology-online-calculator` —
+  exposes exact ayanamsa, JD, LST, sidereal Moon with nakshatra + balance.
+- Firdaria: all THREE variants (day; night nodes-after-Mars; night
+  nodes-at-end) server-rendered in one page as tabs #tab1/#tab2/#tab3. Nodes
+  always in the 75y major sequence; node majors have no subs.
+- Decennials: day + night tables both pre-rendered (night has no visible tab
+  link); L1 = 129 months on a 360-day-year default.
+- Lunar mansions: `/lunar-mansions-astrology-online-calculator` — defaults
+  SIDEREAL (Lahiri) with 27 nakshatras; division (27/28-manzil/28-Ibn-Arabi)
+  and ayanamsa are independent knobs.
+- Planetary hours: `/planetary-hours-today-astrology-calculator` — city
+  autocomplete hides in a COLLAPSED sub-form (`Toggle('select_local_tz_id')`)
+  whose hidden date fields duplicate the visible ones; ruler glyphs carry alt
+  text here (unlike the traditional page); no explicit sunrise/sunset labels
+  (sunrise = day-hour-1 start).
+
+## Midpoints
+
+Midpoint calculator's default `planeta_navrat=sluna` view silently DROPS
+Node/Ascendant and Node/MC (48 of 50 pairs render); `planeta_navrat=all` gives
+the full 105 pairs (15 points, no Fortune/Vertex). Activation label "Tri (135°)"
+means trioctile/sesquiquadrate, NOT trine. Payload carries `mid_NN` decimal
+midpoint longitudes.
+
+## Traditional-astrology page (dignity hunting)
+
+Has NO essential/accidental dignity tables at all (no scores, no almuten) —
+verified including the horary variant. What it DOES have: Egyptian bounds ring
+(`hranice=1`), sect, planetary hours (glyphs without alt text), prenatal syzygy,
+full speculum (MD/AD/SA/OA/OD), an under-beams annotation, and per-house ruler
+placements. Terms select offers Egyptian/Ptolemy/Chaldean.

--- a/domain-skills/astro-seek/pages-2026-08.md
+++ b/domain-skills/astro-seek/pages-2026-08.md
@@ -88,6 +88,64 @@ the full 105 pairs (15 points, no Fortune/Vertex). Activation label "Tri (135°)
 means trioctile/sesquiquadrate, NOT trine. Payload carries `mid_NN` decimal
 midpoint longitudes.
 
+## Chart Graphics Customizer (`/calculate-custom-natal-chart/`)
+
+Reached from the natal results page's "Customize your favourite chart graphics
+layout" link (link carries the full birth payload). One form, action = same URL.
+**Every style `<select>` auto-submits on `.change()`** — `jQuery(...).val(v).change()`
+navigates immediately; don't call `forms[0].submit()` after it and don't touch
+the DOM between change and load. `house_layout` is a **URL-override no-op** on a
+fixed chart-image URL because the layout selects a different chart STYLE token
+server-side. Form-driven mapping (value → style token, fixture 1-1-1990 12:00
+London): 0→`chart1`, 9→`chart2`, 1→`chart8`, 2→`chart4def`, 22→`chart4def .svg`
+(real `image/svg+xml`, the "New SVG vectors" mode), 6→`chart4w`, 4→`chart4y`,
+5→`chart4z`, 7→`chart4zone3` (page default), 10→`chart5`, 12→`chart5s`. All are
+`__radix_astroseek_customized_` filenames and re-render per query.
+
+## AstroCartography (`/astrocartography-online-astro-map-relocation`)
+
+Single-subject form (`#city`), but **`forms[0].target` is `_blank`** — submit
+opens the results in a NEW tab (`/calculate-full-astrocartography2/`); the form
+page stays put, which looks like a silent submit failure. Grab the new tab from
+`list_tabs()`. Results page has exactly one map `<img>`:
+`horoscope-relocation-chart5__astrocartography_mundo_{D-M-YYYY_HH-MM}.png` —
+despite `.png` + `gif=1` in the query it serves **image/gif** (~690KB world map,
+AC/DC/MC/IC lines). Payload carries per-planet ecliptic lon + RA + declination.
+
+## Graphic ephemeris = "Circular Graphic Ephemeris" only
+
+There is NO linear/45° graphic-ephemeris tool anywhere on the site (checked
+tools-search + all nav). The only graphic ephemeris is the circular one at
+`/monthly-planetary-movement-astrology-ephemeris-overview` →
+`/calculate-monthly-planetary-movement/`. The `narozeni_mesic2` select doubles
+as the mode switch: values `01`–`12` (also `301`–`312`, `401`–`412` style
+variants) = one month, all planets; values `101`–`113` etc. = **whole-year
+single-planet** view (101 Sun … 110 Pluto, 111 Node, 112 Lilith, 113 Chiron,
+102 Full Moons). Geocentric only. Chart img: `horoscope-monthly-motion2__ephemeris-motion-YYYY-month.png`
+(monthly) / `horoscope-circular-annual-motion2__…` (annual).
+
+## Vedic diamond/square charts (sidereal results tabs)
+
+AS DOES have North-Indian (diamond) and South-Indian (square) vedic renderers —
+they live as tabs on the sidereal/kundli results page
+(`/calculate-sidereal-chart/`): `#tab2` South (Square), `#tab7` North (Diamond),
+`#tab5` Vedic table. Tab links use NBSP in their text ("South\xa0(Square)") —
+match with `replace(/ /g,' ')`. The on-page grids are pure HTML/CSS (no
+canvas/svg/img), with a D-Chart select (D1–D60) + "1st House from" control per
+tab. Each tab's "Print chart" link exposes the server-rendered SVG:
+`horoscope-chart6vedic-700__sidereal_radix_astroseek-{date}.svg` (South default;
+`b6=north` renders the North diamond). Real `image/svg+xml`, ~130KB.
+
+## Moon calendar monthly page is a list-table, not a grid
+
+`/moon-phases-calendar-<month>-<year>` renders one `<table>` with a row per day
+(32 rows × 4 columns): Date (weekday + linked day) | Moon Phase (thumbnail img +
+phase name) | Moon Sign (glyph + name; ingress days show "from HH:MM (h:mm pm)"
+with old sign above, new sign below) | Organs influenced + a Surgery yes/no
+column. Quarter-phase rows bold the phase name; New/Full rows are highlighted
+with exact time ("FULL MOON at 04:18") and eclipse annotation. Default UT/GMT
+(header link switches to local tz). No 7-column month grid exists on the page.
+
 ## Traditional-astrology page (dignity hunting)
 
 Has NO essential/accidental dignity tables at all (no scores, no almuten) —

--- a/domain-skills/astro-seek/scraping.md
+++ b/domain-skills/astro-seek/scraping.md
@@ -1,0 +1,140 @@
+# Astro-Seek — Scraping Result Pages
+
+Result pages are **fully server-rendered HTML**. `http_get(results_url)` returns ~800KB containing every table, copy-paste block, and chart `<img>` you need. No browser, no JS execution, no auth.
+
+The forms-side workflow lives in `forms.md`; this file is what to do once you have the response HTML.
+
+## What the page contains (in DOM order)
+
+The table below describes a **birth-chart** results page. Other tools differ:
+
+- **Transit chart** (`/calculate-transit-chart/`) does NOT expose a `Planet | Sign | Degree | House | Motion` header — its layout is annual-transits-first and tables are grouped differently. Test `hdr_ok` tool-by-tool before relying on the pattern.
+- **Search/calendar tools** (ephemeris, transit-calendar) emit dated rows only — no chart `<img>`, no planet positions table in the shape below. Scrape `<tr>` rows directly.
+
+| # | Block | Selector hint |
+|---|---|---|
+| 1 | Birth-data summary | `<h1>` text "1 January 1990 - 12:00 (GMT)…" |
+| 2 | Chart wheel `<img>` (multiple styles) | `img[src*="horoscope-chart"]` — see `chart-output.md` |
+| 3 | Planet positions table | first `<table>` whose first row is `Planet | Sign | Degree | House | Motion` |
+| 4 | House cusps table — left half (cusps 1–6) | second `<table>`, rows like `1: | Aries (ASC) | 11°49'53"` |
+| 5 | House cusps table — right half (cusps 7–12) | third `<table>`, mirror of #4 starting at `7: | Libra (DESC)` |
+| 6 | Major aspects table (Sun–Pluto) | `<table>` with header `Planet | Aspect | Planet | Orb | A/S` |
+| 7 | Other aspects table (involving ASC/MC/Node/Lilith/Chiron/Fortune/Vertex) | `<table>` with header `Object | Aspect | Planet | Orb | Aspect` |
+| 8 | Parallels table | `<table>` with header `Object | Aspect | Planet | Orb` (no A/S column) |
+| 9 | Copy-paste blocks (5 of them — planet positions, house positions, planet aspects, other aspects, parallels) | `<textarea>` or `<div onclick="selectText('positions_chart_gpt')">` |
+| 10 | Minor aspects / harmonics table | `<table>` with header `(1*/n of 360°)` |
+| 11 | Sun-to-planet arcs table | header `Sun-Planet | ArcPhase Degree | ArcReturns` |
+| 12 | Sensitive degrees table | header starts `Deg°` |
+| 13 | Tab 5 — full coordinate table | header `Planet | Long | Lat | RA | Decl | Az | Alt | Speed` |
+| 14 | Tab 6 — dominant planets | header `Planet | Sign(?) | House(?) | Angle(?) | Ruler(excl.) | Aspects(excl.) | SUMPoints | Dominant%` |
+
+**Tables have no `id` and no class.** Locate them by header content, not by ordinal — astro-seek occasionally inserts ad/info rows between tables and the order shifts between tools.
+
+```python
+# Robust pattern: parse all tables, find the one whose first row matches the header you want
+import re
+def find_table(html, header_re):
+    for m in re.finditer(r'<table[^>]*>(.*?)</table>', html, re.S):
+        head = re.search(r'<tr[^>]*>(.*?)</tr>', m.group(1), re.S)
+        if head and re.search(header_re, head.group(1), re.I):
+            return m.group(1)
+    return None
+
+planets = find_table(html, r'Planet.{0,40}Sign.{0,40}Degree.{0,40}House')
+```
+
+For anything beyond simple regex, parse with `bs4` or `lxml` — both work fine on the response.
+
+## Two ways to read planet positions — pick by need
+
+**Reading numerical positions for verification?** Parse the chart-image URL query string. It carries decimal-degree floats with no entity encoding. See `chart-output.md` for the full param list.
+
+**Reading display-formatted positions (sign + degree + retrograde label)?** Scrape the planet-positions table or the copy-paste text block. The text block (`Sun in Capricorn 10°48', in 10th House`) is a single regex away.
+
+## Degree separators are Unicode, not ASCII
+
+Astro-seek uses fancy quotes for arcminutes and arcseconds:
+
+| Glyph | Codepoint | HTML entity | Meaning |
+|---|---|---|---|
+| `°` | U+00B0 | `&deg;` | degrees |
+| `'` | U+2019 | `&rsquo;` | arcminutes |
+| `''` (two) | U+2019 U+2019 | `&rsquo;&rsquo;` | arcseconds |
+
+**Not** `'` (U+0027) or `"` (U+0022). Match with `°` and `\u2019` (`'`), or strip entities first if you've decoded.
+
+```python
+import html as h
+text = h.unescape(raw)              # &deg; -> °, &rsquo; -> ’
+m = re.match(r"(\d+)°(\d+)\u2019(\d+)\u2019\u2019", text)   # deg, min, sec
+```
+
+## Ephemeris / search / calendar row format
+
+Search tools emit no chart `<img>` and no planet-positions table. The row format **differs between search tools** — there is no universal regex. Known layouts:
+
+### Ephemeris search (`/calculate-ephemeris-search-engine/`)
+
+```
+July 23, 2026 , 12:00 [noon] UT/GMT    Sun: 0°40' Leo
+July 24, 2026 , 12:00 [noon] UT/GMT    Sun: 1°37' Leo
+```
+
+English month names, month-first (`Month DD, YYYY`), `HH:MM [noon] UT/GMT` timestamp, planet-colon-sign-degree payload with Unicode `°` and `\u2019` glyphs.
+
+```python
+ROW_RE = re.compile(
+    r'(January|February|March|April|May|June|July|August|September|October|November|December)'
+    r'\s+(\d{1,2}),\s*(\d{4})\s*,\s*(\d{1,2}:\d{2})[^<]*?'      # date + time
+    r'([A-Z][a-z]+):\s*(\d+)°(\d+)\u2019\s*([A-Z][a-z]+)',       # planet: deg°min' Sign
+    re.S,
+)
+for tr in re.findall(r'<tr[^>]*>(.*?)</tr>', html, re.S):
+    txt = re.sub(r'<[^>]+>', ' ', tr)  # strip tags; keep entities and glyphs
+    txt = html_.unescape(txt)
+    for month, day, year, hm, planet, deg, minute, sign in ROW_RE.findall(txt):
+        ...
+```
+
+Pass `aya=lahiri` (or other sidereal values) to switch zodiacs; the row format is unchanged, only the sign labels shift.
+
+### Aspect-search engine (`/calculate-astrology-aspects-online-search-engine/`)
+
+Completely different shape. Year-first, **3-letter abbreviated months**, time in parentheses, two degree values side by side (one per planet), no Unicode apostrophe between degrees and minutes, optional `(Rx)` for retrograde:
+
+```
+2026, Sep 01 (09:58)   13°39   13°39  (Rx) chart
+2028, Sep 21 (11:58)   10°33   10°33  (Rx) chart
+```
+
+The planets themselves aren't in the row — they're in the query (`kalendar_planeta_1`, `kalendar_planeta_2`), so you already know which pair the degrees belong to. Use `&nbsp;`-tolerant cleanup and a distinct regex:
+
+```python
+import html as h, re
+def parse_aspect_rows(html_src):
+    for m in re.finditer(r'<tr[^>]*>(.*?)</tr>', html_src, re.S):
+        txt = re.sub(r'<[^>]+>', ' ', m.group(1))
+        txt = h.unescape(txt)                         # &nbsp; -> \xa0, &deg; -> °
+        txt = re.sub(r'\s+', ' ', txt).strip()
+        row = re.match(
+            r'(\d{4}),\s*(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})'
+            r'\s*\((\d{1,2}:\d{2})\)\s*(\d+)°(\d+)\s+(\d+)°(\d+)\s*(\(Rx\))?',
+            txt,
+        )
+        if row:
+            yield row.groups()  # year, mon, day, hm, d1deg, d1min, d2deg, d2min, rx
+```
+
+Verified tools: ephemeris uses the first format; `/calculate-astrology-aspects-online-search-engine/` uses the second. Probe a new search tool's row shape before reusing either regex.
+
+## Cookies and rate limits
+
+`PHPSESSID` is set on first visit but **not required** for results URLs or for the city API. No rate limiting observed during this session — bulk-fetch with `ThreadPoolExecutor` is fine, but be polite.
+
+## When you do need a browser
+
+- **Tab 3 (Horoscope Shape).** It's a `<div>` placeholder that loads a highslide image gallery only on click. If you need the rendered shape PNG, drive a browser, click the tab, wait, then download the image.
+- **Customize-tab download buttons.** Tab 2 lets the user generate `chart4zone3` variants with custom backgrounds. The relevant query params are visible in the DOM but the toggles are JS-driven; building the URL by hand is faster than clicking through.
+- **Anything that opens highslide modals** — the modal contents only mount on click.
+
+For everything else, `http_get` is fastest.

--- a/domain-skills/astro-seek/url-patterns.md
+++ b/domain-skills/astro-seek/url-patterns.md
@@ -34,6 +34,7 @@ Every tool has a paired form-page URL and results URL. Both are GET. The form's 
 | Ephemeris search | `/ephemeris-search-engine-astrology-planet-positions` | `/calculate-ephemeris-search-engine/` |
 | Aspect search | `/astrology-aspects-online-search-engine` | `/calculate-astrology-aspects-online-search-engine/` (`#select_local_tz_anchor`) |
 | Traditional | `/traditional-astrology` | same pattern |
+| Custom bi/tri/quadri-wheel generators (paste positions, not birth data) | see `custom-chart-generators.md` | `/calculate-tri-wheel-chart-astrology-calculator/` |
 
 Discover the results URL on a new tool by reading `document.forms[0].action`. The action sometimes ends with `#tabs_redraw` — that's a scroll anchor, not a query. **A tool may have multiple forms** — aspect-search has four (`forms[0]` is a timezone sub-form, `forms[1]` is the real search); always read the action of the specific form you plan to submit.
 

--- a/domain-skills/astro-seek/url-patterns.md
+++ b/domain-skills/astro-seek/url-patterns.md
@@ -30,7 +30,7 @@ Every tool has a paired form-page URL and results URL. Both are GET. The form's 
 | Progressions (secondary) | `/astrology-secondary-progressions-directions-chart` | `/calculate-secondary-directions-progressions/` (`#tabs_redraw`) |
 | Asteroids | `/asteroids-astrology-online-calculator` | `/calculate-asteroids/` |
 | Sidereal | `/sidereal-astrology-chart-calculator` | `/calculate-sidereal-chart/` |
-| House-systems comparison | `/house-systems-astrology-calculator-comparison` | `/calculate-house-systems/` |
+| House-systems comparison | `/astrology-house-systems-calculator` (moved 2026-08; old `/house-systems-...-comparison` 404s) | `/calculate-house-systems/` |
 | Ephemeris search | `/ephemeris-search-engine-astrology-planet-positions` | `/calculate-ephemeris-search-engine/` |
 | Aspect search | `/astrology-aspects-online-search-engine` | `/calculate-astrology-aspects-online-search-engine/` (`#select_local_tz_anchor`) |
 | Traditional | `/traditional-astrology` | same pattern |

--- a/domain-skills/astro-seek/url-patterns.md
+++ b/domain-skills/astro-seek/url-patterns.md
@@ -1,0 +1,129 @@
+# Astro-Seek — URL Patterns
+
+`https://astro-seek.com` — the astrology-tools site Astrolabi re-implements. Tools live across a few subdomains, all forms submit by **GET**, so a fully-formed URL is a permalink.
+
+This file is the reference for URL *construction* (the fast path for bulk scraping). The default path is form-driving — open the tool page, set selects, type the city, submit — because the form's autocomplete handles several hidden fields for you. See `forms.md` for the form-driving recipe.
+
+## Subdomain map
+
+| Subdomain | What lives here |
+|---|---|
+| `www.astro-seek.com` | Marketing/blog/zodiac articles. Mixed Czech/English. |
+| `horoscopes.astro-seek.com` | All compute tools (birth chart, transit, synastry, ephemeris, asteroids, returns, …). English-only. |
+| `mooncalendar.astro-seek.com` | Lunar calendar. |
+| `numerology.astro-seek.com` | Numerology tools. |
+| `famouspeople.astro-seek.com` | Celebrity natal-chart database. |
+| `es.astro-seek.com` / `pt.` / `de.` / `fr.` / `ru.` / `it.` / `tr.` / `ko.` | Localized marketing — different content, not a translation of `horoscopes.*`. |
+
+The `?lang=en` query param has no effect on `horoscopes.astro-seek.com` (it's English already) and does not switch language on the marketing subdomain either — language is host-based.
+
+## Form URL → Results URL
+
+Every tool has a paired form-page URL and results URL. Both are GET. The form's `action` attribute gives the results URL.
+
+| Tool | Form URL | Results URL |
+|---|---|---|
+| Birth chart | `/birth-chart-horoscope-online` | `/calculate-birth-chart-horoscope-online/` |
+| Transit chart | `/transit-chart-planetary-transits` | `/calculate-transit-chart/` (`#tabs_redraw`) — see note below |
+| Synastry | `/synastry-chart-online-calculator` | `/calculate-love-compatibility/` (`#tabs_redraw`) |
+| Composite | `/composite-chart-horoscope` | `/calculate-composite-chart-horoscope/` (`#tabs_redraw`) |
+| Progressions (secondary) | `/astrology-secondary-progressions-directions-chart` | `/calculate-secondary-directions-progressions/` (`#tabs_redraw`) |
+| Asteroids | `/asteroids-astrology-online-calculator` | `/calculate-asteroids/` |
+| Sidereal | `/sidereal-astrology-chart-calculator` | `/calculate-sidereal-chart/` |
+| House-systems comparison | `/house-systems-astrology-calculator-comparison` | `/calculate-house-systems/` |
+| Ephemeris search | `/ephemeris-search-engine-astrology-planet-positions` | `/calculate-ephemeris-search-engine/` |
+| Aspect search | `/astrology-aspects-online-search-engine` | `/calculate-astrology-aspects-online-search-engine/` (`#select_local_tz_anchor`) |
+| Traditional | `/traditional-astrology` | same pattern |
+
+Discover the results URL on a new tool by reading `document.forms[0].action`. The action sometimes ends with `#tabs_redraw` — that's a scroll anchor, not a query. **A tool may have multiple forms** — aspect-search has four (`forms[0]` is a timezone sub-form, `forms[1]` is the real search); always read the action of the specific form you plan to submit.
+
+**Transit-chart result page has a surprising primary.** `/calculate-transit-chart/?…` headlines an **annual-transits-in-natal** graph (`horoscope-chart8annual-700__annual_transits_in_natal_chart_…`) plus a natal radix — the **transit bi-wheel** you probably want is rendered further down the page under a different base path (`horoscope-synastry-chart{N}-700__transits_…`). Don't assume the first 700×700 image is what you asked for.
+
+## Query-param prefixes per subject
+
+The compute backend uses Czech field names. Single-person tools use bare names; relationship and transit tools use prefixed names.
+
+| Prefix | Subject | Used by |
+|---|---|---|
+| (none) | The single chart | Birth chart, asteroids, sidereal, traditional, draconic, kundli, …everything single-subject |
+| `muz_` | Person A / natal | Synastry, composite, transit (natal side), progressed synastry, secondary progressions (natal side) |
+| `zena_` | Person B / transit date / progression date | Synastry, composite, transit (transit side), progressions. On secondary progressions the zena side has no `#zena_city` — the progression date reuses the natal location. |
+| `tranzity_` | Transit date on composite-chart | Composite only — the composite page also renders a composite-vs-transits bi-wheel and `#tranzity_city` is the third autocomplete input |
+| `ingres_` | Date for the "current planets" widget at the bottom of every form page | Universal |
+
+`muz` / `zena` are Czech for "man" / "woman". Treat them as opaque keys — the position is by prefix, not gender.
+
+## Universal birth-data fields
+
+For each subject prefix `P` (where `P=""`, `"muz_"`, or `"zena_"`):
+
+```
+P + narozeni_den         day, 1-31           (option values unpadded "1".."31")
+P + narozeni_mesic       month, 1-12         (option values unpadded "1".."12")
+P + narozeni_rok         year, 1800-2099     (out-of-range uses P + year_of_birth_input)
+P + narozeni_hodina      hour, 0-23          (option values zero-padded "00".."23")
+P + narozeni_minuta      minute, 0-59        (option values zero-padded "00".."59")
+P + narozeni_sekunda     second, 0-59        (option values zero-padded "00".."59")
+P + narozeni_city        display string, e.g. "London, UK, England"
+```
+
+For URL-building the server accepts either padded or unpadded numbers; for form-driving, match the option value exactly or jQuery's `.val()` silently no-ops.
+
+Plus the city-derived hidden fields. **The autocomplete populates all of these automatically when you drive the form** — on the URL fast path, you must supply them all yourself, especially `sirka_*`/`delka_*`. Omitting `sirka_*`/`delka_*` silently computes at lat 0°/lon 0°.
+
+```
+P + narozeni_mesto_hidden          city, e.g. "London"
+P + narozeni_stat_hidden           ISO country, e.g. "GB"
+P + narozeni_podstat_hidden        sub-region, e.g. "England"
+P + narozeni_podstat_kratky_hidden short region code, e.g. "NY"
+P + narozeni_tzid_id               internal timezone id, e.g. "345"
+P + narozeni_sirka_stupne          latitude degrees (REQUIRED for correct cusps)
+P + narozeni_sirka_minuty          latitude minutes
+P + narozeni_sirka_smer            lat direction: "0"=N, "1"=S
+P + narozeni_delka_stupne          longitude degrees (REQUIRED)
+P + narozeni_delka_minuty          longitude minutes
+P + narozeni_delka_smer            lon direction: "0"=E, "1"=W
+P + narozeni_input_hidden          full input string (rarely needed)
+```
+
+A submit also needs `send_calculation=1`. Single-subject tools also pass `input_natal=1`.
+
+The results URL itself is the permalink. The page links to its own URL with `&edit_input_data=1` appended for the "Edit birth data" button, so to mutate inputs without losing the chart, append that flag.
+
+## Chart-image URL pattern
+
+Chart bitmaps live on two base paths — see `chart-output.md` for the full anatomy. Quick form:
+
+```
+Single wheel (radix, composite):
+  horoscope-chart{STYLE}-{SIZE}__{TYPE}_{date}.{png|gif}?{payload}
+
+Bi-wheel (transits, progressions; synastry is a special case, see below):
+  horoscope-synastry-chart{N}-{SIZE}__{TYPE}_{d1}_a_{d2}.png?{payload}
+```
+
+- Single-wheel `STYLE` tokens seen in the wild: `4def` (default), `4zone3` (watermark), `3` (classic), `1` (sidereal default), `1snew` (asteroids default), `8snew` (asteroids alternate), `4` (sidereal/composite alternate). The STYLE is **tool-dependent** — `4def` is birth chart + composite default, but sidereal emits only `chart1-700` / `chart4-700` and asteroids emits only `chart1snew-700` / `chart8snew-700`. Always inspect the actual DOM rather than assuming `chart4def`.
+- Bi-wheel `{N}` is numeric. Seen: `5`, `20`, `23`, `24`, `27`. Defaults also vary by tool — `chart20` is the transit + progressions default, but **synastry's primary is `chart23`**.
+- `{TYPE}` for bi-wheels is **English**: `transits`, `synastry`, `progressions` (plural), `secondary-progressions` (hyphenated!), `composite_transits` (composite's bi-wheel overlay). Czech field names (`tranzit`, `synastrie`) do not appear in URLs.
+- **Synastry's chart filename omits `{TYPE}` entirely** and uses `_p_` as the date separator: `horoscope-synastry-chart23-700__{d1}_p_{d2}.png`. Don't assume every bi-wheel has an `{TYPE}_` prefix.
+- Date: `D-M-YYYY_HH-MM`. Bi-wheel date form: `D-M-YYYY_HH-M_a_D-M-YYYY_HH-M` (minutes occasionally lose their leading zero — don't key off exact format). Progressed-chart20 omits the time on the second date (`_a_19-4-2026`) while chart24 keeps it (`_a_19-4-2026_12-00`) — the two styles on the same page disagree.
+- File extension is `.png` everywhere, but the actual bytes are GIF for birth-chart radix and PNG for nearly everything else — see `chart-output.md`.
+- Downloads require `User-Agent: Mozilla/5.0` (plain urllib → HTTP 403). `http_get` already sets it.
+- Some tools append `nocache=21` to the chart URL (verified on sidereal `chart1-700`). Treat it as a server-side cache-buster — its presence means "this chart is re-rendered per query".
+
+## Chart-less tools
+
+Search / calendar tools (ephemeris, transit-calendar, aspect-search) emit **no chart `<img>`** on their results page. The payload is entirely in HTML rows. Don't try `naturalWidth === 700` filters on these — you will get zero hits.
+
+## Lazy-loaded variants
+
+Several chart styles co-exist on a single results page (modern, zone, classic). `naturalWidth === 700` is not uniquely the primary — `chart4def-700` AND `chart4zone3-700` both render at 700×700 when scrolled into view. Filter by the style token AND size:
+
+```js
+Array.from(document.querySelectorAll('img'))
+  .filter(i => /horoscope-chart4def-700__radix_/.test(i.src)
+            && !/minor_aspects|astroseek/.test(i.src)
+            && i.naturalWidth === 700)
+```
+
+Also: `<img loading="lazy">` reports `naturalWidth === 0` until scrolled into view. When running against `http_get` HTML (no layout), drop the `naturalWidth` check and trust the URL pattern.

--- a/domain-skills/clutch/scraping.md
+++ b/domain-skills/clutch/scraping.md
@@ -1,0 +1,62 @@
+# Clutch — B2B service-provider directory (agencies, dev shops, consultancies)
+
+Field-tested 2026-09-02 from a Browser Use cloud browser (US proxy). Browser required; `http_get` is not needed once you know the URL.
+
+## URL patterns (the obvious ones 404)
+
+| Works | 404 |
+|---|---|
+| `https://clutch.co/developers/artificial-intelligence` | `/agencies/artificial-intelligence`, `/agencies/corporate-training` |
+| `https://clutch.co/developers/<category-slug>` (e.g. `/developers/mobile-application`) | `/it-services/ai-consulting`, `/hr/corporate-training`, `/hr/training`, `/business-services/corporate-training` |
+
+The 404 page title is `404 - Not Found` — check `document.title` before extracting.
+
+## Extraction: innerText is enough (no DOM selectors needed)
+
+Each provider renders as a fixed block of lines in `document.body.innerText`:
+
+```
+<Name>
+<rating float>          e.g. 4.8
+<N> reviews
+[Premier Verified|Verified]   (optional)
+$<min project>+         e.g. $25,000+
+$<lo> - $<hi> / hr      e.g. $50 - $99 / hr
+<size>                  e.g. 50 - 249
+<City, ST | City, Country>
+SERVICES PROVIDED
+<pct>% <service>        (repeated; last one may end "+N services")
+<AI-generated review summary paragraph>
+See all N projects / View Profile / Visit Website
+```
+
+Parser that worked on the first page (52 providers):
+
+```python
+import re, json
+lines = [l.strip() for l in js("document.body.innerText").split("\n") if l.strip()]
+rows, i = [], 0
+while i < len(lines) - 8:
+    if re.fullmatch(r"\d\.\d", lines[i+1]) and re.fullmatch(r"\d+ reviews?", lines[i+2]):
+        j = i + 3; badge = ""
+        if "Verified" in lines[j]: badge = lines[j]; j += 1
+        minp = lines[j] if lines[j].startswith("$") else "";  j += bool(minp)
+        rate = lines[j] if "/ hr" in lines[j] else "";        j += bool(rate)
+        size = lines[j] if re.fullmatch(r"[\d,]+ - [\d,]+|[\d,]+\+|Freelancer", lines[j]) else ""; j += bool(size)
+        loc = lines[j]; j += 1
+        services = []
+        if lines[j] == "SERVICES PROVIDED":
+            j += 1
+            while j < len(lines) and re.match(r"\d+% ", lines[j]): services.append(lines[j]); j += 1
+        rows.append({"name": lines[i], "rating": float(lines[i+1]), "reviews": int(lines[i+2].split()[0]),
+                     "badge": badge, "min_project": minp, "hourly": rate, "size": size, "location": loc, "services": services})
+        i = j
+    else:
+        i += 1
+```
+
+## Notes
+- First page = ~50 providers, sorted by Clutch's sponsored/"Premier Verified" ranking; use `?page=2` for more.
+- Locations are `City, ST` for US and `City, Country` elsewhere — filter US with `re.search(r", [A-Z]{2}$", loc)`.
+- Full-page screenshot of the listing is ~17k px tall; take viewport shots per block if you need images.
+- Wait `wait(4)` after `wait_for_load()`; the page is server-rendered but the review summaries hydrate late.

--- a/domain-skills/dropbox/shared-folder-downloads.md
+++ b/domain-skills/dropbox/shared-folder-downloads.md
@@ -1,0 +1,36 @@
+# Dropbox — downloading files from a shared folder link
+
+Verified 2026-08-10 on a `/scl/fo/<id>/h?rlkey=<key>` share (logged-in session).
+
+## The working recipe
+
+1. **Route downloads somewhere readable first** — macOS blocks agents from
+   `~/Downloads` (TCC). CDP fixes it:
+   `cdp("Browser.setDownloadBehavior", behavior="allow", downloadPath=<your dir>)`
+   Persists for the session.
+2. **Deep-link each file's preview page**:
+   `https://www.dropbox.com/scl/fo/<id>/h/<subpath>/<file>?rlkey=<key>&dl=0`
+   The `<subpath>` must be the FULL path inside the share — check the share's
+   root listing first (folders may nest, e.g. everything under `all_ast/`).
+   A wrong path silently falls back to the share ROOT (no error page) — and a
+   Download click there requests a whole-folder zip. Verify you're on a file
+   preview before clicking.
+3. **Click the download button by text**: it's locale-dependent
+   (`Baixar` in pt-BR) — match `/baixar|download/i` over `button,a`.
+4. **Poll the download dir for the exact filename** (~5–25 s for small files).
+
+## What does NOT work
+
+- `curl`/`http_get` on `?dl=1` for folder-scoped file URLs → returns the HTML
+  preview page, even with cookies. Only real per-file share links support
+  direct `dl=1` fetch.
+- In-page `fetch(url, {credentials:"include"})` of `dl=1` → same HTML; the
+  content URL is minted by Dropbox JS only on the button click.
+- The page HTML contains no `dropboxusercontent` links to scrape.
+
+## Trap: filename conventions vary per folder
+
+In the swisseph share, asteroid files ≥ 100000 drop the `e`:
+`se90377s.se1` but `s136199s.se1`. If a deep link "times out", screenshot the
+parent folder and check the real names — the click probably landed on the
+root's folder-download button.

--- a/domain-skills/maven/scraping.md
+++ b/domain-skills/maven/scraping.md
@@ -1,0 +1,31 @@
+# Maven — cohort-based course marketplace (maven.com)
+
+Field-tested 2026-09-02 from a Browser Use cloud browser. `http_get` on maven.com returns 403; use the browser.
+
+## URL patterns
+
+| Goal | URL | Note |
+|---|---|---|
+| Category listing | `https://maven.com/courses/<category>` e.g. `/courses/ai`, `/courses/leadership` | |
+| Audience × topic listing | `https://maven.com/courses/for-leaders/ai`, `/courses/for-leaders/agentic-ai`, `/courses/for-product-managers/agentic-ai`, `/courses/for-engineers/agentic-ai`, `/courses/for-marketers/agentic-ai` | best for "courses aimed at X" |
+| Topic × subtopic | `https://maven.com/courses/ai/agentic-ai` | |
+| Search | `https://maven.com/courses?search=...` | **ignored** — renders the default Trending list. Use category URLs instead. |
+| Course page | `https://maven.com/<instructor-slug>/<course-slug>` | rating, review count, price, cohort dates, syllabus, testimonials all on one page |
+| Maven for Business | `https://maven.com/business` | how they sell seats to companies |
+
+## Listing extraction
+Cards are `<a href="/...">` elements whose text contains the duration and start date (`"6 weeks · Starts Sep 5"`). Lazy-loaded — scroll first:
+
+```python
+navigate("https://maven.com/courses/for-leaders/agentic-ai"); wait_for_load(); wait(4)
+for _ in range(6): scroll(700, 400, dy=1500); wait(0.6)
+cards = json.loads(js("""JSON.stringify([...document.querySelectorAll('a[href^="/"]')]
+  .map(a=>({t:a.innerText.replace(/\\n+/g,' | ').slice(0,220),h:a.href}))
+  .filter(x=>/\\$|weeks|Starts/i.test(x.t)))"""))
+```
+Card text order: `title | duration | · | Starts <date> | instructor(s) | rank`. Prices are on the course page, not the card.
+
+## Gotchas
+- The nav's "AI / Product / Engineering / …" links are the category URLs above; "Cohort-based Courses" is the page title on every listing, so don't use `document.title` to verify which listing you're on — check `location.href`.
+- Full-page screenshots of listings are ~6k px tall and 1–2 MB; the harness handles it but allow ~20 s per capture on the cloud browser.
+- Two harness scripts driving the same `BU_NAME` daemon concurrently will fight over the single tab — run captures sequentially.


### PR DESCRIPTION
Two new domain skills, field-tested 2026-09-02 from a Browser Use cloud browser (US proxy) during a market-research run.

**clutch/scraping.md**
- The working directory URL pattern is `clutch.co/developers/<category>` (e.g. `/developers/artificial-intelligence`); `/agencies/...`, `/it-services/ai-consulting`, `/hr/corporate-training` all 404 with title `404 - Not Found`.
- Each provider renders as a fixed block of `innerText` lines (name, rating, reviews, badge, min project, hourly rate, size, location, services, summary). Includes a parser that turned the first page into 52 structured rows.

**maven/scraping.md**
- `maven.com/courses?search=` ignores the query and renders the Trending list. The audience × topic URLs (`/courses/for-leaders/ai`, `/courses/for-leaders/agentic-ai`, `/courses/ai/agentic-ai`, …) are the reliable listings.
- Cards are lazy-loaded; scroll first, then read `a[href^="/"]` elements whose text has the duration/start date. Prices live on the course page, not the card.
- Trap: two harness scripts on the same `BU_NAME` fight over the single tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds domain-skill playbooks for five scraping targets — Anna's Archive, Astro-Seek, Clutch, Dropbox, and Maven — documenting field-tested URL patterns, extraction recipes, and the traps that cost debugging time.

**Per-target coverage**
- Anna's Archive: browser-based search that clears the DDoS-Guard challenge, md5 result extraction, and the fast-download API outside the browser.
- Astro-Seek: URL patterns, form-driving recipes, chart-image URL anatomy, result-page scraping, and site gotchas across ten tools, including the SVG-in-`<object>` dial and GIF-in-PNG-clothing birth chart.
- Clutch: the working `/developers/<category>` URL pattern and an innerText parser that yields ~50 structured provider rows; also documents the 404ing `/agencies` and `/it-services` guesses.
- Dropbox: shared-folder downloads via deep-linked preview pages plus CDP download behavior, with locale-dependent button matching.
- Maven: the ignored search param, audience × topic category URLs, and lazy-loaded card extraction, plus a warning that two scripts on one `BU_NAME` daemon fight over the single tab.

**Important side effects**
- Clutch, Maven, and Anna's Archive now require a real browser — plain HTTP gets 403s or ad-parking redirects where documented.
- Astro-Seek now challenges plain HTTP with Cloudflare, so the old bulk-HTTP fast path is dead.

<sup>Written for commit ec17876a772e16c099a0528be4ed07385711ed77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

