### PR TITLE
docs(screenshots): rAF pages blank in background tabs; smooth-scroll capture trap

### DIFF
--- a/interaction-skills/screenshots.md
+++ b/interaction-skills/screenshots.md
@@ -15,3 +15,12 @@ capture_screenshot("/tmp/shot.png", max_dim=1800)
 The downscale only happens when the image actually exceeds `max_dim`, so it's safe to leave on for every shot.
 
 Use full-page screenshots (`full=True`) only when you need to see content below the fold — they are much larger and slower than viewport-only.
+
+## Canvas / rAF pages paint nothing in a background tab
+
+Chrome pauses `requestAnimationFrame` in tabs that are not in the foreground. A page that paints through rAF (scroll-scrubbed canvas animations, WebGL, ASCII/particle engines) opened with `new_tab()` but left unfocused never draws a frame: the DOM screenshots fine, the canvas comes back blank, and it looks like a JS error that isn't there.
+
+- Before screenshotting such a page, foreground the attached tab: `cdp("Page.bringToFront")`, then `wait(0.5)`.
+- Quick check that the canvas actually painted: `js("(()=>{const c=document.querySelector('canvas');const d=c.getContext('2d').getImageData(0,0,c.width,c.height).data;let n=0;for(let i=3;i<d.length;i+=28)if(d[i])n++;return n})()")` — 0 means no frame ran.
+- Sites that set `html { scroll-behavior: smooth }` animate `window.scrollTo`, so a capture a moment later lands mid-scroll. Set `js("document.documentElement.style.scrollBehavior='auto'")` once, then scroll and capture; print `js("scrollY")` next to each shot to confirm where it landed.
+


### PR DESCRIPTION
Two field-tested traps hit while screenshotting a scroll-driven canvas page:

- Chrome pauses \`requestAnimationFrame\` in unfocused tabs. A canvas/WebGL/particle page opened with \`new_tab()\` but not foregrounded never paints, so captures come back with a blank canvas and it looks like a JS error. Fix: \`cdp("Page.bringToFront")\` before capturing; a one-liner checks whether the canvas has any painted pixels.
- Pages with \`html { scroll-behavior: smooth }\` animate \`window.scrollTo\`, so scroll-then-capture lands mid-scroll. Set \`scrollBehavior='auto'\` on the root once and print \`scrollY\` next to each shot.

Added to \`interaction-skills/screenshots.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXkQDCQVVpbsUyHE7d7LTe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents two screenshotting traps in `interaction-skills/screenshots.md`: Chrome pauses `requestAnimationFrame` in unfocused tabs so canvas-driven pages capture blank, and pages with `scroll-behavior: smooth` animate scrolls so captures land mid-scroll. Adds fixes to bring the tab to the front before capturing and disable smooth scrolling before scroll-then-capture shots.

<sup>Written for commit 3e84ffbc95998a2a2eda257f9f6bcdeda3ee27e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

