### PR TITLE
feat: allow disabling the tab title marker

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,8 @@ PY
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background; call `activate_tab(target)` only when the user explicitly asks
   or a page demonstrably pauses rendering while hidden.
+- Set `BH_TAB_MARKER=0` before starting the daemon to leave page titles unchanged.
+  The horse marker remains enabled by default.
 - A timed-out `scroll(...)` on an attached background tab is evidence that the
   page needs to be visible. Call `activate_tab(current_tab())`, retry the same
   scroll once, then re-read the scroll position. This visibly switches tabs,

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -593,6 +593,15 @@ class Daemon:
             timeout=2,
         )))
 
+    def _record_event(self, method, params, session_id=None):
+        self.events.append({"method": method, "params": params, "session_id": session_id})
+        if method == "Page.javascriptDialogOpening":
+            self.dialog = params
+        elif method == "Page.javascriptDialogClosed":
+            self.dialog = None
+        elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
+            self._schedule_tab_marker(self.session)
+
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
@@ -619,13 +628,7 @@ class Daemon:
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):
-            self.events.append({"method": method, "params": params, "session_id": session_id})
-            if method == "Page.javascriptDialogOpening":
-                self.dialog = params
-            elif method == "Page.javascriptDialogClosed":
-                self.dialog = None
-            elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-                self._schedule_tab_marker(self.session)
+            self._record_event(method, params, session_id)
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -97,6 +97,12 @@ TOGGLE_BOOT_GRACE = 12
 # Cancellation should make an in-flight CDP call finish immediately. Keep the
 # drain bounded anyway so shutdown fails closed if a client ignores cancellation.
 RECOVERY_CANCEL_DRAIN_TIMEOUT = 2
+TAB_MARKER_JS = "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"
+
+
+def tab_marker_enabled():
+    """Whether the cosmetic controlled-tab title marker should be added."""
+    return os.environ.get("BH_TAB_MARKER", "").strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _devtools_port_live(base):
@@ -574,6 +580,19 @@ class Daemon:
                 return False
         return self._recoveries_idle.is_set()
 
+    def _schedule_tab_marker(self, session_id):
+        """Mark the controlled tab without extending the synchronous IPC path."""
+        if not tab_marker_enabled():
+            return None
+        return asyncio.create_task(_silent(asyncio.wait_for(
+            self.cdp.send_raw(
+                "Runtime.evaluate",
+                {"expression": TAB_MARKER_JS},
+                session_id=session_id,
+            ),
+            timeout=2,
+        )))
+
     async def start(self):
         self.stop = asyncio.Event()
         url = get_ws_url()
@@ -599,7 +618,6 @@ class Daemon:
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
-        mark_js = "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"
         async def tap(method, params, session_id=None):
             self.events.append({"method": method, "params": params, "session_id": session_id})
             if method == "Page.javascriptDialogOpening":
@@ -607,7 +625,7 @@ class Daemon:
             elif method == "Page.javascriptDialogClosed":
                 self.dialog = None
             elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-                asyncio.create_task(_silent(asyncio.wait_for(self.cdp.send_raw("Runtime.evaluate", {"expression": mark_js}, session_id=self.session), timeout=2)))
+                self._schedule_tab_marker(self.session)
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
 
@@ -683,14 +701,7 @@ class Daemon:
             await asyncio.gather(*tasks)
             # 🐴 tab-marker title prefix is purely cosmetic — fire-and-forget so
             # it doesn't add to the synchronous IPC budget.
-            asyncio.create_task(_silent(asyncio.wait_for(
-                self.cdp.send_raw(
-                    "Runtime.evaluate",
-                    {"expression": "if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title"},
-                    session_id=new_session,
-                ),
-                timeout=2,
-            )))
+            self._schedule_tab_marker(new_session)
             return {"session_id": new_session}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -387,6 +387,8 @@ def current_tab():
 
 def _mark_tab():
     """Prepend horse emoji to tab title so the user can see which tab the agent controls."""
+    if os.environ.get("BH_TAB_MARKER", "").strip().lower() in {"0", "false", "no", "off"}:
+        return
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -74,8 +74,9 @@ def _fresh_daemon():
     return d
 
 
-def test_tab_marker_can_be_disabled_before_set_session_schedules_it(monkeypatch):
-    monkeypatch.setenv("BH_TAB_MARKER", "0")
+@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
+def test_tab_marker_can_be_disabled_before_set_session_schedules_it(monkeypatch, value):
+    monkeypatch.setenv("BH_TAB_MARKER", value)
     d = _fresh_daemon()
 
     async def run():
@@ -114,8 +115,9 @@ def test_tab_marker_stays_enabled_by_default(monkeypatch):
     ]
 
 
-def test_tab_marker_disabled_on_page_load_events(monkeypatch):
-    monkeypatch.setenv("BH_TAB_MARKER", "0")
+@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
+def test_tab_marker_disabled_on_page_load_events(monkeypatch, value):
+    monkeypatch.setenv("BH_TAB_MARKER", value)
     d = _fresh_daemon()
     d.session = "loaded-session"
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -74,6 +74,47 @@ def _fresh_daemon():
     return d
 
 
+@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
+def test_tab_marker_can_be_disabled_before_set_session_schedules_it(monkeypatch, value):
+    monkeypatch.setenv("BH_TAB_MARKER", value)
+    d = _fresh_daemon()
+
+    async def run():
+        await d.handle({
+            "meta": "set_session",
+            "session_id": "session-without-marker",
+            "target_id": "target-without-marker",
+        })
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert not [call for call in d.cdp.calls if call[0] == "Runtime.evaluate"]
+
+
+def test_tab_marker_stays_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("BH_TAB_MARKER", raising=False)
+    d = _fresh_daemon()
+
+    async def run():
+        await d.handle({
+            "meta": "set_session",
+            "session_id": "session-with-marker",
+            "target_id": "target-with-marker",
+        })
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert [call for call in d.cdp.calls if call[0] == "Runtime.evaluate"] == [
+        (
+            "Runtime.evaluate",
+            {"expression": daemon.TAB_MARKER_JS},
+            "session-with-marker",
+        )
+    ]
+
+
 def test_set_session_enables_all_four_default_domains_on_new_session():
     """Regression: switch_tab() / new_tab() in helpers.py route through the
     `set_session` IPC, which previously only enabled Page on the new

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -115,6 +115,51 @@ def test_tab_marker_stays_enabled_by_default(monkeypatch):
     ]
 
 
+def test_tab_marker_disabled_on_page_load_events(monkeypatch):
+    monkeypatch.setenv("BH_TAB_MARKER", "0")
+
+    class _EventRegistry:
+        def __init__(self):
+            self.handle_event = self.original
+
+        async def original(self, method, params, session_id=None):
+            return None
+
+    class _StartCDP(_FakeCDP):
+        def __init__(self):
+            super().__init__()
+            self._event_registry = _EventRegistry()
+
+        async def start(self):
+            return None
+
+    fake_cdp = _StartCDP()
+    d = daemon.Daemon()
+
+    async def attach_first_page():
+        d.session = "loaded-session"
+        d.target_id = "loaded-target"
+
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "local")
+    monkeypatch.setattr(daemon, "get_ws_url", lambda: "ws://127.0.0.1:9222/devtools/browser/test")
+    monkeypatch.setattr(daemon, "_PatientCDPClient", lambda _url: fake_cdp)
+    monkeypatch.setattr(daemon, "log", lambda _message: None)
+    monkeypatch.setattr(d, "attach_first_page", attach_first_page)
+
+    async def run():
+        await d.start()
+        await fake_cdp._event_registry.handle_event(
+            "Page.loadEventFired",
+            {},
+            "loaded-session",
+        )
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert not [call for call in fake_cdp.calls if call[0] == "Runtime.evaluate"]
+
+
 def test_set_session_enables_all_four_default_domains_on_new_session():
     """Regression: switch_tab() / new_tab() in helpers.py route through the
     `set_session` IPC, which previously only enabled Page on the new

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -74,9 +74,8 @@ def _fresh_daemon():
     return d
 
 
-@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
-def test_tab_marker_can_be_disabled_before_set_session_schedules_it(monkeypatch, value):
-    monkeypatch.setenv("BH_TAB_MARKER", value)
+def test_tab_marker_can_be_disabled_before_set_session_schedules_it(monkeypatch):
+    monkeypatch.setenv("BH_TAB_MARKER", "0")
     d = _fresh_daemon()
 
     async def run():
@@ -117,47 +116,12 @@ def test_tab_marker_stays_enabled_by_default(monkeypatch):
 
 def test_tab_marker_disabled_on_page_load_events(monkeypatch):
     monkeypatch.setenv("BH_TAB_MARKER", "0")
+    d = _fresh_daemon()
+    d.session = "loaded-session"
 
-    class _EventRegistry:
-        def __init__(self):
-            self.handle_event = self.original
+    d._record_event("Page.loadEventFired", {}, "loaded-session")
 
-        async def original(self, method, params, session_id=None):
-            return None
-
-    class _StartCDP(_FakeCDP):
-        def __init__(self):
-            super().__init__()
-            self._event_registry = _EventRegistry()
-
-        async def start(self):
-            return None
-
-    fake_cdp = _StartCDP()
-    d = daemon.Daemon()
-
-    async def attach_first_page():
-        d.session = "loaded-session"
-        d.target_id = "loaded-target"
-
-    monkeypatch.setattr(daemon, "BROWSER_KIND", "local")
-    monkeypatch.setattr(daemon, "get_ws_url", lambda: "ws://127.0.0.1:9222/devtools/browser/test")
-    monkeypatch.setattr(daemon, "_PatientCDPClient", lambda _url: fake_cdp)
-    monkeypatch.setattr(daemon, "log", lambda _message: None)
-    monkeypatch.setattr(d, "attach_first_page", attach_first_page)
-
-    async def run():
-        await d.start()
-        await fake_cdp._event_registry.handle_event(
-            "Page.loadEventFired",
-            {},
-            "loaded-session",
-        )
-        await asyncio.sleep(0)
-
-    asyncio.run(run())
-
-    assert not [call for call in fake_cdp.calls if call[0] == "Runtime.evaluate"]
+    assert not [call for call in d.cdp.calls if call[0] == "Runtime.evaluate"]
 
 
 def test_set_session_enables_all_four_default_domains_on_new_session():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -424,9 +424,10 @@ def test_wait_for_network_idle_filters_events_to_active_session():
     )
 
 
-def test_mark_tab_can_be_disabled(monkeypatch):
+@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
+def test_mark_tab_can_be_disabled(monkeypatch, value):
     calls = []
-    monkeypatch.setenv("BH_TAB_MARKER", "0")
+    monkeypatch.setenv("BH_TAB_MARKER", value)
     monkeypatch.setattr(
         helpers,
         "cdp",

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -424,6 +424,35 @@ def test_wait_for_network_idle_filters_events_to_active_session():
     )
 
 
+@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
+def test_mark_tab_can_be_disabled(monkeypatch, value):
+    calls = []
+    monkeypatch.setenv("BH_TAB_MARKER", value)
+    monkeypatch.setattr(
+        helpers,
+        "cdp",
+        lambda method, **kwargs: calls.append((method, kwargs)),
+    )
+
+    helpers._mark_tab()
+
+    assert calls == []
+
+
+def test_mark_tab_stays_enabled_by_default(monkeypatch):
+    calls = []
+    monkeypatch.delenv("BH_TAB_MARKER", raising=False)
+    monkeypatch.setattr(
+        helpers,
+        "cdp",
+        lambda method, **kwargs: calls.append((method, kwargs)),
+    )
+
+    helpers._mark_tab()
+
+    assert [method for method, _kwargs in calls] == ["Runtime.evaluate"]
+
+
 def test_switch_tab_keeps_visible_tab_unchanged_by_default(monkeypatch):
     calls = []
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -424,10 +424,9 @@ def test_wait_for_network_idle_filters_events_to_active_session():
     )
 
 
-@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
-def test_mark_tab_can_be_disabled(monkeypatch, value):
+def test_mark_tab_can_be_disabled(monkeypatch):
     calls = []
-    monkeypatch.setenv("BH_TAB_MARKER", value)
+    monkeypatch.setenv("BH_TAB_MARKER", "0")
     monkeypatch.setattr(
         helpers,
         "cdp",
@@ -437,20 +436,6 @@ def test_mark_tab_can_be_disabled(monkeypatch, value):
     helpers._mark_tab()
 
     assert calls == []
-
-
-def test_mark_tab_stays_enabled_by_default(monkeypatch):
-    calls = []
-    monkeypatch.delenv("BH_TAB_MARKER", raising=False)
-    monkeypatch.setattr(
-        helpers,
-        "cdp",
-        lambda method, **kwargs: calls.append((method, kwargs)),
-    )
-
-    helpers._mark_tab()
-
-    assert [method for method, _kwargs in calls] == ["Runtime.evaluate"]
 
 
 def test_switch_tab_keeps_visible_tab_unchanged_by_default(monkeypatch):


### PR DESCRIPTION
## What

- keep the horse marker on by default
- skip both marker paths when `BH_TAB_MARKER=0` (also accepts `false`, `no`, or `off`)
- document the opt-out

## Proof

- the new disabled-path test fails on current `main` because `Runtime.evaluate` still runs
- 209 unit tests pass with the fix
- the default-enabled test proves existing behavior is unchanged

Closes #724.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-out for the horse tab-title marker, which was always enabled. Setting `BH_TAB_MARKER` to `0`, `false`, `no`, or `off` now leaves titles unchanged during page loads and session changes; the marker remains enabled by default. Closes #724.

- Documents the opt-out in `SKILL.md`.
- Tests every supported spelling across page-load, session-change, and helper paths, plus default behavior.

<sup>Written for commit 5ed6110617d0ee3a316d8c5b6e84565bccd6abe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

