### PR TITLE
fix: discover Brave Origin profiles on macOS

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -928,6 +928,7 @@ _BROWSER_LAUNCH = (
     ("chromium", "Chromium", ("chromium", "chromium-browser"), "chromium"),
     ("chrome", "Google Chrome", ("google-chrome-stable", "google-chrome"), "chrome"),
     ("edge", "Microsoft Edge", ("microsoft-edge", "microsoft-edge-stable"), "msedge"),
+    ("brave-origin", "Brave Origin", (), None),
     ("brave", "Brave Browser", ("brave-browser", "brave"), "brave"),
     ("arc", "Arc", (), None),
     ("dia", "Dia", (), None),

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -46,6 +46,7 @@ _MAC_PROFILES = (
     "Library/Application Support/Microsoft Edge Dev",
     "Library/Application Support/Microsoft Edge Canary",
     "Library/Application Support/BraveSoftware/Brave-Browser",
+    "Library/Application Support/BraveSoftware/Brave-Origin",
 )
 _LINUX_PROFILES = (
     ".config/google-chrome",

--- a/tests/unit/test_brave_origin.py
+++ b/tests/unit/test_brave_origin.py
@@ -1,0 +1,67 @@
+"""Rudi's macOS-only discovery failure; no real browser is launched."""
+import os
+from types import SimpleNamespace
+from urllib.error import HTTPError
+
+import pytest
+
+from browser_harness import admin, daemon
+
+
+@pytest.fixture
+def origin_profile(monkeypatch, tmp_path):
+    monkeypatch.setattr(daemon.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    profile = tmp_path / "Library/Application Support/BraveSoftware/Brave-Origin"
+    profile.mkdir(parents=True)
+    (profile / "Local State").write_text('{}')
+    monkeypatch.setattr(daemon, "PROFILES", daemon.profile_dirs())
+    return profile
+
+
+def test_origin_running_without_google_chrome(origin_profile):
+    (origin_profile / "SingletonLock").symlink_to(f"test-host-{os.getpid()}")
+    assert daemon.supported_browser_running()
+
+
+def test_origin_directory_alone_is_not_a_running_browser(origin_profile):
+    assert not daemon.supported_browser_running()
+
+
+@pytest.mark.parametrize("status", [404, 403])
+def test_origin_port_discovery_keeps_permission_gate(monkeypatch, origin_profile, status):
+    (origin_profile / "DevToolsActivePort").write_text("9222\n/devtools/browser/origin\n")
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+
+    def urlopen(url, **kwargs):
+        assert url == "http://127.0.0.1:9222/json/version"
+        raise HTTPError(url, status, "fixture", {}, None)
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", urlopen)
+    if status == 403:
+        with pytest.raises(RuntimeError, match="permission-blocked"):
+            daemon.get_ws_url()
+    else:
+        assert daemon.get_ws_url() == "ws://127.0.0.1:9222/devtools/browser/origin"
+
+
+def test_origin_relaunch_uses_origin_not_regular_brave(monkeypatch, origin_profile):
+    monkeypatch.delenv("BH_CHROME_PATH", raising=False)
+    monkeypatch.delenv("CHROME_PATH", raising=False)
+    calls = []
+    monkeypatch.setattr("subprocess.run", lambda cmd, **kw: calls.append(cmd) or SimpleNamespace(returncode=0))
+    assert admin._launch_browser() == (None, origin_profile)
+    assert calls == [["open", "-a", "Brave Origin"]]
+
+
+@pytest.mark.parametrize("profile,app", [
+    ("BraveSoftware/Brave-Origin", "Brave Origin"),
+    ("BraveSoftware/Brave-Browser", "Brave Browser"),
+    ("Google/Chrome", "Google Chrome"),
+    ("Google/Chrome Canary", "Google Chrome Canary"),
+    ("Application Support/Microsoft Edge", "Microsoft Edge"),
+])
+def test_launch_mapping_preserves_existing_browsers(profile, app):
+    assert admin._browser_launch_spec(profile)[0] == app


### PR DESCRIPTION
## Fix

Brave Origin on macOS stores its profile under `BraveSoftware/Brave-Origin`, which the daemon does not scan. With Origin as the only installed browser, discovery reports `chrome-not-running`. The generic `brave` launch rule would also select regular Brave instead of Origin.

Add the macOS profile and a more specific `brave-origin` launch rule before `brave`. Two production lines; no change to debugging permission checks, existing browser priority, or Linux/Windows profile lists.

## Tests

- Before the fix: three regression failures prove missing running-browser detection, wrong fallback profile, and wrong app selection.
- After: 214 unit tests pass, including ten focused cases covering a running Origin-only profile, a non-running profile, Origin launch, Chrome/Canary/Edge/regular Brave selection, DevToolsActivePort discovery, and permission-denied rejection.
- `git diff --check` passes.
- No real browser was started or controlled by these tests. Brave Origin is not installed on this development machine; a live Origin attach still needs the reporter or a machine with Origin.

This deliberately does not change doctor's broader process-name heuristic, tracked separately in #704, or guess Origin's Linux/Windows paths.

Fixes #727.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes discovery of Brave Origin profiles on macOS so the daemon no longer reports "chrome-not-running" when Origin is the only installed browser, and relaunch selects Origin instead of regular Brave.

<sup>Written for commit c2f5f3cc4820fa279bd81e1774f93b995366f325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

