### PR TITLE
fix: redact sensitive data in capture_cli_event() telemetry

### DIFF
--- a/src/browser_harness/telemetry.py
+++ b/src/browser_harness/telemetry.py
@@ -144,6 +144,52 @@ def _safe_properties(properties: dict | None) -> dict:
     return out
 
 
+# FORBIDDEN_KEYS-based filtering only catches secrets that arrive as a named
+# dict key. capture_cli_event() also sends freeform text (a piped script,
+# stdout, a traceback) where the same secrets show up embedded in the
+# content itself -- e.g. `password='hunter2'`, an Authorization header, or a
+# local filesystem path. These patterns redact that content in place.
+_HEADER_SECRET_RE = re.compile(r"(?i)\b(authorization|cookie)\b\s*:\s*[^\n]*")
+_ASSIGNMENT_SECRET_RE = re.compile(
+    r"(?i)\b(password|passwd|pwd|token|secret|api[_-]?key)\b(\s*[:=]\s*)(['\"]?)([^\s'\",)]+)\3"
+)
+_PATH_RE = re.compile(r"(?:[A-Za-z]:\\|/)[^\s'\"]+")
+
+
+def _redact_secrets(text: str) -> str:
+    text = _HEADER_SECRET_RE.sub(lambda m: f"{m.group(1)}: [redacted]", text)
+    text = _ASSIGNMENT_SECRET_RE.sub(
+        lambda m: f"{m.group(1)}{m.group(2)}{m.group(3)}[redacted]{m.group(3)}", text
+    )
+    text = _PATH_RE.sub("[path-redacted]", text)
+    return text
+
+
+def _scrub_text(text: str | None) -> str | None:
+    if text is None:
+        return None
+    return _redact_secrets(text[:MAX_TASK_LENGTH])
+
+
+def _scrub_steps(value):
+    """Recursively drop FORBIDDEN_KEYS-named dict keys and redact freeform
+    string content -- mirrors _safe_properties()'s key filtering, but for
+    the nested step/argument structures capture_cli_event() sends."""
+    if isinstance(value, dict):
+        out = {}
+        for key, val in value.items():
+            lowered = str(key).lower()
+            if any(word in lowered for word in FORBIDDEN_KEYS):
+                continue
+            out[key] = _scrub_steps(val)
+        return out
+    if isinstance(value, list):
+        return [_scrub_steps(item) for item in value]
+    if isinstance(value, str):
+        return _redact_secrets(value)[:120]
+    return value
+
+
 # Env markers each coding agent injects into subprocesses
 _AGENT_ENV_MARKERS: tuple[tuple[str, str], ...] = (
     ("AGENT=amp", "amp"),
@@ -278,15 +324,15 @@ def capture_cli_event(
                 "agent_client": _detect_agent_client(),
                 "model": os.environ.get("BROWSER_USE_AGENT_MODEL") or None,
                 "model_provider": os.environ.get("BROWSER_USE_MODEL_PROVIDER") or None,
-                "task": task[:MAX_TASK_LENGTH] if task is not None else None,
+                "task": _scrub_text(task),
                 "task_length": len(task) if task is not None else None,
-                "output": output,
+                "output": _scrub_text(output),
                 "output_length": output_length,
-                "steps": steps,
+                "steps": _scrub_steps(steps) if steps is not None else None,
                 "step_count": step_count,
                 "duration_seconds": duration_seconds,
                 "exit_code": exit_code,
-                "error_message": error_message,
+                "error_message": _scrub_text(error_message),
             },
         }
         _send_detached(payload)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,34 @@
+from browser_harness import telemetry
+
+
+def test_capture_cli_event_redacts_sensitive_task_output_and_steps(monkeypatch):
+    """Regression test for #681.
+
+    telemetry.py defines a real scrubber, _safe_properties(), that drops
+    password/token/url/-named keys and truncates values. It is wired into
+    capture() but NOT into capture_cli_event() -- the function that actually
+    fires on every CLI invocation and builds its payload (task/output/steps/
+    error_message) directly, unredacted. This must not leave the process.
+    """
+    monkeypatch.setattr(telemetry, "is_enabled", lambda: True)
+    monkeypatch.setattr(telemetry, "_install_id", lambda *a, **k: "test-install-id")
+    sent = {}
+    monkeypatch.setattr(telemetry, "_send_detached", sent.update)
+
+    telemetry.capture_cli_event(
+        action="run",
+        command="browser-harness",
+        task="login(username='alice', password='hunter2')",
+        output="Authorization: Bearer sk-live-abcdef123456",
+        steps=[{"fn": "login", "args": {"password": "hunter2"}}],
+        error_message="Traceback: /Users/alice/secret-project/script.py",
+    )
+
+    payload_text = str(sent)
+    assert "hunter2" not in payload_text, "raw password leaked into telemetry payload"
+    assert "sk-live-abcdef123456" not in payload_text, (
+        "raw token leaked into telemetry payload"
+    )
+    assert "secret-project" not in payload_text, (
+        "local path leaked into telemetry payload"
+    )


### PR DESCRIPTION
_safe_properties() already scrubs password, token, and url named fields, but it's only wired into capture(). capture_cli_event(), the function that fires on every CLI run, builds its payload straight from the raw task script, stdout, and step arguments, so a login flow's password or a page's auth token could end up in the telemetry payload sent by default.

Adds redaction for task, output, steps, and error_message before they leave the process: strips auth headers, redacts assignments like password=, token=, and secret=, and drops absolute paths.

Adds tests/unit/test_telemetry.py covering the leak.

Fixes #681

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #681 by redacting sensitive data in `capture_cli_event()` telemetry before it leaves the process. Previously every CLI run sent raw task scripts, stdout, step arguments, and error messages, so passwords, auth tokens, and local paths could reach PostHog.

**Bug Fixes**
- Redacts auth headers, `password=`/`token=`/`secret=` assignments, and absolute paths from telemetry fields.
- Recursively drops forbidden-key step arguments using the same rules as `capture()`.
- Adds unit tests covering the telemetry leak.

<sup>Written for commit 87894ff230cfa6af49fa33d22cfcfeff1dd9925e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

