### PR TITLE
fix: hold a startup lock in serve() so a second invocation can't evict a live daemon

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -162,31 +162,74 @@ def identify(name, timeout=1.0):
         except OSError: pass
 
 
+def _lock_path(name):  return _RUNTIME / f"{_runtime_stem(name)}.lock"
+
+
+def _acquire_startup_lock(name):
+    """Claim exclusive ownership of `name`'s endpoint for the life of this server.
+
+    Without this, two invocations racing for the same name could both pass a
+    prior ping-based "not already running" check -- that check-then-act gap
+    can be tens of seconds wide (CDP handshake, an unclicked Allow popup) --
+    and the second would silently unlink + rebind over a still-live first
+    daemon's socket, orphaning it with no error raised anywhere.
+    O_CREAT|O_EXCL is atomic at the filesystem level, unlike the bare
+    `if os.path.exists(...): os.unlink(...)` it guards here.
+
+    Raises RuntimeError if a live daemon already holds the lock. Reclaims a
+    stale lock (previous holder crashed/was killed without cleanup) once
+    ping() confirms nothing currently answers for `name`."""
+    path = _lock_path(name)
+    for _attempt in range(2):
+        try:
+            fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, str(os.getpid()).encode())
+            os.close(fd)
+            return path
+        except FileExistsError:
+            if ping(name, timeout=1.0):
+                raise RuntimeError(
+                    f"a browser-harness daemon is already running for BU_NAME={name!r}"
+                ) from None
+            try: path.unlink()  # stale lock, no live owner -- reclaim it
+            except FileNotFoundError: pass
+    raise RuntimeError(f"failed to acquire startup lock for BU_NAME={name!r}")
+
+
 async def serve(name, handler):
     """Run the server until cancelled. handler(reader, writer) sees the same interface either way."""
     global _server_token
-    if not IS_WINDOWS:
-        path = str(_sock_path(name))
-        if os.path.exists(path): os.unlink(path)
-        # umask 0o077 makes bind() create the socket as 0600 — no TOCTOU window before chmod.
-        old_umask = os.umask(0o077)
-        try: server = await asyncio.start_unix_server(handler, path=path)
-        finally: os.umask(old_umask)
-        _server_token = None
-        async with server: await asyncio.Event().wait()
-        return
-    server = await asyncio.start_server(handler, "127.0.0.1", 0)
-    port = server.sockets[0].getsockname()[1]
-    _server_token = secrets.token_hex(32)
-    pf = port_path(name)
-    # Atomic write so a concurrent reader never sees a half-written file.
-    tmp = pf.with_name(pf.name + ".tmp")
-    tmp.write_text(json.dumps({"port": port, "token": _server_token}), encoding="utf-8")
-    os.replace(tmp, pf)
+    # Off-thread: _acquire_startup_lock() does blocking socket I/O (ping()) to
+    # check a stale lock's liveness; running it inline would block this same
+    # event loop that a *different* daemon's handler (in-process, e.g. tests)
+    # needs to answer that very ping on.
+    lock_path = await asyncio.to_thread(_acquire_startup_lock, name)
     try:
-        async with server: await asyncio.Event().wait()
+        if not IS_WINDOWS:
+            path = str(_sock_path(name))
+            if os.path.exists(path): os.unlink(path)
+            # umask 0o077 makes bind() create the socket as 0600 — no TOCTOU window before chmod.
+            old_umask = os.umask(0o077)
+            try: server = await asyncio.start_unix_server(handler, path=path)
+            finally: os.umask(old_umask)
+            _server_token = None
+            async with server: await asyncio.Event().wait()
+            return
+        server = await asyncio.start_server(handler, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        _server_token = secrets.token_hex(32)
+        pf = port_path(name)
+        # Atomic write so a concurrent reader never sees a half-written file.
+        tmp = pf.with_name(pf.name + ".tmp")
+        tmp.write_text(json.dumps({"port": port, "token": _server_token}), encoding="utf-8")
+        os.replace(tmp, pf)
+        try:
+            async with server: await asyncio.Event().wait()
+        finally:
+            try: pf.unlink()
+            except FileNotFoundError: pass
     finally:
-        try: pf.unlink()
+        try: lock_path.unlink()
         except FileNotFoundError: pass
 
 

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,3 +1,10 @@
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
 from browser_harness import _ipc as ipc
 
 
@@ -126,3 +133,94 @@ def test_ping_returns_false_when_pong_field_is_missing_or_not_true(monkeypatch):
         assert ipc.ping("default", timeout=0.0) is False, (
             f"ping() should require pong is exactly True; got: {resp!r}"
         )
+
+
+# --- serve(): startup mutual exclusion ---
+
+
+def test_serve_does_not_silently_evict_a_still_running_daemon(monkeypatch):
+    """Regression test for #692.
+
+    already_running() is a ping check performed *before* serve() binds, with
+    no lock held across that gap. serve() itself does a check-then-act:
+    `if os.path.exists(path): os.unlink(path)` then binds a new listener at
+    the same path -- unconditionally, with no ownership check. Two
+    invocations racing for the same name can both pass the "not already
+    running" check; the second then silently unlinks and rebinds over the
+    first daemon's live socket, orphaning it with no error raised anywhere.
+
+    This asserts the observable contract from the issue: once a daemon is
+    up and reachable, a second serve() attempt for the same name must not
+    silently take over -- either the first stays reachable, or the second
+    attempt fails loudly. POSIX-only (exercises the AF_UNIX socket file).
+    """
+    if ipc.IS_WINDOWS:
+        pytest.skip("POSIX-only: exercises the AF_UNIX socket-file race")
+
+    # AF_UNIX sun_path is 104 bytes on macOS -- pytest's own tmp_path nests
+    # too deep for that, so use a short-named dir directly under /tmp
+    # instead (same constraint _ipc.py itself documents for BH_RUNTIME_DIR).
+    runtime_dir = Path(tempfile.mkdtemp(prefix="bhipc-", dir="/tmp"))
+    monkeypatch.setattr(ipc, "_RUNTIME", runtime_dir)
+    name = "race"
+
+    async def handler_one(reader, writer):
+        await reader.readline()
+        writer.write(b'{"pong": true, "pid": 111}\n')
+        await writer.drain()
+        writer.close()
+
+    async def handler_two(reader, writer):
+        await reader.readline()
+        writer.write(b'{"pong": true, "pid": 222}\n')
+        await writer.drain()
+        writer.close()
+
+    async def scenario():
+        task_one = asyncio.create_task(ipc.serve(name, handler_one))
+        try:
+            for _ in range(200):
+                if ipc._sock_path(name).exists():
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("first daemon never bound its socket")
+
+            # identify() is blocking socket I/O; run it off-thread so it
+            # doesn't stall the event loop the server tasks need to run on.
+            first_pid = await asyncio.to_thread(ipc.identify, name, 1.0)
+            assert first_pid == 111, "sanity check: first daemon should answer first"
+
+            task_two = asyncio.create_task(ipc.serve(name, handler_two))
+            try:
+                await asyncio.sleep(0.2)  # let a racing serve() unlink + rebind
+
+                assert not task_one.done(), (
+                    "the first daemon's serve() task must not be silently "
+                    "torn down by a second invocation for the same name"
+                )
+                second_pid = await asyncio.to_thread(ipc.identify, name, 1.0)
+                assert second_pid == first_pid, (
+                    "a second serve() call silently took over the socket for "
+                    "a still-running daemon (reached pid "
+                    f"{second_pid} instead of the original {first_pid}) -- "
+                    "it must either fail to start or leave the first daemon "
+                    "reachable, never evict it silently"
+                )
+            finally:
+                task_two.cancel()
+                try:
+                    await task_two
+                except (asyncio.CancelledError, Exception):
+                    pass
+        finally:
+            task_one.cancel()
+            try:
+                await task_one
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        shutil.rmtree(runtime_dir, ignore_errors=True)


### PR DESCRIPTION
already_running() pings before serve() binds, but nothing holds the gap between the two. That gap can stretch to tens of seconds through the CDP handshake, especially when an Allow remote debugging popup sits unclicked. A second browser_harness invocation for the same BU_NAME can pass the same check and then serve() will unconditionally unlink and rebind over the first daemon's socket, orphaning it with no error anywhere.

Adds a startup lock file per daemon name, created with O_CREAT and O_EXCL so the claim itself is atomic instead of check then act. If the lock already exists, a live daemon still answering it means the new invocation fails loudly instead of silently taking over. A stale lock left by a crashed process gets reclaimed.

Adds a regression test in tests/unit/test_ipc.py that starts two servers for the same name and asserts the first stays reachable.

Fixes #692

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in `serve()` where a second invocation for the same daemon name could silently unlink and rebind over a live daemon's socket, orphaning it with no error. The daemon now claims a per-name startup lock before binding; a second invocation fails loudly if a live daemon already holds it, and stale locks from crashed processes are reclaimed.

**Bug Fixes**
- The lock is created with `O_CREAT | O_EXCL` so the claim is atomic, closing the check-then-act gap that previously let a second process pass the "not already running" ping.
- Adds a regression test asserting the first daemon stays reachable when a second `serve()` is attempted for the same name.

<sup>Written for commit 8f535efded69dbea88656a6f7e896e88ac517f1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

