### PR TITLE
Bump browser-harness to 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.10"
+version = "0.1.11"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Change
Version bump 0.1.10 -> 0.1.11. Cutting a release so the fixes merged since v0.1.10 (2026-08-25) reach PyPI, including the tab-management prompt guidance in SKILL.md (#36769c8).

## Why
32 unmerged-to-release commits on main; `browser-use` CLI pins `browser-harness==` exactly, so nothing ships until this is tagged.

## Proof
- `uv run --with pytest python -m pytest tests/unit -q` -> 204 passed
- Local `python -m build` wheel contains `browser_harness/SKILL.md` with the new tab guidance

## Risk / rollout / rollback
- Version-only diff. Publish happens via the `v0.1.11` GitHub release -> `release.yml` -> PyPI.
- Rollback: yank 0.1.11 on PyPI; `browser-use` stays pinned to 0.1.10 until its own pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY3ATYZkSS6g2RoGiStQip

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `browser-harness` from 0.1.10 to 0.1.11 to ship fixes merged since v0.1.10, including the new tab-management guidance in `SKILL.md`. `browser-use` pins this version exactly, so this release is required for those fixes to reach users.

<sup>Written for commit 19b843c2297c39dae4e68e4a3f27d549e3d0c2e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

