### PR TITLE
fix: hold a startup lock in serve() so a second invocation can't evict a live daemon

### DIFF
--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -162,31 +162,74 @@ def identify(name, timeout=1.0):
         except OSError: pass
 
 
+def _lock_path(name):  return _RUNTIME / f"{_runtime_stem(name)}.lock"
+
+
+def _acquire_startup_lock(name):
+    """Claim exclusive ownership of `name`'s endpoint for the life of this server.
+
+    Without this, two invocations racing for the same name could both pass a
+    prior ping-based "not already running" check -- that check-then-act gap
+    can be tens of seconds wide (CDP handshake, an unclicked Allow popup) --
+    and the second would silently unlink + rebind over a still-live first
+    daemon's socket, orphaning it with no error raised anywhere.
+    O_CREAT|O_EXCL is atomic at the filesystem level, unlike the bare
+    `if os.path.exists(...): os.unlink(...)` it guards here.
+
+    Raises RuntimeError if a live daemon already holds the lock. Reclaims a
+    stale lock (previous holder crashed/was killed without cleanup) once
+    ping() confirms nothing currently answers for `name`."""
+    path = _lock_path(name)
+    for _attempt in range(2):
+        try:
+            fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, str(os.getpid()).encode())
+            os.close(fd)
+            return path
+        except FileExistsError:
+            if ping(name, timeout=1.0):
+                raise RuntimeError(
+                    f"a browser-harness daemon is already running for BU_NAME={name!r}"
+                ) from None
+            try: path.unlink()  # stale lock, no live owner -- reclaim it
+            except FileNotFoundError: pass
+    raise RuntimeError(f"failed to acquire startup lock for BU_NAME={name!r}")
+
+
 async def serve(name, handler):
     """Run the server until cancelled. handler(reader, writer) sees the same interface either way."""
     global _server_token
-    if not IS_WINDOWS:
-        path = str(_sock_path(name))
-        if os.path.exists(path): os.unlink(path)
-        # umask 0o077 makes bind() create the socket as 0600 — no TOCTOU window before chmod.
-        old_umask = os.umask(0o077)
-        try: server = await asyncio.start_unix_server(handler, path=path)
-        finally: os.umask(old_umask)
-        _server_token = None
-        async with server: await asyncio.Event().wait()
-        return
-    server = await asyncio.start_server(handler, "127.0.0.1", 0)
-    port = server.sockets[0].getsockname()[1]
-    _server_token = secrets.token_hex(32)
-    pf = port_path(name)
-    # Atomic write so a concurrent reader never sees a half-written file.
-    tmp = pf.with_name(pf.name + ".tmp")
-    tmp.write_text(json.dumps({"port": port, "token": _server_token}), encoding="utf-8")
-    os.replace(tmp, pf)
+    # Off-thread: _acquire_startup_lock() does blocking socket I/O (ping()) to
+    # check a stale lock's liveness; running it inline would block this same
+    # event loop that a *different* daemon's handler (in-process, e.g. tests)
+    # needs to answer that very ping on.
+    lock_path = await asyncio.to_thread(_acquire_startup_lock, name)
     try:
-        async with server: await asyncio.Event().wait()
+        if not IS_WINDOWS:
+            path = str(_sock_path(name))
+            if os.path.exists(path): os.unlink(path)
+            # umask 0o077 makes bind() create the socket as 0600 — no TOCTOU window before chmod.
+            old_umask = os.umask(0o077)
+            try: server = await asyncio.start_unix_server(handler, path=path)
+            finally: os.umask(old_umask)
+            _server_token = None
+            async with server: await asyncio.Event().wait()
+            return
+        server = await asyncio.start_server(handler, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        _server_token = secrets.token_hex(32)
+        pf = port_path(name)
+        # Atomic write so a concurrent reader never sees a half-written file.
+        tmp = pf.with_name(pf.name + ".tmp")
+        tmp.write_text(json.dumps({"port": port, "token": _server_token}), encoding="utf-8")
+        os.replace(tmp, pf)
+        try:
+            async with server: await asyncio.Event().wait()
+        finally:
+            try: pf.unlink()
+            except FileNotFoundError: pass
     finally:
-        try: pf.unlink()
+        try: lock_path.unlink()
         except FileNotFoundError: pass
 
 

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -165,7 +165,21 @@ def identify(name, timeout=1.0):
 def _lock_path(name):  return _RUNTIME / f"{_runtime_stem(name)}.lock"
 
 
-def _acquire_startup_lock(name):
+def _lock_holder_alive(path):
+    """True iff the PID recorded in `path` is still a live process. Unreadable
+    or corrupt contents count as not-alive (safe to reclaim)."""
+    try:
+        pid = int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, OSError, SystemError, OverflowError):
+        return False
+
+
+def acquire_startup_lock(name):
     """Claim exclusive ownership of `name`'s endpoint for the life of this server.
 
     Without this, two invocations racing for the same name could both pass a
@@ -176,9 +190,20 @@ def _acquire_startup_lock(name):
     O_CREAT|O_EXCL is atomic at the filesystem level, unlike the bare
     `if os.path.exists(...): os.unlink(...)` it guards here.
 
-    Raises RuntimeError if a live daemon already holds the lock. Reclaims a
-    stale lock (previous holder crashed/was killed without cleanup) once
-    ping() confirms nothing currently answers for `name`."""
+    Staleness is decided by whether the PID recorded in the lock is still a
+    live process, not by pinging the endpoint: the lock is meant to be held
+    from before the endpoint exists (through the CDP handshake) to after it
+    is torn down, so "nothing answers yet/anymore" is not evidence the lock
+    holder is gone -- a ping-based check would let a second invocation steal
+    the lock out from under a holder that simply hasn't bound yet.
+
+    Raises RuntimeError if a live process already holds the lock. Reclaims a
+    stale lock (previous holder crashed/was killed without cleanup).
+
+    Call once per daemon lifetime and pass the returned path to serve();
+    release it with release_startup_lock() only after the endpoint itself
+    has been torn down, so a replacement can never bind while this process's
+    old endpoint files might still be cleaned up out from under it."""
     path = _lock_path(name)
     for _attempt in range(2):
         try:
@@ -187,7 +212,7 @@ def _acquire_startup_lock(name):
             os.close(fd)
             return path
         except FileExistsError:
-            if ping(name, timeout=1.0):
+            if _lock_holder_alive(path):
                 raise RuntimeError(
                     f"a browser-harness daemon is already running for BU_NAME={name!r}"
                 ) from None
@@ -196,14 +221,27 @@ def _acquire_startup_lock(name):
     raise RuntimeError(f"failed to acquire startup lock for BU_NAME={name!r}")
 
 
-async def serve(name, handler):
-    """Run the server until cancelled. handler(reader, writer) sees the same interface either way."""
+def release_startup_lock(lock_path):
+    try: lock_path.unlink()
+    except FileNotFoundError: pass
+
+
+async def serve(name, handler, lock_path=None):
+    """Run the server until cancelled. handler(reader, writer) sees the same interface either way.
+
+    `lock_path`: a lock already claimed via acquire_startup_lock(). Pass one
+    when the caller needs to hold it across more than this call (e.g. a CDP
+    handshake beforehand and endpoint cleanup after) -- the caller then owns
+    releasing it via release_startup_lock(), not this function. Omit it to
+    have serve() claim and release its own lock for the duration of the call."""
     global _server_token
-    # Off-thread: _acquire_startup_lock() does blocking socket I/O (ping()) to
-    # check a stale lock's liveness; running it inline would block this same
-    # event loop that a *different* daemon's handler (in-process, e.g. tests)
-    # needs to answer that very ping on.
-    lock_path = await asyncio.to_thread(_acquire_startup_lock, name)
+    owns_lock = lock_path is None
+    if owns_lock:
+        # Off-thread: acquire_startup_lock() does blocking file I/O to check a
+        # stale lock's liveness; running it inline would block this same event
+        # loop that a *different* daemon's handler (in-process, e.g. tests)
+        # needs to run on.
+        lock_path = await asyncio.to_thread(acquire_startup_lock, name)
     try:
         if not IS_WINDOWS:
             path = str(_sock_path(name))
@@ -229,8 +267,8 @@ async def serve(name, handler):
             try: pf.unlink()
             except FileNotFoundError: pass
     finally:
-        try: lock_path.unlink()
-        except FileNotFoundError: pass
+        if owns_lock:
+            await asyncio.to_thread(release_startup_lock, lock_path)
 
 
 def expected_token():

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -216,9 +216,17 @@ def acquire_startup_lock(name):
     old endpoint files might still be cleaned up out from under it."""
     path = _lock_path(name)
     for _attempt in range(2):
-        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-        tmp.write_text(str(os.getpid()), encoding="utf-8")
-        os.chmod(tmp, 0o600)
+        # Random suffix (not just our pid) so the staging path isn't
+        # predictable, and O_CREAT|O_EXCL so if something has pre-created it
+        # anyway -- e.g. a symlink planted by another local user in a shared
+        # runtime dir -- we fail instead of writing through it via a plain
+        # open()-and-truncate, which follows symlinks.
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
+        fd = os.open(str(tmp), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        try:
+            os.write(fd, str(os.getpid()).encode())
+        finally:
+            os.close(fd)
         try:
             os.link(str(tmp), str(path))
             return path
@@ -230,7 +238,7 @@ def acquire_startup_lock(name):
             try: path.unlink()  # stale lock, no live owner -- reclaim it
             except FileNotFoundError: pass
         finally:
-            try: tmp.unlink()
+            try: os.unlink(tmp)
             except FileNotFoundError: pass
     raise RuntimeError(f"failed to acquire startup lock for BU_NAME={name!r}")
 

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -166,11 +166,16 @@ def _lock_path(name):  return _RUNTIME / f"{_runtime_stem(name)}.lock"
 
 
 def _lock_holder_alive(path):
-    """True iff the PID recorded in `path` is still a live process. Unreadable
-    or corrupt contents count as not-alive (safe to reclaim)."""
+    """True iff the PID recorded in `path` is still a live process. Unreadable,
+    corrupt, or out-of-range contents count as not-alive (safe to reclaim)."""
     try:
         pid = int(path.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
+        return False
+    # Same bounds as identify() above: os.kill(0, sig) hits the calling process
+    # group rather than a specific process, and a value outside pid_t's range
+    # makes os.kill() raise OverflowError instead of telling us "not alive".
+    if not 0 < pid < (1 << 31):
         return False
     try:
         os.kill(pid, 0)
@@ -187,8 +192,13 @@ def acquire_startup_lock(name):
     can be tens of seconds wide (CDP handshake, an unclicked Allow popup) --
     and the second would silently unlink + rebind over a still-live first
     daemon's socket, orphaning it with no error raised anywhere.
-    O_CREAT|O_EXCL is atomic at the filesystem level, unlike the bare
-    `if os.path.exists(...): os.unlink(...)` it guards here.
+    The claim itself is a write-then-link: the PID is written to a private
+    temp file first, then published via os.link(), which atomically creates
+    the lock's directory entry only if it doesn't already exist. That keeps
+    another invocation from ever observing a lock that exists but is still
+    empty -- which a plain O_CREAT|O_EXCL-then-write would allow, and which
+    would read as "corrupt, not-alive" and get reclaimed out from under the
+    process that just created it.
 
     Staleness is decided by whether the PID recorded in the lock is still a
     live process, not by pinging the endpoint: the lock is meant to be held
@@ -206,10 +216,11 @@ def acquire_startup_lock(name):
     old endpoint files might still be cleaned up out from under it."""
     path = _lock_path(name)
     for _attempt in range(2):
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(str(os.getpid()), encoding="utf-8")
+        os.chmod(tmp, 0o600)
         try:
-            fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-            os.write(fd, str(os.getpid()).encode())
-            os.close(fd)
+            os.link(str(tmp), str(path))
             return path
         except FileExistsError:
             if _lock_holder_alive(path):
@@ -217,6 +228,9 @@ def acquire_startup_lock(name):
                     f"a browser-harness daemon is already running for BU_NAME={name!r}"
                 ) from None
             try: path.unlink()  # stale lock, no live owner -- reclaim it
+            except FileNotFoundError: pass
+        finally:
+            try: tmp.unlink()
             except FileNotFoundError: pass
     raise RuntimeError(f"failed to acquire startup lock for BU_NAME={name!r}")
 

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -764,7 +764,7 @@ class Daemon:
             return {"error": msg}
 
 
-async def serve(d):
+async def serve(d, lock_path=None):
     async def handler(reader, writer):
         try:
             line = await reader.readline()
@@ -782,7 +782,7 @@ async def serve(d):
         finally:
             writer.close()
 
-    serve_task = asyncio.create_task(ipc.serve(NAME, handler))
+    serve_task = asyncio.create_task(ipc.serve(NAME, handler, lock_path=lock_path))
     stop_task = asyncio.create_task(d.stop.wait())
     await asyncio.sleep(0.05)  # let serve() bind so sock_addr() resolves to the live endpoint
     log(f"listening on {ipc.sock_addr(NAME)} (name={NAME}, remote={REMOTE_ID or 'local'})")
@@ -820,9 +820,19 @@ async def serve(d):
 
 
 async def main():
-    d = Daemon()
-    await d.start()
-    await serve(d)
+    # Claim the name before the CDP handshake (not inside serve()), so the
+    # startup-lock's protection covers the whole gap a racing invocation could
+    # otherwise land in -- including a handshake stuck on an unclicked "Allow
+    # remote debugging?" popup. Held until after serve() has torn down this
+    # daemon's own endpoint, so a replacement can never bind while that
+    # teardown might still be racing it.
+    lock_path = await asyncio.to_thread(ipc.acquire_startup_lock, NAME)
+    try:
+        d = Daemon()
+        await d.start()
+        await serve(d, lock_path)
+    finally:
+        await asyncio.to_thread(ipc.release_startup_lock, lock_path)
 
 
 def already_running():

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -835,6 +835,11 @@ async def main():
     global _OWNS_REMOTE
     lock_path = await asyncio.to_thread(ipc.acquire_startup_lock, NAME)
     _OWNS_REMOTE = True
+    # Written only now, not by _run() before main() is even called: a losing
+    # invocation runs the same open(PID, "w") line before it ever attempts the
+    # lock, which would overwrite the winner's already-written PID file with
+    # its own -- and then have nothing to stop it un-writing that file too.
+    open(PID, "w").write(str(os.getpid()))
     try:
         d = Daemon()
         await d.start()
@@ -854,7 +859,6 @@ def _run():
         print(f"daemon already running on {SOCK}", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
-    open(PID, "w").write(str(os.getpid()))
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
@@ -865,12 +869,13 @@ def _run():
     finally:
         # A losing invocation (RuntimeError from acquire_startup_lock because
         # another live daemon already owns NAME) never set _OWNS_REMOTE, so it
-        # must not stop REMOTE_ID's browser -- that's the winner's browser,
-        # not something this process started.
+        # never wrote PID and must not stop REMOTE_ID's browser -- that's the
+        # winner's browser, not something this process started -- or unlink
+        # the winner's PID file.
         if _OWNS_REMOTE:
             stop_remote()
-        try: os.unlink(PID)
-        except FileNotFoundError: pass
+            try: os.unlink(PID)
+            except FileNotFoundError: pass
 
 
 if __name__ == "__main__":

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -88,6 +88,12 @@ INTERNAL = ("chrome://", "chrome-untrusted://", "devtools://", "chrome-extension
 BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 _REMOTE_STOPPED = False
+# Set once main() has claimed the startup lock, i.e. once this process is the
+# one actually responsible for REMOTE_ID's browser rather than a duplicate
+# invocation that lost the race for the same BU_NAME. Gates stop_remote() in
+# the __main__ finally block below so a losing invocation can't stop the
+# winner's browser out from under it.
+_OWNS_REMOTE = False
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
 # Chrome 144+ shows a per-connection popup. Keep popup open enough to click.
 LOCAL_HANDSHAKE_TIMEOUT = 45
@@ -826,7 +832,9 @@ async def main():
     # remote debugging?" popup. Held until after serve() has torn down this
     # daemon's own endpoint, so a replacement can never bind while that
     # teardown might still be racing it.
+    global _OWNS_REMOTE
     lock_path = await asyncio.to_thread(ipc.acquire_startup_lock, NAME)
+    _OWNS_REMOTE = True
     try:
         d = Daemon()
         await d.start()
@@ -841,7 +849,7 @@ def already_running():
     return ipc.ping(NAME, timeout=1.0)
 
 
-if __name__ == "__main__":
+def _run():
     if already_running():
         print(f"daemon already running on {SOCK}", file=sys.stderr)
         sys.exit(0)
@@ -855,6 +863,15 @@ if __name__ == "__main__":
         log(f"fatal: {e}")
         sys.exit(1)
     finally:
-        stop_remote()
+        # A losing invocation (RuntimeError from acquire_startup_lock because
+        # another live daemon already owns NAME) never set _OWNS_REMOTE, so it
+        # must not stop REMOTE_ID's browser -- that's the winner's browser,
+        # not something this process started.
+        if _OWNS_REMOTE:
+            stop_remote()
         try: os.unlink(PID)
         except FileNotFoundError: pass
+
+
+if __name__ == "__main__":
+    _run()

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -596,11 +596,13 @@ def test_shutdown_closes_only_the_daemon_owned_tab(monkeypatch):
         d.stop = asyncio.Event()
         d.stop.set()
 
-    async def wait_forever(*_args):
+    async def wait_forever(*_args, **_kwargs):
         await asyncio.Event().wait()
 
     d.start = start
     monkeypatch.setattr(daemon, "Daemon", lambda: d)
+    monkeypatch.setattr(daemon.ipc, "acquire_startup_lock", lambda _name: "test.lock")
+    monkeypatch.setattr(daemon.ipc, "release_startup_lock", lambda _lock_path: None)
     monkeypatch.setattr(daemon.ipc, "serve", wait_forever)
     monkeypatch.setattr(daemon.ipc, "sock_addr", lambda _name: "test-socket")
     monkeypatch.setattr(daemon.ipc, "cleanup_endpoint", lambda _name: None)
@@ -611,6 +613,67 @@ def test_shutdown_closes_only_the_daemon_owned_tab(monkeypatch):
     assert d.cdp.closed == ["daemon-tab"]
     assert d.dedicated_target_id is None
     assert d.target_id == "user-selected-tab"
+
+
+def test_main_holds_startup_lock_across_handshake_and_endpoint_cleanup(monkeypatch):
+    """Regression test for cubic review comments on #692 (findings 2 and 4).
+
+    The lock must be claimed before Daemon.start()'s CDP handshake -- not
+    inside serve(), which only runs after that handshake completes -- or a
+    racing invocation is free to run its own handshake unprotected, which is
+    the exact gap this PR's lock was meant to close. And it must be released
+    only after serve()'s own endpoint cleanup has finished, or a replacement
+    invocation can acquire the freed lock and bind its own endpoint before
+    this daemon's still-pending cleanup_endpoint() call deletes it out from
+    under them.
+    """
+    calls = []
+    d = daemon.Daemon()
+
+    async def start():
+        calls.append("cdp_start")
+
+    d.start = start
+    monkeypatch.setattr(daemon, "Daemon", lambda: d)
+    monkeypatch.setattr(
+        daemon.ipc, "acquire_startup_lock", lambda _name: calls.append("acquire_lock") or "test.lock"
+    )
+    monkeypatch.setattr(
+        daemon.ipc, "release_startup_lock", lambda _lp: calls.append("release_lock")
+    )
+
+    async def fake_serve(_d, _lock_path):
+        # The real serve() calls ipc.cleanup_endpoint(NAME) as its last step.
+        daemon.ipc.cleanup_endpoint(daemon.NAME)
+        calls.append("serve")
+
+    monkeypatch.setattr(daemon, "serve", fake_serve)
+    monkeypatch.setattr(daemon.ipc, "cleanup_endpoint", lambda _name: calls.append("cleanup_endpoint"))
+
+    asyncio.run(daemon.main())
+
+    assert calls == ["acquire_lock", "cdp_start", "cleanup_endpoint", "serve", "release_lock"]
+
+
+def test_main_never_touches_endpoint_when_a_daemon_already_holds_the_lock(monkeypatch):
+    """Regression test for cubic review comment on #692 (finding 3, P0).
+
+    A duplicate invocation that loses the startup-lock race must exit before
+    ever calling cleanup_endpoint() -- that call unconditionally deletes the
+    socket/port file for NAME, which would orphan the live daemon that still
+    holds the lock even though it's still running.
+    """
+    def fake_acquire(_name):
+        raise RuntimeError(f"a browser-harness daemon is already running for BU_NAME={_name!r}")
+
+    cleanup_calls = []
+    monkeypatch.setattr(daemon.ipc, "acquire_startup_lock", fake_acquire)
+    monkeypatch.setattr(daemon.ipc, "cleanup_endpoint", lambda _name: cleanup_calls.append(_name))
+
+    with pytest.raises(RuntimeError, match="already running"):
+        asyncio.run(daemon.main())
+
+    assert cleanup_calls == []
 
 
 def test_delayed_stale_request_follows_recovery_during_domain_enable(monkeypatch):

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -676,6 +676,55 @@ def test_main_never_touches_endpoint_when_a_daemon_already_holds_the_lock(monkey
     assert cleanup_calls == []
 
 
+def test_run_skips_stop_remote_when_startup_lock_was_never_acquired(monkeypatch, tmp_path):
+    """Regression test for cubic review comment on #692 (finding 3, P0).
+
+    A duplicate invocation that loses the startup-lock race raises out of
+    main() before Daemon.start() (or _OWNS_REMOTE) ever runs. The old code
+    still ran stop_remote() unconditionally in the __main__ finally block,
+    which would stop REMOTE_ID's cloud browser -- the winner's browser, not
+    anything this losing process started.
+    """
+    monkeypatch.setattr(daemon, "already_running", lambda: False)
+    monkeypatch.setattr(daemon, "LOG", str(tmp_path / "daemon.log"))
+    monkeypatch.setattr(daemon, "PID", str(tmp_path / "daemon.pid"))
+    monkeypatch.setattr(daemon, "_OWNS_REMOTE", False)
+    monkeypatch.setattr(daemon, "log", lambda _message: None)
+
+    async def fake_main():
+        raise RuntimeError("a browser-harness daemon is already running for BU_NAME='default'")
+
+    monkeypatch.setattr(daemon, "main", fake_main)
+    stop_calls = []
+    monkeypatch.setattr(daemon, "stop_remote", lambda: stop_calls.append(True))
+
+    with pytest.raises(SystemExit):
+        daemon._run()
+
+    assert stop_calls == []
+
+
+def test_run_still_calls_stop_remote_after_a_daemon_that_actually_ran(monkeypatch, tmp_path):
+    """The P0 fix must not skip cleanup for the process that legitimately
+    acquired the lock and owns REMOTE_ID's browser."""
+    monkeypatch.setattr(daemon, "already_running", lambda: False)
+    monkeypatch.setattr(daemon, "LOG", str(tmp_path / "daemon.log"))
+    monkeypatch.setattr(daemon, "PID", str(tmp_path / "daemon.pid"))
+    monkeypatch.setattr(daemon, "_OWNS_REMOTE", False)
+    monkeypatch.setattr(daemon, "log", lambda _message: None)
+
+    async def fake_main():
+        daemon._OWNS_REMOTE = True
+
+    monkeypatch.setattr(daemon, "main", fake_main)
+    stop_calls = []
+    monkeypatch.setattr(daemon, "stop_remote", lambda: stop_calls.append(True))
+
+    daemon._run()
+
+    assert stop_calls == [True]
+
+
 def test_delayed_stale_request_follows_recovery_during_domain_enable(monkeypatch):
     """Publish the replacement before post-attach domain setup can yield."""
     class _RecoveryWindowCDP(_FakeCDP):

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import pytest
 
@@ -723,6 +724,64 @@ def test_run_still_calls_stop_remote_after_a_daemon_that_actually_ran(monkeypatc
     daemon._run()
 
     assert stop_calls == [True]
+
+
+def test_run_never_touches_pid_file_when_startup_lock_was_never_acquired(monkeypatch, tmp_path):
+    """Regression test for cubic review comment on #692 (P2, second review pass).
+
+    _run() used to write PID unconditionally before even attempting the
+    lock, so a losing invocation would overwrite the winner's already-written
+    PID file with its own pid, and then its unconditional os.unlink(PID) in
+    the finally block would delete that file outright -- both while the
+    winner was still alive and using it. PID is now written inside main(),
+    only after the lock is actually acquired, and only unlinked when
+    _OWNS_REMOTE is set.
+    """
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text("12345", encoding="utf-8")  # the winner's PID
+    monkeypatch.setattr(daemon, "already_running", lambda: False)
+    monkeypatch.setattr(daemon, "LOG", str(tmp_path / "daemon.log"))
+    monkeypatch.setattr(daemon, "PID", str(pid_path))
+    monkeypatch.setattr(daemon, "_OWNS_REMOTE", False)
+    monkeypatch.setattr(daemon, "log", lambda _message: None)
+
+    async def fake_main():
+        raise RuntimeError("a browser-harness daemon is already running for BU_NAME='default'")
+
+    monkeypatch.setattr(daemon, "main", fake_main)
+    monkeypatch.setattr(daemon, "stop_remote", lambda: None)
+
+    with pytest.raises(SystemExit):
+        daemon._run()
+
+    assert pid_path.read_text(encoding="utf-8") == "12345"
+
+
+def test_main_writes_pid_file_only_after_acquiring_the_lock(monkeypatch, tmp_path):
+    """PID must be written inside main(), after the lock is claimed -- not
+    unconditionally by _run() before main() even attempts it, which would let
+    a losing invocation overwrite the winner's PID file with its own."""
+    pid_path = tmp_path / "daemon.pid"
+    monkeypatch.setattr(daemon, "PID", str(pid_path))
+    d = daemon.Daemon()
+
+    async def start():
+        pass
+
+    d.start = start
+    monkeypatch.setattr(daemon, "Daemon", lambda: d)
+    monkeypatch.setattr(daemon.ipc, "acquire_startup_lock", lambda _name: "test.lock")
+    monkeypatch.setattr(daemon.ipc, "release_startup_lock", lambda _lp: None)
+
+    async def fake_serve(_d, _lock_path):
+        # By the time serve() runs, main() must already have written PID.
+        assert pid_path.read_text(encoding="utf-8") == str(os.getpid())
+
+    monkeypatch.setattr(daemon, "serve", fake_serve)
+
+    asyncio.run(daemon.main())
+
+    assert pid_path.read_text(encoding="utf-8") == str(os.getpid())
 
 
 def test_delayed_stale_request_follows_recovery_during_domain_enable(monkeypatch):

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,3 +1,10 @@
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
 from browser_harness import _ipc as ipc
 
 
@@ -126,3 +133,94 @@ def test_ping_returns_false_when_pong_field_is_missing_or_not_true(monkeypatch):
         assert ipc.ping("default", timeout=0.0) is False, (
             f"ping() should require pong is exactly True; got: {resp!r}"
         )
+
+
+# --- serve(): startup mutual exclusion ---
+
+
+def test_serve_does_not_silently_evict_a_still_running_daemon(monkeypatch):
+    """Regression test for #692.
+
+    already_running() is a ping check performed *before* serve() binds, with
+    no lock held across that gap. serve() itself does a check-then-act:
+    `if os.path.exists(path): os.unlink(path)` then binds a new listener at
+    the same path -- unconditionally, with no ownership check. Two
+    invocations racing for the same name can both pass the "not already
+    running" check; the second then silently unlinks and rebinds over the
+    first daemon's live socket, orphaning it with no error raised anywhere.
+
+    This asserts the observable contract from the issue: once a daemon is
+    up and reachable, a second serve() attempt for the same name must not
+    silently take over -- either the first stays reachable, or the second
+    attempt fails loudly. POSIX-only (exercises the AF_UNIX socket file).
+    """
+    if ipc.IS_WINDOWS:
+        pytest.skip("POSIX-only: exercises the AF_UNIX socket-file race")
+
+    # AF_UNIX sun_path is 104 bytes on macOS -- pytest's own tmp_path nests
+    # too deep for that, so use a short-named dir directly under /tmp
+    # instead (same constraint _ipc.py itself documents for BH_RUNTIME_DIR).
+    runtime_dir = Path(tempfile.mkdtemp(prefix="bhipc-", dir="/tmp"))
+    monkeypatch.setattr(ipc, "_RUNTIME", runtime_dir)
+    name = "race"
+
+    async def handler_one(reader, writer):
+        await reader.readline()
+        writer.write(b'{"pong": true, "pid": 111}\n')
+        await writer.drain()
+        writer.close()
+
+    async def handler_two(reader, writer):
+        await reader.readline()
+        writer.write(b'{"pong": true, "pid": 222}\n')
+        await writer.drain()
+        writer.close()
+
+    async def scenario():
+        task_one = asyncio.create_task(ipc.serve(name, handler_one))
+        try:
+            for _ in range(200):
+                if ipc._sock_path(name).exists():
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("first daemon never bound its socket")
+
+            # identify() is blocking socket I/O; run it off-thread so it
+            # doesn't stall the event loop the server tasks need to run on.
+            first_pid = await asyncio.to_thread(ipc.identify, name, 1.0)
+            assert first_pid == 111, "sanity check: first daemon should answer first"
+
+            task_two = asyncio.create_task(ipc.serve(name, handler_two))
+            try:
+                await asyncio.sleep(0.2)  # let a racing serve() unlink + rebind
+
+                assert not task_one.done(), (
+                    "the first daemon's serve() task must not be silently "
+                    "torn down by a second invocation for the same name"
+                )
+                second_pid = await asyncio.to_thread(ipc.identify, name, 1.0)
+                assert second_pid == first_pid, (
+                    "a second serve() call silently took over the socket for "
+                    "a still-running daemon (reached pid "
+                    f"{second_pid} instead of the original {first_pid}) -- "
+                    "it must either fail to start or leave the first daemon "
+                    "reachable, never evict it silently"
+                )
+            finally:
+                task_two.cancel()
+                try:
+                    await task_two
+                except (asyncio.CancelledError, Exception):
+                    pass
+        finally:
+            task_one.cancel()
+            try:
+                await task_one
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        shutil.rmtree(runtime_dir, ignore_errors=True)

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -133,6 +134,48 @@ def test_ping_returns_false_when_pong_field_is_missing_or_not_true(monkeypatch):
         assert ipc.ping("default", timeout=0.0) is False, (
             f"ping() should require pong is exactly True; got: {resp!r}"
         )
+
+
+# --- acquire_startup_lock(): staleness must track process liveness, not ping ---
+
+
+def test_acquire_startup_lock_rejects_a_lock_held_by_a_live_pid_that_isnt_answering_yet(
+    monkeypatch, tmp_path
+):
+    """Regression test for cubic review comment on #692 (finding 1).
+
+    A daemon that has claimed the lock but hasn't bound its endpoint yet (mid
+    CDP handshake, or an unclicked "Allow remote debugging?" popup) has no
+    endpoint to ping. Deciding staleness by pinging would treat "nothing
+    answers yet" as "the holder is gone" and let a second invocation steal
+    the lock and race to bind -- exactly the bug this lock exists to prevent.
+    Staleness must be decided by whether the recorded PID is still alive.
+    """
+    monkeypatch.setattr(ipc, "_RUNTIME", tmp_path)
+    lock_path = ipc._lock_path("worker")
+    lock_path.write_text(str(os.getpid()), encoding="utf-8")  # our own pid: always alive
+
+    with pytest.raises(RuntimeError, match="already running"):
+        ipc.acquire_startup_lock("worker")
+
+    assert lock_path.read_text(encoding="utf-8") == str(os.getpid())
+
+
+def test_acquire_startup_lock_reclaims_a_lock_left_by_a_dead_pid(monkeypatch, tmp_path):
+    monkeypatch.setattr(ipc, "_RUNTIME", tmp_path)
+    lock_path = ipc._lock_path("worker")
+    lock_path.write_text("999999", encoding="utf-8")
+
+    def fake_kill(pid, _sig):
+        if pid == 999999:
+            raise ProcessLookupError()
+
+    monkeypatch.setattr(ipc.os, "kill", fake_kill)
+
+    reclaimed = ipc.acquire_startup_lock("worker")
+
+    assert reclaimed == lock_path
+    assert lock_path.read_text(encoding="utf-8") == str(os.getpid())
 
 
 # --- serve(): startup mutual exclusion ---

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -178,6 +178,53 @@ def test_acquire_startup_lock_reclaims_a_lock_left_by_a_dead_pid(monkeypatch, tm
     assert lock_path.read_text(encoding="utf-8") == str(os.getpid())
 
 
+def test_acquire_startup_lock_reclaims_a_lock_containing_pid_zero(monkeypatch, tmp_path):
+    """Regression test for cubic review comment on #692 (finding 4).
+
+    os.kill(0, 0) signals the caller's own process group and succeeds, so a
+    lock file containing "0" would read as a live holder forever without the
+    same pid-range guard identify() already applies elsewhere.
+    """
+    monkeypatch.setattr(ipc, "_RUNTIME", tmp_path)
+    lock_path = ipc._lock_path("worker")
+    lock_path.write_text("0", encoding="utf-8")
+
+    reclaimed = ipc.acquire_startup_lock("worker")
+
+    assert reclaimed == lock_path
+    assert lock_path.read_text(encoding="utf-8") == str(os.getpid())
+
+
+def test_acquire_startup_lock_never_publishes_the_lock_before_its_pid_is_written(
+    monkeypatch, tmp_path
+):
+    """Regression test for cubic review comment on #692 (finding 1).
+
+    The old O_CREAT|O_EXCL-then-write left a window where the lock's
+    directory entry existed before its PID was written. A racing acquire
+    that hit that window would read the file as empty, treat it as corrupt
+    (not-alive), and reclaim a lock another process was still creating.
+    Publishing must happen via os.link() from an already-fully-written temp
+    file, so the lock is never observable with partial content.
+    """
+    monkeypatch.setattr(ipc, "_RUNTIME", tmp_path)
+    real_link = os.link
+    seen_content_at_publish = {}
+
+    def spy_link(src, dst):
+        seen_content_at_publish["content"] = Path(src).read_text(encoding="utf-8")
+        return real_link(src, dst)
+
+    monkeypatch.setattr(ipc.os, "link", spy_link)
+
+    lock_path = ipc.acquire_startup_lock("worker")
+
+    assert seen_content_at_publish["content"] == str(os.getpid())
+    assert lock_path.read_text(encoding="utf-8") == str(os.getpid())
+    # The private temp file used to stage the write must not linger.
+    assert list(tmp_path.iterdir()) == [lock_path]
+
+
 # --- serve(): startup mutual exclusion ---
 
 

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -225,6 +225,32 @@ def test_acquire_startup_lock_never_publishes_the_lock_before_its_pid_is_written
     assert list(tmp_path.iterdir()) == [lock_path]
 
 
+def test_acquire_startup_lock_refuses_to_write_through_a_preexisting_staging_path(
+    monkeypatch, tmp_path
+):
+    """Regression test for cubic review comment on #692 (P2, second review pass).
+
+    The staging file used to be published with tmp.write_text(), which opens
+    with default flags and follows symlinks -- so a local attacker who could
+    predict or pre-create that path as a symlink could make us overwrite an
+    arbitrary file with our own pid instead of writing a private temp file.
+    Creation is now O_CREAT|O_EXCL, so a pre-existing path (symlink or not)
+    makes acquisition fail loudly instead of writing through it.
+    """
+    monkeypatch.setattr(ipc, "_RUNTIME", tmp_path)
+    monkeypatch.setattr(ipc.secrets, "token_hex", lambda _n: "predictable")
+
+    victim = tmp_path / "victim.txt"
+    victim.write_text("do not touch", encoding="utf-8")
+    staged_name = f"{ipc._lock_path('worker').name}.{os.getpid()}.predictable.tmp"
+    (tmp_path / staged_name).symlink_to(victim)
+
+    with pytest.raises(FileExistsError):
+        ipc.acquire_startup_lock("worker")
+
+    assert victim.read_text(encoding="utf-8") == "do not touch"
+
+
 # --- serve(): startup mutual exclusion ---
 
 


### PR DESCRIPTION
already_running() pings before serve() binds, but nothing holds the gap between the two. That gap can stretch to tens of seconds through the CDP handshake, especially when an Allow remote debugging popup sits unclicked. A second browser_harness invocation for the same BU_NAME can pass the same check and then serve() will unconditionally unlink and rebind over the first daemon's socket, orphaning it with no error anywhere.

Adds a startup lock file per daemon name, created with O_CREAT and O_EXCL so the claim itself is atomic instead of check then act. If the lock already exists, a live daemon still answering it means the new invocation fails loudly instead of silently taking over. A stale lock left by a crashed process gets reclaimed.

Adds a regression test in tests/unit/test_ipc.py that starts two servers for the same name and asserts the first stays reachable.

Fixes #692

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `serve()` where a second invocation for the same daemon name could silently unlink and rebind over a live daemon's socket, orphaning it with no error. A per-daemon startup lock now makes the second invocation fail loudly instead.

- Acquires the lock in `main()` before the CDP handshake and releases it only after endpoint teardown, so the whole startup gap is covered.
- Publishes the lock via write-then-link from an `O_CREAT|O_EXCL` staging file, so it is never visible before its PID is written and a pre-existing symlink fails loudly; stale locks are reclaimed by PID liveness, not by pinging the endpoint.
- Writes the PID file only after acquiring the lock, so a losing invocation can't overwrite or unlink the winner's PID file.
- A duplicate invocation that loses the race exits before touching the endpoint or stopping the remote browser.
- Adds regression tests for the lock race, stale-lock reclamation, write ordering, and lock ordering in `main()`.

Fixes #692.

<sup>Written for commit 71f3fdac6f76a88ab85193ee76a9d875fa6f4ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

