### PR TITLE
fix: fail closed in get_ws_url() when a named daemon opts out of local fallback

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -370,7 +370,11 @@ def ensure_daemon(wait=60.0, name=None, env=None):
     launched_browser = None
     opened_inspect = False
     for _ in range(3):
-        e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
+        # The explicit `name` argument must win over anything in `env` — otherwise a
+        # caller-supplied env={"BU_NAME": ...} silently overrides which daemon this
+        # spawns as, defeating callers (and the fail-closed guard in get_ws_url())
+        # that rely on `name` to say what the daemon's identity actually is.
+        e = {**os.environ, **(env or {}), **({"BU_NAME": name} if name else {})}
         try:
             stderr_sink = open(ipc.log_path(name or NAME), "ab")
         except OSError:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -252,6 +252,20 @@ def get_ws_url():
         if platform.system() == "Windows":
             hint += "; on Windows also check that a firewall/antivirus isn't blocking localhost connections"
         raise RuntimeError(f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- {hint}")
+    # A named/managed daemon may have been launched with a pinned BU_CDP_URL that a
+    # later respawn (parent restart, session teardown) fails to carry forward. Falling
+    # through to the local profile scan below would then silently attach to whatever
+    # browser happens to be running on the user's default profile instead of the
+    # dedicated automation Chrome the caller pinned -- opt in to failing loudly instead
+    # with BU_NO_LOCAL_FALLBACK=1. Off by default: named local daemons sharing the
+    # user's default browser (each getting its own tab, see attach_first_page) are a
+    # legitimate, currently-supported setup and must keep scanning PROFILES normally.
+    if NAME != "default" and (os.environ.get("BU_NO_LOCAL_FALLBACK") or "").strip().lower() not in ("", "0", "false", "no", "off"):
+        raise RuntimeError(
+            f"pinned endpoint lost for managed daemon BU_NAME={NAME!r}: BU_CDP_WS/BU_CDP_URL "
+            "is unset and BU_NO_LOCAL_FALLBACK is set, so refusing to scan the default browser "
+            "profile -- relaunch the session with its pinned endpoint restored"
+        )
     deadline = time.time() + 30
     next_liveness_check = 0.0
     while time.time() < deadline:

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -163,6 +163,35 @@ def test_local_chrome_mode_is_false_when_env_provides_remote_cdp():
     assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
 
 
+def test_ensure_daemon_spawn_env_lets_explicit_name_win_over_env_bu_name(monkeypatch):
+    """Regression test: ensure_daemon(name="managed", env={"BU_NAME": "default"})
+    must spawn a daemon with BU_NAME=managed, not "default". The env dict was
+    previously merged in after the explicit name, so a caller-supplied
+    BU_NAME in env silently won -- defeating callers, and the fail-closed
+    guard in get_ws_url(), that rely on `name` to say what the spawned
+    daemon's identity actually is."""
+    process = FakeProcess()
+    alive_calls = []
+
+    def fake_daemon_alive(_name):
+        alive_calls.append(_name)
+        return len(alive_calls) > 1
+
+    monkeypatch.setattr(admin, "daemon_alive", fake_daemon_alive)
+    monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda _env: True)
+    captured_env = {}
+
+    def fake_popen(*_args, env, **_kwargs):
+        captured_env.update(env)
+        return process
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    admin.ensure_daemon(name="managed", env={"BU_NAME": "default"})
+
+    assert captured_env["BU_NAME"] == "managed"
+
+
 def test_require_existing_daemon_fails_without_spawning(monkeypatch):
     monkeypatch.setattr(admin, "daemon_alive", lambda _name: False)
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -21,6 +21,112 @@ def test_safe_connection_label_removes_credentials_paths_and_queries(url, label)
     assert daemon._safe_connection_label(url) == label
 
 
+class _FakeResponse:
+    """Minimal stand-in for urllib's addinfourl: supports .read() directly
+    (used by the PROFILES-scan branch) and the context-manager protocol."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_get_ws_url_fails_closed_for_named_daemon_instead_of_scanning_default_profile(
+    monkeypatch, tmp_path
+):
+    """Regression test for #479.
+
+    get_ws_url() checks BU_CDP_WS then BU_CDP_URL, and if neither is set,
+    falls straight into scanning PROFILES (the user's default Chrome/Brave/
+    etc. profile dirs) with no guard at all. For a named/managed daemon that
+    was explicitly pinned to a dedicated automation Chrome via BU_CDP_URL, a
+    later respawn that loses that pinned env would then silently attach to
+    whatever browser happens to be running on the user's real daily-driver
+    profile instead of failing loudly.
+
+    Note this guard is opt-in (BU_NO_LOCAL_FALLBACK=1), not automatic on
+    NAME != "default": named local daemons that share the user's default
+    browser (each getting its own dedicated tab -- see
+    Daemon.attach_first_page's "Named daemons ... share one browser" branch)
+    are a legitimate, currently-supported setup and must keep scanning
+    PROFILES normally. This test simulates a caller that knows its daemon is
+    meant to be pinned and has opted in to failing closed.
+    """
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setenv("BU_NO_LOCAL_FALLBACK", "1")
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+
+    default_profile = tmp_path / "default-chrome-profile"
+    default_profile.mkdir()
+    (default_profile / "DevToolsActivePort").write_text(
+        "9999\n/devtools/browser/abc123\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(daemon, "PROFILES", [default_profile])
+    monkeypatch.setattr(daemon, "supported_browser_running", lambda: True)
+    monkeypatch.setattr(daemon, "remote_debugging_toggle_profiles", list)
+    monkeypatch.setattr(daemon, "remote_debugging_user_enabled", lambda: True)
+
+    urlopen_calls = []
+
+    def fake_urlopen(url, timeout=1):
+        urlopen_calls.append(url)
+        return _FakeResponse(
+            b'{"webSocketDebuggerUrl": "ws://127.0.0.1:9999/devtools/browser/abc123"}'
+        )
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match=r"(?i)pinned|managed daemon|BU_CDP_"):
+        daemon.get_ws_url()
+
+    assert not urlopen_calls, (
+        "get_ws_url() must not scan/attach to the default browser profile "
+        "for a named daemon that opted in to failing closed"
+    )
+
+
+def test_get_ws_url_still_scans_default_profile_for_named_local_daemon_by_default(
+    monkeypatch, tmp_path
+):
+    """Companion to the regression test above: without BU_NO_LOCAL_FALLBACK
+    set, a named daemon must keep falling back to the local profile scan --
+    this is the existing, legitimate "parallel named daemons share the
+    user's default local browser" setup and must not regress."""
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.delenv("BU_NO_LOCAL_FALLBACK", raising=False)
+    monkeypatch.setattr(daemon, "NAME", "worker-a")
+
+    default_profile = tmp_path / "default-chrome-profile"
+    default_profile.mkdir()
+    (default_profile / "DevToolsActivePort").write_text(
+        "9999\n/devtools/browser/abc123\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(daemon, "PROFILES", [default_profile])
+    monkeypatch.setattr(daemon, "supported_browser_running", lambda: True)
+    monkeypatch.setattr(daemon, "remote_debugging_toggle_profiles", list)
+    monkeypatch.setattr(daemon, "remote_debugging_user_enabled", lambda: True)
+
+    def fake_urlopen(url, timeout=1):
+        return _FakeResponse(
+            b'{"webSocketDebuggerUrl": "ws://127.0.0.1:9999/devtools/browser/abc123"}'
+        )
+
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
+
+    assert (
+        daemon.get_ws_url() == "ws://127.0.0.1:9999/devtools/browser/abc123"
+    )
+
+
 def test_remote_stop_retries_and_succeeds(monkeypatch):
     attempts = []
     monkeypatch.setattr(daemon, "REMOTE_ID", "browser-1")

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -115,7 +115,10 @@ def test_get_ws_url_still_scans_default_profile_for_named_local_daemon_by_defaul
     monkeypatch.setattr(daemon, "remote_debugging_toggle_profiles", list)
     monkeypatch.setattr(daemon, "remote_debugging_user_enabled", lambda: True)
 
+    urlopen_calls = []
+
     def fake_urlopen(url, timeout=1):
+        urlopen_calls.append(url)
         return _FakeResponse(
             b'{"webSocketDebuggerUrl": "ws://127.0.0.1:9999/devtools/browser/abc123"}'
         )
@@ -125,6 +128,10 @@ def test_get_ws_url_still_scans_default_profile_for_named_local_daemon_by_defaul
     assert (
         daemon.get_ws_url() == "ws://127.0.0.1:9999/devtools/browser/abc123"
     )
+    # Must come from the DevToolsActivePort port found via the PROFILES scan
+    # (9999), not the 9222/9223 fallback probe -- otherwise this test would
+    # pass even if get_ws_url() skipped PROFILES scanning entirely.
+    assert urlopen_calls == ["http://127.0.0.1:9999/json/version"]
 
 
 def test_remote_stop_retries_and_succeeds(monkeypatch):


### PR DESCRIPTION
get_ws_url() falls back to scanning the default Chrome and Brave profile dirs whenever BU_CDP_WS and BU_CDP_URL are both unset. That includes a named daemon that was pinned to a dedicated automation Chrome. If that daemon respawns and loses its pinned env, it silently attaches to whatever browser happens to be running on the user's own daily driver profile instead of failing.

Named daemons also have a real, existing setup where several of them intentionally share the user's default local browser, each getting its own tab. A blanket rule that named daemons always refuse the fallback would break that, so the guard is opt in through BU_NO_LOCAL_FALLBACK=1 rather than automatic.

Adds two tests in tests/unit/test_daemon.py: one confirming a named daemon with the flag set refuses to scan the default profile, one confirming a named daemon without the flag still works as before.

Fixes #479

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `get_ws_url()` so a named daemon that loses its pinned `BU_CDP_URL`/`BU_CDP_WS` endpoint fails loudly instead of silently attaching to whatever browser is running on the user's default Chrome/Brave profile.

- The guard is opt-in via `BU_NO_LOCAL_FALLBACK=1`; named daemons that intentionally share the user's default browser keep scanning profiles as before.
- `ensure_daemon()` now lets its explicit `name` argument override any `BU_NAME` in a caller-supplied `env`, so callers can't bypass the fail-closed guard by sneaking in `BU_NAME=default`.
- Adds regression tests for the fail-closed path, the unchanged default fallback, and the `name`-over-`env` precedence.

Fixes #479.

<sup>Written for commit 6bd8f230342a6e1d0b449c0d9700dabf247a6e80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

