### PR TITLE
Keep one Chrome approval pending per daemon

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -61,14 +61,22 @@ If Chrome is running but remote debugging is not enabled, the harness opens:
 chrome://inspect/#remote-debugging
 ```
 
-On macOS, when Chrome asks for remote-debugging permission, run:
+On macOS, when local Chrome asks for remote-debugging permission, keep the
+original browser command running and call `mac-approve` in another shell/tool
+call. Preserve the exact daemon name: if the waiting command used
+`BU_NAME=r7k2`, run:
 
 ```text
-browser-harness mac-approve
+BU_NAME=r7k2 browser-harness mac-approve
 ```
 
-Continue browser work when it returns `ready`; otherwise follow its printed
-instruction.
+For the default daemon, omit the `BU_NAME` prefix. The original command resumes
+when the helper returns `ready`; do not rerun it. If the helper reports
+`accessibility-required`, ask the user once to grant the app launching
+browser-harness (for example Terminal, iTerm, or Codex) access in System
+Settings > Privacy & Security > Accessibility, then call `mac-approve` once
+again. This is only for local Chrome; do not call it for `BU_CDP_URL`,
+`BU_CDP_WS`, or Browser Use Cloud.
 
 ## Remote Browsers
 
@@ -192,7 +200,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-harness mac-approve`. Do not poll in a loop — the daemon holds one connection.
+- On macOS, if local Chrome shows an "Allow remote debugging?" popup, call `mac-approve` once with the same `BU_NAME` while the original browser command waits. Do not poll or rerun the browser command; remote and cloud browsers do not use this helper.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -153,7 +153,7 @@ def _parked_log_grace():
 
         return float(LOCAL_HANDSHAKE_TIMEOUT) + 60
     except Exception:
-        return 36060.0
+        return 3660.0
 
 
 def _is_daemon_process(pid):
@@ -354,6 +354,21 @@ def _is_local_chrome_mode(env=None):
     )
 
 
+def _daemon_wait_windows(wait, local):
+    """Return normal startup and Chrome-approval wait windows in seconds."""
+    explicit_wait = wait is not None
+    startup_wait = float(wait) if explicit_wait else 60.0
+    approval_wait = startup_wait
+    if local and not explicit_wait:
+        try:
+            from .daemon import LOCAL_HANDSHAKE_TIMEOUT
+
+            approval_wait = float(LOCAL_HANDSHAKE_TIMEOUT)
+        except Exception:
+            approval_wait = 3600.0
+    return startup_wait, approval_wait
+
+
 def daemon_alive(name=None):
     # Ping handshake (not a bare connect) so a stale .port file + port reuse
     # after a daemon crash doesn't make us mistake an unrelated listener for ours.
@@ -511,7 +526,7 @@ def run_doctor_fix_snap():
     return 0
 
 
-def ensure_daemon(wait=60.0, name=None, env=None):
+def ensure_daemon(wait=None, name=None, env=None):
     """Idempotent. Self-heals stale daemon, closed Chrome (launches it), cold
     Chrome, and missing Allow on chrome://inspect."""
     if daemon_alive(name):
@@ -541,6 +556,10 @@ def ensure_daemon(wait=60.0, name=None, env=None):
 
     import subprocess, sys
     local = _is_local_chrome_mode(env)
+    startup_wait, approval_wait = _daemon_wait_windows(wait, local)
+    # Remote/CDP daemons retain the normal 60s startup bound. Only a local
+    # Chrome handshake displaying the per-connection approval sheet extends a
+    # default caller's deadline, so Browser Use cloud startup is unaffected.
     launched_browser = None
     opened_inspect = False
     for _ in range(3):
@@ -550,7 +569,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
         except OSError:
             stderr_sink = subprocess.DEVNULL
         if local:
-            with _spawn_lock(name, timeout=wait) as lock:
+            with _spawn_lock(name, timeout=startup_wait) as lock:
                 if lock.fd is None:
                     raise RuntimeError("daemon-starting: another browser-harness daemon is still starting; retry later")
                 if daemon_alive(name):
@@ -574,11 +593,12 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             )
         if stderr_sink is not subprocess.DEVNULL:
             stderr_sink.close()
-        spawned = time.time()
-        deadline = spawned + wait
+        spawned = time.monotonic()
+        deadline = spawned + startup_wait
         hinted = not local
+        approval_waiting = False
         pending_died = False
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             if daemon_alive(name):
                 _cleanup_unattached_browser_launch(launched_browser)
                 return
@@ -588,9 +608,19 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             if p is None and pending_pid and _pending_pid_record(ipc.pid_path(name or NAME)) != pending_pid:
                 pending_died = True
                 break
-            if not hinted and time.time() - spawned > 2 and (_log_tail(name) or "").startswith("handshake-wait"):
+            log_tail = _log_tail(name) or ""
+            if local and not approval_waiting and log_tail.startswith("handshake-wait"):
+                approval_waiting = True
+                deadline = max(deadline, spawned + approval_wait)
+            if not hinted and time.monotonic() - spawned > 2 and log_tail.startswith("handshake-wait"):
+                daemon_name = name or NAME
+                approve_command = (
+                    "browser-harness mac-approve"
+                    if daemon_name == "default"
+                    else f"BU_NAME={daemon_name} browser-harness mac-approve"
+                )
                 action = (
-                    "run `browser-harness mac-approve` in another shell or click Allow"
+                    f"run `{approve_command}` in another shell or click Allow"
                     if sys.platform == "darwin"
                     else "click Allow"
                 )
@@ -601,6 +631,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 hinted = True
             time.sleep(0.2)
         msg = _log_tail(name) or ""
+        permission_wait = local and (msg.startswith("handshake-wait") or _needs_chrome_permission_popup(msg))
         if local and pending_died:
             # Serialize cleanup with publishers and remove only the generation
             # we observed. Another waiter may already have published a healthy
@@ -611,21 +642,31 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                         ipc.pid_path(name or NAME).unlink()
                     except FileNotFoundError:
                         pass
+            if permission_wait:
+                # A denied/expired approval may already have dropped its sheet.
+                # Never auto-spawn a replacement here: that would immediately
+                # create another Chrome prompt and recreate the retry loop.
+                raise RuntimeError(
+                    "permission-blocked: the pending Chrome connection ended before approval; "
+                    "browser-harness did not retry or create another connection."
+                )
             continue
         if local and msg.startswith("handshake-wait"):
             # Leave it running: this daemon's connection is what holds the popup
             # on screen. Killing it dropped the popup and the retry raised a new
             # one, which is how a single approval turned into an endless prompt.
             raise RuntimeError(
-                "permission-blocked: Chrome's Allow popup is still open and waiting -- click Allow in Chrome, then retry. "
-                "Do not restart the daemon; the same popup stays valid."
+                "permission-blocked: Chrome's Allow popup is still open and the pending daemon was left running. "
+                "Approve that exact popup; browser-harness did not retry or create another connection."
             )
         if local and _needs_chrome_permission_popup(msg):
-            print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
-            if not _parked_daemon_pid(name):
-                restart_daemon(name)
+            print(
+                'browser-harness: Chrome is asking "Allow remote debugging?". '
+                "Approve that exact popup; no replacement connection was started.",
+                file=sys.stderr,
+            )
             raise RuntimeError(
-                "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
+                "permission-blocked: Chrome did not approve the connection; browser-harness did not retry or create another connection."
             )
         if local and launched_browser is None and _chrome_not_running(msg):
             # Chrome is closed — launch the browser and retry
@@ -646,10 +687,13 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             from .daemon import remote_debugging_toggle_profiles, remote_debugging_user_enabled
             if remote_debugging_user_enabled():
                 # chrome://inspect toggle is already on — connection died
-                print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
-                restart_daemon(name)
+                print(
+                    'browser-harness: Chrome is asking "Allow remote debugging?". '
+                    "Approve that exact popup; no replacement connection was started.",
+                    file=sys.stderr,
+                )
                 raise RuntimeError(
-                    "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
+                    "permission-blocked: Chrome did not approve the connection; browser-harness did not retry or create another connection."
                 )
             restart_daemon(name)
             _open_chrome_inspect_once()

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -188,6 +188,20 @@ def _pending_pid_record(path):
     return pid if _is_daemon_process(pid) else None
 
 
+def _fingerprinted_pending_pid(path):
+    """Return a pending PID only when its published start fingerprint matches."""
+    try:
+        record = json.loads(path.read_text())
+        pid = record["pid"]
+        fingerprint = record.get("started")
+    except (FileNotFoundError, OSError, TypeError, KeyError, json.JSONDecodeError):
+        return None
+    if type(pid) is not int or not 0 < pid < (1 << 31) or fingerprint is None:
+        return None
+    current = _process_start_time(pid)
+    return pid if current is not None and current == fingerprint else None
+
+
 def _pid_number(path):
     """Read only the PID field, without treating it as a trusted identity."""
     try:
@@ -735,15 +749,17 @@ def restart_daemon(name=None, require_clean=False):
     With require_clean=True, an unavailable daemon or any response other than
     {"ok": true} raises before endpoint cleanup or process termination.
 
-    Identity is verified via ipc.identify() before any process signal, so
-    a stale pid file whose number has been reused by an unrelated process
-    is never SIGTERM'd. If the daemon is unreachable, we just clean up the
-    pid file and socket and return — never escalate to a kill-by-pid-file.
+    Ready-daemon identity is verified via ipc.identify() before any process
+    signal. A local daemon waiting on Chrome approval has no IPC socket yet;
+    `--reload` may stop that exact pending generation only when its atomically
+    published process-start fingerprint still matches. A stale or legacy PID
+    file is never trusted for signaling.
     """
     import signal
 
     name = name or NAME
-    pid_path = str(ipc.pid_path(name))
+    pending_path = ipc.pid_path(name)
+    pid_path = str(pending_path)
 
     # Two pieces of information are tracked separately:
     #   - daemon_pid: the daemon's self-reported PID, or None. Only daemons
@@ -757,6 +773,9 @@ def restart_daemon(name=None, require_clean=False):
     daemon_alive = daemon_pid is not None or ipc.ping(name, timeout=1.0)
     if require_clean and not daemon_alive:
         raise RuntimeError(f"daemon {name!r} is unavailable for required clean shutdown")
+    pending_pid = None
+    if not daemon_alive and (_log_tail(name) or "").startswith("handshake-wait"):
+        pending_pid = _fingerprinted_pending_pid(pending_path)
     # Snapshot the daemon's process start-time as a secondary identity check.
     # The IPC socket can disappear before the process exits (e.g. the shutdown
     # path tears down the socket and then waits on a slow remote `stop` PATCH),
@@ -817,6 +836,15 @@ def restart_daemon(name=None, require_clean=False):
                     os.kill(daemon_pid, signal.SIGTERM)
                 except (ProcessLookupError, OSError, SystemError, OverflowError):
                     pass
+
+    if pending_pid is not None and _fingerprinted_pending_pid(pending_path) == pending_pid:
+        # The pre-IPC daemon cannot receive meta:shutdown. The parent-published
+        # start fingerprint is its cancellation capability: re-check it at the
+        # signal boundary so a reused PID is never terminated.
+        try:
+            os.kill(pending_pid, signal.SIGTERM)
+        except (ProcessLookupError, OSError, SystemError, OverflowError):
+            pass
 
     ipc.cleanup_endpoint(name)
     try:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -775,7 +775,13 @@ def restart_daemon(name=None, require_clean=False):
         raise RuntimeError(f"daemon {name!r} is unavailable for required clean shutdown")
     pending_pid = None
     if not daemon_alive and (_log_tail(name) or "").startswith("handshake-wait"):
+        parked_pid = _parked_daemon_pid(name)
         pending_pid = _fingerprinted_pending_pid(pending_path)
+        if parked_pid is not None and pending_pid is None:
+            raise RuntimeError(
+                f"pending daemon {name!r} is live but has no verifiable process fingerprint; "
+                "it was not signaled and its ownership records were preserved"
+            )
     # Snapshot the daemon's process start-time as a secondary identity check.
     # The IPC socket can disappear before the process exits (e.g. the shutdown
     # path tears down the socket and then waits on a slow remote `stop` PATCH),

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import secrets
 import socket
 import subprocess
 import sys
@@ -137,6 +138,179 @@ def _log_tail(name):
         return ipc.log_path(name or NAME).read_text(encoding="utf-8", errors="replace").strip().splitlines()[-1]
     except (FileNotFoundError, IndexError, OSError):
         return None
+
+
+def _parked_log_grace():
+    """How long a `handshake-wait` breadcrumb stays believable.
+
+    It has to track the daemon's own patience: the popup can legitimately sit
+    there for LOCAL_HANDSHAKE_TIMEOUT, so a shorter window would stop
+    recognising a genuinely parked daemon and spawn a second one, which is the
+    exact bug this file removes.
+    """
+    try:
+        from .daemon import LOCAL_HANDSHAKE_TIMEOUT
+
+        return float(LOCAL_HANDSHAKE_TIMEOUT) + 60
+    except Exception:
+        return 36060.0
+
+
+def _is_daemon_process(pid):
+    """Best effort: does `pid` look like one of our daemons?
+
+    Guards against pid reuse — a dead daemon's number can be handed to an
+    unrelated process, and treating that as parked would make every caller wait
+    instead of spawning. Where the check cannot run (Windows, no ps) we fall
+    back to the log-freshness guard rather than blocking startup.
+    """
+    command = (
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command",
+         f"(Get-CimInstance Win32_Process -Filter 'ProcessId={pid}').CommandLine"]
+        if sys.platform == "win32"
+        else ["ps", "-o", "command=", "-p", str(pid)]
+    )
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=2)
+    except Exception:
+        return False
+    if result.returncode != 0:
+        return False
+    out = result.stdout
+    if not out.strip():
+        return False
+    return "browser_harness" in out
+
+
+def _pending_pid_record(path):
+    """Read a parent-published PID plus process-start fingerprint."""
+    try:
+        raw = path.read_text()
+        try:
+            record = json.loads(raw)
+            pid = int(record["pid"])
+            fingerprint = record.get("started")
+        except (json.JSONDecodeError, TypeError, KeyError):
+            fields = raw.split()
+            pid = int(fields[0])
+            fingerprint = None
+    except (FileNotFoundError, OSError, ValueError, IndexError):
+        return None
+    if pid <= 0:
+        return None
+    if fingerprint is not None:
+        current = _process_start_time(pid)
+        return pid if current is not None and current == fingerprint else None
+    return pid if _is_daemon_process(pid) else None
+
+
+def _pid_number(path):
+    """Read only the PID field, without treating it as a trusted identity."""
+    try:
+        raw = path.read_text()
+        try:
+            return int(json.loads(raw)["pid"])
+        except (json.JSONDecodeError, TypeError, KeyError):
+            return int(raw.split()[0])
+    except (FileNotFoundError, OSError, ValueError, IndexError):
+        return None
+
+
+def _publish_pid(path, pid):
+    fingerprint = _process_start_time(pid)
+    value = json.dumps({"pid": pid, "started": fingerprint}, sort_keys=True, separators=(",", ":"))
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
+    tmp.write_text(value)
+    os.replace(tmp, path)
+
+
+def _parked_daemon_pid(name=None):
+    """PID of a daemon whose handshake is still parked on Chrome's Allow popup.
+
+    A parked daemon has no IPC socket yet, so daemon_alive() and identify() both
+    say "nothing there" and every caller used to spawn a sibling, raising a
+    second popup and truncating the first daemon's log. The pid file plus a
+    fresh `handshake-wait` breadcrumb identify it without needing IPC.
+    """
+    if not (_log_tail(name) or "").startswith("handshake-wait"):
+        return None
+    pid = _pending_pid_record(ipc.pid_path(name or NAME))
+    if pid is None:
+        return None
+    return pid
+
+
+def _starting_daemon_pid(name=None):
+    """PID of a daemon child in the short gap before it writes handshake-wait."""
+    path = ipc.pid_path(name or NAME)
+    try:
+        pid = _pending_pid_record(path)
+    except OSError:
+        return None
+    return pid
+
+
+class _spawn_lock:
+    """Only one process spawns a daemon at a time.
+
+    Two cold invocations that both miss the parked check would otherwise open
+    two connections and raise two popups, which is the bug this file is fixing.
+    Best effort: if the lock cannot be taken we still proceed, because failing
+    to start is worse than an extra popup.
+    """
+
+    def __init__(self, name=None, timeout=30.0):
+        self.path = ipc.pid_path(name or NAME).with_suffix(".spawnlock")
+        self.timeout = timeout
+        self.fd = None
+
+    def _try_lock(self):
+        if sys.platform == "win32":
+            import msvcrt
+            os.lseek(self.fd, 0, os.SEEK_SET)
+            try:
+                msvcrt.locking(self.fd, msvcrt.LK_NBLCK, 1)
+                return True
+            except OSError:
+                return False
+        import fcntl
+        try:
+            fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+    def __enter__(self):
+        deadline = time.time() + self.timeout
+        self.fd = os.open(str(self.path), os.O_CREAT | os.O_RDWR, 0o600)
+        if os.fstat(self.fd).st_size == 0:
+            os.write(self.fd, b"1")
+        while True:
+            if self._try_lock():
+                return self
+            if time.time() >= deadline:
+                os.close(self.fd)
+                self.fd = None
+                return self
+            time.sleep(0.1)
+
+    def __exit__(self, *exc):
+        if self.fd is not None:
+            try:
+                if sys.platform == "win32":
+                    import msvcrt
+                    os.lseek(self.fd, 0, os.SEEK_SET)
+                    msvcrt.locking(self.fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(self.fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+        return False
 
 
 def _needs_chrome_remote_debugging_prompt(msg):
@@ -375,20 +549,45 @@ def ensure_daemon(wait=60.0, name=None, env=None):
             stderr_sink = open(ipc.log_path(name or NAME), "ab")
         except OSError:
             stderr_sink = subprocess.DEVNULL
-        p = subprocess.Popen(
-            [sys.executable, "-m", "browser_harness.daemon"],
-            env=e, stdout=subprocess.DEVNULL, stderr=stderr_sink, **ipc.spawn_kwargs(),
-        )
+        if local:
+            with _spawn_lock(name, timeout=wait) as lock:
+                if lock.fd is None:
+                    raise RuntimeError("daemon-starting: another browser-harness daemon is still starting; retry later")
+                if daemon_alive(name):
+                    if stderr_sink is not subprocess.DEVNULL:
+                        stderr_sink.close()
+                    return
+                pending_pid = _parked_daemon_pid(name) or _starting_daemon_pid(name)
+                if pending_pid:
+                    p = None
+                else:
+                    p = subprocess.Popen(
+                        [sys.executable, "-m", "browser_harness.daemon"],
+                        env=e, stdout=subprocess.DEVNULL, stderr=stderr_sink, **ipc.spawn_kwargs(),
+                    )
+                    _publish_pid(ipc.pid_path(name or NAME), p.pid)
+                    pending_pid = p.pid
+        else:
+            p = subprocess.Popen(
+                [sys.executable, "-m", "browser_harness.daemon"],
+                env=e, stdout=subprocess.DEVNULL, stderr=stderr_sink, **ipc.spawn_kwargs(),
+            )
         if stderr_sink is not subprocess.DEVNULL:
             stderr_sink.close()
         spawned = time.time()
         deadline = spawned + wait
         hinted = not local
+        pending_died = False
         while time.time() < deadline:
             if daemon_alive(name):
                 _cleanup_unattached_browser_launch(launched_browser)
                 return
-            if p.poll() is not None: break
+            if p is not None and p.poll() is not None:
+                pending_died = True
+                break
+            if p is None and pending_pid and _pending_pid_record(ipc.pid_path(name or NAME)) != pending_pid:
+                pending_died = True
+                break
             if not hinted and time.time() - spawned > 2 and (_log_tail(name) or "").startswith("handshake-wait"):
                 action = (
                     "run `browser-harness mac-approve` in another shell or click Allow"
@@ -402,14 +601,29 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 hinted = True
             time.sleep(0.2)
         msg = _log_tail(name) or ""
+        if local and pending_died:
+            # Serialize cleanup with publishers and remove only the generation
+            # we observed. Another waiter may already have published a healthy
+            # successor while this caller was leaving its wait loop.
+            with _spawn_lock(name, timeout=1.0) as cleanup_lock:
+                if cleanup_lock.fd is not None and _pid_number(ipc.pid_path(name or NAME)) == pending_pid:
+                    try:
+                        ipc.pid_path(name or NAME).unlink()
+                    except FileNotFoundError:
+                        pass
+            continue
         if local and msg.startswith("handshake-wait"):
-            restart_daemon(name)
+            # Leave it running: this daemon's connection is what holds the popup
+            # on screen. Killing it dropped the popup and the retry raised a new
+            # one, which is how a single approval turned into an endless prompt.
             raise RuntimeError(
-                "permission-blocked: Chrome's Allow popup was not clicked in time -- wait for the user to click Allow, then retry."
+                "permission-blocked: Chrome's Allow popup is still open and waiting -- click Allow in Chrome, then retry. "
+                "Do not restart the daemon; the same popup stays valid."
             )
         if local and _needs_chrome_permission_popup(msg):
             print('browser-harness: Chrome is asking "Allow remote debugging?". Click Allow in Chrome, then retry browser work.', file=sys.stderr)
-            restart_daemon(name)
+            if not _parked_daemon_pid(name):
+                restart_daemon(name)
             raise RuntimeError(
                 "permission-blocked: wait for the user to click Allow in the Chrome permission popup before retrying."
             )
@@ -451,6 +665,7 @@ def ensure_daemon(wait=60.0, name=None, env=None):
                 "Retry after the user confirms; do not retry before."
             )
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
+    raise RuntimeError(f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
 
 
 def require_existing_daemon(name=None):

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -188,8 +188,8 @@ def _pending_pid_record(path):
     return pid if _is_daemon_process(pid) else None
 
 
-def _fingerprinted_pending_pid(path):
-    """Return a pending PID only when its published start fingerprint matches."""
+def _fingerprinted_pending_generation(path):
+    """Return (PID, start fingerprint) only while that generation is alive."""
     try:
         record = json.loads(path.read_text())
         pid = record["pid"]
@@ -199,7 +199,12 @@ def _fingerprinted_pending_pid(path):
     if type(pid) is not int or not 0 < pid < (1 << 31) or fingerprint is None:
         return None
     current = _process_start_time(pid)
-    return pid if current is not None and current == fingerprint else None
+    return (pid, fingerprint) if current is not None and current == fingerprint else None
+
+
+def _fingerprinted_pending_pid(path):
+    generation = _fingerprinted_pending_generation(path)
+    return generation[0] if generation is not None else None
 
 
 def _pid_number(path):
@@ -760,6 +765,12 @@ def restart_daemon(name=None, require_clean=False):
     name = name or NAME
     pending_path = ipc.pid_path(name)
     pid_path = str(pending_path)
+    pending_generation = None
+    pending_unverified = False
+    if (_log_tail(name) or "").startswith("handshake-wait"):
+        parked_pid = _parked_daemon_pid(name)
+        pending_generation = _fingerprinted_pending_generation(pending_path)
+        pending_unverified = parked_pid is not None and pending_generation is None
 
     # Two pieces of information are tracked separately:
     #   - daemon_pid: the daemon's self-reported PID, or None. Only daemons
@@ -773,15 +784,37 @@ def restart_daemon(name=None, require_clean=False):
     daemon_alive = daemon_pid is not None or ipc.ping(name, timeout=1.0)
     if require_clean and not daemon_alive:
         raise RuntimeError(f"daemon {name!r} is unavailable for required clean shutdown")
-    pending_pid = None
-    if not daemon_alive and (_log_tail(name) or "").startswith("handshake-wait"):
-        parked_pid = _parked_daemon_pid(name)
-        pending_pid = _fingerprinted_pending_pid(pending_path)
-        if parked_pid is not None and pending_pid is None:
-            raise RuntimeError(
-                f"pending daemon {name!r} is live but has no verifiable process fingerprint; "
-                "it was not signaled and its ownership records were preserved"
-            )
+    if not daemon_alive and pending_unverified:
+        raise RuntimeError(
+            f"pending daemon {name!r} is live but has no verifiable process fingerprint; "
+            "it was not signaled and its ownership records were preserved"
+        )
+    if not daemon_alive and pending_generation is not None:
+        with _spawn_lock(name, timeout=5.0) as owner_lock:
+            if owner_lock.fd is None:
+                raise RuntimeError(
+                    f"pending daemon {name!r} is changing ownership; it was not signaled"
+                )
+            current_generation = _fingerprinted_pending_generation(pending_path)
+            if current_generation != pending_generation:
+                raise RuntimeError(
+                    f"pending daemon {name!r} changed ownership; the successor was not signaled "
+                    "and its records were preserved"
+                )
+            if ipc.ping(name, timeout=0.2):
+                raise RuntimeError(
+                    f"pending daemon {name!r} became ready during cancellation; run --reload again"
+                )
+            try:
+                os.kill(pending_generation[0], signal.SIGTERM)
+            except (ProcessLookupError, OSError, SystemError, OverflowError):
+                pass
+            ipc.cleanup_endpoint(name)
+            try:
+                os.unlink(pid_path)
+            except FileNotFoundError:
+                pass
+        return
     # Snapshot the daemon's process start-time as a secondary identity check.
     # The IPC socket can disappear before the process exits (e.g. the shutdown
     # path tears down the socket and then waits on a slow remote `stop` PATCH),
@@ -842,15 +875,6 @@ def restart_daemon(name=None, require_clean=False):
                     os.kill(daemon_pid, signal.SIGTERM)
                 except (ProcessLookupError, OSError, SystemError, OverflowError):
                     pass
-
-    if pending_pid is not None and _fingerprinted_pending_pid(pending_path) == pending_pid:
-        # The pre-IPC daemon cannot receive meta:shutdown. The parent-published
-        # start fingerprint is its cancellation capability: re-check it at the
-        # signal boundary so a reused PID is never terminated.
-        try:
-            os.kill(pending_pid, signal.SIGTERM)
-        except (ProcessLookupError, OSError, SystemError, OverflowError):
-            pass
 
     ipc.cleanup_endpoint(name)
     try:

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -140,22 +140,6 @@ def _log_tail(name):
         return None
 
 
-def _parked_log_grace():
-    """How long a `handshake-wait` breadcrumb stays believable.
-
-    It has to track the daemon's own patience: the popup can legitimately sit
-    there for LOCAL_HANDSHAKE_TIMEOUT, so a shorter window would stop
-    recognising a genuinely parked daemon and spawn a second one, which is the
-    exact bug this file removes.
-    """
-    try:
-        from .daemon import LOCAL_HANDSHAKE_TIMEOUT
-
-        return float(LOCAL_HANDSHAKE_TIMEOUT) + 60
-    except Exception:
-        return 3660.0
-
-
 def _is_daemon_process(pid):
     """Best effort: does `pid` look like one of our daemons?
 
@@ -358,14 +342,7 @@ def _daemon_wait_windows(wait, local):
     """Return normal startup and Chrome-approval wait windows in seconds."""
     explicit_wait = wait is not None
     startup_wait = float(wait) if explicit_wait else 60.0
-    approval_wait = startup_wait
-    if local and not explicit_wait:
-        try:
-            from .daemon import LOCAL_HANDSHAKE_TIMEOUT
-
-            approval_wait = float(LOCAL_HANDSHAKE_TIMEOUT)
-        except Exception:
-            approval_wait = 3600.0
+    approval_wait = None if local and not explicit_wait else startup_wait
     return startup_wait, approval_wait
 
 
@@ -558,7 +535,7 @@ def ensure_daemon(wait=None, name=None, env=None):
     local = _is_local_chrome_mode(env)
     startup_wait, approval_wait = _daemon_wait_windows(wait, local)
     # Remote/CDP daemons retain the normal 60s startup bound. Only a local
-    # Chrome handshake displaying the per-connection approval sheet extends a
+    # Chrome handshake displaying the per-connection approval sheet removes a
     # default caller's deadline, so Browser Use cloud startup is unaffected.
     launched_browser = None
     opened_inspect = False
@@ -598,7 +575,7 @@ def ensure_daemon(wait=None, name=None, env=None):
         hinted = not local
         approval_waiting = False
         pending_died = False
-        while time.monotonic() < deadline:
+        while deadline is None or time.monotonic() < deadline:
             if daemon_alive(name):
                 _cleanup_unattached_browser_launch(launched_browser)
                 return
@@ -611,7 +588,7 @@ def ensure_daemon(wait=None, name=None, env=None):
             log_tail = _log_tail(name) or ""
             if local and not approval_waiting and log_tail.startswith("handshake-wait"):
                 approval_waiting = True
-                deadline = max(deadline, spawned + approval_wait)
+                deadline = None if approval_wait is None else max(deadline, spawned + approval_wait)
             if not hinted and time.monotonic() - spawned > 2 and log_tail.startswith("handshake-wait"):
                 daemon_name = name or NAME
                 approve_command = (

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -117,10 +117,11 @@ _REMOTE_STOPPED = False
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
 # Chrome 144+ shows a per-connection popup, and the connection that raised it is
 # the only thing keeping it on screen. 45s expired while the user was in another
-# app, which dropped the popup and made the next call raise a fresh one. Ten
-# hours covers a workday or laptop sleep without imposing an infinite stuck
-# process; BH_ALLOW_TIMEOUT lets unattended runs fail sooner.
-def _allow_timeout(default=36000.0):
+# app, which dropped the popup and made the next call raise a fresh one. One
+# hour gives the user or an accessibility helper time to approve without
+# imposing an infinite stuck process; BH_ALLOW_TIMEOUT lets unattended runs
+# fail sooner or interactive runs wait longer.
+def _allow_timeout(default=3600.0):
     raw = os.environ.get("BH_ALLOW_TIMEOUT")
     if not raw:
         return default

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
-import asyncio, json, os, platform, socket, sys, time, urllib.error, urllib.request
+import asyncio, json, math, os, platform, socket, sys, time, urllib.error, urllib.request
 from urllib.parse import urlparse
 from collections import deque
 from pathlib import Path
@@ -74,6 +74,31 @@ _WINDOWS_PROFILES = (  # relative to %LOCALAPPDATA%; SxS = Canary channel
 )
 
 
+def _publish_own_pid(path=PID, pid=None):
+    """Atomically retain or publish this daemon's PID record.
+
+    The parent may already have published a process-start fingerprint while
+    holding the spawn lock. Never truncate that record: another cold caller
+    must not observe an empty PID file and start a sibling daemon.
+    """
+    pid = pid or os.getpid()
+    target = Path(path)
+    try:
+        published = target.read_text()
+        try:
+            published_pid = int(json.loads(published)["pid"])
+        except (json.JSONDecodeError, TypeError, KeyError):
+            published_pid = int(published.split()[0])
+    except (FileNotFoundError, OSError, ValueError, IndexError):
+        published = str(pid)
+        published_pid = pid
+    if published_pid != pid:
+        published = str(pid)
+    tmp = target.with_name(f"{target.name}.{pid}.tmp")
+    tmp.write_text(published)
+    os.replace(tmp, target)
+
+
 def profile_dirs(system=None):
     system = system or platform.system()
     if system == "Windows":
@@ -90,8 +115,23 @@ BU_API = "https://api.browser-use.com/api/v3"
 REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 _REMOTE_STOPPED = False
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
-# Chrome 144+ shows a per-connection popup. Keep popup open enough to click.
-LOCAL_HANDSHAKE_TIMEOUT = 45
+# Chrome 144+ shows a per-connection popup, and the connection that raised it is
+# the only thing keeping it on screen. 45s expired while the user was in another
+# app, which dropped the popup and made the next call raise a fresh one. Ten
+# hours covers a workday or laptop sleep without imposing an infinite stuck
+# process; BH_ALLOW_TIMEOUT lets unattended runs fail sooner.
+def _allow_timeout(default=36000.0):
+    raw = os.environ.get("BH_ALLOW_TIMEOUT")
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if math.isfinite(value) and value > 0 else default
+
+
+LOCAL_HANDSHAKE_TIMEOUT = _allow_timeout()
 # How long get_ws_url() keeps waiting for DevToolsActivePort before giving up
 NO_TOGGLE_GRACE = 3
 TOGGLE_BOOT_GRACE = 12
@@ -851,7 +891,7 @@ if __name__ == "__main__":
         print(f"daemon already running on {SOCK}", file=sys.stderr)
         sys.exit(0)
     open(LOG, "w").close()
-    open(PID, "w").write(str(os.getpid()))
+    _publish_own_pid()
     try:
         asyncio.run(main())
     except KeyboardInterrupt:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,5 +1,5 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
-import asyncio, json, math, os, platform, socket, sys, time, urllib.error, urllib.request
+import asyncio, json, os, platform, socket, sys, time, urllib.error, urllib.request
 from urllib.parse import urlparse
 from collections import deque
 from pathlib import Path
@@ -116,23 +116,11 @@ REMOTE_ID = os.environ.get("BU_BROWSER_ID")
 _REMOTE_STOPPED = False
 BROWSER_KIND = "cloud" if REMOTE_ID else ("cdp" if (os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL")) else "local")
 # Chrome 144+ shows a per-connection popup, and the connection that raised it is
-# the only thing keeping it on screen. 45s expired while the user was in another
-# app, which dropped the popup and made the next call raise a fresh one. One
-# hour gives the user or an accessibility helper time to approve without
-# imposing an infinite stuck process; BH_ALLOW_TIMEOUT lets unattended runs
-# fail sooner or interactive runs wait longer.
-def _allow_timeout(default=3600.0):
-    raw = os.environ.get("BH_ALLOW_TIMEOUT")
-    if not raw:
-        return default
-    try:
-        value = float(raw)
-    except ValueError:
-        return default
-    return value if math.isfinite(value) and value > 0 else default
-
-
-LOCAL_HANDSHAKE_TIMEOUT = _allow_timeout()
+# the only thing keeping it on screen. There is deliberately no approval
+# deadline: expiry would drop the sheet and make a later attempt create another
+# connection and another prompt. Chrome/process death and explicit cancellation
+# still terminate the pending connection.
+LOCAL_HANDSHAKE_TIMEOUT = None
 # How long get_ws_url() keeps waiting for DevToolsActivePort before giving up
 NO_TOGGLE_GRACE = 3
 TOGGLE_BOOT_GRACE = 12
@@ -420,7 +408,7 @@ def is_reusable_new_tab_page(t):
 
 
 class _PatientCDPClient(CDPClient):
-    """CDPClient with the WS opening handshake stretched to LOCAL_HANDSHAKE_TIMEOUT."""
+    """CDPClient whose local Chrome approval handshake has no deadline."""
 
     async def start(self):
         import websockets
@@ -663,8 +651,8 @@ class Daemon:
                 )
             if BROWSER_KIND == "local" and ("timed out" in str(e).lower() or "403" in str(e)) and remote_debugging_user_enabled():
                 raise RuntimeError(
-                    f"permission-blocked: Chrome's 'Allow remote debugging?' popup was not accepted within {LOCAL_HANDSHAKE_TIMEOUT}s"
-                    " -- wait for the user to click Allow, then retry"
+                    "permission-blocked: Chrome did not approve the remote debugging connection; "
+                    "browser-harness did not retry or create another connection"
                 )
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
         await self.attach_first_page()

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1123,24 +1123,10 @@ def test_dead_pending_cleanup_does_not_unlink_successor(tmp_path, monkeypatch):
     assert pid_file.read_text() == "222"
 
 
-def test_allow_timeout_is_patient_and_configurable(monkeypatch):
-    from browser_harness import daemon as daemon_mod
-
-    monkeypatch.delenv("BH_ALLOW_TIMEOUT", raising=False)
-    assert daemon_mod._allow_timeout() == 3600
-    monkeypatch.setenv("BH_ALLOW_TIMEOUT", "30")
-    assert daemon_mod._allow_timeout() == 30
-    for bad in ("", "nonsense", "0", "-5", "inf", "-inf", "nan"):
-        monkeypatch.setenv("BH_ALLOW_TIMEOUT", bad)
-        assert daemon_mod._allow_timeout() == 3600
-
-
-def test_default_local_wait_matches_allow_window_without_affecting_remote(monkeypatch):
+def test_default_local_approval_has_no_deadline_without_affecting_remote():
     from browser_harness import admin as admin_mod
-    from browser_harness import daemon as daemon_mod
 
-    monkeypatch.setattr(daemon_mod, "LOCAL_HANDSHAKE_TIMEOUT", 3600)
-    assert admin_mod._daemon_wait_windows(None, local=True) == (60.0, 3600.0)
+    assert admin_mod._daemon_wait_windows(None, local=True) == (60.0, None)
     assert admin_mod._daemon_wait_windows(None, local=False) == (60.0, 60.0)
     assert admin_mod._daemon_wait_windows(7, local=True) == (7.0, 7.0)
 
@@ -1241,11 +1227,11 @@ def test_parked_daemon_ignored_when_the_pid_was_reused(tmp_path, monkeypatch):
 
 
 def test_parked_daemon_survives_wall_clock_age_while_process_is_live(tmp_path, monkeypatch):
-    """Laptop sleep advances wall time but not the handshake's monotonic timer."""
+    """A live pending approval has no age-based expiry, including across sleep."""
     from browser_harness import admin as admin_mod
 
     _park_daemon(tmp_path, monkeypatch, os.getpid())
-    stale = time.time() - (admin_mod._parked_log_grace() + 60)
+    stale = time.time() - 86400
     os.utime(tmp_path / "daemon.log", (stale, stale))
     assert admin_mod._parked_daemon_pid() == os.getpid()
 
@@ -1301,16 +1287,3 @@ def test_pending_pid_record_rejects_reused_pid(tmp_path, monkeypatch):
     pid_file.write_text(json.dumps({"pid": os.getpid(), "started": "old-start"}))
     monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "new-start")
     assert admin_mod._pending_pid_record(pid_file) is None
-
-
-def test_parked_grace_tracks_the_daemon_handshake_timeout(monkeypatch):
-    """A daemon may hold the popup for the whole handshake window, so the
-    breadcrumb must stay believable at least that long — including when
-    BH_ALLOW_TIMEOUT shortens that window."""
-    from browser_harness import admin as admin_mod
-    from browser_harness import daemon as daemon_mod
-
-    assert admin_mod._parked_log_grace() > daemon_mod.LOCAL_HANDSHAKE_TIMEOUT
-
-    monkeypatch.setattr(daemon_mod, "LOCAL_HANDSHAKE_TIMEOUT", 30)
-    assert admin_mod._parked_log_grace() > 30

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1331,3 +1331,26 @@ def test_restart_daemon_never_signals_reused_pending_pid(tmp_path, monkeypatch):
     admin_mod.restart_daemon("pending")
 
     assert not pid_file.exists()
+
+
+def test_restart_daemon_preserves_live_pending_without_fingerprint(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text("4321")
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "identify", lambda *a, **k: None)
+    monkeypatch.setattr(admin_mod.ipc, "ping", lambda *a, **k: False)
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "handshake-wait: click Allow")
+    monkeypatch.setattr(admin_mod, "_is_daemon_process", lambda pid: pid == 4321)
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: None)
+    monkeypatch.setattr(
+        admin_mod.os,
+        "kill",
+        lambda *a: (_ for _ in ()).throw(AssertionError("unverified PID must not be signaled")),
+    )
+
+    with pytest.raises(RuntimeError, match="ownership records were preserved"):
+        admin_mod.restart_daemon("pending")
+
+    assert pid_file.read_text() == "4321"

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1354,3 +1354,32 @@ def test_restart_daemon_preserves_live_pending_without_fingerprint(tmp_path, mon
         admin_mod.restart_daemon("pending")
 
     assert pid_file.read_text() == "4321"
+
+
+def test_restart_daemon_does_not_cancel_successor_generation(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(json.dumps({"pid": 111, "started": "old-start"}))
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "identify", lambda *a, **k: None)
+    monkeypatch.setattr(admin_mod.ipc, "ping", lambda *a, **k: False)
+    monkeypatch.setattr(admin_mod.ipc, "cleanup_endpoint", lambda name: None)
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "handshake-wait: click Allow")
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: 111)
+    generations = iter([(111, "old-start"), (222, "new-start")])
+    monkeypatch.setattr(
+        admin_mod,
+        "_fingerprinted_pending_generation",
+        lambda path: next(generations),
+    )
+    monkeypatch.setattr(
+        admin_mod.os,
+        "kill",
+        lambda *a: (_ for _ in ()).throw(AssertionError("successor must not be signaled")),
+    )
+
+    with pytest.raises(RuntimeError, match="changed ownership; the successor was not signaled"):
+        admin_mod.restart_daemon("pending")
+
+    assert pid_file.exists()

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1065,8 +1065,8 @@ def test_ensure_daemon_returns_when_the_parked_daemon_finishes(tmp_path, monkeyp
     admin_mod.ensure_daemon(wait=5.0)  # returns, does not raise
 
 
-def test_ensure_daemon_replaces_pending_child_that_exited(tmp_path, monkeypatch):
-    """A dead pending PID must not leave callers waiting on its stale log."""
+def test_ensure_daemon_does_not_replace_pending_approval_that_exited(tmp_path, monkeypatch):
+    """A failed approval attempt must not create another Chrome prompt."""
     from browser_harness import admin as admin_mod
 
     pid_file = tmp_path / "daemon.pid"
@@ -1091,9 +1091,9 @@ def test_ensure_daemon_replaces_pending_child_that_exited(tmp_path, monkeypatch)
     spawned = []
     monkeypatch.setattr(admin_mod.subprocess, "Popen", lambda *a, **k: spawned.append(a) or Dead())
 
-    with pytest.raises(RuntimeError, match="didn't come up"):
+    with pytest.raises(RuntimeError, match="did not retry or create another connection"):
         admin_mod.ensure_daemon(wait=0.1)
-    assert spawned, "the dead pending child must be replaced"
+    assert spawned == []
 
 
 def test_dead_pending_cleanup_does_not_unlink_successor(tmp_path, monkeypatch):
@@ -1118,7 +1118,7 @@ def test_dead_pending_cleanup_does_not_unlink_successor(tmp_path, monkeypatch):
     monkeypatch.setattr(admin_mod, "_pending_pid_record", old_dies_as_successor_arrives)
     monkeypatch.setattr(admin_mod.subprocess, "Popen", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop after cleanup")))
 
-    with pytest.raises(RuntimeError, match="stop after cleanup"):
+    with pytest.raises(RuntimeError, match="did not retry or create another connection"):
         admin_mod.ensure_daemon(wait=0.1)
     assert pid_file.read_text() == "222"
 
@@ -1127,12 +1127,56 @@ def test_allow_timeout_is_patient_and_configurable(monkeypatch):
     from browser_harness import daemon as daemon_mod
 
     monkeypatch.delenv("BH_ALLOW_TIMEOUT", raising=False)
-    assert daemon_mod._allow_timeout() == 36000
+    assert daemon_mod._allow_timeout() == 3600
     monkeypatch.setenv("BH_ALLOW_TIMEOUT", "30")
     assert daemon_mod._allow_timeout() == 30
     for bad in ("", "nonsense", "0", "-5", "inf", "-inf", "nan"):
         monkeypatch.setenv("BH_ALLOW_TIMEOUT", bad)
-        assert daemon_mod._allow_timeout() == 36000
+        assert daemon_mod._allow_timeout() == 3600
+
+
+def test_default_local_wait_matches_allow_window_without_affecting_remote(monkeypatch):
+    from browser_harness import admin as admin_mod
+    from browser_harness import daemon as daemon_mod
+
+    monkeypatch.setattr(daemon_mod, "LOCAL_HANDSHAKE_TIMEOUT", 3600)
+    assert admin_mod._daemon_wait_windows(None, local=True) == (60.0, 3600.0)
+    assert admin_mod._daemon_wait_windows(None, local=False) == (60.0, 60.0)
+    assert admin_mod._daemon_wait_windows(7, local=True) == (7.0, 7.0)
+
+
+def test_permission_blocked_exit_is_not_retried(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod.ipc, "spawn_kwargs", lambda: {})
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: False)
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "permission-blocked: approval expired")
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "start")
+    monkeypatch.setattr(
+        admin_mod,
+        "restart_daemon",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("approval must not restart")),
+    )
+
+    class Dead:
+        pid = 4321
+
+        def poll(self):
+            return 1
+
+    spawned = []
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", lambda *a, **k: spawned.append(a) or Dead())
+
+    with pytest.raises(RuntimeError, match="did not retry or create another connection"):
+        admin_mod.ensure_daemon(wait=0.1)
+    assert len(spawned) == 1
 
 
 def test_cold_spawn_publishes_child_before_releasing_lock(tmp_path, monkeypatch):

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,4 +1,8 @@
+import json
+import os
 import signal
+import time
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -970,3 +974,299 @@ def test_run_update_of_installed_wheel_never_pulls_an_enclosing_repo(tmp_path, m
         f"run_update must not shell out to git for a wheel install; ran {commands}"
     )
     assert ["uv", "tool", "upgrade", "browser-harness"] in commands
+
+
+# --- Chrome's "Allow remote debugging?" popup: one pending startup per name --
+# Chrome 144+ raises the popup per CDP connection, and the connection that
+# raised it is what keeps it on screen. ensure_daemon used to kill that daemon
+# whenever the click did not land in time, which dropped the popup and made the
+# next call raise a new one. Users with several daemons saw it for ever.
+
+
+def _park_daemon(tmp_path, monkeypatch, pid, *, is_daemon=True):
+    """Simulate a daemon parked on the popup: pid file + fresh handshake log."""
+    from browser_harness import admin as admin_mod
+
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "handshake-wait: click Allow")
+    log_file = tmp_path / "daemon.log"
+    log_file.write_text("handshake-wait: click Allow")
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(str(pid))
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod, "_is_daemon_process", lambda p: is_daemon)
+
+
+def test_parked_daemon_is_detected_from_pid_file_and_log(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, os.getpid())
+    assert admin_mod._parked_daemon_pid() == os.getpid()
+
+
+def test_parked_daemon_liveness_never_uses_os_kill(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, os.getpid())
+    monkeypatch.setattr(admin_mod, "_pending_pid_record", lambda path: os.getpid())
+    monkeypatch.setattr(admin_mod.os, "kill", lambda *a: (_ for _ in ()).throw(AssertionError("os.kill is destructive on Windows")))
+    assert admin_mod._parked_daemon_pid() == os.getpid()
+
+
+def test_parked_daemon_ignored_when_the_process_is_gone(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, 2147480000, is_daemon=False)  # never a live daemon
+    assert admin_mod._parked_daemon_pid() is None
+
+
+def test_parked_daemon_ignored_without_the_handshake_breadcrumb(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, os.getpid())
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "connecting to ws://...")
+    assert admin_mod._parked_daemon_pid() is None
+
+
+def test_ensure_daemon_waits_for_the_parked_daemon_instead_of_spawning(tmp_path, monkeypatch):
+    """The second invocation must join the popup already on screen."""
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, os.getpid())
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: False)
+
+    spawned = []
+
+    def refuse_spawn(*args, **kwargs):
+        spawned.append(args)
+        raise AssertionError("spawned a sibling daemon while one was parked")
+
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", refuse_spawn)
+
+    with pytest.raises(RuntimeError, match="popup is still open"):
+        admin_mod.ensure_daemon(wait=0.3)
+    assert spawned == []
+
+
+def test_ensure_daemon_returns_when_the_parked_daemon_finishes(tmp_path, monkeypatch):
+    """Clicking Allow completes the parked handshake; no new daemon needed."""
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, os.getpid())
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    calls = {"n": 0}
+
+    def alive(name=None):
+        calls["n"] += 1
+        return calls["n"] > 2  # the user clicks Allow on the third poll
+
+    monkeypatch.setattr(admin_mod, "daemon_alive", alive)
+    admin_mod.ensure_daemon(wait=5.0)  # returns, does not raise
+
+
+def test_ensure_daemon_replaces_pending_child_that_exited(tmp_path, monkeypatch):
+    """A dead pending PID must not leave callers waiting on its stale log."""
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    pid_file.write_text(str(os.getpid()))
+    log_file.write_text("handshake-wait: click Allow")
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod.ipc, "spawn_kwargs", lambda: {})
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: False)
+    pending = iter([os.getpid(), None])
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: next(pending, None))
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_pending_pid_record", lambda path: None)
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "start")
+
+    class Dead:
+        pid = 4321
+        def poll(self): return 1
+
+    spawned = []
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", lambda *a, **k: spawned.append(a) or Dead())
+
+    with pytest.raises(RuntimeError, match="didn't come up"):
+        admin_mod.ensure_daemon(wait=0.1)
+    assert spawned, "the dead pending child must be replaced"
+
+
+def test_dead_pending_cleanup_does_not_unlink_successor(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    pid_file.write_text("111")
+    log_file.write_text("handshake-wait: click Allow")
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: False)
+    pending = iter([111, None])
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: next(pending, None))
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: None)
+
+    def old_dies_as_successor_arrives(path):
+        pid_file.write_text("222")
+        return None
+
+    monkeypatch.setattr(admin_mod, "_pending_pid_record", old_dies_as_successor_arrives)
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop after cleanup")))
+
+    with pytest.raises(RuntimeError, match="stop after cleanup"):
+        admin_mod.ensure_daemon(wait=0.1)
+    assert pid_file.read_text() == "222"
+
+
+def test_allow_timeout_is_patient_and_configurable(monkeypatch):
+    from browser_harness import daemon as daemon_mod
+
+    monkeypatch.delenv("BH_ALLOW_TIMEOUT", raising=False)
+    assert daemon_mod._allow_timeout() == 36000
+    monkeypatch.setenv("BH_ALLOW_TIMEOUT", "30")
+    assert daemon_mod._allow_timeout() == 30
+    for bad in ("", "nonsense", "0", "-5", "inf", "-inf", "nan"):
+        monkeypatch.setenv("BH_ALLOW_TIMEOUT", bad)
+        assert daemon_mod._allow_timeout() == 36000
+
+
+def test_cold_spawn_publishes_child_before_releasing_lock(tmp_path, monkeypatch):
+    """A second cold caller sees the first child before its log exists."""
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod.ipc, "spawn_kwargs", lambda: {})
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: False)
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_is_daemon_process", lambda pid: pid == 4321)
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "start-4321")
+
+    class Starting:
+        pid = 4321
+
+        def poll(self): return None
+
+    spawned = []
+
+    def spawn(*args, **kwargs):
+        spawned.append(args)
+        pid_file.write_text("4321")
+        return Starting()
+
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", spawn)
+
+    with pytest.raises(RuntimeError, match="didn't come up"):
+        admin_mod.ensure_daemon(wait=0)
+    assert len(spawned) == 1
+    assert json.loads(pid_file.read_text()) == {"pid": 4321, "started": "start-4321"}
+    old = time.time() - 86400
+    os.utime(pid_file, (old, old))
+    with pytest.raises(RuntimeError, match="didn't come up"):
+        admin_mod.ensure_daemon(wait=0)
+    assert len(spawned) == 1
+
+
+def test_starting_daemon_survives_wall_clock_age_before_log(tmp_path, monkeypatch):
+    """Sleep can age the PID mtime before the child writes handshake-wait."""
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(json.dumps({"pid": os.getpid(), "started": "start"}))
+    old = time.time() - 86400
+    os.utime(pid_file, (old, old))
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "start")
+    assert admin_mod._starting_daemon_pid() == os.getpid()
+
+
+def test_parked_daemon_ignored_when_the_pid_was_reused(tmp_path, monkeypatch):
+    """A recycled pid belonging to something else must not look parked."""
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, os.getpid(), is_daemon=False)
+    assert admin_mod._parked_daemon_pid() is None
+
+
+def test_parked_daemon_survives_wall_clock_age_while_process_is_live(tmp_path, monkeypatch):
+    """Laptop sleep advances wall time but not the handshake's monotonic timer."""
+    from browser_harness import admin as admin_mod
+
+    _park_daemon(tmp_path, monkeypatch, os.getpid())
+    stale = time.time() - (admin_mod._parked_log_grace() + 60)
+    os.utime(tmp_path / "daemon.log", (stale, stale))
+    assert admin_mod._parked_daemon_pid() == os.getpid()
+
+
+def test_spawn_lock_is_exclusive_then_released(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: tmp_path / "daemon.pid")
+    with admin_mod._spawn_lock(timeout=0.2) as first:
+        assert first.fd is not None
+        with admin_mod._spawn_lock(timeout=0.2) as second:
+            assert second.fd is None  # someone else holds it; proceed anyway
+    with admin_mod._spawn_lock(timeout=0.2) as third:
+        assert third.fd is not None  # released on exit
+
+
+def test_spawn_lock_does_not_expire_while_owner_is_alive(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: tmp_path / "daemon.pid")
+    with admin_mod._spawn_lock(timeout=0.1) as first:
+        old = time.time() - 86400
+        os.utime(first.path, (old, old))
+        with admin_mod._spawn_lock(timeout=0.1) as second:
+            assert second.fd is None
+
+
+def test_spawn_lock_owner_cannot_unlink_successor(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: tmp_path / "daemon.pid")
+    first = admin_mod._spawn_lock(timeout=0.1)
+    first.__enter__()
+    first.path.write_text(f"{os.getpid()} successor")
+    first.__exit__()
+    assert first.path.read_text() == f"{os.getpid()} successor"
+
+
+def test_process_identity_check_fails_closed_when_unavailable(monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    def unavailable(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(admin_mod.subprocess, "run", unavailable)
+    assert admin_mod._is_daemon_process(os.getpid()) is False
+
+
+def test_pending_pid_record_rejects_reused_pid(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(json.dumps({"pid": os.getpid(), "started": "old-start"}))
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "new-start")
+    assert admin_mod._pending_pid_record(pid_file) is None
+
+
+def test_parked_grace_tracks_the_daemon_handshake_timeout(monkeypatch):
+    """A daemon may hold the popup for the whole handshake window, so the
+    breadcrumb must stay believable at least that long — including when
+    BH_ALLOW_TIMEOUT shortens that window."""
+    from browser_harness import admin as admin_mod
+    from browser_harness import daemon as daemon_mod
+
+    assert admin_mod._parked_log_grace() > daemon_mod.LOCAL_HANDSHAKE_TIMEOUT
+
+    monkeypatch.setattr(daemon_mod, "LOCAL_HANDSHAKE_TIMEOUT", 30)
+    assert admin_mod._parked_log_grace() > 30

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1287,3 +1287,47 @@ def test_pending_pid_record_rejects_reused_pid(tmp_path, monkeypatch):
     pid_file.write_text(json.dumps({"pid": os.getpid(), "started": "old-start"}))
     monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "new-start")
     assert admin_mod._pending_pid_record(pid_file) is None
+
+
+def test_restart_daemon_stops_exact_fingerprinted_pending_approval(tmp_path, monkeypatch):
+    import signal
+
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(json.dumps({"pid": 4321, "started": "same-start"}))
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "identify", lambda *a, **k: None)
+    monkeypatch.setattr(admin_mod.ipc, "ping", lambda *a, **k: False)
+    monkeypatch.setattr(admin_mod.ipc, "cleanup_endpoint", lambda name: None)
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "handshake-wait: click Allow")
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "same-start")
+    signals = []
+    monkeypatch.setattr(admin_mod.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    admin_mod.restart_daemon("pending")
+
+    assert signals == [(4321, signal.SIGTERM)]
+    assert not pid_file.exists()
+
+
+def test_restart_daemon_never_signals_reused_pending_pid(tmp_path, monkeypatch):
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text(json.dumps({"pid": 4321, "started": "old-start"}))
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "identify", lambda *a, **k: None)
+    monkeypatch.setattr(admin_mod.ipc, "ping", lambda *a, **k: False)
+    monkeypatch.setattr(admin_mod.ipc, "cleanup_endpoint", lambda name: None)
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "handshake-wait: click Allow")
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "new-start")
+    monkeypatch.setattr(
+        admin_mod.os,
+        "kill",
+        lambda *a: (_ for _ in ()).throw(AssertionError("reused PID must not be signaled")),
+    )
+
+    admin_mod.restart_daemon("pending")
+
+    assert not pid_file.exists()

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,8 +1,27 @@
 import asyncio
+import os
 
 import pytest
 
 from browser_harness import daemon
+
+
+def test_publish_own_pid_never_truncates_parent_record(tmp_path, monkeypatch):
+    pid_file = tmp_path / "daemon.pid"
+    pid_file.write_text('{"pid":4321,"started":"process start with spaces"}')
+    real_replace = os.replace
+    observed = []
+
+    def replace(src, dst):
+        observed.append(pid_file.read_text())
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", replace)
+    daemon._publish_own_pid(pid_file, pid=4321)
+
+    expected = '{"pid":4321,"started":"process start with spaces"}'
+    assert observed == [expected]
+    assert pid_file.read_text() == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Chrome 144+ asks for approval for every new CDP connection. Browser Harness is meant to hold one connection open, but three startup paths could turn one pending approval into several prompts for the same daemon name:

1. `ensure_daemon` killed the process holding the permission sheet after its caller stopped waiting.
2. A daemon has no IPC socket until Chrome accepts the connection, so concurrent cold callers could start sibling processes.
3. The WebSocket handshake expired after 45 seconds.

This keeps the first pending daemon alive, atomically publishes a process-fingerprinted PID while holding a per-name owner lock, and makes later callers join it instead of opening another Chrome connection. The lock cannot be age-stolen from a live owner after laptop sleep, and an old owner cannot unlink a successor lock.

For local Chrome, the approval handshake and the original default caller have no deadline. They wait until Chrome approves, Chrome or the daemon exits, the transport actually fails, or the user explicitly runs `--reload`. Approval failures never auto-retry or create a replacement connection. `--reload` serializes its ownership snapshot, cancellation, and cleanup under the same per-name lock, then signals only the exact atomically published PID whose process-start fingerprint still matches. Stale, legacy, PID-reused, and successor records are never trusted.

Browser Use Cloud and explicit `BU_CDP_URL` / `BU_CDP_WS` startup retain their existing bounded behavior. The no-deadline path is local-Chrome-only.

On macOS the bundled skill tells the agent to keep the original command running and invoke `mac-approve` once with the exact same `BU_NAME`. It explains the one-time Accessibility grant and explicitly excludes remote and cloud browsers.

After approval, the daemon stays alive until Chrome closes the CDP session, the machine or process kills it, or Browser Harness is explicitly reloaded.

## Proof

- Full unit suite: 268 passed.
- Deterministic regressions cover atomic daemon PID publication, live-lock survival across old mtimes, successor-generation ownership, PID reuse, fail-closed process identity, deadline-free local approval, bounded remote startup, no retry after an approval failure, and fingerprint-verified cancellation of a pre-IPC pending daemon.
- Live macOS Chrome on the final no-deadline code: a fresh named daemon raised one sheet and printed the exact-name helper command; `mac-approve` returned `ready`; the original waiting command resumed and loaded Hacker News; a second command reused the connection without another prompt. The test tabs and daemon were then closed.
- Live cancellation: another pending named daemon was stopped with `--reload`; the waiting caller exited without retrying, and independent checks confirmed its process, PID record, and endpoint were gone.
- Chrome's M144 documentation says it asks every time a client requests a remote debugging session.

## Scope boundary

Different `BU_NAME` values still create different CDP connections. Sharing one daemon among concurrent agents requires explicit tab/session coordination because the daemon has shared mutable default-tab state. The existing staleness probe from #631 is also not changed here. This PR prevents duplicate pending starts and approval retry churn; it does not claim one connection across all names or all of Chrome's lifetime.
