### PR TITLE
Document Gemini Spark skill editing

### DIFF
--- a/agent-workspace/domain-skills/gemini/spark-skills.md
+++ b/agent-workspace/domain-skills/gemini/spark-skills.md
@@ -1,0 +1,14 @@
+# Gemini Spark skills
+
+## Editing a skill
+
+- Open `https://gemini.google.com/spark/skills` and locate the skill card by a button name that starts with the exact skill name followed by a space. Avoid a broad `hasText` match because one skill description can mention another skill name.
+- The editor exposes `Skill description` and `Skill instructions` textboxes, `Save skill`, and `Skills, go back` controls.
+- The instruction editor is a rich contenteditable field. After replacing long text, compare rendered text with repeated blank lines normalized rather than comparing raw `textContent`.
+- After saving, wait for the `Skill saved` notice to disappear before using `Skills, go back`. Navigating away while the notice is still active can show a misleading `Leave without saving?` dialog even when the save button already says `Saved`.
+
+## Recovering earlier content
+
+Completed Spark task conversations can retain skill confirmation cards. Search `remy-confirmation-card` elements whose `data-test-id="header"` text matches the skill name, then inspect the matching `data-test-id="body"` content. Prefer the newest confirmed card that predates the unwanted edit.
+
+Always verify the restored description and instructions by reopening the skill after the final save.


### PR DESCRIPTION
Adds a focused Gemini Spark domain skill covering exact skill-card selection, rich-text readback, save confirmation timing, recovery from historical confirmation cards, and final reopen verification. No account-specific identifiers or credentials are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Gemini Spark domain skill that documents how to reliably edit skills, covering exact skill-card selection, rich-text readback, save confirmation timing, recovery from historical confirmation cards, and final reopen verification.

<sup>Written for commit e223618e7b8fbd9bf378cf19f3971b2cce429f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

