### PR TITLE
domain-skills: add cigar retailer inventory workflows

### DIFF
--- a/domain-skills/cigarplace/inventory.md
+++ b/domain-skills/cigarplace/inventory.md
@@ -1,0 +1,64 @@
+# Cigar Place — product inventory and cart checks
+
+`https://www.cigarplace.biz` uses a Magento-style catalog. Its rendered search
+and category tables expose price and availability per packaging option.
+
+## Find canonical product URLs
+
+The root sitemap is complete and is easier than guessing slugs:
+
+```python
+import re
+
+xml = http_get("https://www.cigarplace.biz/sitemap.xml")
+urls = re.findall(r"<loc>(.*?)</loc>", xml)
+matches = [u for u in urls if "late-hour" in u.lower()]
+```
+
+Useful brand-category routes include:
+
+- `/all-brands/padron-cigars/padron-1964-anniversary-maduro.html`
+- `/all-brands/padron-cigars/padron-1926-serie-maduro.html`
+- `/all-brands/padron-cigars/padron-family-reserve.html`
+- `/all-brands/padron-cigars/padron-maduro.html`
+- `/all-brands/winston-churchill-the-late-hour.html`
+
+## Extract pack-specific rows
+
+Each product's first table row contains `.product-name a` and
+`.product-size`; subsequent rows for other pack sizes omit those cells because
+of `rowspan`. Carry the most recent product name and URL forward while walking
+all `tr` elements.
+
+Stable selectors:
+
+- name and URL: `.product-name a`
+- size: `.product-size`
+- packaging: `.col-packaging`
+- MSRP: `.col-msrp`
+- displayed price: `.col-price`
+- availability/action: `.col-action`
+
+Within `.col-action`, `Add to Cart` means that exact packaging row is
+purchasable; `Notify Me` means it is out of stock. Do not infer all variations'
+stock from the product detail page: that page displays one selected pack at a
+time.
+
+## Cart confirmation
+
+On a product detail page the selected pack can be added with the visible
+`.button.btn-cart` control. Verify the result with a screenshot of
+`/checkout/cart/`; the cart lists product, packaging, MSRP, price, quantity,
+subtotal, sales tax, and excise tax. Shipping requires a country and postal
+code, so do not report a final shipping or tax total before those values are
+provided.
+
+Current shipping rules and recurring promotions are described at these stable
+routes:
+
+- `/shipping/`
+- `/first-of-the-month-shipping/`
+- `/early-bird-special/`
+
+Check the homepage banner before treating a time-limited shipping promotion as
+active.

--- a/domain-skills/cigarsdaily/inventory.md
+++ b/domain-skills/cigarsdaily/inventory.md
@@ -1,0 +1,61 @@
+# Cigars Daily — product inventory and variants
+
+`https://cigarsdaily.com` runs WooCommerce. For catalog, price, and stock
+checks, use the public Store API before scraping the rendered search page.
+
+## Search the catalog
+
+```python
+import json
+from urllib.parse import quote
+
+products = json.loads(http_get(
+    "https://cigarsdaily.com/wp-json/wc/store/v1/products"
+    f"?search={quote('Padron')}&per_page=100"
+))
+```
+
+Useful parent fields are `name`, `permalink`, `type`, `prices`, `variations`,
+`is_purchasable`, and `is_in_stock`. Money in `prices` is expressed in minor
+units; divide by `10 ** currency_minor_unit`.
+
+## Verify each pack size separately
+
+Do not use the variable parent's `is_in_stock` to claim that a particular box
+or pack is available. Each object in `variations` has an `id`; fetch that ID as
+a product:
+
+```python
+variant = json.loads(http_get(
+    f"https://cigarsdaily.com/wp-json/wc/store/v1/products/{variation_id}"
+))
+
+result = {
+    "pack": variant["variation"],
+    "price": variant["prices"]["price"],
+    "purchasable": variant["is_purchasable"],
+    "in_stock": variant["is_in_stock"],
+    "stock_text": variant["stock_availability"]["text"],
+    "max_quantity": variant["add_to_cart"]["maximum"],
+}
+```
+
+The variation endpoint supplies the exact pack price, pack-specific stock, and
+maximum purchasable quantity. The HTML search page can show only the first 25
+results behind a `LOAD MORE` control, so the API is both faster and more
+complete.
+
+## Visual verification
+
+For a first visit use `new_tab()`, then capture a screenshot. Search pages use
+the standard WordPress route:
+
+```python
+new_tab("https://cigarsdaily.com/?s=Padron&post_type=product")
+wait_for_load()
+wait(2)
+screenshot("/tmp/cigarsdaily-search.png")
+```
+
+The page explicitly appends `- Out of Stock` to unavailable variation labels,
+which is a useful visual cross-check against the Store API.


### PR DESCRIPTION
Documents reusable inventory and cart-check workflows for Cigars Daily and Cigar Place. Covers WooCommerce Store API variant-level stock, Magento row selectors, canonical URL discovery, and availability/cart verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inventory and cart-check workflow docs for Cigars Daily and Cigar Place, so stock and pricing checks on both sites follow documented, stable paths instead of ad-hoc scraping.

- `domain-skills/cigarsdaily/inventory.md` covers the WooCommerce Store API for variant-level stock and price checks, plus a visual out-of-stock cross-check.
- `domain-skills/cigarplace/inventory.md` covers Magento row selectors, canonical URL discovery, and cart confirmation via checkout screenshots.

<sup>Written for commit 2cceab4d45f2afc6555ef90db285c2ccb0999e6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

