### PR TITLE
Bump browser-harness to 0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.11"
+version = "0.1.12"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Change

Bump `browser-harness` from 0.1.11 to 0.1.12.

This release ships the changes merged after v0.1.11:

- #728: discover Brave Origin profiles on macOS.
- #737: keep one local Chrome approval connection pending per daemon name, remove the normal approval deadline and retry loop, add safe cancellation, and teach the bundled skill to invoke `mac-approve` with the exact `BU_NAME`.

## Proof

- `uv run --with pytest python -m pytest -q` — 268 passed.
- `uv build` — source distribution and wheel built successfully.
- The wheel contains `browser_harness/SKILL.md`.
- Live macOS Chrome proof for #737 loaded Hacker News after Accessibility approval and reused the same daemon without a second prompt.

## Risk and rollout

- Version-only diff; implementation was reviewed and merged separately in #728 and #737.
- Publishing the GitHub release triggers `.github/workflows/release.yml` and trusted publishing to PyPI.
- `browser-use` pins browser-harness separately, so its bundled copy remains on the old version until that dependency is bumped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `browser-harness` from 0.1.11 to 0.1.12, shipping macOS Brave profile discovery and a reworked Chrome approval flow.

- Adds discovery of Brave Origin profiles on macOS.
- Keeps one local Chrome approval connection pending per daemon name, removes the normal approval deadline and retry loop, adds safe cancellation, and teaches the bundled skill to invoke `mac-approve` with the exact `BU_NAME`.
- Publishing the GitHub release triggers trusted publishing to PyPI.
- `browser-use` pins `browser-harness` separately, so its bundled copy remains on 0.1.11 until that dependency is bumped.

<sup>Written for commit 4322be0983418acfc8eb3e8c61b32c654632a251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

