### PR TITLE
chore: pin Harness release dependencies for 0.1.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.12"
       - name: Build distributions
         run: |
-          python -m pip install --upgrade build
+          python -m pip install build==1.6.0
           python -m build
       - name: Publish distributions
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=77"]
+requires = ["setuptools==84.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "browser-harness"
-version = "0.1.12"
+version = "0.1.13"
 description = "The simplest, thinnest, and most powerful harness to control your real browser with your agent."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=2.0.0,<3"]
+mcp = ["mcp==2.1.1"]
 
 [project.scripts]
 browser-harness = "browser_harness.run:main"


### PR DESCRIPTION
## Summary
- pin the MCP extra to the verified `mcp==2.1.1` release
- pin the setuptools build backend to `84.0.0`
- pin the release builder to `build==1.6.0`
- bump Browser Harness to `0.1.13`

## Validation
- `uv run --extra mcp --with pytest python -m pytest tests/unit -q` (251 passed)
- `uvx --from pip-audit pip-audit --path .venv/lib/python3.13/site-packages` (no known vulnerabilities)
- clean wheel and sdist build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Harness release dependencies and bumps `browser-harness` to `0.1.13` so builds and the MCP extra are reproducible.

- Pins the `mcp` extra to `mcp==2.1.1`.
- Pins the setuptools build backend to `84.0.0` and the release builder to `build==1.6.0`.
- Removes the version range for `mcp`, which means the extra no longer accepts future 2.x releases.

<sup>Written for commit 0d8f571a2423b97f00b68f71106061802082ad0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

