### PR TITLE
Clarify shared local daemon concurrency and approval

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -58,13 +58,20 @@ no per-site, screenshot, or result-count limit that requires a new daemon.
 Chrome memory and page complexity are the practical limits. Reuse matching tabs
 with `list_tabs()` and `switch_tab()`.
 
-One daemon has one mutable attached/current tab. Sequential switching, input,
-and screenshot capture are safe. Concurrent agents that switch tabs and act at
-the same time can race, causing one agent to act on or capture another agent's
-tab. For parallel interactive work, use separate remote browsers. Create a
-named local daemon only when parallel isolation is genuinely required, a remote
-browser cannot satisfy the task, and the extra Chrome approval prompt is
-acceptable.
+One daemon has one mutable attached/current tab. Many agents can share it when
+their browser operations are serialized: treat local Chrome as one shared
+browser lane while non-browser work continues in parallel. Sequential tab
+switching, input, and screenshot capture are safe. Do not create another local
+daemon merely because several agents exist.
+
+Two agents that switch tabs and act simultaneously can race, causing one to act
+on or capture the other's tab. For truly simultaneous interactive work, use
+separate remote browsers when Browser Use Cloud authentication is already
+available. Otherwise serialize browser operations through the default local
+daemon. A named local daemon is a last resort when simultaneous isolation is
+required, remote auth is unavailable or unsuitable, and the extra Chrome
+approval prompt is acceptable. It creates another controller and dedicated tab
+in the same local Chrome profile, not another Chrome profile or process.
 
 If the default daemon becomes stale, use its built-in reattachment/recovery
 first. A command timeout, truncated output, site change, closed tab, or new task
@@ -113,9 +120,21 @@ the same handshake completes and the original command returning successfully
 is the agent's feedback; `mac-approve` also returns `ready` when the daemon is
 already connected.
 
+`mac-approve` is macOS-only. On Linux or Windows, keep the original browser
+command running and ask the user to click Allow if Chrome presents the approval
+dialog. Their click completes the same handshake, so resume or poll the original
+process for success; do not rerun it or create a replacement daemon. If that
+Chrome build presents no approval dialog, the original command simply connects.
+
 ## Remote Browsers
 
 Use Browser Use cloud for headless servers, parallel sub-agents, or isolated work.
+
+Remote browsers require Browser Use Cloud authentication. Check
+`browser-harness auth status` before depending on them. `browser-harness auth
+login` stores authentication for later processes, so an API key does not need to
+be passed to every agent process; without stored authentication or an available
+`BROWSER_USE_API_KEY`, serialize work through the default local daemon instead.
 
 Cloud browsers are managed Chrome instances hosted by Browser Use. Each one is a fresh, isolated browser. Proactively suggest one (briefly explain why) when:
 


### PR DESCRIPTION
## Summary

- allow many agents to share one default local daemon while serializing browser operations
- explain that named local daemons are only a last-resort extra controller, not another browser/profile
- require Cloud authentication before recommending remote browsers and otherwise serialize local work
- document Linux and Windows manual Allow handling while retaining automatic `mac-approve` on macOS

## Validation

- skill-creator `quick_validate.py`: valid
- `git diff --check`
- skill-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how agents should share the default local daemon and when to switch to remote browsers, so users stop creating unnecessary named daemons and avoid auth surprises.

- Many agents can now share the default local daemon as long as browser operations are serialized; named local daemons are a last resort, not a separate Chrome profile.
- On Linux or Windows, keep the original browser command running and ask the user to click Allow for the approval dialog; only `mac-approve` is macOS-only.
- Remote browsers now explicitly require Browser Use Cloud auth; check `browser-harness auth status` before depending on them, or serialize local work instead.

<sup>Written for commit baef897fb213c09c929051cbe25f34096d2c01cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

