### PR TITLE
docs: close unneeded task tabs on completion

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,9 @@ PY
   `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
   tab. Do not leave duplicate tabs on the same URL or close tabs you did not
   create.
+- At task completion, close tabs created for the task that are no longer needed.
+  Keep a tab open if the user needs to see it, it is needed for a known follow-up,
+  or closing it could discard unsaved work or other important state.
 - `new_tab()` and `switch_tab()` attach and move the horse marker without
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background; call `activate_tab(target)` only when the user explicitly asks


### PR DESCRIPTION
## Why

A local aggregate audit found 331 live Chrome tabs, including 100 excess exact-URL duplicates. Across 419 recorded harness sessions, agents called `new_tab()` 1,002 times but `close_tab()` only 108 times.

The existing skill says to avoid duplicate tabs and not close tabs it did not create, but never tells the agent to clean up when work is complete.

## Change

Add one completion rule: close tabs created for the task when they are no longer needed. Keep them open when the user needs to see the result, they are needed for a known follow-up, or closing could discard unsaved work or other important state.

This deliberately adds no ownership snapshot, automatic runtime cleanup, or browser-wide tab cap. Multiple agents may share and switch tabs in the same browser; the agent simply cleans up the task tabs it knows it no longer needs.

## Verification

- `git diff --check`
- `uv run --with pytest pytest tests/unit/test_skill.py -q` (1 passed)
- `uv build`
- Confirmed the built wheel contains the updated packaged `browser_harness/SKILL.md`