### PR TITLE
feat: multiplex agents across browser tabs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,9 +25,9 @@ PY
 
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
-- First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
-  preserves the attached tab across separate CLI invocations, so do not call
-  `new_tab()` again in every script.
+- First navigation for a task is `target_id = new_tab(url)`, not
+  `goto_url(url)`. Print and remember that target ID. At the start of each later
+  CLI invocation, call `switch_tab(target_id)`; do not call `new_tab()` again.
 - Keep one working tab per task/site. Before opening another, inspect
   `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
   tab. Do not leave duplicate tabs on the same URL or close tabs you did not
@@ -61,20 +61,28 @@ no per-site, screenshot, or result-count limit that requires a new daemon.
 Chrome memory and page complexity are the practical limits. Reuse matching tabs
 with `list_tabs()` and `switch_tab()`.
 
-One daemon has one mutable attached/current tab. Many agents can share it when
-their browser operations are serialized: treat local Chrome as one shared
-browser lane while non-browser work continues in parallel. Sequential tab
-switching, input, and screenshot capture are safe. Do not create another local
-daemon merely because several agents exist.
+One daemon can serve many agents concurrently. After `new_tab()` or
+`switch_tab()`, every helper call in that script goes to that target. The daemon
+keeps one reusable CDP session per target and multiplexes them over its single
+Chrome connection. Agents on different tabs need no shared browser lock and
+should all omit `BU_NAME`.
 
-Two agents that switch tabs and act simultaneously can race, causing one to act
-on or capture the other's tab. For truly simultaneous interactive work, use
-separate remote browsers when Browser Use Cloud authentication is already
-available. Otherwise serialize browser operations through the default local
-daemon. A named local daemon is a last resort when simultaneous isolation is
-required, remote auth is unavailable or unsuitable, and the extra Chrome
-approval prompt is acceptable. It creates another controller and dedicated tab
-in the same local Chrome profile, not another Chrome profile or process.
+The only identity an agent must retain between CLI invocations is its tab's
+`target_id`. Start each later script with `switch_tab(target_id)`. If the target
+no longer exists because the tab or browser was closed, find a matching tab
+with `list_tabs()` or create a new one. Two agents can technically attach to the
+same target, but simultaneous actions on that same page remain a semantic race;
+give each concurrent task its own tab.
+
+Do not create an agent ID, context name, lock, or separate daemon. An agent does
+not need to detect other agents. Within its script, `current_tab()` means the
+target that script selected, regardless of Chrome's visible front tab.
+
+Use a named local daemon only when a genuinely separate browser-level CDP
+connection is required and the extra Chrome approval prompt is acceptable. It
+does not create a separate Chrome profile or process. Use separate remote
+browsers when tasks need isolated cookies, storage, browser lifecycle, network,
+or crash boundaries rather than merely different tabs.
 
 If the default daemon becomes stale, use its built-in reattachment/recovery
 first. A command timeout, truncated output, site change, closed tab, or new task
@@ -131,17 +139,23 @@ Chrome build presents no approval dialog, the original command simply connects.
 
 ## Remote Browsers
 
-Use Browser Use cloud for headless servers, parallel sub-agents, or isolated work.
+Use Browser Use cloud for headless servers, isolated profiles, bot-sensitive
+work, or parallel tasks that need full browser isolation rather than separate
+tabs in the same local Chrome.
 
 Remote browsers require Browser Use Cloud authentication. Check
 `browser-harness auth status` before depending on them. `browser-harness auth
 login` stores authentication for later processes, so an API key does not need to
-be passed to every agent process; without stored authentication or an available
-`BROWSER_USE_API_KEY`, serialize work through the default local daemon instead.
+be passed to every agent process. Without stored authentication or an available
+`BROWSER_USE_API_KEY`, agents can still use separate targets through the default
+local daemon; only foreground and shared-browser-UI operations need serialization.
 
 Cloud browsers are managed Chrome instances hosted by Browser Use. Each one is a fresh, isolated browser. Proactively suggest one (briefly explain why) when:
 
-- **The user wants multiple concurrent tasks.** Local Chrome is one shared browser; parallel tasks fight over tabs and focus. One cloud browser per task keeps them fully isolated.
+- **The user wants isolated concurrent tasks.** The default local daemon can
+  multiplex different tabs, but those tabs still share one Chrome profile,
+  cookies, storage, network, process resources, and browser lifecycle. One
+  cloud browser per task provides full isolation.
 - **Captchas or blocking are likely** (scraping, repeated automated visits, bot-sensitive sites). Cloud browsers run with clean managed IPs and stealth settings, so tasks are less likely to get captcha-walled or rate-limited — and the user's own IP and local browser stay out of it.
 
 You can also direct the user to try the same agent behind Browser Harness, fully hosted, in Browser Use Cloud (it's called the v4 agent): https://cloud.browser-use.com?utm_source=skill&utm_medium=browser-use&utm_campaign=v4.

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -435,8 +435,13 @@ class Daemon:
         self._recoveries_idle.set()
         self._shutting_down = False
         self._session_replacements = {}
+        self.target_sessions = {}
+        self.session_targets = {}
+        self._target_attach_tasks = {}
         self.events = deque(maxlen=BUF)
+        self.events_by_target = {}
         self.dialog = None
+        self.dialogs_by_target = {}
         self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self, replaces_session=None, enable_domains=True):
@@ -476,6 +481,7 @@ class Daemon:
             ))["sessionId"]
             self._record_session_replacement(replaces_session, self.session)
             self.target_id = tid
+            self._remember_target_session(tid, self.session)
             log(f"attached {tid} ({page.get('url','')[:80]}) session={self.session}")
             if enable_domains:
                 await self._enable_default_domains(self.session)
@@ -509,6 +515,7 @@ class Daemon:
         ))["sessionId"]
         self._record_session_replacement(replaces_session, self.session)
         self.target_id = pages[0]["targetId"]
+        self._remember_target_session(self.target_id, self.session)
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
         if take_over:
             try:
@@ -541,11 +548,10 @@ class Daemon:
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.
 
-        Used by both initial attach and set_session (called after switch_tab/
-        new_tab). Without this, helpers that depend on Network.* events —
-        notably wait_for_network_idle() — silently stop receiving events
-        after a tab switch, because each fresh CDP session starts with all
-        domains disabled.
+        Used by initial attach, legacy set_session, and each daemon-owned target
+        session. Without this, helpers that depend on Network.* events — notably
+        wait_for_network_idle() — silently stop receiving events after a tab
+        switch, because each fresh CDP session starts with all domains disabled.
 
         Runs the four enables in parallel via gather so the worst-case time is
         bounded by a single CDP round trip rather than four sequential ones —
@@ -561,6 +567,46 @@ class Daemon:
             except Exception as e:
                 log(f"enable {d} on {session_id}: {e}")
         await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
+
+    def _remember_target_session(self, target_id, session_id):
+        previous = self.target_sessions.get(target_id)
+        if previous and previous != session_id:
+            self.session_targets.pop(previous, None)
+        self.target_sessions[target_id] = session_id
+        self.session_targets[session_id] = target_id
+
+    def _forget_target_session(self, target_id, session_id=None):
+        current = self.target_sessions.get(target_id)
+        if session_id is not None and current != session_id:
+            return
+        if current:
+            self.session_targets.pop(current, None)
+        self.target_sessions.pop(target_id, None)
+
+    async def _ensure_target_session(self, target_id):
+        """Return the daemon-owned CDP session for one page target."""
+        existing = self.target_sessions.get(target_id)
+        if existing:
+            return existing
+        if self._shutting_down:
+            raise RuntimeError("daemon is shutting down")
+        task = self._target_attach_tasks.get(target_id)
+        if task is None:
+            async def attach():
+                session_id = (await self.cdp.send_raw(
+                    "Target.attachToTarget", {"targetId": target_id, "flatten": True}
+                ))["sessionId"]
+                self._remember_target_session(target_id, session_id)
+                await self._enable_default_domains(session_id)
+                return session_id
+
+            task = asyncio.create_task(attach())
+            self._target_attach_tasks[target_id] = task
+        try:
+            return await task
+        finally:
+            if self._target_attach_tasks.get(target_id) is task:
+                self._target_attach_tasks.pop(target_id, None)
 
     def _record_session_replacement(self, stale_session, replacement_session):
         """Remember which recovered session still controls the same tab."""
@@ -624,13 +670,38 @@ class Daemon:
         )))
 
     def _record_event(self, method, params, session_id=None):
-        self.events.append({"method": method, "params": params, "session_id": session_id})
+        target_id = self.session_targets.get(session_id)
+        event = {
+            "method": method,
+            "params": params,
+            "session_id": session_id,
+            "target_id": target_id,
+        }
+        self.events.append(event)
+        if target_id:
+            self.events_by_target.setdefault(target_id, deque(maxlen=BUF)).append(event)
         if method == "Page.javascriptDialogOpening":
-            self.dialog = params
+            if target_id:
+                self.dialogs_by_target[target_id] = params
+            if not session_id or target_id == self.target_id:
+                self.dialog = params
         elif method == "Page.javascriptDialogClosed":
-            self.dialog = None
+            if target_id:
+                self.dialogs_by_target.pop(target_id, None)
+            if not session_id or target_id == self.target_id:
+                self.dialog = None
+        elif method == "Target.targetDestroyed":
+            destroyed_target_id = params.get("targetId")
+            self.dialogs_by_target.pop(destroyed_target_id, None)
+            self.events_by_target.pop(destroyed_target_id, None)
+            self._forget_target_session(destroyed_target_id)
+        elif method == "Target.detachedFromTarget":
+            detached_session_id = params.get("sessionId")
+            detached_target_id = self.session_targets.get(detached_session_id)
+            if detached_target_id:
+                self._forget_target_session(detached_target_id, detached_session_id)
         elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-            self._schedule_tab_marker(self.session)
+            self._schedule_tab_marker(session_id or self.session)
 
     async def start(self):
         self.stop = asyncio.Event()
@@ -676,7 +747,16 @@ class Daemon:
         # signaling — protects against SIGTERM-by-stale-pid-file after PID reuse.
         if meta == "ping":        return {"pong": True, "pid": os.getpid(), "browser_kind": BROWSER_KIND}
         if meta == "drain_events":
-            out = list(self.events); self.events.clear()
+            target_id = req.get("target_id") or self.target_id
+            if target_id:
+                out = list(self.events_by_target.pop(target_id, ()))
+                self.events = deque(
+                    (event for event in self.events if event.get("target_id") != target_id),
+                    maxlen=BUF,
+                )
+            else:
+                out = list(self.events); self.events.clear()
+                self.events_by_target.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
         if meta == "current_tab":
@@ -708,35 +788,31 @@ class Daemon:
             return {"target_id": self.target_id, "session_id": self.session, "page": page}
         if meta == "set_session":
             async with self._session_state_lock:
-                old_session = self.session
                 self.session = req.get("session_id")
                 self.target_id = req.get("target_id") or self.target_id
                 new_session = self.session
-            # Run the old-session Network.disable (defense in depth — keeps
-            # background-tab traffic out of the global event buffer; the
-            # consumer-side filter in wait_for_network_idle is the actual
-            # correctness gate) in parallel with the four enables on the new
-            # session. Different sessions, independent CDP requests. Keeps
-            # the synchronous reply under the helper's 5s IPC read timeout
-            # even on a remote daemon — sequentially these would have stacked
-            # to ~22s worst case.
-            tasks = []
-            if old_session and old_session != new_session:
-                async def disable_old():
-                    try:
-                        await asyncio.wait_for(
-                            self.cdp.send_raw("Network.disable", session_id=old_session),
-                            timeout=2,
-                        )
-                    except Exception: pass
-                tasks.append(disable_old())
-            tasks.append(self._enable_default_domains(new_session))
-            await asyncio.gather(*tasks)
+                if new_session and self.target_id:
+                    self._remember_target_session(self.target_id, new_session)
+            # Backward compatibility for older helpers that still move the
+            # daemon-wide default. Never disable domains on the old session:
+            # a target-aware client may still be using that tab concurrently.
+            await self._enable_default_domains(new_session)
             # 🐴 tab-marker title prefix is purely cosmetic — fire-and-forget so
             # it doesn't add to the synchronous IPC budget.
             self._schedule_tab_marker(new_session)
             return {"session_id": new_session}
-        if meta == "pending_dialog": return {"dialog": self.dialog}
+        if meta == "prepare_target":
+            target_id = req.get("target_id")
+            if not target_id:
+                return {"error": "target_id is required"}
+            try:
+                session_id = await self._ensure_target_session(target_id)
+            except Exception as e:
+                return {"error": str(e)}
+            return {"session_id": session_id, "target_id": target_id}
+        if meta == "pending_dialog":
+            target_id = req.get("target_id")
+            return {"dialog": self.dialogs_by_target.get(target_id) if target_id else self.dialog}
         if meta == "shutdown":
             # Flip the barrier synchronously with recovery registration, then
             # cancel/drain existing handlers. In particular, a CDP replay that
@@ -762,9 +838,18 @@ class Daemon:
 
         method = req["method"]
         params = req.get("params") or {}
-        # Browser-level Target.* calls must not use a session (stale or otherwise).
-        # For everything else, explicit session in req wins; else default.
-        sid = None if method.startswith("Target.") else (req.get("session_id") or self.session)
+        target_id = req.get("target_id")
+        # Browser-wide commands must not use a target session (stale or otherwise).
+        # For everything else, explicit session in req wins, then the request's
+        # target, then the legacy daemon default.
+        try:
+            sid = (
+                None if method.startswith(("Target.", "Browser."))
+                else req.get("session_id")
+                or (await self._ensure_target_session(target_id) if target_id else self.session)
+            )
+        except Exception as e:
+            return {"error": str(e)}
         try:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
@@ -774,6 +859,24 @@ class Daemon:
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):
                     return {"error": msg}
+                if target_id:
+                    recovery_task = self._begin_recovery()
+                    if recovery_task is None:
+                        return {"error": "daemon is shutting down"}
+                    try:
+                        self._forget_target_session(target_id, sid)
+                        replacement_session = await self._ensure_target_session(target_id)
+                        if self.target_id == target_id:
+                            self._record_session_replacement(self.session, replacement_session)
+                            self.session = replacement_session
+                        try:
+                            return {"result": await self.cdp.send_raw(
+                                method, params, session_id=replacement_session
+                            )}
+                        except Exception as retry_error:
+                            return {"error": str(retry_error)}
+                    finally:
+                        self._finish_recovery(recovery_task)
                 recovery_task = self._begin_recovery()
                 if recovery_task is None:
                     return {"error": "daemon is shutting down"}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -44,6 +44,10 @@ DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS = 5.0
 # their IPC socket alive within the caller's existing 90-second process budget.
 SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS = 60.0
 
+# One CLI process only needs to remember its tab. The daemon owns and reuses the
+# CDP session for that target over its single browser-level WebSocket.
+_TARGET_ID = None
+
 
 class _IPCResponseTimeout(TimeoutError):
     pass
@@ -72,12 +76,24 @@ def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
 def cdp(method, session_id=None, _response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS, **params):
     """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1)."""
     return _send(
-        {"method": method, "params": params, "session_id": session_id},
+        {
+            "method": method,
+            "params": params,
+            "session_id": session_id,
+            "target_id": _TARGET_ID,
+        },
         response_timeout=_response_timeout,
     ).get("result", {})
 
 
-def drain_events():  return _send({"meta": "drain_events"})["events"]
+def drain_events():
+    """Drain events for this CLI process's selected tab only."""
+    return _send({"meta": "drain_events", "target_id": _TARGET_ID})["events"]
+
+
+def _set_client_tab(target_id):
+    global _TARGET_ID
+    _TARGET_ID = target_id
 
 
 def _js_snippet(expression, limit=160):
@@ -162,7 +178,10 @@ def page_info():
     If a native dialog (alert/confirm/prompt/beforeunload) is open, returns
     {dialog: {type, message, ...}} instead — the page's JS thread is frozen
     until the dialog is handled (see interaction-skills/dialogs.md)."""
-    dialog = _send({"meta": "pending_dialog"}).get("dialog")
+    dialog = _send({
+        "meta": "pending_dialog",
+        "target_id": _TARGET_ID,
+    }).get("dialog")
     if dialog:
         return {"dialog": dialog}
     expression = "JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})"
@@ -377,7 +396,16 @@ def list_tabs(include_chrome=True):
     return out
 
 def current_tab():
-    r = _send({"meta": "current_tab"})
+    if _TARGET_ID is None:
+        r = _send({"meta": "current_tab"})
+        _set_client_tab(r["targetId"])
+    else:
+        info = cdp("Target.getTargetInfo", targetId=_TARGET_ID)["targetInfo"]
+        r = {
+            "targetId": info["targetId"],
+            "url": info.get("url", ""),
+            "title": info.get("title", ""),
+        }
     return {
         "targetId": r["targetId"],
         "target_id": r["targetId"],
@@ -417,20 +445,21 @@ def switch_tab(target, activate=False):
     target_id = _target_id(target)
     # Unmark old tab. Horse emoji is a surrogate pair in JS UTF-16 strings (2 code units),
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
-    try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
-    except Exception: pass
+    if _TARGET_ID:
+        try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
+        except Exception: pass
     if activate:
         activate_tab(target_id)
-    sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
-    _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
+    prepared = _send({"meta": "prepare_target", "target_id": target_id})
+    _set_client_tab(target_id)
     _mark_tab()
-    return sid
+    return prepared["session_id"]
 
 def new_tab(url="about:blank"):
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    if url != "about:blank":
+    if url != "about:blank" and _TARGET_ID is not None:
         try:
             cur = current_tab()
             cur_url = cur.get("url") or ""
@@ -538,10 +567,13 @@ def wait_for_network_idle(timeout=10.0, idle_ms=500):
     deadline = time.time() + timeout
     last_activity = time.time()
     inflight = set()
-    active_session = _send({"meta": "session"}).get("session_id")
+    active_target = _TARGET_ID
+    active_session = None if active_target else _send({"meta": "session"}).get("session_id")
     while time.time() < deadline:
         for e in drain_events():
-            if e.get("session_id") != active_session:
+            if active_target and e.get("target_id") != active_target:
+                continue
+            if active_session and e.get("session_id") != active_session:
                 continue
             method = e.get("method", "")
             params = e.get("params", {})

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -146,11 +146,7 @@ def test_tab_marker_disabled_on_page_load_events(monkeypatch, value):
 
 
 def test_set_session_enables_all_four_default_domains_on_new_session():
-    """Regression: switch_tab() / new_tab() in helpers.py route through the
-    `set_session` IPC, which previously only enabled Page on the new
-    session. With Network disabled, wait_for_network_idle() silently stops
-    receiving events after a tab switch. Initial attach enables all four
-    (Page, DOM, Runtime, Network); set_session must enable the same set."""
+    """Legacy set_session must retain domain parity with initial attach."""
     d = _fresh_daemon()
     new_session = "session-AFTER-switch"
 
@@ -170,6 +166,177 @@ def test_set_session_enables_all_four_default_domains_on_new_session():
     )
     assert d.session == new_session
     assert d.target_id == "target-2"
+
+
+def test_prepare_target_attaches_once_without_changing_daemon_default():
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+    d.session = "daemon-default-session"
+    d.target_id = "daemon-default-target"
+
+    result = asyncio.run(d.handle({
+        "meta": "prepare_target",
+        "target_id": "agent-target",
+    }))
+    again = asyncio.run(d.handle({
+        "meta": "prepare_target",
+        "target_id": "agent-target",
+    }))
+
+    assert result == {"session_id": "session-for-agent-target", "target_id": "agent-target"}
+    assert again == result
+    assert d.session == "daemon-default-session"
+    assert d.target_id == "daemon-default-target"
+    enabled = {
+        method for method, _params, session_id in d.cdp.calls
+        if session_id == "session-for-agent-target" and method.endswith(".enable")
+    }
+    assert enabled == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
+    assert [method for method, _params, _session in d.cdp.calls].count("Target.attachToTarget") == 1
+    assert not [
+        call for call in d.cdp.calls
+        if call[0] == "Network.disable" and call[2] == "daemon-default-session"
+    ]
+
+
+def test_concurrent_prepare_target_calls_share_one_attachment():
+    class _SlowAttachCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Target.attachToTarget":
+                await asyncio.sleep(0)
+                return {"sessionId": "shared-session"}
+            return {}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _SlowAttachCDP()
+        requests = [
+            d.handle({"meta": "prepare_target", "target_id": "shared-target"}),
+            d.handle({"meta": "prepare_target", "target_id": "shared-target"}),
+        ]
+        return d, await asyncio.gather(*requests)
+
+    d, results = asyncio.run(run())
+
+    expected = {"session_id": "shared-session", "target_id": "shared-target"}
+    assert results == [expected, expected]
+    assert [call[0] for call in d.cdp.calls].count("Target.attachToTarget") == 1
+
+
+def test_concurrent_clients_keep_commands_on_their_target_sessions():
+    class _ConcurrentCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            await asyncio.sleep(0)
+            return {"value": f"{session_id}:{params['expression']}"}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _ConcurrentCDP()
+        d.session = "daemon-default-session"
+        d.target_sessions = {"target-a": "session-a", "target-b": "session-b"}
+        d.session_targets = {"session-a": "target-a", "session-b": "target-b"}
+        return d, await asyncio.gather(
+            d.handle({
+                "method": "Runtime.evaluate",
+                "params": {"expression": "agent-a"},
+                "target_id": "target-a",
+            }),
+            d.handle({
+                "method": "Runtime.evaluate",
+                "params": {"expression": "agent-b"},
+                "target_id": "target-b",
+            }),
+        )
+
+    d, results = asyncio.run(run())
+
+    assert results == [
+        {"result": {"value": "session-a:agent-a"}},
+        {"result": {"value": "session-b:agent-b"}},
+    ]
+    assert d.session == "daemon-default-session"
+
+
+def test_browser_domain_commands_bypass_the_selected_target_session():
+    d = _fresh_daemon()
+    d._remember_target_session("agent-target", "agent-session")
+
+    asyncio.run(d.handle({
+        "method": "Browser.getVersion",
+        "params": {},
+        "target_id": "agent-target",
+    }))
+
+    assert d.cdp.calls == [("Browser.getVersion", {}, None)]
+
+
+def test_target_scoped_event_drain_does_not_consume_another_agents_events():
+    d = _fresh_daemon()
+    d.session_targets = {"session-a": "target-a", "session-b": "target-b"}
+    d._record_event("Network.requestWillBeSent", {"requestId": "a"}, "session-a")
+    d._record_event("Network.requestWillBeSent", {"requestId": "b"}, "session-b")
+
+    first = asyncio.run(d.handle({"meta": "drain_events", "target_id": "target-a"}))
+    second = asyncio.run(d.handle({"meta": "drain_events", "target_id": "target-b"}))
+
+    assert [event["params"]["requestId"] for event in first["events"]] == ["a"]
+    assert [event["params"]["requestId"] for event in second["events"]] == ["b"]
+
+
+def test_default_event_drain_does_not_consume_another_targets_events():
+    d = _fresh_daemon()
+    d.target_id = "default-target"
+    d.session_targets = {"default-session": "default-target", "other-session": "other-target"}
+    d._record_event("Network.requestWillBeSent", {"requestId": "default"}, "default-session")
+    d._record_event("Network.requestWillBeSent", {"requestId": "other"}, "other-session")
+
+    default = asyncio.run(d.handle({"meta": "drain_events"}))
+    other = asyncio.run(d.handle({"meta": "drain_events", "target_id": "other-target"}))
+
+    assert [event["params"]["requestId"] for event in default["events"]] == ["default"]
+    assert [event["params"]["requestId"] for event in other["events"]] == ["other"]
+
+
+def test_pending_dialog_is_scoped_to_the_requesting_target():
+    d = _fresh_daemon()
+    d.session_targets = {"session-a": "target-a", "session-b": "target-b"}
+    d._record_event("Page.javascriptDialogOpening", {"message": "A"}, "session-a")
+    d._record_event("Page.javascriptDialogOpening", {"message": "B"}, "session-b")
+
+    a = asyncio.run(d.handle({"meta": "pending_dialog", "target_id": "target-a"}))
+    b = asyncio.run(d.handle({"meta": "pending_dialog", "target_id": "target-b"}))
+
+    assert a == {"dialog": {"message": "A"}}
+    assert b == {"dialog": {"message": "B"}}
+
+
+def test_pending_dialog_survives_a_later_command_for_the_same_target():
+    d = _fresh_daemon()
+    d.session_targets["old-session"] = "same-target"
+    d._record_event("Page.javascriptDialogOpening", {"message": "Still open"}, "old-session")
+
+    result = asyncio.run(d.handle({
+        "meta": "pending_dialog",
+        "target_id": "same-target",
+    }))
+
+    assert result == {"dialog": {"message": "Still open"}}
+
+
+def test_target_destroyed_cleans_cached_target_state():
+    d = _fresh_daemon()
+    d._remember_target_session("agent-target", "agent-session")
+    d._record_event("Network.requestWillBeSent", {"requestId": "a"}, "agent-session")
+    d._record_event("Page.javascriptDialogOpening", {"message": "A"}, "agent-session")
+
+    d._record_event("Target.targetDestroyed", {"targetId": "agent-target"})
+
+    assert "agent-session" not in d.session_targets
+    assert "agent-target" not in d.target_sessions
+    assert "agent-target" not in d.events_by_target
+    assert "agent-target" not in d.dialogs_by_target
 
 
 def test_set_session_falls_back_to_existing_target_id_when_not_provided():
@@ -212,14 +379,12 @@ def test_enable_default_domains_swallows_errors_per_domain():
     assert "Network.enable" in attempted
 
 
-def test_set_session_disables_network_on_old_session_before_enabling_new():
-    """When switching tabs, the previous session's Network domain must be
-    disabled so background tabs (polling, SSE, etc.) stop emitting events
-    into the global buffer that wait_for_network_idle reads. Initial attach
-    has no `old_session` so this disable doesn't fire then."""
+def test_set_session_keeps_old_target_domains_enabled():
+    """A legacy client moving the default must not disrupt target-aware clients."""
     d = _fresh_daemon()
     d.session = "session-OLD"
     d.target_id = "target-OLD"
+    d._remember_target_session("target-OLD", "session-OLD")
 
     asyncio.run(d.handle({
         "meta": "set_session",
@@ -227,49 +392,17 @@ def test_set_session_disables_network_on_old_session_before_enabling_new():
         "target_id": "target-NEW",
     }))
 
-    disabled = [
-        (method, sid) for (method, _params, sid) in d.cdp.calls
-        if method == "Network.disable"
-    ]
-    assert disabled == [("Network.disable", "session-OLD")], (
-        f"Network.disable must fire on the old session before re-enabling on "
-        f"the new one. Got: {disabled}"
-    )
-
-    # Sanity: the new session still gets Network.enable.
+    assert not [call for call in d.cdp.calls if call[0] == "Network.disable"]
+    assert d.target_sessions["target-OLD"] == "session-OLD"
     enabled_on_new = {
         method for (method, _p, sid) in d.cdp.calls
         if sid == "session-NEW" and method.endswith(".enable")
     }
-    assert "Network.enable" in enabled_on_new
+    assert enabled_on_new == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
 
 
-def test_set_session_does_not_disable_network_when_no_previous_session():
-    """First set_session call (e.g. very early in startup before any attach)
-    has no old_session — the Network.disable path must be skipped."""
-    d = _fresh_daemon()
-    d.session = None  # no prior attach
-
-    asyncio.run(d.handle({
-        "meta": "set_session",
-        "session_id": "session-FIRST",
-        "target_id": "target-FIRST",
-    }))
-
-    disables = [m for (m, _p, _s) in d.cdp.calls if m == "Network.disable"]
-    assert disables == [], (
-        f"Network.disable must not fire when there's no previous session "
-        f"to disable. Got: {disables}"
-    )
-
-
-def test_set_session_runs_disable_and_enables_in_parallel():
-    """The four Domain.enable calls (plus Network.disable on the old session)
-    must run concurrently via asyncio.gather, not sequentially. With the old
-    sequential code, helpers.switch_tab() would block in _send() for up to
-    ~22s on a slow/remote daemon while the helper's IPC socket has a 5s
-    read timeout, causing client-side socket timeouts. Verifying that all
-    five CDP calls reach send_raw before any returns proves parallelization."""
+def test_set_session_runs_enables_in_parallel():
+    """Legacy set_session keeps the four domain enables concurrent."""
     class _ConcurrencyProbeCDP:
         def __init__(self):
             self.calls = []
@@ -290,7 +423,6 @@ def test_set_session_runs_disable_and_enables_in_parallel():
     async def run():
         d = daemon.Daemon()
         d.cdp = _ConcurrencyProbeCDP()
-        d.session = "session-OLD"  # ensures Network.disable on old fires
         d.cdp.release = asyncio.Event()
 
         handle_task = asyncio.create_task(d.handle({
@@ -302,8 +434,7 @@ def test_set_session_runs_disable_and_enables_in_parallel():
         # in-flight. Cap iterations to avoid hanging if parallelization breaks.
         for _ in range(50):
             await asyncio.sleep(0)
-            # 5 = Network.disable on OLD + 4 enables on NEW.
-            if d.cdp.in_flight >= 5:
+            if d.cdp.in_flight >= 4:
                 break
         peak = d.cdp.max_concurrent
         d.cdp.release.set()
@@ -311,62 +442,12 @@ def test_set_session_runs_disable_and_enables_in_parallel():
         return peak, d.cdp.calls
 
     peak, calls = asyncio.run(run())
-    assert peak == 5, (
-        f"set_session must run disable + 4 enables concurrently via gather "
-        f"(observed peak in-flight = {peak}; expected 5 = 1 disable on OLD + "
-        f"4 enables on NEW). Sequential await would peak at 1."
-    )
-    # Sanity: the right calls were made.
-    methods = sorted({m for (m, _p, _s) in calls})
-    assert "Network.disable" in methods
-    assert {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}.issubset(methods)
-
-
-def test_set_session_first_attach_runs_four_enables_in_parallel():
-    """When there's no previous session, the disable path is skipped — only
-    the four enables run, still in parallel."""
-    class _ConcurrencyProbeCDP:
-        def __init__(self):
-            self.calls = []
-            self.in_flight = 0
-            self.max_concurrent = 0
-            self.release = None
-
-        async def send_raw(self, method, params=None, session_id=None):
-            self.calls.append((method, params, session_id))
-            self.in_flight += 1
-            self.max_concurrent = max(self.max_concurrent, self.in_flight)
-            try:
-                await self.release.wait()
-            finally:
-                self.in_flight -= 1
-            return {}
-
-    async def run():
-        d = daemon.Daemon()
-        d.cdp = _ConcurrencyProbeCDP()
-        d.session = None  # no previous session
-        d.cdp.release = asyncio.Event()
-
-        handle_task = asyncio.create_task(d.handle({
-            "meta": "set_session",
-            "session_id": "session-FIRST",
-            "target_id": "target-FIRST",
-        }))
-        for _ in range(50):
-            await asyncio.sleep(0)
-            if d.cdp.in_flight >= 4:
-                break
-        peak = d.cdp.max_concurrent
-        d.cdp.release.set()
-        await handle_task
-        return peak
-
-    peak = asyncio.run(run())
     assert peak == 4, (
-        f"first set_session must run 4 enables concurrently "
-        f"(observed peak = {peak}). No Network.disable should fire."
+        f"set_session must run four enables concurrently "
+        f"(observed peak in-flight = {peak}). Sequential await would peak at 1."
     )
+    methods = sorted({m for (m, _p, _s) in calls})
+    assert {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}.issubset(methods)
 
 
 def test_current_tab_meta_passes_attached_target_id():
@@ -845,3 +926,30 @@ def test_explicit_stale_session_is_not_redirected():
     assert d.cdp.calls == [
         ("Runtime.evaluate", {"expression": "1"}, "explicit-stale-session")
     ]
+
+
+def test_stale_target_session_reattaches_to_the_same_target():
+    class _StaleTargetCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Runtime.evaluate" and session_id == "stale-session":
+                raise RuntimeError("Session with given id not found")
+            if method == "Target.attachToTarget":
+                return {"sessionId": "replacement-session"}
+            if method == "Runtime.evaluate" and session_id == "replacement-session":
+                return {"value": "same-target"}
+            return {}
+
+    d = daemon.Daemon()
+    d.cdp = _StaleTargetCDP()
+    d._remember_target_session("agent-target", "stale-session")
+
+    result = asyncio.run(d.handle({
+        "method": "Runtime.evaluate",
+        "params": {"expression": "1"},
+        "target_id": "agent-target",
+    }))
+
+    assert result == {"result": {"value": "same-target"}}
+    assert d.target_sessions["agent-target"] == "replacement-session"
+    assert d.session_targets["replacement-session"] == "agent-target"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -9,6 +9,11 @@ from PIL import Image
 from browser_harness import helpers
 
 
+@pytest.fixture(autouse=True)
+def _reset_client_tab(monkeypatch):
+    monkeypatch.setattr(helpers, "_TARGET_ID", None)
+
+
 def _run(fake_png, width, height, **kwargs):
     fake = lambda method, **_: {"data": fake_png(width, height)}
     with patch("browser_harness.helpers.cdp", side_effect=fake), tempfile.TemporaryDirectory() as d:
@@ -61,6 +66,7 @@ def test_screenshot_uses_long_response_timeout_without_forwarding_it_to_cdp(fake
         "method": "Page.captureScreenshot",
         "params": {"format": "png", "captureBeyondViewport": False},
         "session_id": None,
+        "target_id": None,
     }
     assert send.call_args.kwargs == {
         "response_timeout": helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS
@@ -439,21 +445,57 @@ def test_mark_tab_can_be_disabled(monkeypatch, value):
     assert calls == []
 
 
+def test_cdp_routes_calls_with_the_cli_target(monkeypatch):
+    requests = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", "target-agent-a")
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request, response_timeout=helpers.DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS:
+            requests.append(request) or {"result": {}},
+    )
+
+    helpers.cdp("Page.captureScreenshot")
+    helpers.cdp("Target.getTargets")
+
+    assert requests == [
+        {
+            "method": "Page.captureScreenshot",
+            "params": {},
+            "session_id": None,
+            "target_id": "target-agent-a",
+        },
+        {
+            "method": "Target.getTargets",
+            "params": {},
+            "session_id": None,
+            "target_id": "target-agent-a",
+        },
+    ]
+
+
 def test_switch_tab_keeps_visible_tab_unchanged_by_default(monkeypatch):
     calls = []
 
     def fake_cdp(method, **kwargs):
         calls.append((method, kwargs))
-        if method == "Target.attachToTarget":
-            return {"sessionId": "session-new"}
         return {}
 
     monkeypatch.setattr(helpers, "cdp", fake_cdp)
-    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request: calls.append(("ipc", request)) or {"session_id": "session-new"},
+    )
     monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
 
     assert helpers.switch_tab({"target_id": "target-new"}) == "session-new"
     assert not any(method == "Target.activateTarget" for method, _ in calls)
+    assert ("ipc", {
+        "meta": "prepare_target",
+        "target_id": "target-new",
+    }) in calls
+    assert helpers._TARGET_ID == "target-new"
 
 
 def test_switch_tab_can_explicitly_activate_visible_tab(monkeypatch):
@@ -461,12 +503,14 @@ def test_switch_tab_can_explicitly_activate_visible_tab(monkeypatch):
 
     def fake_cdp(method, **kwargs):
         calls.append((method, kwargs))
-        if method == "Target.attachToTarget":
-            return {"sessionId": "session-new"}
         return {}
 
     monkeypatch.setattr(helpers, "cdp", fake_cdp)
-    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request: calls.append(("ipc", request)) or {"session_id": "session-new"},
+    )
     monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
 
     assert helpers.switch_tab("target-new", activate=True) == "session-new"
@@ -480,12 +524,14 @@ def test_new_tab_creates_and_attaches_in_background(monkeypatch):
         calls.append((method, kwargs))
         if method == "Target.createTarget":
             return {"targetId": "target-new"}
-        if method == "Target.attachToTarget":
-            return {"sessionId": "session-new"}
         return {}
 
     monkeypatch.setattr(helpers, "cdp", fake_cdp)
-    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request: calls.append(("ipc", request)) or {"session_id": "session-new"},
+    )
     monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
 
     assert helpers.new_tab() == "target-new"
@@ -493,8 +539,45 @@ def test_new_tab_creates_and_attaches_in_background(monkeypatch):
     assert not any(method == "Target.activateTarget" for method, _ in calls)
 
 
+def test_first_new_tab_does_not_reuse_the_daemon_default_tab(monkeypatch):
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "agent-owned-target"}
+        return {}
+
+    monkeypatch.setattr(helpers, "current_tab", lambda: pytest.fail("must not inspect shared default"))
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: {"session_id": "agent-owned-session"})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    assert helpers.new_tab("https://example.com") == "agent-owned-target"
+    assert ("Target.createTarget", {"url": "about:blank", "background": True}) in calls
+
+
+def test_current_tab_stays_on_the_cli_process_target(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", "target-agent-a")
+
+    def fake_cdp(method, **params):
+        calls.append((method, params))
+        return {"targetInfo": {
+            "targetId": params["targetId"],
+            "url": "https://a.example/",
+            "title": "Agent A",
+        }}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+
+    assert helpers.current_tab()["targetId"] == "target-agent-a"
+    assert calls == [("Target.getTargetInfo", {"targetId": "target-agent-a"})]
+
+
 def test_new_tab_reuses_an_empty_data_document(monkeypatch):
     calls = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", "target-placeholder")
     monkeypatch.setattr(
         helpers,
         "current_tab",


### PR DESCRIPTION
## Summary

- reuse one default daemon and one browser-level WebSocket for many agents and tabs
- make the agent's remembered `target_id` the only client identity
- route every normal helper atomically through the daemon's cached `target_id -> session_id` mapping
- scope network events and native-dialog state to the target instead of one daemon-global tab
- keep `switch_tab()` background-first and fully supported; no mode flag, agent ID, lock, or per-agent `BU_NAME`
- preserve the old daemon-global session as a compatibility fallback for older clients

## Design

Each CLI process owns a lightweight current-target pointer. `new_tab()` returns that target ID; later invocations restore it once with `switch_tab(target_id)`. The daemon attaches each target once, enables the normal CDP domains, and reuses that session across calls and client processes on its existing Chrome connection.

Different targets can receive navigation, DOM, input, screenshot, event, and dialog operations concurrently. The only shared lane is genuinely browser-global state: the visibly frontmost tab, native Chrome UI, profile/cookies, clipboard, downloads, permissions, and browser lifetime. Concurrent tasks that need those isolated should use separate remote browsers.

There is no Browser Harness target-count cap. Chrome memory, renderer processes, page complexity, and the machine are the practical limits.

## User impact

- launching another agent no longer implies another daemon or another Chrome approval
- closing Codex or a terminal does not kill the detached daemon
- `switch_tab()` changes only that CLI process's target, so another agent cannot redirect its later helpers
- closing/restarting Chrome still destroys the browser WebSocket and target IDs; the next connection may require one approval for that Chrome lifetime
- remote-browser behavior and authentication are unchanged

## Validation

- `uv run --with pytest python -m pytest tests/unit -q` — 262 passed
- `uv run --with pyyaml python /Users/magnus/.codex/skills/.system/skill-creator/scripts/quick_validate.py .` — skill valid
- live Browser Use Cloud smoke used one daemon/WebSocket and two simultaneous CLI processes on different targets; both used `switch_tab()`, `page_info()`, `click_at_xy()`, `js()`, and `capture_screenshot()` and independently reached `A done` / `B done`
- one-process live smoke switched A → B → A with ordinary helpers in 82–169 ms per switch with recording disabled
- temporary cloud browser was stopped after the test
- `git diff --check`
