### PR TITLE
fix: match Chrome's localized Allow sheet in mac-approve

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -106,7 +106,10 @@ BU_NAME=r7k2 browser-harness mac-approve
 ```
 
 For the default daemon, omit the `BU_NAME` prefix. The original command resumes
-when the helper returns `ready`; do not rerun it. If the helper reports
+when the helper returns `ready`; do not rerun it. The helper matches Chrome's
+own localized sheet strings, so it works in any Chrome UI language; for one it
+does not know, set `BH_ALLOW_SHEET_TITLES` and `BH_ALLOW_LABELS` (comma-separated)
+to the sheet title and the Allow button text. If the helper reports
 `accessibility-required`, ask the user once to grant the app launching
 browser-harness (for example Terminal, iTerm, or Codex) access in System
 Settings > Privacy & Security > Accessibility, then call `mac-approve` once

--- a/src/browser_harness/macos.py
+++ b/src/browser_harness/macos.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import platform
 import subprocess
 from pathlib import Path
@@ -9,45 +10,139 @@ from pathlib import Path
 from .admin import daemon_browser_ready
 from .daemon import remote_debugging_toggle_profiles
 
+# Chrome localizes the per-connection sheet, so the AppleScript cannot match
+# English literals. These are Chromium's own strings for
+# IDS_DEV_TOOLS_CONNECTION_DIALOG_TITLE and IDS_DEV_TOOLS_CONNECTION_DIALOG_ALLOW_TEXT
+# (chrome/app/generated_resources.grd and resources/generated_resources_<locale>.xtb).
+# BH_ALLOW_SHEET_TITLES and BH_ALLOW_LABELS (comma-separated) extend the tables for
+# a Chrome UI language that is not listed.
+ALLOW_SHEET_TITLES = (
+    "Allow remote debugging?",  # en
+    "リモート デバッグを許可しますか？",  # ja
+    "要允许远程调试吗？",  # zh-CN
+    "允許遠端偵錯嗎？",  # zh-TW
+    "원격 디버깅을 허용하시겠습니까?",  # ko
+    "Remote-Fehlerbehebung zulassen?",  # de
+    "Autoriser le débogage à distance ?",  # fr
+    "¿Permitir depuración remota?",  # es
+    "¿Deseas permitir la depuración remota?",  # es-419
+    "Permitir a depuração remota?",  # pt-BR
+    "Permitir depuração remota?",  # pt-PT
+    "Vuoi consentire il debug remoto?",  # it
+    "Foutopsporing op afstand toestaan?",  # nl
+    "Czy zezwalać na debugowanie zdalne?",  # pl
+    "Разрешить удаленную отладку?",  # ru
+    "Дозволити дистанційне налагодження?",  # uk
+    "Povolit vzdálené ladění?",  # cs
+    "Uzaktan hata ayıklamaya izin verilsin mi?",  # tr
+    "Cho phép gỡ lỗi từ xa?",  # vi
+    "อนุญาตให้ใช้การแก้ไขข้อบกพร่องจากระยะไกลใช่ไหม",  # th
+    "Izinkan proses debug jarak jauh?",  # id
+    "السماح بتصحيح الأخطاء عن بُعد؟",  # ar
+    "לאפשר ניפוי באגים מרחוק?",  # he
+    "क्या आपको बाहरी ऐप्लिकेशन के ज़रिए डिबग करने की अनुमति देनी है?",  # hi
+    "Vill du tillåta fjärrfelsökning?",  # sv
+    "Vil du tillade ekstern fejlretning?",  # da
+    "Vil du tillate ekstern feilsøking?",  # nb
+    "Sallitaanko vianetsintä etänä?",  # fi
+    "Να επιτρέπεται η απομακρυσμένη αποσφαλμάτωση;",  # el
+)
+
+ALLOW_BUTTON_LABELS = (
+    "Allow",  # en
+    "許可する",  # ja
+    "允许",  # zh-CN
+    "允許",  # zh-TW
+    "허용",  # ko
+    "Zulassen",  # de
+    "Autoriser",  # fr
+    "Permitir",  # es, es-419, pt-BR, pt-PT
+    "Consenti",  # it
+    "Toestaan",  # nl
+    "Zezwalaj",  # pl
+    "Разрешить",  # ru
+    "Дозволити",  # uk
+    "Povolit",  # cs
+    "İzin ver",  # tr
+    "Cho phép",  # vi
+    "อนุญาต",  # th
+    "Izinkan",  # id
+    "سماح",  # ar
+    "זה בסדר",  # he
+    "अनुमति दें",  # hi
+    "Tillåt",  # sv
+    "Tillad",  # da
+    "Tillat",  # nb
+    "Salli",  # fi
+    "Επιτρέπεται",  # el
+)
+
+# argv: <title count> <titles...> <labels...>. The sheet is chosen by its exact
+# title and the button by its exact label; Cancel and "Turn off in settings" are
+# never candidates. Chrome gives this dialog no default button and focuses
+# Cancel, so pressing "the default button" would be unsafe.
 _APPLESCRIPT = r'''using terms from application "System Events"
-    on clickAllow(nodeRef)
+    on buttonLabel(nodeRef)
         try
-            if (role of nodeRef as text) is "AXButton" and ¬
-                (description of nodeRef as text) is "Allow" then
-                perform action "AXPress" of nodeRef
-                return true
+            set d to (description of nodeRef as text)
+            if d is not "" then return d
+        end try
+        try
+            return (title of nodeRef as text)
+        end try
+        return ""
+    end buttonLabel
+
+    on pressAllow(nodeRef, labels)
+        try
+            if (role of nodeRef as text) is "AXButton" then
+                if labels contains my buttonLabel(nodeRef) then
+                    perform action "AXPress" of nodeRef
+                    return true
+                end if
+                return false
             end if
         end try
         try
             repeat with childRef in UI elements of nodeRef
-                if my clickAllow(childRef) then return true
+                if my pressAllow(childRef, labels) then return true
             end repeat
         end try
         return false
-    end clickAllow
+    end pressAllow
+
+    on isAllowSheet(sheetRef, titles)
+        try
+            return titles contains (name of sheetRef as text)
+        end try
+        return false
+    end isAllowSheet
 end using terms from
 
-set resultText to "not-found"
-tell application "System Events"
-    if exists process "Google Chrome" then
-        tell process "Google Chrome"
-            repeat with w in windows
-                try
-                    repeat with s in sheets of w
-                        if (name of s as text) is "Allow remote debugging?" then
-                            if my clickAllow(s) then
+on run argv
+    set titleCount to (item 1 of argv) as integer
+    set titles to items 2 thru (titleCount + 1) of argv
+    set labels to items (titleCount + 2) thru -1 of argv
+    set resultText to "not-found"
+    tell application "System Events"
+        if exists process "Google Chrome" then
+            tell process "Google Chrome"
+                repeat with w in windows
+                    try
+                        repeat with s in sheets of w
+                            if my isAllowSheet(s, titles) and my pressAllow(s, labels) then
                                 set resultText to "ready"
                                 exit repeat
                             end if
-                        end if
-                    end repeat
-                end try
-                if resultText is "ready" then exit repeat
-            end repeat
-        end tell
-    end if
-end tell
-return resultText
+                        end repeat
+                    end try
+                    if resultText is "ready" then exit repeat
+                end repeat
+            end tell
+        end if
+    end tell
+    return resultText
+end run
 '''
 
 
@@ -55,6 +150,33 @@ _ACCESSIBILITY_DETAIL = (
     "allow the app launching browser-harness (for example Terminal, iTerm, or Codex) "
     "in System Settings > Privacy & Security > Accessibility"
 )
+
+# osascript localizes its error text; the OSStatus codes do not.
+# -25211 kAXErrorAPIDisabled (assistive access), -1743 errAEEventNotPermitted.
+_ACCESSIBILITY_ERROR_MARKERS = ("not authorized", "assistive", "-25211", "-1743")
+
+
+def _extra_strings(env_name: str) -> tuple[str, ...]:
+    raw = os.environ.get(env_name, "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def allow_sheet_titles() -> tuple[str, ...]:
+    return ALLOW_SHEET_TITLES + _extra_strings("BH_ALLOW_SHEET_TITLES")
+
+
+def allow_button_labels() -> tuple[str, ...]:
+    return ALLOW_BUTTON_LABELS + _extra_strings("BH_ALLOW_LABELS")
+
+
+def _osascript_command() -> list[str]:
+    titles = allow_sheet_titles()
+    return ["osascript", "-", str(len(titles)), *titles, *allow_button_labels()]
+
+
+def _accessibility_denied(detail: str) -> bool:
+    lowered = detail.lower()
+    return any(marker in lowered for marker in _ACCESSIBILITY_ERROR_MARKERS)
 
 
 def _google_chrome_root() -> Path:
@@ -83,7 +205,7 @@ def approve_remote_debugging() -> tuple[str, str | None]:
 
     try:
         completed = subprocess.run(
-            ["osascript"],
+            _osascript_command(),
             input=_APPLESCRIPT,
             text=True,
             capture_output=True,
@@ -97,7 +219,7 @@ def approve_remote_debugging() -> tuple[str, str | None]:
 
     if completed.returncode != 0:
         detail = completed.stderr.strip() or "osascript failed"
-        if "not authorized" in detail.lower() or "assistive" in detail.lower():
+        if _accessibility_denied(detail):
             return (
                 "accessibility-required",
                 _ACCESSIBILITY_DETAIL,

--- a/tests/unit/test_macos.py
+++ b/tests/unit/test_macos.py
@@ -45,10 +45,85 @@ def test_mac_approve_runs_osascript_only_after_checkbox_is_enabled(monkeypatch):
     status, detail = macos.approve_remote_debugging()
 
     assert (status, detail) == ("ready", None)
-    assert calls[0][0] == (["osascript"],)
-    assert "Allow remote debugging?" in calls[0][1]["input"]
+    argv = calls[0][0][0]
+    assert argv[:2] == ["osascript", "-"]
     assert "AXPress" in calls[0][1]["input"]
     assert "activate" not in calls[0][1]["input"]
+
+
+def _argv_tables(argv):
+    title_count = int(argv[2])
+    return argv[3 : 3 + title_count], argv[3 + title_count :]
+
+
+def test_mac_approve_passes_chromes_localized_sheet_strings(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    _no_ready_daemon(monkeypatch)
+    _enable_chrome_toggle(monkeypatch)
+    monkeypatch.delenv("BH_ALLOW_SHEET_TITLES", raising=False)
+    monkeypatch.delenv("BH_ALLOW_LABELS", raising=False)
+    calls = []
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs))
+        or SimpleNamespace(returncode=0, stdout="ready\n", stderr=""),
+    )
+
+    macos.approve_remote_debugging()
+
+    titles, labels = _argv_tables(calls[0][0][0])
+    assert "Allow remote debugging?" in titles
+    assert "リモート デバッグを許可しますか？" in titles
+    assert "Allow" in labels
+    assert "許可する" in labels
+    assert "Cancel" not in labels
+    assert "Turn off in settings" not in labels
+    # The literals no longer live in the script; the script reads argv.
+    assert "Allow remote debugging?" not in calls[0][1]["input"]
+    assert "on run argv" in calls[0][1]["input"]
+
+
+def test_mac_approve_extends_tables_from_env(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    _no_ready_daemon(monkeypatch)
+    _enable_chrome_toggle(monkeypatch)
+    monkeypatch.setenv("BH_ALLOW_SHEET_TITLES", "Fernwartung erlauben? , Ander titel")
+    monkeypatch.setenv("BH_ALLOW_LABELS", "Ja,Oui")
+    calls = []
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs))
+        or SimpleNamespace(returncode=0, stdout="ready\n", stderr=""),
+    )
+
+    macos.approve_remote_debugging()
+
+    titles, labels = _argv_tables(calls[0][0][0])
+    assert titles[-2:] == ["Fernwartung erlauben?", "Ander titel"]
+    assert "Allow remote debugging?" in titles
+    assert labels[-2:] == ["Ja", "Oui"]
+    assert "Allow" in labels
+
+
+def test_mac_approve_maps_localized_accessibility_error_code_to_guidance(monkeypatch):
+    monkeypatch.setattr(macos.platform, "system", lambda: "Darwin")
+    _no_ready_daemon(monkeypatch)
+    _enable_chrome_toggle(monkeypatch)
+    japanese_denial = (
+        "System Events でエラーが起きました: osascript には補助アクセスが許可されていません。(-25211)"
+    )
+    monkeypatch.setattr(
+        macos.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=japanese_denial),
+    )
+
+    status, detail = macos.approve_remote_debugging()
+
+    assert status == "accessibility-required"
+    assert "Accessibility" in detail
 
 
 def test_mac_approve_returns_not_found_without_a_prompt(monkeypatch):


### PR DESCRIPTION
Closes #707

## Problem

Chrome localizes the per-connection "Allow remote debugging?" sheet. `mac-approve` matched two English literals (`name of sheet is "Allow remote debugging?"`, `description of button is "Allow"`), so on any non-English macOS the recursion was never entered and it returned `not-found` while the sheet was up. On Japanese Chrome the sheet is `リモート デバッグを許可しますか？` and the button `許可する`; six consecutive `mac-approve` calls returned `not-found` with the sheet visible and Accessibility granted.

## Change

- The sheet is chosen by exact title and the button by exact label from Chromium's own strings for `IDS_DEV_TOOLS_CONNECTION_DIALOG_TITLE` and `IDS_DEV_TOOLS_CONNECTION_DIALOG_ALLOW_TEXT` (`chrome/app/generated_resources.grd` + `generated_resources_<locale>.xtb`), 29 locales.
- Both tables travel as `osascript` argv, so the script carries no literals. `BH_ALLOW_SHEET_TITLES` / `BH_ALLOW_LABELS` (comma-separated) extend them for a language not listed.
- Cancel and "Turn off in settings" are never candidates. Chromium's `DevToolsConnectionDialog` sets `OverrideDefaultButton(kNone)` and focuses Cancel, so pressing "the default button" would be unsafe; the label match stays.
- osascript's Accessibility denial is also detected by OSStatus code (`-25211`, `-1743`), because that error text is localized as well.
- One paragraph in SKILL.md telling agents the helper is locale-independent and how to extend it.

## Verification

- `pytest tests/unit`: 254 passed (3 new mac-approve cases: localized tables in argv, env extension, localized Accessibility error code).
- Live on Japanese macOS 15 / Chrome 152, twice: `--reload`, start a local browser command, confirm the sheet is visible and `doctor` shows 0 browser connections, run the AppleScript directly (bypassing the `daemon_browser_ready` short-circuit). It returned `ready`, the parked daemon attached, `doctor` showed 1 connection.
- The script still returns `not-found` with no sheet up, and never activates Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `mac-approve` to match Chrome's localized "Allow remote debugging?" sheet, so it no longer returns `not-found` on non-English macOS.

- Matches the sheet title and Allow button from Chromium's own strings for 29 locales, passed to osascript as argv.
- Extends the tables via `BH_ALLOW_SHEET_TITLES` and `BH_ALLOW_LABELS` env vars for unlisted languages.
- Detects the Accessibility denial by OSStatus code (-25211, -1743) as well as English text, since error text is localized.
- Never treats Cancel as a default button because Chrome focuses it.

<sup>Written for commit de30402118ec4a6e175b184dcade206f992dbd4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

