### PR TITLE
fix(helpers): switch to surviving tab before closing current tab (#379)

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -439,7 +439,7 @@ class Daemon:
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
 
-    async def attach_first_page(self, replaces_session=None, enable_domains=True):
+    async def attach_first_page(self, replaces_session=None, enable_domains=True, exclude_target_id=None):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
         # Named daemons (BU_NAME != "default") share one browser with other
@@ -452,7 +452,7 @@ class Daemon:
             # Clean it up before returning from this early path as well.
             if BROWSER_KIND == "local":
                 await self._close_inspect_tabs(targets)
-            pages_by_id = {t["targetId"]: t for t in targets if t["type"] == "page"}
+            pages_by_id = {t["targetId"]: t for t in targets if t["type"] == "page" and t["targetId"] != exclude_target_id}
             # A stale CDP session does not necessarily mean its tab disappeared.
             # Reattach to the current tab first, then the daemon's dedicated tab.
             page = pages_by_id.get(self.target_id) or pages_by_id.get(self.dedicated_target_id)
@@ -461,7 +461,7 @@ class Daemon:
                 # inside a narrow lock so they share one replacement tab.
                 async with self._dedicated_target_lock:
                     refreshed = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
-                    pages_by_id = {t["targetId"]: t for t in refreshed if t["type"] == "page"}
+                    pages_by_id = {t["targetId"]: t for t in refreshed if t["type"] == "page" and t["targetId"] != exclude_target_id}
                     page = pages_by_id.get(self.target_id) or pages_by_id.get(self.dedicated_target_id)
                     if page is None:
                         tid = (await self.cdp.send_raw(
@@ -481,22 +481,26 @@ class Daemon:
                 await self._enable_default_domains(self.session)
             return page
 
-        pages = [t for t in targets if is_real_page(t)]
+        pages = [t for t in targets if is_real_page(t) and t["targetId"] != exclude_target_id]
         if not pages:
             # Fresh browser (ex: BU cloud) starts w about:blank; reuse it
-            pages = [t for t in targets if is_reusable_blank_page(t)]
+            pages = [t for t in targets if is_reusable_blank_page(t) and t["targetId"] != exclude_target_id]
         if not pages:
             # Freshly launched browser (ex: harness relaunching closed Chrome)
             # starts with just the New Tab Page. Reuse it — creating about:blank
-            pages = [t for t in targets if is_reusable_new_tab_page(t)]
+            pages = [t for t in targets if is_reusable_new_tab_page(t) and t["targetId"] != exclude_target_id]
         take_over = None
         if not pages and harness_opened_inspect():
             # After perms granted, only tab is often chrome://inspect
             # Attach to it instead of creating a new about:blank
-            inspect_tabs = [t for t in targets if is_inspect_tab(t)]
+            inspect_tabs = [t for t in targets if is_inspect_tab(t) and t["targetId"] != exclude_target_id]
             if inspect_tabs:
                 pages = [inspect_tabs[0]]
                 take_over = inspect_tabs[0]["targetId"]
+        if not pages:
+            other_pages = [t for t in targets if t.get("type") == "page" and t["targetId"] != exclude_target_id]
+            if other_pages:
+                pages = [other_pages[0]]
         if not pages:
             # No usable pages - create one instead of attaching to omnibox popup.
             tid = (await self.cdp.send_raw(
@@ -736,6 +740,48 @@ class Daemon:
             # it doesn't add to the synchronous IPC budget.
             self._schedule_tab_marker(new_session)
             return {"session_id": new_session}
+        if meta == "close_tab":
+            old_session = None
+            new_session = None
+            close_error = None
+            async with self._session_state_lock:
+                target_to_close = req.get("target_id") or self.target_id
+                if not target_to_close:
+                    return {"error": "not_attached"}
+                if target_to_close == self.target_id:
+                    old_session = self.session
+                    await self.attach_first_page(
+                        replaces_session=old_session,
+                        enable_domains=False,
+                        exclude_target_id=target_to_close,
+                    )
+                    new_session = self.session
+                elif target_to_close == self.dedicated_target_id:
+                    self.dedicated_target_id = None
+                try:
+                    await self.cdp.send_raw("Target.closeTarget", {"targetId": target_to_close})
+                except Exception as e:
+                    close_error = e
+
+            if new_session:
+                tasks = []
+                if old_session and old_session != new_session:
+                    async def disable_old():
+                        try:
+                            await asyncio.wait_for(
+                                self.cdp.send_raw("Network.disable", session_id=old_session),
+                                timeout=2,
+                            )
+                        except Exception:
+                            pass
+                    tasks.append(disable_old())
+                tasks.append(self._enable_default_domains(new_session))
+                await asyncio.gather(*tasks)
+                self._schedule_tab_marker(new_session)
+
+            if close_error is not None:
+                return {"error": str(close_error)}
+            return {"success": True}
         if meta == "pending_dialog": return {"dialog": self.dialog}
         if meta == "shutdown":
             # Flip the barrier synchronously with recovery registration, then

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -751,7 +751,7 @@ class Daemon:
                 if target_to_close == self.target_id:
                     old_session = self.session
                     await self.attach_first_page(
-                        replaces_session=old_session,
+                        replaces_session=None,
                         enable_domains=False,
                         exclude_target_id=target_to_close,
                     )
@@ -759,7 +759,9 @@ class Daemon:
                 elif target_to_close == self.dedicated_target_id:
                     self.dedicated_target_id = None
                 try:
-                    await self.cdp.send_raw("Target.closeTarget", {"targetId": target_to_close})
+                    res = await self.cdp.send_raw("Target.closeTarget", {"targetId": target_to_close})
+                    if isinstance(res, dict) and res.get("success") is False:
+                        close_error = RuntimeError("Target.closeTarget failed")
                 except Exception as e:
                     close_error = e
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -452,10 +452,32 @@ def new_tab(url="about:blank"):
 
 def close_tab(target=None):
     """Close a tab. If `target` is omitted, closes the currently attached tab.
-    Accepts a raw targetId string or a dict from list_tabs()/current_tab()."""
+    Accepts a raw targetId string or a dict from list_tabs()/current_tab().
+
+    Closing the attached tab first switches the harness to another real tab (or
+    a fresh about:blank tab if no other tab exists) before closing, preventing
+    dangling session state in the daemon.
+    """
     target_id = _target_id(target)
+    try:
+        cur = current_tab()
+        cur_id = cur.get("targetId") or cur.get("target_id")
+    except Exception:
+        cur_id = None
     if target_id is None:
-        target_id = current_tab()["targetId"]
+        target_id = cur_id
+    if target_id is None:
+        return
+    if target_id == cur_id:
+        other_tabs = [t for t in list_tabs(include_chrome=False) if (t.get("targetId") or t.get("target_id")) != target_id]
+        if other_tabs:
+            switch_tab(other_tabs[0]["targetId"])
+        else:
+            all_other = [t for t in list_tabs(include_chrome=True) if (t.get("targetId") or t.get("target_id")) != target_id]
+            if all_other:
+                switch_tab(all_other[0]["targetId"])
+            else:
+                new_tab("about:blank")
     cdp("Target.closeTarget", targetId=target_id)
 
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -452,33 +452,9 @@ def new_tab(url="about:blank"):
 
 def close_tab(target=None):
     """Close a tab. If `target` is omitted, closes the currently attached tab.
-    Accepts a raw targetId string or a dict from list_tabs()/current_tab().
-
-    Closing the attached tab first switches the harness to another real tab (or
-    a fresh about:blank tab if no other tab exists) before closing, preventing
-    dangling session state in the daemon.
-    """
+    Accepts a raw targetId string or a dict from list_tabs()/current_tab()."""
     target_id = _target_id(target)
-    try:
-        cur = current_tab()
-        cur_id = cur.get("targetId") or cur.get("target_id")
-    except Exception:
-        cur_id = None
-    if target_id is None:
-        target_id = cur_id
-    if target_id is None:
-        return
-    if target_id == cur_id:
-        other_tabs = [t for t in list_tabs(include_chrome=False) if (t.get("targetId") or t.get("target_id")) != target_id]
-        if other_tabs:
-            switch_tab(other_tabs[0]["targetId"])
-        else:
-            all_other = [t for t in list_tabs(include_chrome=True) if (t.get("targetId") or t.get("target_id")) != target_id]
-            if all_other:
-                switch_tab(all_other[0]["targetId"])
-            else:
-                new_tab("about:blank")
-    cdp("Target.closeTarget", targetId=target_id)
+    return _send({"meta": "close_tab", "target_id": target_id})
 
 
 def ensure_real_tab():

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -890,6 +890,7 @@ def test_close_tab_current_switches_to_surviving_tab_and_closes_old():
     assert ("Network.disable", None, "session-current") in d.cdp.calls
     for domain in ("Page", "DOM", "Runtime", "Network"):
         assert (f"{domain}.enable", None, "session-for-tab-survivor") in d.cdp.calls
+    assert "session-current" not in d._session_replacements
 
 
 def test_close_tab_current_creates_about_blank_when_no_other_tabs():
@@ -907,3 +908,20 @@ def test_close_tab_current_creates_about_blank_when_no_other_tabs():
     assert d.target_id == "created-1"
     assert d.session == "session-for-created-1"
     assert ("Target.closeTarget", {"targetId": "tab-current"}, None) in d.cdp.calls
+    assert "session-current" not in d._session_replacements
+
+
+def test_close_tab_returns_error_when_close_target_fails():
+    class _FailingCloseCDP(_AttachCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            if method == "Target.closeTarget":
+                return {"success": False}
+            return await super().send_raw(method, params=params, session_id=session_id)
+
+    d = daemon.Daemon()
+    d.cdp = _FailingCloseCDP([{"targetId": "tab-current", "type": "page", "url": "https://a.com"}])
+    d.target_id = "tab-current"
+    d.session = "session-current"
+
+    res = asyncio.run(d.handle({"meta": "close_tab"}))
+    assert res == {"error": "Target.closeTarget failed"}

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -845,3 +845,65 @@ def test_explicit_stale_session_is_not_redirected():
     assert d.cdp.calls == [
         ("Runtime.evaluate", {"expression": "1"}, "explicit-stale-session")
     ]
+
+
+def test_close_tab_not_attached_returns_error():
+    d = daemon.Daemon()
+    d.cdp = _FakeCDP()
+    d.target_id = None
+    res = asyncio.run(d.handle({"meta": "close_tab"}))
+    assert res == {"error": "not_attached"}
+
+
+def test_close_tab_closes_non_current_tab_without_switching():
+    d = daemon.Daemon()
+    d.cdp = _FakeCDP()
+    d.target_id = "tab-current"
+    d.session = "session-current"
+
+    res = asyncio.run(d.handle({"meta": "close_tab", "target_id": "tab-other"}))
+
+    assert res == {"success": True}
+    assert d.target_id == "tab-current"
+    assert d.session == "session-current"
+    assert ("Target.closeTarget", {"targetId": "tab-other"}, None) in d.cdp.calls
+    attach_calls = [m for m, _p, _s in d.cdp.calls if m == "Target.attachToTarget"]
+    assert attach_calls == []
+
+
+def test_close_tab_current_switches_to_surviving_tab_and_closes_old():
+    existing = [
+        {"targetId": "tab-current", "url": "https://a.com", "type": "page"},
+        {"targetId": "tab-survivor", "url": "https://b.com", "type": "page"},
+    ]
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP(existing)
+    d.target_id = "tab-current"
+    d.session = "session-current"
+
+    res = asyncio.run(d.handle({"meta": "close_tab"}))
+
+    assert res == {"success": True}
+    assert d.target_id == "tab-survivor"
+    assert d.session == "session-for-tab-survivor"
+    assert ("Target.closeTarget", {"targetId": "tab-current"}, None) in d.cdp.calls
+    assert ("Network.disable", None, "session-current") in d.cdp.calls
+    for domain in ("Page", "DOM", "Runtime", "Network"):
+        assert (f"{domain}.enable", None, "session-for-tab-survivor") in d.cdp.calls
+
+
+def test_close_tab_current_creates_about_blank_when_no_other_tabs():
+    existing = [
+        {"targetId": "tab-current", "url": "https://a.com", "type": "page"},
+    ]
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP(existing)
+    d.target_id = "tab-current"
+    d.session = "session-current"
+
+    res = asyncio.run(d.handle({"meta": "close_tab"}))
+
+    assert res == {"success": True}
+    assert d.target_id == "created-1"
+    assert d.session == "session-for-created-1"
+    assert ("Target.closeTarget", {"targetId": "tab-current"}, None) in d.cdp.calls

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -511,6 +511,119 @@ def test_new_tab_reuses_an_empty_data_document(monkeypatch):
     assert calls == [("goto_url", "https://example.com")]
 
 
+def test_close_tab_closes_non_current_tab_without_switching(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
+    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
+
+    helpers.close_tab("tab-other")
+    assert calls == [("Target.closeTarget", {"targetId": "tab-other"})]
+
+
+def test_close_tab_current_switches_to_surviving_real_tab(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
+    monkeypatch.setattr(
+        helpers,
+        "list_tabs",
+        lambda include_chrome=True: [
+            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
+            {"targetId": "tab-survivor", "url": "https://survivor.com", "title": "Survivor"},
+        ],
+    )
+    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
+
+    helpers.close_tab()
+    assert calls == [
+        ("switch_tab", "tab-survivor"),
+        ("Target.closeTarget", {"targetId": "tab-current"}),
+    ]
+
+
+def test_close_tab_current_switches_to_chrome_tab_when_no_real_tabs(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
+
+    def fake_list_tabs(include_chrome=True):
+        if not include_chrome:
+            return [{"targetId": "tab-current", "url": "https://current.com", "title": "Current"}]
+        return [
+            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
+            {"targetId": "tab-inspect", "url": "chrome://inspect/#remote-debugging", "title": "Inspect"},
+        ]
+
+    monkeypatch.setattr(helpers, "list_tabs", fake_list_tabs)
+    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
+
+    helpers.close_tab()
+    assert calls == [
+        ("switch_tab", "tab-inspect"),
+        ("Target.closeTarget", {"targetId": "tab-current"}),
+    ]
+
+
+def test_close_tab_current_opens_blank_when_no_other_tabs(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
+    monkeypatch.setattr(
+        helpers,
+        "list_tabs",
+        lambda include_chrome=True: [
+            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
+        ],
+    )
+    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
+    monkeypatch.setattr(
+        helpers,
+        "new_tab",
+        lambda *args, **kwargs: calls.append(("new_tab", args, kwargs)) or "tab-blank",
+    )
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
+
+    helpers.close_tab()
+    assert calls == [
+        ("new_tab", ("about:blank",), {}),
+        ("Target.closeTarget", {"targetId": "tab-current"}),
+    ]
+
+
+def test_close_tab_accepts_dict_target_closing_current(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
+    monkeypatch.setattr(
+        helpers,
+        "list_tabs",
+        lambda include_chrome=True: [
+            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
+            {"targetId": "tab-survivor", "url": "https://survivor.com", "title": "Survivor"},
+        ],
+    )
+    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
+
+    helpers.close_tab({"targetId": "tab-current"})
+    assert calls == [
+        ("switch_tab", "tab-survivor"),
+        ("Target.closeTarget", {"targetId": "tab-current"}),
+    ]
+
+
+def test_close_tab_noop_when_not_attached(monkeypatch):
+    calls = []
+
+    def fake_current_tab():
+        raise RuntimeError("not attached")
+
+    monkeypatch.setattr(helpers, "current_tab", fake_current_tab)
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
+
+    helpers.close_tab()
+    assert calls == []
+
+
 # --- press_key physical key identity (#685) ---
 
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -511,117 +511,32 @@ def test_new_tab_reuses_an_empty_data_document(monkeypatch):
     assert calls == [("goto_url", "https://example.com")]
 
 
-def test_close_tab_closes_non_current_tab_without_switching(monkeypatch):
+def test_close_tab_sends_meta_close_tab_with_none_for_current_tab(monkeypatch):
     calls = []
-    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
-    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
-    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
-
-    helpers.close_tab("tab-other")
-    assert calls == [("Target.closeTarget", {"targetId": "tab-other"})]
-
-
-def test_close_tab_current_switches_to_surviving_real_tab(monkeypatch):
-    calls = []
-    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
-    monkeypatch.setattr(
-        helpers,
-        "list_tabs",
-        lambda include_chrome=True: [
-            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
-            {"targetId": "tab-survivor", "url": "https://survivor.com", "title": "Survivor"},
-        ],
-    )
-    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
-    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
-
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(request) or {"success": True})
     helpers.close_tab()
-    assert calls == [
-        ("switch_tab", "tab-survivor"),
-        ("Target.closeTarget", {"targetId": "tab-current"}),
-    ]
+    assert calls == [{"meta": "close_tab", "target_id": None}]
 
 
-def test_close_tab_current_switches_to_chrome_tab_when_no_real_tabs(monkeypatch):
+def test_close_tab_sends_target_id_string(monkeypatch):
     calls = []
-    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
-
-    def fake_list_tabs(include_chrome=True):
-        if not include_chrome:
-            return [{"targetId": "tab-current", "url": "https://current.com", "title": "Current"}]
-        return [
-            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
-            {"targetId": "tab-inspect", "url": "chrome://inspect/#remote-debugging", "title": "Inspect"},
-        ]
-
-    monkeypatch.setattr(helpers, "list_tabs", fake_list_tabs)
-    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
-    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
-
-    helpers.close_tab()
-    assert calls == [
-        ("switch_tab", "tab-inspect"),
-        ("Target.closeTarget", {"targetId": "tab-current"}),
-    ]
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(request) or {"success": True})
+    helpers.close_tab("tab-123")
+    assert calls == [{"meta": "close_tab", "target_id": "tab-123"}]
 
 
-def test_close_tab_current_opens_blank_when_no_other_tabs(monkeypatch):
+def test_close_tab_accepts_dict_with_targetId(monkeypatch):
     calls = []
-    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
-    monkeypatch.setattr(
-        helpers,
-        "list_tabs",
-        lambda include_chrome=True: [
-            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
-        ],
-    )
-    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
-    monkeypatch.setattr(
-        helpers,
-        "new_tab",
-        lambda *args, **kwargs: calls.append(("new_tab", args, kwargs)) or "tab-blank",
-    )
-    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
-
-    helpers.close_tab()
-    assert calls == [
-        ("new_tab", ("about:blank",), {}),
-        ("Target.closeTarget", {"targetId": "tab-current"}),
-    ]
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(request) or {"success": True})
+    helpers.close_tab({"targetId": "tab-456"})
+    assert calls == [{"meta": "close_tab", "target_id": "tab-456"}]
 
 
-def test_close_tab_accepts_dict_target_closing_current(monkeypatch):
+def test_close_tab_accepts_dict_with_target_id(monkeypatch):
     calls = []
-    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "tab-current", "url": "https://current.com"})
-    monkeypatch.setattr(
-        helpers,
-        "list_tabs",
-        lambda include_chrome=True: [
-            {"targetId": "tab-current", "url": "https://current.com", "title": "Current"},
-            {"targetId": "tab-survivor", "url": "https://survivor.com", "title": "Survivor"},
-        ],
-    )
-    monkeypatch.setattr(helpers, "switch_tab", lambda target, **kwargs: calls.append(("switch_tab", target)))
-    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
-
-    helpers.close_tab({"targetId": "tab-current"})
-    assert calls == [
-        ("switch_tab", "tab-survivor"),
-        ("Target.closeTarget", {"targetId": "tab-current"}),
-    ]
-
-
-def test_close_tab_noop_when_not_attached(monkeypatch):
-    calls = []
-
-    def fake_current_tab():
-        raise RuntimeError("not attached")
-
-    monkeypatch.setattr(helpers, "current_tab", fake_current_tab)
-    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
-
-    helpers.close_tab()
-    assert calls == []
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(request) or {"success": True})
+    helpers.close_tab({"target_id": "tab-789"})
+    assert calls == [{"meta": "close_tab", "target_id": "tab-789"}]
 
 
 # --- press_key physical key identity (#685) ---


### PR DESCRIPTION
## Problem Context

`close_tab()` closes the currently attached tab when called without arguments. It previously sent `Target.closeTarget` directly to Chrome without updating daemon session state.

The daemon still pointed to the closed `targetId` and `sessionId`. Subsequent calls such as `current_tab()`, `page_info()`, or `js()` failed immediately with `RuntimeError: cdp_disconnected`.

## Why This Fix Is Needed

`SKILL.md` instructs agents to close task tabs on completion. Calling `close_tab()` as documented left the daemon in a broken state for any subsequent interaction.

Callers had to manually call `switch_tab()` after closing to recover.

## Changes

- Detects when the target being closed is the currently attached tab.
- Switches to an available surviving user tab before issuing `Target.closeTarget`.
- Falls back to internal tabs or creates a fresh `about:blank` tab if no other user tab exists.
- Leaves closing of non-current tabs unchanged and fast.
- Adds comprehensive unit tests in `tests/unit/test_helpers.py`.

Fixes #379

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`close_tab()` now switches to a surviving tab before closing the currently attached tab, so the daemon keeps a valid session and later calls like `current_tab()`, `page_info()`, or `js()` still work. Previously it sent `Target.closeTarget` directly and left the daemon pointing at the closed tab, forcing callers to run `switch_tab()` manually to recover.

- Switching and closing are serialized under the session-state lock so concurrent `close_tab` and attach calls can't race.
- If another user tab exists, it switches to that; otherwise it reuses a Chrome internal tab or creates `about:blank`.
- Closing a non-current tab is unchanged and still closes directly.
- A failed `Target.closeTarget` (or a missing attached tab) now returns an error instead of silently leaving stale state.
- Adds unit tests for all close paths, including no-attached-tab behavior.

Fixes #379.

<sup>Written for commit 236dc8579833e7754a585012451495db6678bcc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

