### PR TITLE
test: fix Windows unit test suite failures (#680)

### DIFF
--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1,6 +1,7 @@
 import json
 import os
 import signal
+import sys
 import time
 import subprocess
 from pathlib import Path
@@ -45,17 +46,27 @@ def test_cleanup_unattached_browser_launch_stops_posix_process_group(monkeypatch
     killed = []
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
     monkeypatch.setattr("browser_harness.daemon._devtools_port_live", lambda _profile: False)
-    monkeypatch.setattr(admin.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+    monkeypatch.setattr(admin.os, "killpg", lambda pid, sig: killed.append((pid, sig)), raising=False)
 
     admin._cleanup_unattached_browser_launch((process, Path("/profile")))
 
     assert killed == [(123, signal.SIGTERM)]
 
 
+def test_cleanup_unattached_browser_launch_stops_windows_process(monkeypatch):
+    process = FakeProcess()
+    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", True)
+    monkeypatch.setattr("browser_harness.daemon._devtools_port_live", lambda _profile: False)
+
+    admin._cleanup_unattached_browser_launch((process, Path("/profile")))
+
+    assert process.terminated is True
+
+
 def test_cleanup_unattached_browser_launch_keeps_cdp_browser(monkeypatch):
     process = FakeProcess()
     monkeypatch.setattr("browser_harness.daemon._devtools_port_live", lambda _profile: True)
-    monkeypatch.setattr(admin.os, "killpg", lambda _pid, _sig: pytest.fail("must keep the attached browser"))
+    monkeypatch.setattr(admin.os, "killpg", lambda _pid, _sig: pytest.fail("must keep the attached browser"), raising=False)
 
     admin._cleanup_unattached_browser_launch((process, Path("/profile")))
 
@@ -88,7 +99,7 @@ def test_explicit_chrome_path_retains_matching_profile_on_linux(monkeypatch, tmp
     monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: process)
     killed = []
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+    monkeypatch.setattr(admin.os, "killpg", lambda pid, sig: killed.append((pid, sig)), raising=False)
 
     launch = admin._launch_browser()
     assert launch == (process, profile)
@@ -112,7 +123,7 @@ def test_explicit_chrome_path_remains_unowned_without_platform_cleanup(monkeypat
     monkeypatch.setattr("browser_harness.daemon.remote_debugging_toggle_profiles", lambda: [profile])
     monkeypatch.setattr("platform.system", lambda: system)
     monkeypatch.setattr("subprocess.Popen", lambda *_args, **_kwargs: process)
-    monkeypatch.setattr(admin.os, "killpg", lambda *_args: pytest.fail("must not terminate an unowned browser"))
+    monkeypatch.setattr(admin.os, "killpg", lambda *_args: pytest.fail("must not terminate an unowned browser"), raising=False)
 
     launch = admin._launch_browser()
     assert launch == (process, None)
@@ -377,6 +388,7 @@ def test_is_snap_browser(path, expected):
     assert admin._is_snap_browser(path) == expected
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="snap probes are Linux-specific and symlinks require privileges on Windows")
 def test_doctor_probe_preserves_snap_bin_env_symlink(monkeypatch, tmp_path):
     target = tmp_path / "usr" / "bin" / "snap"
     target.parent.mkdir(parents=True)
@@ -396,6 +408,7 @@ def test_doctor_probe_preserves_snap_bin_env_symlink(monkeypatch, tmp_path):
     assert admin._is_snap_browser(path)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="snap probes are Linux-specific and symlinks require privileges on Windows")
 def test_doctor_probe_preserves_snap_bin_path_symlink(monkeypatch, tmp_path):
     target = tmp_path / "usr" / "bin" / "snap"
     target.parent.mkdir(parents=True)

--- a/tests/unit/test_skill.py
+++ b/tests/unit/test_skill.py
@@ -1,4 +1,5 @@
 from importlib import resources
+from pathlib import Path
 
 
 def _frontmatter(text: str) -> str:
@@ -10,6 +11,10 @@ def _frontmatter(text: str) -> str:
 
 def test_packaged_skill_frontmatter_is_valid_simple_yaml():
     text = resources.files("browser_harness").joinpath("SKILL.md").read_text()
+    if text.strip().startswith("../../") or not text.startswith("---\n"):
+        root_skill = Path(__file__).resolve().parents[2] / "SKILL.md"
+        if root_skill.exists():
+            text = root_skill.read_text()
     metadata = {}
 
     for line in _frontmatter(text).splitlines():

--- a/tests/unit/test_skill.py
+++ b/tests/unit/test_skill.py
@@ -11,7 +11,7 @@ def _frontmatter(text: str) -> str:
 
 def test_packaged_skill_frontmatter_is_valid_simple_yaml():
     text = resources.files("browser_harness").joinpath("SKILL.md").read_text()
-    if text.strip().startswith("../../") or not text.startswith("---\n"):
+    if text.strip().startswith("../../"):
         root_skill = Path(__file__).resolve().parents[2] / "SKILL.md"
         if root_skill.exists():
             text = root_skill.read_text()


### PR DESCRIPTION
## Problem Context

Running the unit test suite on Windows resulted in test failures across `tests/unit/test_admin.py` and `tests/unit/test_skill.py`.

The failures had three distinct causes:
1. `os.killpg` does not exist on Windows. `monkeypatch.setattr(admin.os, "killpg", ...)` raised `AttributeError` during setup.
2. Snap probe tests created symlinks via `Path.symlink_to`. On Windows, symlink creation requires elevated privileges and raised `OSError: [WinError 1314]`. Snap is also a Linux-only packaging format.
3. Windows checkouts without symlink support checked out `SKILL.md` as plain relative symlink text. `test_skill.py` failed to parse frontmatter on that stub.

## Why This Fix Is Needed

Windows is a supported platform in browser-harness. Windows users and contributors need to run the unit test suite locally.

CI also requires these tests to pass on Windows runners.

## Changes

- Adds `raising=False` to `monkeypatch.setattr(admin.os, "killpg", ...)` in `tests/unit/test_admin.py`.
- Adds `test_cleanup_unattached_browser_launch_stops_windows_process` to cover `process.terminate()` on Windows.
- Guards Linux snap symlink tests with `@pytest.mark.skipif(sys.platform == "win32", ...)`.
- Updates `tests/unit/test_skill.py` to resolve repo root `SKILL.md` when the packaged file contains symlink pointer text.

Fixes #680

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows unit test suite so `test_admin.py` and `test_skill.py` pass on Windows. No production code changes.

- Adds `raising=False` to `killpg` monkeypatches and a test for the Windows `process.terminate()` path.
- Skips snap probe symlink tests on Windows because symlink creation requires privileges and snap is Linux-only.
- Resolves the repo-root `SKILL.md` when the packaged file contains relative symlink pointer text.

<sup>Written for commit ee5a2d5b0af67587964c27a41b9cf1dba681ae46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

