### PR TITLE
fix(auth): prevent OAuth callback server hang on browser preconnect (#691)

### DIFF
--- a/src/browser_harness/auth.py
+++ b/src/browser_harness/auth.py
@@ -6,11 +6,12 @@ or tells the agent to run `browser-harness auth login`. OAuth details live here.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 import argparse
 import base64
 import getpass
 import hashlib
+import html
 import json
 import os
 from pathlib import Path
@@ -393,6 +394,8 @@ def _exchange_authorization_code(code: str, redirect_uri: str, verifier: str) ->
 
 def _callback_server(callback: PendingCallback) -> HTTPServer:
     class Handler(BaseHTTPRequestHandler):
+        timeout = 10
+
         def do_GET(self):  # noqa: N802 - stdlib handler API
             parsed = urllib.parse.urlparse(self.path)
             if parsed.path != CALLBACK_PATH:
@@ -407,18 +410,27 @@ def _callback_server(callback: PendingCallback) -> HTTPServer:
                 callback.code = _one(qs, "code")
                 callback.error = _one(qs, "error")
                 callback.error_description = _one(qs, "error_description")
-            callback.complete = True
-            body = b"<html><body><h1>Browser Use Cloud login complete</h1><p>You can close this tab.</p></body></html>"
+            if callback.error:
+                detail = f": {callback.error_description}" if callback.error_description else ""
+                body = (
+                    f"<html><body><h1>Browser Use Cloud login failed</h1>"
+                    f"<p>{html.escape(callback.error)}{html.escape(detail)}</p></body></html>"
+                ).encode("utf-8")
+            else:
+                body = b"<html><body><h1>Browser Use Cloud login complete</h1><p>You can close this tab.</p></body></html>"
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+            callback.complete = True
 
         def log_message(self, fmt, *args):
             return
 
-    return HTTPServer(("127.0.0.1", 0), Handler)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server.daemon_threads = True
+    return server
 
 
 def _post_json(url: str, payload: dict) -> dict:

--- a/src/browser_harness/auth.py
+++ b/src/browser_harness/auth.py
@@ -443,13 +443,14 @@ def _callback_server(callback: PendingCallback) -> HTTPServer:
                 else:
                     body = b"<html><body><h1>Browser Use Cloud login complete</h1><p>You can close this tab.</p></body></html>"
 
-                callback.complete = True
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                self.wfile.flush()
 
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+                callback.complete = True
 
         def log_message(self, fmt, *args):
             return

--- a/src/browser_harness/auth.py
+++ b/src/browser_harness/auth.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import secrets
 import stat
 import sys
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -393,6 +394,8 @@ def _exchange_authorization_code(code: str, redirect_uri: str, verifier: str) ->
 
 
 def _callback_server(callback: PendingCallback) -> HTTPServer:
+    lock = threading.Lock()
+
     class Handler(BaseHTTPRequestHandler):
         timeout = 10
 
@@ -402,28 +405,51 @@ def _callback_server(callback: PendingCallback) -> HTTPServer:
                 self.send_error(404)
                 return
             qs = urllib.parse.parse_qs(parsed.query)
-            state = _one(qs, "state")
-            if state != callback.state:
-                callback.error = "invalid_state"
-                callback.error_description = "OAuth callback state did not match"
-            else:
-                callback.code = _one(qs, "code")
-                callback.error = _one(qs, "error")
-                callback.error_description = _one(qs, "error_description")
-            if callback.error:
-                detail = f": {callback.error_description}" if callback.error_description else ""
-                body = (
-                    f"<html><body><h1>Browser Use Cloud login failed</h1>"
-                    f"<p>{html.escape(callback.error)}{html.escape(detail)}</p></body></html>"
-                ).encode("utf-8")
-            else:
-                body = b"<html><body><h1>Browser Use Cloud login complete</h1><p>You can close this tab.</p></body></html>"
+            with lock:
+                if callback.complete:
+                    if callback.error:
+                        detail = f": {callback.error_description}" if callback.error_description else ""
+                        body = (
+                            f"<html><body><h1>Browser Use Cloud login failed</h1>"
+                            f"<p>{html.escape(callback.error)}{html.escape(detail)}</p></body></html>"
+                        ).encode("utf-8")
+                    else:
+                        body = b"<html><body><h1>Browser Use Cloud login complete</h1><p>You can close this tab.</p></body></html>"
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html; charset=utf-8")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+
+                state = _one(qs, "state")
+                if state != callback.state:
+                    callback.error = "invalid_state"
+                    callback.error_description = "OAuth callback state did not match"
+                else:
+                    callback.code = _one(qs, "code")
+                    callback.error = _one(qs, "error")
+                    callback.error_description = _one(qs, "error_description")
+                    if not callback.error and not callback.code:
+                        callback.error = "missing_code"
+                        callback.error_description = "OAuth callback returned no authorization code"
+
+                if callback.error:
+                    detail = f": {callback.error_description}" if callback.error_description else ""
+                    body = (
+                        f"<html><body><h1>Browser Use Cloud login failed</h1>"
+                        f"<p>{html.escape(callback.error)}{html.escape(detail)}</p></body></html>"
+                    ).encode("utf-8")
+                else:
+                    body = b"<html><body><h1>Browser Use Cloud login complete</h1><p>You can close this tab.</p></body></html>"
+
+                callback.complete = True
+
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
-            callback.complete = True
 
         def log_message(self, fmt, *args):
             return

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -171,3 +171,57 @@ def test_complete_browser_auth_raises_on_missing_code():
 
     with pytest.raises(AuthError, match="auth callback did not include a code"):
         complete_browser_auth(start)
+
+
+def test_callback_server_missing_code_renders_failure():
+    cb = PendingCallback(state="secret-state")
+    server = _callback_server(cb)
+    host, port = server.server_address
+    t = threading.Thread(target=server.handle_request, daemon=True)
+    t.start()
+
+    url = f"http://{host}:{port}/browser-use-cloud/callback?state=secret-state"
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        body = resp.read().decode("utf-8")
+        assert resp.status == 200
+
+    t.join(timeout=2)
+    server.server_close()
+
+    assert cb.complete is True
+    assert cb.error == "missing_code"
+    assert "Browser Use Cloud login failed" in body
+    assert "missing_code" in body
+
+
+def test_callback_server_duplicate_requests_preserves_first():
+    cb = PendingCallback(state="secret-state")
+    server = _callback_server(cb)
+    host, port = server.server_address
+
+    t1 = threading.Thread(target=server.handle_request, daemon=True)
+    t1.start()
+
+    url1 = f"http://{host}:{port}/browser-use-cloud/callback?state=secret-state&code=first-valid-code"
+    with urllib.request.urlopen(url1, timeout=5) as resp:
+        body1 = resp.read().decode("utf-8")
+        assert resp.status == 200
+
+    t1.join(timeout=2)
+
+    t2 = threading.Thread(target=server.handle_request, daemon=True)
+    t2.start()
+
+    url2 = f"http://{host}:{port}/browser-use-cloud/callback?state=wrong-state&error=second_error"
+    with urllib.request.urlopen(url2, timeout=5) as resp:
+        body2 = resp.read().decode("utf-8")
+        assert resp.status == 200
+
+    t2.join(timeout=2)
+    server.server_close()
+
+    assert cb.complete is True
+    assert cb.code == "first-valid-code"
+    assert cb.error is None
+    assert "Browser Use Cloud login complete" in body1
+    assert "Browser Use Cloud login complete" in body2

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,173 @@
+import socket
+import threading
+import time
+import urllib.parse
+import urllib.request
+from unittest.mock import patch
+
+import pytest
+
+from browser_harness import auth
+from browser_harness.auth import (
+    AuthError,
+    BrowserAuthStart,
+    PendingCallback,
+    _callback_server,
+    complete_browser_auth,
+)
+
+
+def test_callback_server_successful_oauth():
+    cb = PendingCallback(state="secret-state")
+    server = _callback_server(cb)
+    host, port = server.server_address
+    t = threading.Thread(target=server.handle_request, daemon=True)
+    t.start()
+
+    url = f"http://{host}:{port}/browser-use-cloud/callback?state=secret-state&code=test-code-123"
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        body = resp.read().decode("utf-8")
+        assert resp.status == 200
+
+    t.join(timeout=2)
+    server.server_close()
+
+    assert cb.complete is True
+    assert cb.code == "test-code-123"
+    assert cb.error is None
+    assert "Browser Use Cloud login complete" in body
+
+
+def test_callback_server_invalid_state():
+    cb = PendingCallback(state="secret-state")
+    server = _callback_server(cb)
+    host, port = server.server_address
+    t = threading.Thread(target=server.handle_request, daemon=True)
+    t.start()
+
+    url = f"http://{host}:{port}/browser-use-cloud/callback?state=wrong-state&code=test-code-123"
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        body = resp.read().decode("utf-8")
+        assert resp.status == 200
+
+    t.join(timeout=2)
+    server.server_close()
+
+    assert cb.complete is True
+    assert cb.code is None
+    assert cb.error == "invalid_state"
+    assert "Browser Use Cloud login failed" in body
+    assert "invalid_state" in body
+
+
+def test_callback_server_oauth_error():
+    cb = PendingCallback(state="secret-state")
+    server = _callback_server(cb)
+    host, port = server.server_address
+    t = threading.Thread(target=server.handle_request, daemon=True)
+    t.start()
+
+    url = f"http://{host}:{port}/browser-use-cloud/callback?state=secret-state&error=access_denied&error_description=User+declined"
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        body = resp.read().decode("utf-8")
+        assert resp.status == 200
+
+    t.join(timeout=2)
+    server.server_close()
+
+    assert cb.complete is True
+    assert cb.error == "access_denied"
+    assert cb.error_description == "User declined"
+    assert "Browser Use Cloud login failed" in body
+    assert "access_denied" in body
+
+
+def test_callback_server_preconnect_does_not_block_callback():
+    cb = PendingCallback(state="secret-state")
+    server = _callback_server(cb)
+    host, port = server.server_address
+
+    preconnect = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    preconnect.connect((host, port))
+
+    start = BrowserAuthStart(
+        server=server,
+        callback=cb,
+        redirect_uri=f"http://{host}:{port}/browser-use-cloud/callback",
+        verifier="test-verifier",
+        auth_url="http://auth.example.com",
+        expires_in=600,
+        opened=True,
+    )
+
+    def send_real_callback():
+        time.sleep(0.1)
+        url = f"http://{host}:{port}/browser-use-cloud/callback?state=secret-state&code=valid-code"
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            resp.read()
+
+    sender = threading.Thread(target=send_real_callback, daemon=True)
+    sender.start()
+
+    try:
+        with patch.object(auth, "_exchange_authorization_code", return_value={"api_key": "bu_test_key_123", "api_key_id": "key-id-1"}):
+            with patch.object(auth, "save_auth_record"):
+                record = complete_browser_auth(start, timeout=3.0)
+                assert record.api_key == "bu_test_key_123"
+                assert record.api_key_id == "key-id-1"
+    finally:
+        preconnect.close()
+        sender.join(timeout=2)
+
+
+def test_complete_browser_auth_timeout():
+    cb = PendingCallback(state="secret-state")
+    server = _callback_server(cb)
+    host, port = server.server_address
+
+    start = BrowserAuthStart(
+        server=server,
+        callback=cb,
+        redirect_uri=f"http://{host}:{port}/browser-use-cloud/callback",
+        verifier="test-verifier",
+        auth_url="http://auth.example.com",
+        expires_in=600,
+        opened=True,
+    )
+
+    with pytest.raises(AuthError, match="timed out waiting for browser auth callback"):
+        complete_browser_auth(start, timeout=0.1)
+
+
+def test_complete_browser_auth_raises_on_callback_error():
+    cb = PendingCallback(state="secret-state", complete=True, error="access_denied", error_description="consent declined")
+    server = _callback_server(cb)
+    start = BrowserAuthStart(
+        server=server,
+        callback=cb,
+        redirect_uri="http://127.0.0.1:0/callback",
+        verifier="verifier",
+        auth_url="http://auth.example.com",
+        expires_in=600,
+        opened=True,
+    )
+
+    with pytest.raises(AuthError, match="auth failed: access_denied: consent declined"):
+        complete_browser_auth(start)
+
+
+def test_complete_browser_auth_raises_on_missing_code():
+    cb = PendingCallback(state="secret-state", complete=True)
+    server = _callback_server(cb)
+    start = BrowserAuthStart(
+        server=server,
+        callback=cb,
+        redirect_uri="http://127.0.0.1:0/callback",
+        verifier="verifier",
+        auth_url="http://auth.example.com",
+        expires_in=600,
+        opened=True,
+    )
+
+    with pytest.raises(AuthError, match="auth callback did not include a code"):
+        complete_browser_auth(start)


### PR DESCRIPTION
## Problem Context

The browser login flow serves its OAuth redirect from a single-threaded `HTTPServer` on the main thread.

Modern browsers open speculative preconnect TCP connections that carry no immediate request data. When `handle_request()` accepted an idle socket, `readline()` blocked indefinitely because `BaseHTTPRequestHandler.timeout` was not configured. This bypassed the 600-second deadline in `complete_browser_auth()`, leaving `browser-harness auth login` permanently hung.

Additionally, `do_GET` returned "Browser Use Cloud login complete" even when the state check failed or when the provider sent an OAuth error parameter.

## Why This Fix Is Needed

Users and unattended agents attempting `browser-harness auth login` experienced intermittent hangs.

Showing a success page on an authentication failure also misled users while the CLI reported failure.

## Changes

- Uses `ThreadingHTTPServer` with `daemon_threads = True` so idle sockets do not block incoming requests or process shutdown.
- Configures `timeout = 10` on the request handler to bound socket reads.
- Renders an error notice in HTML when `callback.error` is present.
- Sets `callback.complete = True` after the HTTP response is written.
- Adds `tests/unit/test_auth.py` covering successful OAuth, invalid state, provider errors, preconnect non-blocking behavior, and timeout conditions.

Fixes #691

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the OAuth callback server from hanging when a browser preconnect leaves an idle socket blocking the single-threaded server, and makes failures render an error page instead of a success page. This resolves the `browser-harness auth login` hang from #691.

**Bug Fixes**
- Switches to `ThreadingHTTPServer` with daemon threads and a 10-second socket read timeout.
- Serializes callback handling with a lock, validates that a code is present, and marks the callback complete only after the response is flushed.
- Renders an error notice in HTML when the callback contains an error.
- Adds unit tests covering successful OAuth, invalid state, provider errors, missing codes, duplicate requests, preconnect behavior, and timeouts.

<sup>Written for commit 8bc2019954615bdc1af65f5668ac15a0d5771f30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

