### PR TITLE
feat(helpers): support URL and title matching in switch_tab

### DIFF
--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -392,6 +392,14 @@ def _mark_tab():
     try: cdp("Runtime.evaluate", expression="if(!document.title.startsWith('\U0001F434'))document.title='\U0001F434 '+document.title")
     except Exception: pass
 
+def _is_target_id(val: str) -> bool:
+    if len(val) == 32 and all(c in "0123456789abcdefABCDEF" for c in val):
+        return True
+    if len(val) == 36 and val.count("-") == 4:
+        return all(c in "0123456789abcdefABCDEF-" for c in val)
+    return False
+
+
 def _target_id(target):
     """Accept a raw target id, a tab dict, or a URL/title substring."""
     if isinstance(target, dict):
@@ -403,6 +411,12 @@ def _target_id(target):
         query = target
 
     if not isinstance(query, str):
+        return query
+
+    if _is_target_id(query):
+        return query
+
+    if not query or not query.strip():
         return query
 
     try:

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -393,8 +393,37 @@ def _mark_tab():
     except Exception: pass
 
 def _target_id(target):
-    """Accept a raw target id or a tab dict returned by the helpers."""
-    return (target.get("targetId") or target.get("target_id")) if isinstance(target, dict) else target
+    """Accept a raw target id, a tab dict, or a URL/title substring."""
+    if isinstance(target, dict):
+        tid = target.get("targetId") or target.get("target_id")
+        if tid:
+            return tid
+        query = target.get("url") or target.get("title")
+    else:
+        query = target
+
+    if not isinstance(query, str):
+        return query
+
+    try:
+        tabs = list_tabs(include_chrome=True)
+    except Exception:
+        return query
+
+    for t in tabs:
+        if t.get("targetId") == query:
+            return query
+
+    query_lower = query.lower()
+    for t in tabs:
+        if query_lower in (t.get("url") or "").lower():
+            return t["targetId"]
+
+    for t in tabs:
+        if query_lower in (t.get("title") or "").lower():
+            return t["targetId"]
+
+    return query
 
 def activate_tab(target):
     """Make a target the visible Chrome tab.

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -473,6 +473,75 @@ def test_switch_tab_can_explicitly_activate_visible_tab(monkeypatch):
     assert ("Target.activateTarget", {"targetId": "target-new"}) in calls
 
 
+def test_switch_tab_matches_by_url_substring(monkeypatch):
+    calls = []
+    sample_tabs = [
+        {"targetId": "tab-1", "url": "https://example.com", "title": "Example Domain"},
+        {"targetId": "tab-2", "url": "https://github.com/browser-use/browser-harness", "title": "GitHub"},
+    ]
+    monkeypatch.setattr(helpers, "list_tabs", lambda include_chrome=True: sample_tabs)
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-{kwargs['targetId']}"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    sid = helpers.switch_tab("github.com")
+    assert sid == "session-tab-2"
+    assert ("Target.attachToTarget", {"targetId": "tab-2", "flatten": True}) in calls
+
+
+def test_switch_tab_matches_by_title_substring(monkeypatch):
+    calls = []
+    sample_tabs = [
+        {"targetId": "tab-1", "url": "https://example.com", "title": "Example Domain"},
+        {"targetId": "tab-2", "url": "https://github.com", "title": "Pull Requests - Repo"},
+    ]
+    monkeypatch.setattr(helpers, "list_tabs", lambda include_chrome=True: sample_tabs)
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-{kwargs['targetId']}"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    sid = helpers.switch_tab("pull requests")
+    assert sid == "session-tab-2"
+    assert ("Target.attachToTarget", {"targetId": "tab-2", "flatten": True}) in calls
+
+
+def test_switch_tab_matches_by_dict_query(monkeypatch):
+    calls = []
+    sample_tabs = [
+        {"targetId": "tab-1", "url": "https://example.com", "title": "Example Domain"},
+        {"targetId": "tab-2", "url": "https://docs.python.org", "title": "Python Docs"},
+    ]
+    monkeypatch.setattr(helpers, "list_tabs", lambda include_chrome=True: sample_tabs)
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-{kwargs['targetId']}"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    sid = helpers.switch_tab({"url": "docs.python.org"})
+    assert sid == "session-tab-2"
+    assert ("Target.attachToTarget", {"targetId": "tab-2", "flatten": True}) in calls
+
+
 def test_new_tab_creates_and_attaches_in_background(monkeypatch):
     calls = []
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -542,6 +542,52 @@ def test_switch_tab_matches_by_dict_query(monkeypatch):
     assert ("Target.attachToTarget", {"targetId": "tab-2", "flatten": True}) in calls
 
 
+def test_switch_tab_raw_target_id_avoids_list_tabs(monkeypatch):
+    calls = []
+    raw_id = "A" * 32
+
+    def forbidden_list_tabs(*args, **kwargs):
+        raise AssertionError("list_tabs should not be called for raw target IDs")
+
+    monkeypatch.setattr(helpers, "list_tabs", forbidden_list_tabs)
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-{kwargs['targetId']}"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    sid = helpers.switch_tab(raw_id)
+    assert sid == f"session-{raw_id}"
+    assert ("Target.attachToTarget", {"targetId": raw_id, "flatten": True}) in calls
+
+
+def test_switch_tab_empty_query_does_not_match_tabs(monkeypatch):
+    calls = []
+    sample_tabs = [
+        {"targetId": "tab-1", "url": "https://example.com", "title": "Example Domain"},
+    ]
+    monkeypatch.setattr(helpers, "list_tabs", lambda include_chrome=True: sample_tabs)
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.attachToTarget":
+            return {"sessionId": f"session-{kwargs['targetId']}"}
+        return {}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    sid = helpers.switch_tab("")
+    assert sid == "session-"
+    assert ("Target.attachToTarget", {"targetId": "", "flatten": True}) in calls
+
+
 def test_new_tab_creates_and_attaches_in_background(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Problem Context

`mcp_server.py:216` advertises `browser_switch_tab(target)` as:
`Switch to tab by targetId or URL substring.`

However, `helpers.py:_target_id` previously only extracted `targetId` from a dict or passed strings through as raw CDP target IDs.

Passing a URL substring (such as `switch_tab("github.com")`) or a title substring caused a CDP failure because Chrome treated the string as an invalid target ID.

## Why This Feature Is Needed

`SKILL.md` tells agents: *"Before opening another, inspect current_tab() and list_tabs() and use switch_tab() to reuse a matching tab."*

Allowing callers and agents to switch tabs by URL or title substring removes boilerplate manual loops over `list_tabs()`. It also delivers the contract advertised in the MCP server tool definition.

## Changes

- Enhances `_target_id()` in `src/browser_harness/helpers.py`.
- Checks exact `targetId` match first to maintain performance and compatibility.
- Matches case-insensitive substring on `url` second.
- Matches case-insensitive substring on `title` third.
- Falls back to returning the query string if no match is found or if `list_tabs()` cannot be queried.
- Adds unit tests in `tests/unit/test_helpers.py` covering URL substring matching, title substring matching, and dictionary query matching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows `switch_tab` to match tabs by URL or title substring, matching the MCP tool's advertised behavior. Previously only exact target IDs worked; now URL and title substrings are matched case-insensitively, with exact IDs prioritized.

**Details**
- Checks exact `targetId` first, then URL substring, then title substring, falling back to the raw query.
- Recognizes raw CDP target IDs to skip tab listing, and rejects empty or whitespace-only queries.
- Adds unit tests covering URL, title, dict query, raw ID bypass, and empty query matching.

<sup>Written for commit d449e7194085840fc2ab53b2b2750fe211c3cd09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

