### PR TITLE
feat(helpers): add wait_for_download helper and documentation

### DIFF
--- a/interaction-skills/downloads.md
+++ b/interaction-skills/downloads.md
@@ -1,3 +1,39 @@
 # Downloads
 
-Separate browser-triggered downloads from direct `http_get(...)` fetches, and document the minimal signals that prove a download actually started.
+## 1. When to Use `http_get(...)` vs Browser Downloads
+
+If a file has a direct, publicly accessible URL that does not require an active browser session or client-side JavaScript, use `http_get(url)` instead of driving the browser.
+
+When the download requires a logged-in session, form submission, dynamically generated blob, or button click inside the app, use `wait_for_download(...)`.
+
+## 2. Using `wait_for_download`
+
+`wait_for_download` configures `Browser.setDownloadBehavior`, triggers the download action, and waits for the completed file to appear on disk.
+
+```python
+# Click a download button and wait for the file to finish writing
+path = wait_for_download(lambda: click_at_xy(120, 340))
+print(f"Downloaded to {path}")
+```
+
+```python
+# Trigger download via DOM click
+path = wait_for_download(lambda: js("document.querySelector('button.export-csv').click()"))
+print(f"File size: {path.stat().st_size} bytes")
+```
+
+```python
+# Specify a custom download directory
+path = wait_for_download(
+    action_fn=lambda: click_at_xy(200, 150),
+    download_dir="/tmp/my-downloads",
+    timeout=60.0,
+)
+```
+
+## 3. How It Works
+
+1. Sets `Browser.setDownloadBehavior` with `behavior="allow"` and `eventsEnabled=True`.
+2. Runs the provided download action.
+3. Listens for `Browser.downloadWillBegin` and `Browser.downloadProgress` CDP events.
+4. Monitors the target directory to ensure temporary `.crdownload` files finish writing before returning.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, time, urllib.request
+import base64, importlib.util, json, math, os, secrets, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -632,33 +632,57 @@ def wait_for_download(action_fn=None, download_dir=None, timeout=30.0):
     and waits for the downloaded file to finish writing to disk. Returns the Path
     to the completed file.
     """
-    path = Path(download_dir) if download_dir else (ipc._TMP / "downloads")
+    path = Path(download_dir) if download_dir else (ipc._TMP / "downloads" / f"dl_{secrets.token_hex(8)}")
     path.mkdir(parents=True, exist_ok=True)
     before_files = {p.resolve() for p in path.iterdir()}
+    before_mtimes = {p.resolve(): p.stat().st_mtime for p in path.iterdir() if p.is_file()}
 
     cdp("Browser.setDownloadBehavior", behavior="allow", downloadPath=str(path.resolve()), eventsEnabled=True)
+    drain_events()
+
     if action_fn:
         action_fn()
 
     deadline = time.time() + timeout
     guid_filename = {}
     completed_guid = None
+    completed_filepath = {}
 
     while time.time() < deadline:
         for e in drain_events():
             method = e.get("method", "")
             params = e.get("params", {})
             if method == "Browser.downloadWillBegin":
-                guid_filename[params.get("guid")] = params.get("suggestedFilename")
+                guid = params.get("guid")
+                if guid:
+                    guid_filename[guid] = params.get("suggestedFilename")
             elif method == "Browser.downloadProgress":
-                if params.get("state") == "completed":
-                    completed_guid = params.get("guid")
-                elif params.get("state") == "canceled":
-                    name = guid_filename.get(params.get("guid")) or params.get("guid")
-                    raise RuntimeError(f"download was canceled: {name}")
+                guid = params.get("guid")
+                if guid and guid in guid_filename:
+                    if params.get("state") == "completed":
+                        completed_guid = guid
+                        if params.get("filePath"):
+                            completed_filepath[guid] = params.get("filePath")
+                    elif params.get("state") == "canceled":
+                        name = guid_filename.get(guid) or guid
+                        raise RuntimeError(f"download was canceled: {name}")
 
         if completed_guid and completed_guid in guid_filename:
-            target_file = path / guid_filename[completed_guid]
+            if completed_guid in completed_filepath:
+                target_file = Path(completed_filepath[completed_guid])
+            else:
+                suggested = guid_filename[completed_guid]
+                target_file = path / suggested
+                if target_file.resolve() in before_files:
+                    current_candidates = [
+                        p for p in path.iterdir()
+                        if p.is_file() and not p.name.endswith((".crdownload", ".tmp"))
+                    ]
+                    new_candidates = [p for p in current_candidates if p.resolve() not in before_files]
+                    if new_candidates:
+                        target_file = sorted(new_candidates, key=lambda f: f.stat().st_mtime, reverse=True)[0]
+                    elif target_file.exists() and target_file.stat().st_mtime > before_mtimes.get(target_file.resolve(), 0):
+                        pass
             if target_file.exists() and not target_file.name.endswith(".crdownload"):
                 return target_file
 
@@ -666,12 +690,12 @@ def wait_for_download(action_fn=None, download_dir=None, timeout=30.0):
         new_files = current_files - before_files
         finished = [
             f for f in new_files
-            if not f.name.endswith((".crdownload", ".tmp")) and f.is_file() and f.stat().st_size > 0
+            if not f.name.endswith((".crdownload", ".tmp")) and f.is_file()
         ]
         if finished:
             return sorted(finished, key=lambda f: f.stat().st_mtime, reverse=True)[0]
 
-        time.sleep(0.2)
+        time.sleep(0.1)
 
     raise TimeoutError(f"wait_for_download timed out after {timeout:g}s waiting in {path}")
 

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -625,6 +625,56 @@ def upload_file(selector, path):
     if not nid: raise RuntimeError(f"no element for {selector}")
     cdp("DOM.setFileInputFiles", files=[path] if isinstance(path, str) else list(path), nodeId=nid)
 
+def wait_for_download(action_fn=None, download_dir=None, timeout=30.0):
+    """Trigger a download and wait for it to complete.
+
+    Configures Browser.setDownloadBehavior, executes `action_fn()` if provided,
+    and waits for the downloaded file to finish writing to disk. Returns the Path
+    to the completed file.
+    """
+    path = Path(download_dir) if download_dir else (ipc._TMP / "downloads")
+    path.mkdir(parents=True, exist_ok=True)
+    before_files = {p.resolve() for p in path.iterdir()}
+
+    cdp("Browser.setDownloadBehavior", behavior="allow", downloadPath=str(path.resolve()), eventsEnabled=True)
+    if action_fn:
+        action_fn()
+
+    deadline = time.time() + timeout
+    guid_filename = {}
+    completed_guid = None
+
+    while time.time() < deadline:
+        for e in drain_events():
+            method = e.get("method", "")
+            params = e.get("params", {})
+            if method == "Browser.downloadWillBegin":
+                guid_filename[params.get("guid")] = params.get("suggestedFilename")
+            elif method == "Browser.downloadProgress":
+                if params.get("state") == "completed":
+                    completed_guid = params.get("guid")
+                elif params.get("state") == "canceled":
+                    name = guid_filename.get(params.get("guid")) or params.get("guid")
+                    raise RuntimeError(f"download was canceled: {name}")
+
+        if completed_guid and completed_guid in guid_filename:
+            target_file = path / guid_filename[completed_guid]
+            if target_file.exists() and not target_file.name.endswith(".crdownload"):
+                return target_file
+
+        current_files = {p.resolve() for p in path.iterdir()}
+        new_files = current_files - before_files
+        finished = [
+            f for f in new_files
+            if not f.name.endswith((".crdownload", ".tmp")) and f.is_file() and f.stat().st_size > 0
+        ]
+        if finished:
+            return sorted(finished, key=lambda f: f.stat().st_mtime, reverse=True)[0]
+
+        time.sleep(0.2)
+
+    raise TimeoutError(f"wait_for_download timed out after {timeout:g}s waiting in {path}")
+
 def http_get(url, headers=None, timeout=20.0):
     """Pure HTTP — no browser. Use for static pages / APIs. Wrap in ThreadPoolExecutor for bulk.
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -738,3 +738,69 @@ def test_js_keeps_base_exception_from_evaluation_when_detach_also_raises():
         KeyboardInterrupt, match="evaluation interrupted"
     ):
         helpers.js("7", target_id="iframe-target")
+
+
+# --- wait_for_download ---
+
+
+def test_wait_for_download_with_action_and_event(tmp_path, monkeypatch):
+    calls = []
+    events = [
+        {"method": "Browser.downloadWillBegin", "params": {"guid": "g1", "suggestedFilename": "report.pdf"}},
+        {"method": "Browser.downloadProgress", "params": {"guid": "g1", "state": "completed"}},
+    ]
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: calls.append((method, kwargs)) or {})
+    monkeypatch.setattr(helpers, "drain_events", lambda: events)
+
+    def write_download():
+        (tmp_path / "report.pdf").write_bytes(b"%PDF-1.4...")
+
+    result = helpers.wait_for_download(action_fn=write_download, download_dir=tmp_path, timeout=2.0)
+    assert result == tmp_path / "report.pdf"
+    assert ("Browser.setDownloadBehavior", {"behavior": "allow", "downloadPath": str(tmp_path.resolve()), "eventsEnabled": True}) in calls
+
+
+def test_wait_for_download_disk_polling(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
+    monkeypatch.setattr(helpers, "drain_events", lambda: [])
+
+    def create_file():
+        (tmp_path / "export.csv").write_text("a,b,c\n1,2,3\n")
+
+    result = helpers.wait_for_download(action_fn=create_file, download_dir=tmp_path, timeout=2.0)
+    assert result == tmp_path / "export.csv"
+
+
+def test_wait_for_download_ignores_crdownload_until_finished(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
+    monkeypatch.setattr(helpers, "drain_events", lambda: [])
+
+    cr = tmp_path / "data.zip.crdownload"
+
+    def start_and_finish():
+        cr.write_bytes(b"partial")
+        helpers.time.sleep(0.05)
+        cr.rename(tmp_path / "data.zip")
+
+    result = helpers.wait_for_download(action_fn=start_and_finish, download_dir=tmp_path, timeout=2.0)
+    assert result == tmp_path / "data.zip"
+
+
+def test_wait_for_download_canceled_raises(tmp_path, monkeypatch):
+    events = [
+        {"method": "Browser.downloadWillBegin", "params": {"guid": "g1", "suggestedFilename": "file.zip"}},
+        {"method": "Browser.downloadProgress", "params": {"guid": "g1", "state": "canceled"}},
+    ]
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
+    monkeypatch.setattr(helpers, "drain_events", lambda: events)
+
+    with pytest.raises(RuntimeError, match="download was canceled: file.zip"):
+        helpers.wait_for_download(download_dir=tmp_path, timeout=2.0)
+
+
+def test_wait_for_download_timeout_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
+    monkeypatch.setattr(helpers, "drain_events", lambda: [])
+
+    with pytest.raises(TimeoutError, match="wait_for_download timed out"):
+        helpers.wait_for_download(download_dir=tmp_path, timeout=0.1)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -777,12 +777,15 @@ def test_wait_for_download_ignores_crdownload_until_finished(tmp_path, monkeypat
 
     cr = tmp_path / "data.zip.crdownload"
 
-    def start_and_finish():
+    def start_and_finish_async():
         cr.write_bytes(b"partial")
-        helpers.time.sleep(0.05)
-        cr.rename(tmp_path / "data.zip")
+        def delayed_finish():
+            helpers.time.sleep(0.25)
+            cr.rename(tmp_path / "data.zip")
+        import threading
+        threading.Thread(target=delayed_finish, daemon=True).start()
 
-    result = helpers.wait_for_download(action_fn=start_and_finish, download_dir=tmp_path, timeout=2.0)
+    result = helpers.wait_for_download(action_fn=start_and_finish_async, download_dir=tmp_path, timeout=2.0)
     assert result == tmp_path / "data.zip"
 
 
@@ -791,11 +794,69 @@ def test_wait_for_download_canceled_raises(tmp_path, monkeypatch):
         {"method": "Browser.downloadWillBegin", "params": {"guid": "g1", "suggestedFilename": "file.zip"}},
         {"method": "Browser.downloadProgress", "params": {"guid": "g1", "state": "canceled"}},
     ]
+    call_count = 0
+    def fake_drain():
+        nonlocal call_count
+        call_count += 1
+        return [] if call_count == 1 else events
+
     monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
-    monkeypatch.setattr(helpers, "drain_events", lambda: events)
+    monkeypatch.setattr(helpers, "drain_events", fake_drain)
 
     with pytest.raises(RuntimeError, match="download was canceled: file.zip"):
         helpers.wait_for_download(download_dir=tmp_path, timeout=2.0)
+
+
+def test_wait_for_download_empty_file_succeeds(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
+    monkeypatch.setattr(helpers, "drain_events", lambda: [])
+
+    def create_empty_file():
+        (tmp_path / "empty.txt").write_bytes(b"")
+
+    result = helpers.wait_for_download(action_fn=create_empty_file, download_dir=tmp_path, timeout=2.0)
+    assert result == tmp_path / "empty.txt"
+
+
+def test_wait_for_download_uses_filepath_from_event(tmp_path, monkeypatch):
+    custom_file = tmp_path / "custom_downloaded.bin"
+    custom_file.write_bytes(b"hello")
+
+    events = [
+        {"method": "Browser.downloadWillBegin", "params": {"guid": "g1", "suggestedFilename": "file.bin"}},
+        {"method": "Browser.downloadProgress", "params": {"guid": "g1", "state": "completed", "filePath": str(custom_file)}},
+    ]
+    call_count = 0
+    def fake_drain():
+        nonlocal call_count
+        call_count += 1
+        return [] if call_count == 1 else events
+
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
+    monkeypatch.setattr(helpers, "drain_events", fake_drain)
+
+    result = helpers.wait_for_download(download_dir=tmp_path, timeout=2.0)
+    assert result == custom_file
+
+
+def test_wait_for_download_ignores_untracked_guid_cancellation(tmp_path, monkeypatch):
+    events = [
+        {"method": "Browser.downloadProgress", "params": {"guid": "untracked-guid", "state": "canceled"}},
+    ]
+    call_count = 0
+    def fake_drain():
+        nonlocal call_count
+        call_count += 1
+        return [] if call_count == 1 else events
+
+    monkeypatch.setattr(helpers, "cdp", lambda method, **kwargs: {})
+    monkeypatch.setattr(helpers, "drain_events", fake_drain)
+
+    def create_file():
+        (tmp_path / "done.txt").write_text("ok")
+
+    result = helpers.wait_for_download(action_fn=create_file, download_dir=tmp_path, timeout=2.0)
+    assert result == tmp_path / "done.txt"
 
 
 def test_wait_for_download_timeout_raises(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem Context

Downloading files through browser interaction currently requires extensive boilerplate code across agent scripts.

Agents have to manually call `Browser.setDownloadBehavior`, create unique folders, poll for files, and check for incomplete `.crdownload` temporary files. `interaction-skills/downloads.md` was previously a four-line stub noting this gap.

## Why This Feature Is Needed

File downloads are a core browser automation task (e.g. exporting reports, CSVs, PDFs, and invoices).

Providing a clean `wait_for_download(action_fn, download_dir, timeout)` helper eliminates repetitive boilerplate. It ensures downloads settle properly on disk before caller execution proceeds.

## Changes

- Adds `wait_for_download(action_fn=None, download_dir=None, timeout=30.0)` to `src/browser_harness/helpers.py`.
- Configures `Browser.setDownloadBehavior` with `behavior="allow"` and `eventsEnabled=True`.
- Tracks `Browser.downloadWillBegin` and `Browser.downloadProgress` CDP events.
- Handles cancellation cleanly by raising `RuntimeError` if Chrome reports the download was canceled.
- Watches directory changes and ensures temporary `.crdownload` / `.tmp` files are ignored until complete.
- Expands `interaction-skills/downloads.md` with usage instructions and best practices.
- Adds comprehensive unit tests in `tests/unit/test_helpers.py`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `wait_for_download(action_fn, download_dir, timeout)` helper so agent scripts no longer need to manually configure `Browser.setDownloadBehavior`, poll the download directory, and track incomplete `.crdownload` files. It runs the download action, waits for the file to finish writing (including empty files), and returns its `Path`.

- Raises `RuntimeError` when a tracked download is canceled and `TimeoutError` if the file doesn't appear within the timeout; ignores cancellation events for untracked downloads.
- Expands `interaction-skills/downloads.md` with usage examples and guidance on preferring `http_get` for directly accessible URLs.
- Adds unit tests covering event-based completion, disk polling, temp-file/empty-file handling, cancellation, and timeouts.

<sup>Written for commit fa7089b41376dfca09370a4cc963ff36dc17cc01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

