### PR TITLE
fix(mcp): report browser failures as tool errors

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -8,7 +8,7 @@ Run:
 
 The server starts on stdio and exposes one MCP tool per browser-harness
 helper. Each tool ensures the daemon is running, calls the existing helper,
-and returns JSON text. Errors are caught and returned as {"error": ...}.
+and returns JSON text. Helper failures use MCP's tool-error channel.
 """
 import functools
 import json
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from mcp.server import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from PIL import Image
 
 from browser_harness.admin import ensure_daemon
@@ -115,8 +116,8 @@ def _stderr_stdout():
 def _tool(fn):
     """Wrap a helper so it is exposed as an MCP tool and returns JSON text.
 
-    Ensures the daemon is up, runs the helper, catches exceptions (including
-    daemon startup failures), and always returns a JSON string. Tool name and
+    Ensures the daemon is up, runs the helper, and converts operational failures
+    (including daemon startup failures) into MCP tool errors. Tool name and
     description are taken from the wrapped function so the schema matches the
     parameter annotations.
     """
@@ -128,8 +129,8 @@ def _tool(fn):
             with _stderr_stdout():
                 result = fn(*args, **kwargs)
             return _dump(result)
-        except Exception as exc:  # noqa: BLE001 -- MCP tools must serialize arbitrary browser failures.
-            return _dump({"error": str(exc)})
+        except Exception as exc:  # noqa: BLE001 -- browser failures must reach the MCP client.
+            raise ToolError(str(exc)) from exc
 
     return SERVER.tool(name=fn.__name__, description=fn.__doc__ or "")(wrapper)
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp_types import CallToolRequestParams
+
+import mcp_server
+
+
+def _call_tool(name: str):
+    params = CallToolRequestParams(name=name, arguments={})
+    return asyncio.run(mcp_server.SERVER._handle_call_tool(None, params))
+
+
+def test_helper_failure_uses_mcp_tool_error(monkeypatch):
+    monkeypatch.setattr(mcp_server, "ensure_daemon", lambda: None)
+
+    def fail():
+        raise RuntimeError("sentinel browser failure")
+
+    monkeypatch.setattr(mcp_server, "page_info", fail)
+
+    result = _call_tool("browser_page_info")
+
+    assert result.is_error is True
+    assert result.content[0].text == "Error executing tool browser_page_info: sentinel browser failure"
+
+
+def test_helper_success_remains_a_normal_tool_result(monkeypatch):
+    monkeypatch.setattr(mcp_server, "ensure_daemon", lambda: None)
+    monkeypatch.setattr(mcp_server, "page_info", lambda: {"url": "https://example.com"})
+
+    result = _call_tool("browser_page_info")
+
+    assert result.is_error is False
+    assert result.content[0].text == '{"url": "https://example.com"}'


### PR DESCRIPTION
## Problem

The MCP wrapper catches every browser helper exception and returns `{"error": "..."}` as ordinary text. MCP therefore sets `isError: false`, so clients can record a failed click, navigation, or daemon start as a successful tool call.

## Fix

- raise MCP's typed `ToolError` for helper and daemon failures
- keep successful helper output unchanged
- cover both paths at the actual MCP request handler boundary

## Red/green proof

The same in-process MCP request with a failing `browser_page_info` helper returned:

```json
{"content":[{"type":"text","text":"{\"error\": \"sentinel browser failure\"}"}],"isError":false}
```

It now returns:

```json
{"content":[{"type":"text","text":"Error executing tool browser_page_info: sentinel browser failure"}],"isError":true}
```

## Verification

- `uv run --extra mcp --with pytest python -m pytest tests/unit -q` — 253 passed
- `uv build` — source distribution and wheel built
- `git diff --check` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP tool calls now mark browser helper and daemon failures as tool errors, so clients no longer record failed actions as successful calls.

**Bug Fixes**
- Raises `ToolError` from the tool wrapper for helper and daemon startup failures instead of returning `{"error": ...}` text.
- Successful helper output is unchanged.
- Covers both failure and success paths with request-handler boundary tests.

<sup>Written for commit d5dbf185af59c7c153b54a0226d6b03ec9ac2af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

