### PR TITLE
fix: close health check socket in ensure_daemon

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -533,8 +533,11 @@ def ensure_daemon(wait=None, name=None, env=None):
         for last in (False, True):
             try:
                 s, token = ipc.connect(name or NAME, timeout=3.0)
-                resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
-                if "result" in resp: return
+                try:
+                    resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
+                    if "result" in resp: return
+                finally:
+                    s.close()
             except Exception:
                 pass
             if not last: time.sleep(0.5)

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1383,3 +1383,24 @@ def test_restart_daemon_does_not_cancel_successor_generation(tmp_path, monkeypat
         admin_mod.restart_daemon("pending")
 
     assert pid_file.exists()
+
+
+def test_ensure_daemon_closes_health_check_socket_on_success_and_retry(monkeypatch):
+    from unittest.mock import MagicMock
+    from browser_harness import admin as admin_mod
+
+    sock1 = MagicMock()
+    sock2 = MagicMock()
+    sockets = [sock1, sock2]
+
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: True)
+    monkeypatch.setattr(admin_mod.ipc, "connect", lambda name, timeout=3.0: (sockets.pop(0), "tok"))
+    responses = iter([{"error": "probe failed"}, {"result": {}}])
+    monkeypatch.setattr(admin_mod.ipc, "request", lambda s, tok, req: next(responses))
+    monkeypatch.setattr(admin_mod.time, "sleep", lambda s: None)
+
+    admin_mod.ensure_daemon()
+
+    assert sock1.close.call_count == 1
+    assert sock2.close.call_count == 1
+


### PR DESCRIPTION
## Problem

`ensure_daemon()` opens a probe socket via `ipc.connect()` to check whether a daemon is already running. The socket was never closed. On the success branch it returned early, and on failure it fell through to the retry loop. Either path leaked one file descriptor per attempt.

Any long-lived agent or script that calls the harness repeatedly accumulates sockets.

## Fix

Wrap `ipc.request()` in a `try/finally` so the socket is closed on success, on failure, and on exception. This matches the smallest-diff preference in AGENTS.md and mirrors existing `try/finally` usage in `admin.py`.

## Testing

- Added `test_ensure_daemon_closes_health_check_socket_on_success_and_retry`: asserts sockets are closed both when the health check succeeds immediately and across a failed attempt plus retry.
- Full unit suite: `uv run --with pytest python -m pytest tests/unit -q` -> 252 passed.
- `./browser-harness --doctor` runs cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a file descriptor leak in `ensure_daemon()` where the health check probe socket from `ipc.connect()` was never closed on success, failure, or exception, so repeated calls accumulated sockets.

**Testing**
- Added a unit test asserting the socket closes on immediate success and on a failed attempt plus retry.

<sup>Written for commit 1f14ba8d53127448c1b7c5213bc3919a7e284eed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

