### PR TITLE
fix: reject non-object auth.json with AuthError

### DIFF
--- a/src/browser_harness/auth.py
+++ b/src/browser_harness/auth.py
@@ -133,11 +133,14 @@ def auth_path() -> Path:
 def load_auth_file(path: Path | None = None) -> dict:
     path = path or auth_path()
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}
     except (json.JSONDecodeError, UnicodeDecodeError) as e:
         raise AuthError(f"auth file is not valid JSON: {path}") from e
+    if not isinstance(data, dict):
+        raise AuthError(f"auth file must contain a JSON object: {path}")
+    return data
 
 
 def save_auth_record(record: AuthRecord, path: Path | None = None) -> None:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+
+from browser_harness import auth
+
+
+@pytest.mark.parametrize("raw", ["[]", "null", '"token"', "123"])
+def test_load_auth_file_rejects_non_object_json(tmp_path, raw):
+    path = tmp_path / "auth.json"
+    path.write_text(raw, encoding="utf-8")
+    with pytest.raises(auth.AuthError):
+        auth.load_auth_file(path)
+
+
+def test_load_auth_file_accepts_object_and_missing(tmp_path):
+    path = tmp_path / "auth.json"
+    assert auth.load_auth_file(path) == {}
+    path.write_text(json.dumps({"browser_use": {"api_key": "k"}}), encoding="utf-8")
+    assert auth.load_auth_file(path) == {"browser_use": {"api_key": "k"}}
+
+
+def test_stored_auth_record_rejects_non_object_json(tmp_path):
+    path = tmp_path / "auth.json"
+    path.write_text("[]", encoding="utf-8")
+    with pytest.raises(auth.AuthError):
+        auth.stored_auth_record(path)
+
+
+def test_clear_auth_rejects_non_object_json(tmp_path):
+    path = tmp_path / "auth.json"
+    path.write_text("null", encoding="utf-8")
+    with pytest.raises(auth.AuthError):
+        auth.clear_auth(path)


### PR DESCRIPTION
## Problem

`load_auth_file()` returns `json.loads(...)` directly. If `auth.json` contains valid JSON that is not an object (`[]`, `"token"`, `null`, `123`), callers crash with unhandled `AttributeError` or `TypeError`:

- `stored_auth_record()` calls `.get()` on the parsed value.
- `clear_auth()` calls `.get()` and `.pop()`.
- `save_auth_record()` assigns `` existing["browser_use"] ``.

Users get a raw traceback instead of a controlled error.

## Fix

`load_auth_file()` now raises `AuthError` when the parsed JSON is not a dict:

```
AuthError: auth file must contain a JSON object: /path/to/auth.json
```

This uses a slightly different message than the malformed-JSON case (`auth file is not valid JSON`) because the file is valid JSON, just not an object. All existing call sites already catch `AuthError` (e.g. `run.py` `_cloud_auth_configured()`) or broad `Exception`.

## Testing

- New `tests/unit/test_auth.py` covers:
  - `load_auth_file()` raises `AuthError` for `[]`, `null`, `"token"`, and `123`.
  - `load_auth_file()` still returns `{}` for a missing file and the parsed dict for a normal file.
  - `stored_auth_record()` and `clear_auth()` raise `AuthError` instead of `AttributeError`/`TypeError`.
- Full unit suite: `uv run --with pytest python -m pytest tests/unit -q` -> 258 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `load_auth_file()` raise `AuthError` when `auth.json` contains valid JSON that is not an object, so callers like `stored_auth_record()` and `clear_auth()` no longer crash with `AttributeError` or `TypeError`.

- Non-object JSON values (`[]`, `null`, `"token"`, `123`) now fail with `AuthError` instead of a raw traceback.
- Adds unit tests for those cases; missing files and normal objects still behave as before.

<sup>Written for commit ba6fbbfed604ca56fca72bc6f774951e1c8c894d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

