### PR TITLE
fix: reject unknown flags after --update

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -362,8 +362,11 @@ def _run(args):
 
         sys.exit(video.run_cli(args[1:]))
     if args and args[0] == "--update":
-        yes = any(a in {"-y", "--yes"} for a in args[1:])
-        sys.exit(run_update(yes=yes))
+        rest = args[1:]
+        if not set(rest).issubset({"-y", "--yes"}):
+            print("usage: browser-harness --update [-y|--yes]", file=sys.stderr)
+            sys.exit(2)
+        sys.exit(run_update(yes=bool(rest)))
     if args and args[0] == "--reload":
         restart_daemon()
         print("daemon stopped — will restart fresh on next call")

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -276,3 +276,26 @@ def test_cli_doctor_rejects_unknown_flags():
             run.main()
     assert ei.value.code == 2
     assert "usage" in err.getvalue().lower()
+
+
+def test_cli_update_rejects_unknown_flags():
+    err = StringIO()
+    with patch.object(sys, "argv", ["browser-harness", "--update", "--bogus"]), \
+         patch("sys.stderr", err), \
+         patch("browser_harness.run.run_update") as m:
+        with pytest.raises(SystemExit) as ei:
+            run.main()
+    assert ei.value.code == 2
+    assert "usage" in err.getvalue().lower()
+    m.assert_not_called()
+
+
+@pytest.mark.parametrize("flag,expected_yes", [(None, False), ("-y", True), ("--yes", True)])
+def test_cli_update_forwards_yes_flag(flag, expected_yes):
+    argv = ["browser-harness", "--update"] + ([flag] if flag else [])
+    with patch.object(sys, "argv", argv), \
+         patch("browser_harness.run.run_update", return_value=0) as m:
+        with pytest.raises(SystemExit) as ei:
+            run.main()
+    assert ei.value.code == 0
+    m.assert_called_once_with(yes=expected_yes)


### PR DESCRIPTION
## Problem

`browser-harness --update --invalid-flag` silently ignored the unknown flag and ran the updater. Every other subcommand with flags (`doctor`, `skill`, `recordings`) prints a usage line and exits 2 on unexpected arguments.

This is also a footgun: a mistyped command like `browser-harness --update --force` would start an update instead of failing fast.

## Fix

Validate that arguments after `--update` are only `-y`/`--yes`. Anything else prints `usage: browser-harness --update [-y|--yes]` to stderr and exits 2, matching the existing `doctor`/`recordings` pattern.

`yes` becomes `bool(rest)`, which is equivalent to the old `any(...)` now that `rest` is guaranteed to contain only yes flags.

## Testing

- `test_cli_update_rejects_unknown_flags`: `--update --bogus` exits 2, prints usage, and does not call `run_update()`.
- `test_cli_update_forwards_yes_flag`: bare `--update`, `-y`, and `--yes` still call `run_update()` with the right `yes` value.
- Full unit suite: `uv run --with pytest python -m pytest tests/unit -q` -> 255 passed.
- Manual: `./browser-harness --update --bogus` prints the usage line and exits 2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `browser-harness --update` fail fast on unknown flags instead of silently ignoring them and running the updater. It now prints a usage line and exits 2 on unexpected arguments, matching the `doctor` and `recordings` behavior.

- Arguments after `--update` are now validated to be only `-y`/`--yes`; anything else exits 2 without calling `run_update()`.
- Bare `--update`, `-y`, and `--yes` still call `run_update()` with the correct `yes` value.

<sup>Written for commit 07db27ba36905ecc162b4baca09db0a0f438a5b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

