### PR TITLE
fix: download webm export next to the requested output

### DIFF
--- a/src/browser_harness/video_render.py
+++ b/src/browser_harness/video_render.py
@@ -332,7 +332,8 @@ def review(recording: Path) -> int:
 
 
 def _start_export(recording: Path, url: str, webm: Path) -> dict:
-    payload = {"url": url, "downloadPath": str(recording), "filename": webm.name, "marker": MARKER}
+    webm.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"url": url, "downloadPath": str(webm.parent.resolve()), "filename": webm.name, "marker": MARKER}
     filename_js = json.dumps(webm.name)
     code = f"""
 import json, time

--- a/tests/unit/test_video_render.py
+++ b/tests/unit/test_video_render.py
@@ -1,0 +1,22 @@
+import json
+
+from browser_harness import video_render
+
+
+def test_start_export_downloads_into_webm_directory(tmp_path, monkeypatch):
+    recording = tmp_path / "recording"
+    recording.mkdir()
+    webm = tmp_path / "exports" / "video.webm"
+    captured = {}
+
+    def fake_run_harness(code, timeout=30):
+        captured["code"] = code
+        return {"preflight": {}, "clicks": [], "started": True}
+
+    monkeypatch.setattr(video_render, "run_harness", fake_run_harness)
+
+    video_render._start_export(recording, "http://127.0.0.1:9/video.html", webm)
+
+    assert webm.parent.is_dir()
+    assert str(webm.parent.resolve()) in captured["code"]
+    assert json.dumps(webm.name) in captured["code"]


### PR DESCRIPTION
## Problem

`export()` resolves `--output` and polls for `output.with_suffix('.webm')` (`video_render.py:440-445`). But `_start_export()` always configured Chrome with `downloadPath=str(recording)` and only passed `webm.name` as the filename.

For any `--output` that is not a bare filename in the recording directory:

- `--output exports/video.mp4` downloads the webm to `recording/video.webm`, while `export()` polls `recording/exports/video.webm`.
- An absolute `--output /elsewhere/video.mp4` behaves the same.

The poll times out and the export fails. Nested output also targeted a directory that was never created, so Chrome could not write there anyway.

## Fix

In `_start_export()`:

- `webm.parent.mkdir(parents=True, exist_ok=True)` before the download starts. This also covers the later ffmpeg conversion, which writes the mp4 into the same parent.
- `downloadPath=str(webm.parent.resolve())` so Chrome writes exactly where `export()` polls. `.resolve()` keeps the path absolute even if a caller passes a relative recording path.

The default case (bare filename) is unchanged: `webm.parent` equals the recording directory, which the CLI already resolves to an absolute path (`video.py:729`).

## Testing

- New `tests/unit/test_video_render.py`: pins the `_start_export()` contract via a stubbed `run_harness()`. Asserts the webm parent directory is created and the generated script's `downloadPath` points at it, with a nested output path that fails under the old code.
- Full unit suite: `uv run --with pytest python -m pytest tests/unit -q` -> 252 passed.

A full end-to-end export needs a live recording, Chrome, and ffmpeg, so it stays out of unit scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `export()` failing for `--output` paths that aren't bare filenames in the recording directory. Chrome now downloads the webm next to the requested output, so the poll for `output.with_suffix('.webm')` finds it instead of timing out.

**Bug Fixes**
- Creates the webm parent directory before the download starts, covering nested paths and the later ffmpeg conversion.
- Bare filename outputs behave as before.
- Adds a unit test pinning the `_start_export()` contract with a stubbed harness; full suite is 252 passed.

<sup>Written for commit 83e9ecd19f82e51afd2d3c675197271eae7a4ed3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

