### PR TITLE
fix: mask helper arguments in telemetry step trace

### DIFF
--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -149,7 +149,14 @@ _helper_call_count = 0
 
 
 def _step_args(args, kwargs):
-    parts = [repr(a) for a in args] + [f"{k}={v!r}" for k, v in kwargs.items()]
+    # steps reach PostHog verbatim (capture_cli_event bypasses _safe_properties),
+    # so only trivially safe scalars are kept; strings/containers become placeholders
+    def safe(value):
+        if value is None or isinstance(value, (int, float)):
+            return repr(value)
+        return f"<{type(value).__name__}>"
+
+    parts = [safe(a) for a in args] + [f"{k}={safe(v)}" for k, v in kwargs.items()]
     return ", ".join(parts)[:_MAX_STEP_ARGS_LENGTH]
 
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -276,3 +276,22 @@ def test_cli_doctor_rejects_unknown_flags():
             run.main()
     assert ei.value.code == 2
     assert "usage" in err.getvalue().lower()
+
+
+def test_step_args_masks_sensitive_values():
+    assert run._step_args(("#user", "hunter2"), {}) == "<str>, <str>"
+    assert run._step_args((), {"text": "secret-token"}) == "text=<str>"
+    assert run._step_args(({"token": "x"},), {}) == "<dict>"
+    assert run._step_args((0.5, None, True), {}) == "0.5, None, True"
+
+
+def test_traced_helper_records_masked_args(monkeypatch):
+    monkeypatch.setattr(run.recorder, "observe", lambda *a, **k: None)
+    run._helper_trace.clear()
+
+    def fill_input(selector, text):
+        return "ok"
+
+    traced = run._traced("fill_input", fill_input)
+    assert traced("#user", "hunter2") == "ok"
+    assert run._helper_trace[-1]["args"] == "<str>, <str>"


### PR DESCRIPTION
## Problem

`_step_args()` stored the raw `repr()` of every traced helper argument, and `capture_cli_event()` puts `steps` into the PostHog payload directly (`telemetry.py:285`) without passing it through `_safe_properties()`.

So this agent script:

```python
fill_input('#password', 'hunter2')
type_text('sk-live-...')
```

sent `"args": "'#password', 'hunter2'`` and the raw token to PostHog. `FORBIDDEN_KEYS` never applied, because `steps` is a nested list of dicts, not a flat properties dict.

## Fix

Mask values at the single source (`_step_args()` in `run.py`), so sensitive strings never enter the trace buffer at all:

- `None`, `int`, `float` keep their `repr()` (e.g. `wait(0.5)` stays useful).
- Every other value becomes a type placeholder: `fill_input(<str>, <str>)`, `cdp(<str>, params=<dict>)`.

The trace still shows which helpers ran, in what order, with what arity and scalar arguments, which is the signal telemetry needs. Fixed at the source rather than adding a nested sanitizer in `telemetry.py` because `run.py` is the only producer of `steps`, and one choke point keeps the guarantee: nothing sensitive is ever stored, let alone sent.

Note the local session `recorder.observe()` still receives raw args by design; that is local-only storage and unchanged here.

## Testing

- `test_step_args_masks_sensitive_values`: strings, dicts, and kwarg values are masked; numbers, `None`, and bools keep their repr.
- `test_traced_helper_records_masked_args`: a traced helper call records a masked `args` string in the step trace.
- Full unit suite: `uv run --with pytest python -m pytest tests/unit -q` -> 253 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sensitive helper arguments (passwords, tokens) from leaking to PostHog in telemetry step traces. Previously `_step_args()` stored raw `repr()` values that went out verbatim; now only `None`, `int`, and `float` keep their representation, and everything else becomes a type placeholder like `<str>` or `<dict>`.

**Side effects**
- Local session recording still receives raw arguments; that path is unchanged.

<sup>Written for commit e7eeeaa760b483f2ab19952fc97e119dd71c1945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

