### PR TITLE
Prevent agents from automatically foregrounding Chrome

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -37,8 +37,9 @@ PY
   or closing it could discard unsaved work or other important state.
 - `new_tab()` and `switch_tab()` attach and move the horse marker without
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
-  background; call `activate_tab(target)` only when the user explicitly asks
-  or a page demonstrably pauses rendering while hidden.
+  background. Never call `activate_tab(target)` automatically: it brings Chrome
+  to the foreground. Call it only when the user explicitly asks to see or
+  visibly switch to that tab. Do not pair `switch_tab()` with `activate_tab()`.
 - A local daemon is a connection to the whole Chrome instance, not to one site,
   task, card, or agent. Omit `BU_NAME` and reuse the default daemon for normal
   sequential local work across websites, tabs, screenshots, and Codex turns.
@@ -47,11 +48,13 @@ PY
   another Allow prompt.
 - Set `BH_TAB_MARKER=0` before starting the daemon to leave page titles unchanged.
   The horse marker remains enabled by default.
-- A timed-out `scroll(...)` on an attached background tab is evidence that the
-  page needs to be visible. Call `activate_tab(current_tab())`, retry the same
-  scroll once, then re-read the scroll position. This visibly switches tabs,
-  so do not use it when the user has forbidden foreground changes. Do not
-  invent a `Runtime.evaluate` scroll replacement or a cross-frame JS walker.
+- A timeout or page that pauses while hidden is not permission to foreground
+  Chrome. Keep using background CDP operations. For a focus-gated page,
+  temporarily call `cdp("Emulation.setFocusEmulationEnabled", enabled=True)`,
+  perform and verify the operation, then disable it in a `finally` block. If
+  background control still cannot work, report that limitation instead of
+  activating the tab. Do not invent a `Runtime.evaluate` scroll replacement or
+  a cross-frame JS walker.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -4,7 +4,7 @@
 
 When Chrome opens fresh, the only CDP `type: "page"` targets are `chrome://inspect` and `chrome://omnibox-popup.top-chrome/` (a 1px invisible viewport). If the daemon attaches to the omnibox popup, all subsequent work — including `new_tab()` and `goto_url()` — happens on tabs that exist in CDP but may not be visible in the Chrome UI.
 
-The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` to attach to the real tab; call `activate_tab()` only when Chrome must visibly show it.
+The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` to attach to the real tab. Call `activate_tab()` only when the user explicitly asks Chrome to visibly show it.
 
 ## Startup sequence
 
@@ -12,7 +12,7 @@ The daemon's `attach_first_page()` handles this by creating an `about:blank` tab
 2. If stale sockets exist but daemon is dead, clean them up
 3. List open tabs with `list_tabs()` to see what's available
 4. `ensure_real_tab()` attaches to a real page
-5. `switch_tab(target_id)` attaches without changing the visible Chrome tab; use `activate_tab(target_id)` for an explicit visible switch
+5. `switch_tab(target_id)` attaches without changing the visible Chrome tab; use `activate_tab(target_id)` only for a user-requested visible switch
 
 ```python
 if not daemon_alive():

--- a/interaction-skills/scrolling.md
+++ b/interaction-skills/scrolling.md
@@ -8,12 +8,15 @@ Start with the normal `scroll(...)` helper. Chrome on Windows can leave a
 mouse-wheel command unanswered when the attached tab is not visible. If that
 scroll times out:
 
-1. Call `activate_tab(current_tab())` so Chrome shows the attached tab.
-2. Retry the same `scroll(...)` once.
-3. Re-read the page or container scroll position before continuing.
+1. Do not call `activate_tab()`; a timeout is not permission to foreground
+   Chrome.
+2. Temporarily call
+   `cdp("Emulation.setFocusEmulationEnabled", enabled=True)`, retry the same
+   `scroll(...)` once, and re-read the page or container scroll position.
+3. Disable focus emulation in a `finally` block.
 
-The activation is visible to the user, so it is a fallback after a proven
-timeout, not the default. If the user has forbidden visible tab changes, stop
-and name that exact limitation instead. Do not replace wheel input with custom
-`Runtime.evaluate` scrolling or a cross-frame JavaScript walker; those paths
-change page semantics and require context the agent does not have.
+If background scrolling still fails, stop and name that exact limitation.
+Call `activate_tab()` only when the user explicitly asks to see or visibly
+switch to the tab. Do not replace wheel input with custom `Runtime.evaluate`
+scrolling or a cross-frame JavaScript walker; those paths change page semantics
+and require context the agent does not have.

--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -63,7 +63,9 @@ Typical tools:
 
 - `switch_tab()` intentionally does **not** change Chrome's visible tab.
 - Static screenshots and normal CDP input work on the attached background tab.
-- `activate_tab()` is the explicit opt-in for visibility-dependent rendering or a user-requested visible switch.
+- `activate_tab()` is only for a user-requested visible switch. Rendering or
+  input trouble is not permission to foreground Chrome; use background CDP and
+  temporary focus emulation first.
 - `Target.activateTarget` is the CDP-side "show this tab".
 - `list_tabs()` includes `chrome://newtab/` by default; ask for `include_chrome=False` when you want only real pages.
 - `chrome://omnibox-popup.top-chrome/` can appear as a fake page target; ignore it for user-facing tab lists.


### PR DESCRIPTION
## Summary
- reserve `activate_tab()` for explicit user requests
- prohibit pairing background `switch_tab()` with foreground activation
- use temporary CDP focus emulation for focus-gated pages and hidden-tab scrolling

## Validation
- skill validator passed
- `uv run --with pytest python -m pytest tests/unit -q` — 251 passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts `activate_tab()` to explicit user requests so agents no longer automatically bring Chrome to the foreground. Timeouts and pages that pause while hidden are no longer treated as permission to switch the visible tab.

- Focus-gated pages and hidden-tab scroll timeouts now use temporary CDP focus emulation (`Emulation.setFocusEmulationEnabled`) instead.
- Agents must disable focus emulation in a `finally` block and report the limitation if background control still fails.
- Prohibits pairing `switch_tab()` with `activate_tab()`.

<sup>Written for commit 5c5fedf93854a47bd1b2960e5da330d98984cb4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

