### PR TITLE
Share one persistent browser connection across concurrent agent tabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@ From a **git checkout** (no global install required for local testing):
 # doctor — install/daemon/browser state
 ./browser-harness --doctor
 
-# smoke — CDP attach + page_info (Chrome remote debugging must be allowed)
+# smoke — CDP attach + tab listing (Chrome remote debugging must be allowed)
 ./browser-harness <<'PY'
-print(page_info())
+print(list_tabs())
 PY
 
 # unit tests (no live browser)

--- a/SKILL.md
+++ b/SKILL.md
@@ -25,13 +25,12 @@ PY
 
 - Invoke as `browser-harness`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
-- First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
-  preserves the attached tab across separate CLI invocations, so do not call
-  `new_tab()` again in every script.
-- Keep one working tab per task/site. Before opening another, inspect
-  `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
-  tab. Do not leave duplicate tabs on the same URL or close tabs you did not
-  create.
+- First navigation for a task is `target_id = new_tab(url)`, not
+  `goto_url(url)`. Print and remember that target ID. At the start of each later
+  CLI invocation, call `switch_tab(target_id)`; do not call `new_tab()` again.
+- Reuse this task's working tabs with `switch_tab()`. Separate concurrent tasks
+  may need separate tabs on the same URL; a matching URL alone is not proof
+  that a tab is yours. Do not close tabs you did not create.
 - At task completion, close tabs created for the task that are no longer needed.
   Keep a tab open if the user needs to see it, it is needed for a known follow-up,
   or closing it could discard unsaved work or other important state.
@@ -42,7 +41,7 @@ PY
   visibly switch to that tab. Do not pair `switch_tab()` with `activate_tab()`.
 - A local daemon is a connection to the whole Chrome instance, not to one site,
   task, card, or agent. Omit `BU_NAME` and reuse the default daemon for normal
-  sequential local work across websites, tabs, screenshots, and Codex turns.
+  sequential or concurrent local work across websites, tabs, and agent turns.
   Do not invent per-job names such as `gmail1375` or `slack1371`: every new
   local daemon opens another browser-level CDP connection and Chrome may show
   another Allow prompt.
@@ -61,23 +60,47 @@ PY
 
 The default daemon can keep many tabs and visit many sites; browser-harness has
 no per-site, screenshot, or result-count limit that requires a new daemon.
-Chrome memory and page complexity are the practical limits. Reuse matching tabs
-with `list_tabs()` and `switch_tab()`.
+Chrome memory and page complexity are the practical limits. Reuse your task's
+tabs; a matching URL alone does not mean a tab belongs to your task.
 
-One daemon has one mutable attached/current tab. Many agents can share it when
-their browser operations are serialized: treat local Chrome as one shared
-browser lane while non-browser work continues in parallel. Sequential tab
-switching, input, and screenshot capture are safe. Do not create another local
-daemon merely because several agents exist.
+One daemon can serve many agents concurrently. After `new_tab()` or
+`switch_tab()`, every helper call in that script goes to that target. The daemon
+keeps one reusable CDP session per target and multiplexes them over its single
+Chrome connection. Agents on different tabs need no shared browser lock and
+should all omit `BU_NAME`.
 
-Two agents that switch tabs and act simultaneously can race, causing one to act
-on or capture the other's tab. For truly simultaneous interactive work, use
-separate remote browsers when Browser Use Cloud authentication is already
-available. Otherwise serialize browser operations through the default local
-daemon. A named local daemon is a last resort when simultaneous isolation is
-required, remote auth is unavailable or unsuitable, and the extra Chrome
-approval prompt is acceptable. It creates another controller and dedicated tab
-in the same local Chrome profile, not another Chrome profile or process.
+The only identity an agent must retain between CLI invocations is its tab's
+`target_id`. Start each later script with `switch_tab(target_id)`. If the target
+no longer exists because the tab or browser was closed, select another tab
+known to belong to this task or create a new one. Never silently take over an
+unrelated tab. Two agents can technically attach to the same target, but
+simultaneous actions on that same page remain a semantic race;
+give each concurrent task its own tab.
+
+Do not create an agent ID, context name, lock, or separate daemon. An agent does
+not need to detect other agents. Within its script, `current_tab()` means the
+target that script selected, regardless of Chrome's visible front tab.
+
+```python
+# First call: print and retain the ID.
+print(new_tab("https://example.com"))
+# Later call (possibly alongside hundreds of other agents):
+switch_tab("TARGET_ID_FROM_FIRST_CALL")
+print(page_info())
+print(capture_screenshot())  # unique output path; no foreground activation
+```
+
+The connection process is detached from the CLI and has no idle expiry. Ending
+an agent or terminal does not normally end it. Closing Chrome, stopping the
+daemon, logging out, or rebooting still ends the connection; a new local
+connection may need approval again. Sharing a connection removes per-agent
+approval, not Chrome's per-connection security requirement.
+
+Use a named local daemon only when a genuinely separate browser-level CDP
+connection is required and the extra Chrome approval prompt is acceptable. It
+does not create a separate Chrome profile or process. Use separate remote
+browsers when tasks need isolated cookies, storage, browser lifecycle, network,
+or crash boundaries rather than merely different tabs.
 
 If the default daemon becomes stale, use its built-in reattachment/recovery
 first. A command timeout, truncated output, site change, closed tab, or new task
@@ -134,17 +157,25 @@ Chrome build presents no approval dialog, the original command simply connects.
 
 ## Remote Browsers
 
-Use Browser Use cloud for headless servers, parallel sub-agents, or isolated work.
+Use Browser Use cloud for headless servers, isolated profiles, bot-sensitive
+work, or parallel tasks that need full browser isolation rather than separate
+tabs in the same local Chrome.
 
-Remote browsers require Browser Use Cloud authentication. Check
+Browser Use Cloud requires authentication. Check
 `browser-harness auth status` before depending on them. `browser-harness auth
 login` stores authentication for later processes, so an API key does not need to
-be passed to every agent process; without stored authentication or an available
-`BROWSER_USE_API_KEY`, serialize work through the default local daemon instead.
+be passed to every agent process. Without stored authentication or an available
+`BROWSER_USE_API_KEY`, agents can still use separate targets through the default
+local daemon; only foreground and shared-browser-UI operations need serialization.
+Other remote CDP endpoints (`BU_CDP_WS`/`BU_CDP_URL`) use their provider's own
+authentication and do not inherently require a Browser Use API key.
 
 Cloud browsers are managed Chrome instances hosted by Browser Use. Each one is a fresh, isolated browser. Proactively suggest one (briefly explain why) when:
 
-- **The user wants multiple concurrent tasks.** Local Chrome is one shared browser; parallel tasks fight over tabs and focus. One cloud browser per task keeps them fully isolated.
+- **The user wants isolated concurrent tasks.** The default local daemon can
+  multiplex different tabs, but those tabs still share one Chrome profile,
+  cookies, storage, network, process resources, and browser lifecycle. One
+  cloud browser per task provides full isolation.
 - **Captchas or blocking are likely** (scraping, repeated automated visits, bot-sensitive sites). Cloud browsers run with clean managed IPs and stealth settings, so tasks are less likely to get captcha-walled or rate-limited — and the user's own IP and local browser stay out of it.
 
 You can also direct the user to try the same agent behind Browser Harness, fully hosted, in Browser Use Cloud (it's called the v4 agent): https://cloud.browser-use.com?utm_source=skill&utm_medium=browser-use&utm_campaign=v4.
@@ -186,7 +217,8 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Clicking: AX node -> box center -> `click_at_xy(x, y)` -> verify with a targeted `js(...)`/`page_info()` check.
 - Fall back to raw HTML via `js(...)` only when the AX tree lacks the element (canvas, exotic widgets); screenshot when layout or imagery matters.
 - After navigation, call `wait_for_load()`.
-- If the current tab is stale or internal, call `ensure_real_tab()`.
+- If the selected tab is stale or internal, deliberately select another tab
+  belonging to this task or create one; do not take over an arbitrary user tab.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,7 +19,7 @@ Domain skills are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see t
 
 ```bash
 browser-harness <<'PY'
-print(page_info())
+print(list_tabs())  # inspect, then select an exact target or create a task tab
 PY
 ```
 
@@ -28,6 +28,10 @@ PY
 - First navigation for a task is `target_id = new_tab(url)`, not
   `goto_url(url)`. Print and remember that target ID. At the start of each later
   CLI invocation, call `switch_tab(target_id)`; do not call `new_tab()` again.
+- Page helpers require a selection in each CLI process. They never inherit
+  another agent's tab. For an existing tab, inspect `list_tabs()` and select its
+  exact ID. Older scripts must add this selection; a missing-target error is
+  not a connection failure and does not require a new daemon.
 - Reuse this task's working tabs with `switch_tab()`. Separate concurrent tasks
   may need separate tabs on the same URL; a matching URL alone is not proof
   that a tab is yours. Do not close tabs you did not create.
@@ -47,13 +51,12 @@ PY
   another Allow prompt.
 - Set `BH_TAB_MARKER=0` before starting the daemon to leave page titles unchanged.
   The horse marker remains enabled by default.
-- A timeout or page that pauses while hidden is not permission to foreground
-  Chrome. Keep using background CDP operations. For a focus-gated page,
-  temporarily call `cdp("Emulation.setFocusEmulationEnabled", enabled=True)`,
-  perform and verify the operation, then disable it in a `finally` block. If
-  background control still cannot work, report that limitation instead of
-  activating the tab. Do not invent a `Runtime.evaluate` scroll replacement or
-  a cross-frame JS walker.
+- Attached sessions enable `Emulation.setFocusEmulationEnabled` so background
+  tabs can render and receive input without foregrounding Chrome. You can
+  override it with raw CDP (`enabled=False`) when testing visibility/focus;
+  later selections reuse the session and preserve that override. Some remote
+  providers may not support emulation. A timeout is not permission to foreground
+  Chrome or replay a click: inspect the page first, since the action may finish late.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome
@@ -222,7 +225,12 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
-- Raw CDP is available with `cdp("Domain.method", ...)`.
+- Raw CDP is available with `cdp("Domain.method", parameter=value)`; its second
+  positional argument is a session ID, not a parameter dictionary.
+- `drain_events()` reads your selected tab's queue. `drain_events(all_targets=True)`
+  reads the separate connection-wide queue, including browser and raw-session
+  events, without consuming other tabs' queues. Both are bounded recent-event
+  buffers, not a lossless event subscription.
 
 ## Recordings and Videos
 
@@ -238,8 +246,11 @@ browser-harness recordings
 natural nudge to “record,” “show,” “demo,” or “make a video” opts in that task;
 significant work alone does not.
 
-Before browser work, call `start_recording(name, title=...)`, retain its exact
-returned directory, and call `stop_recording()` after verifying the result.
+For a requested recording, select your task's tab first, then call
+`start_recording(name, title=...)`, retain its exact returned directory, and
+call `stop_recording()` after verifying the result. Ordinary browser work does
+not require starting a recording. Tab selection alone does not capture a frame;
+use `capture_screenshot()` whenever you need to inspect or show the current page.
 Never replace that path with `recordings --latest`. For a request made after
 the task, use:
 

--- a/docs/shared-browser.md
+++ b/docs/shared-browser.md
@@ -1,0 +1,158 @@
+# One connection, independent tabs
+
+## Decision
+
+Keep the detached connection process, but stop using its mutable current tab
+as the routing authority for every agent. The agent remembers a Chrome target
+ID; the client sends it on each request. Chrome already multiplexes flattened
+tab sessions over one WebSocket. No agent IDs, browser-wide lock, tab ownership
+database, Page class, or new service installer are needed.
+
+```mermaid
+flowchart LR
+    A[Agent A: target A] --> D[Shared background connection process]
+    B[Agent B: target B] --> D
+    N[Agent N: target N] --> D
+    D <-->|One approved WebSocket| C[Real Chrome and existing profiles]
+    C --> TA[Tab A: session A]
+    C --> TB[Tab B: session B]
+    C --> TN[Tab N: session N]
+```
+
+## Agent experience
+
+First invocation:
+
+```python
+print(new_tab("https://example.com"))
+```
+
+Later invocations, including concurrent invocations by other agents:
+
+```python
+switch_tab("THE_RETURNED_TARGET_ID")
+print(page_info())
+print(capture_screenshot())
+```
+
+`switch_tab()` selects the client process's target, not Chrome's foreground tab
+or the daemon's global default. `new_tab()` always creates a fresh background
+tab. Screenshots get unique default filenames. Only an explicit user request
+should invoke `activate_tab()`. Agents retain full raw CDP access, including
+explicit session IDs for advanced iframe/Target-domain operations.
+
+The same helpers module is not a per-thread context: independent CLI processes
+are the supported concurrent-agent boundary. An orchestrator using one Python
+process can use explicit CDP session IDs or separate worker processes.
+
+## What is actually shared?
+
+| Resource | Behavior |
+|---|---|
+| Chrome connection | One per daemon name; omit `BU_NAME` by default |
+| Tab selection | Local to each CLI process; retain target ID across calls |
+| CDP attachment | Cached per target, with single-flight initialization |
+| Events and dialogs | Routed by target; draining A does not consume B's events |
+| Clicks, typing, screenshots | Can overlap across different tab sessions |
+| Same tab | Concurrent actions can still race; use separate tabs |
+| Cookies/storage/profile | Shared within the relevant Chrome profile, not account isolation |
+| Native foreground, browser settings, download policy | Shared browser/OS state; not independently controllable by every agent |
+| Capacity | No new artificial tab cap; Chrome memory, CPU, rendering and IPC throughput still limit useful concurrency |
+
+One WebSocket interleaves messages; it does not serialize an entire agent task.
+A slow response can coexist with outstanding requests for other sessions.
+Browser-global operations and browser crashes remain shared failure boundaries.
+Use separate browsers for isolation, not just to get independent tab control.
+
+Remote CDP endpoints use the same routing and single-flight startup per name.
+Browser Use Cloud provisioning needs stored authentication or an API key;
+arbitrary `BU_CDP_WS`/`BU_CDP_URL` endpoints have their own authentication rules.
+Separate remote browsers remain opt-in for independent identities/lifetimes.
+
+## Approval and connection lifetime
+
+Chrome DevTools maintainers explicitly confirm that each WebSocket connection
+requires approval, not each tab or agent. Chrome's real-session documentation
+also describes per-connection consent. Sharing the connection is the supported
+way to remove per-agent prompts, not a way to disable consent.
+[Maintainer explanation](https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/1794),
+[Chrome's real-session design](https://developer.chrome.com/blog/chrome-devtools-mcp-debug-your-browser-session?hl=en).
+
+The daemon is already detached from its initiating CLI and has no idle expiry.
+Normal CLI/agent exit does not stop it. This patch also disables timed WebSocket
+pings for local Chrome and preserves the shared process on an ambiguous health
+timeout. Remote keepalive is unchanged. The underlying WebSocket library's
+default heartbeat can otherwise terminate a connection after a late pong.
+[WebSocket keepalive behavior](https://websockets.readthedocs.io/en/stable/topics/keepalive.html).
+
+The local approval handshake already has no default deadline on main. Finite
+command-response timeouts remain useful: they report a stalled operation without
+expiring the connection or replaying an ambiguous mutation. An explicitly
+rejected stale tab session can be reattached once to the *same* target; a closed
+target is not permission to redirect work to some other tab.
+
+Closing Chrome, killing the daemon, logout/reboot, or a real transport failure
+still ends the connection. No implementation can keep a socket to a terminated
+Chrome process alive. On the next connection Windows/Linux users may need one
+approval, shared by all agents; macOS can use the existing narrowly scoped
+`mac-approve` helper with Accessibility permission. This PR does not add a
+background auto-approval watcher.
+
+### Could we avoid even approval after Chrome restarts?
+
+An extension is a viable alternative product direction: `chrome.debugger`
+attaches to tabs through an extension permission, rather than opening the
+remote-debugging WebSocket. A native-messaging bridge could reconnect after
+Chrome restarts. This is an architectural inference from the documented API,
+not an extension implemented or tested by this PR.
+
+It adds per-profile extension installation, a native bridge and platform
+packaging, and debugger permission/UX. The API exposes a restricted set of CDP
+domains, so it is not a transparent replacement for full browser-level CDP.
+For the smallest implementation, keep the shared WebSocket design first.
+[Chrome debugger API](https://developer.chrome.com/docs/extensions/reference/api/debugger).
+
+Launching the default real profile with debugging flags is not a supported
+escape hatch: Chrome 136 changed port/pipe handling to require a non-default
+user-data directory. A disposable automation profile changes the requested
+logged-in user experience. This proposal neither copies credentials nor
+weakens Chrome's security settings.
+[Chrome's debugging-switch change](https://developer.chrome.com/blog/remote-debugging-port?hl=en).
+
+## Review of related open proposals
+
+Reviewed the relevant connection/tab UX diffs, not every unrelated open PR:
+
+| PR | Recommendation |
+|---|---|
+| [#746](https://github.com/browser-use/browser-harness/pull/746) | Right core model. This proposal builds on it and fixes initialization/cancellation, lifecycle cleanup, exact raw-session routing, implicit target pinning and screenshot collisions. Seven targeted regression tests fail against its head `cbe5bc7` and pass here. |
+| [#754](https://github.com/browser-use/browser-harness/pull/754) | Correct socket-leak fix; incorporated the same close-in-finally behavior, with non-destructive timeout handling. |
+| [#734](https://github.com/browser-use/browser-harness/pull/734) | Do not adopt as-is. Its lock is acquired after the browser handshake, and a not-yet-listening owner can be mistaken for a stale lock. Reuse the existing pre-spawn lock, now also for remote endpoints. |
+| [#748](https://github.com/browser-use/browser-harness/pull/748) | Do not automatically select a surviving tab on close. That can redirect an agent into another task. Diagnose connection health independently of the closed default tab instead. |
+| [#751](https://github.com/browser-use/browser-harness/pull/751) | Do not silently choose the first URL/title substring match. Duplicate URLs are normal with many agents, and this resolver also affects closing tabs. Exact IDs are simpler and safer. |
+| [#723](https://github.com/browser-use/browser-harness/pull/723) | Useful keepalive concern, but avoid its global WebSocket monkeypatch and merely longer timeout. Configure the local client directly; unrelated domain-skill changes are outside this PR. |
+| [#725](https://github.com/browser-use/browser-harness/pull/725) | Automatic foregrounding for canvas screenshots conflicts with background-first UX. Rendering limitations need explicit handling, not surprise focus theft. |
+| [#747](https://github.com/browser-use/browser-harness/pull/747) | Useful separate localization work. Exact title/button matching is preferable to generic Allow clicking. Its claim of working in any language is stronger than the finite tables/tests prove; validate localized Chrome before promising that. |
+
+## Verification and rollout
+
+- Unit coverage includes concurrent target routing, per-target dialogs/events,
+  stale-session recovery, attach cancellation, buffer cleanup, health timeouts,
+  target lifetime subscription, raw sessions, and unique screenshots.
+- The opt-in integration test launches a disposable headless Chrome, races
+  independent CLI processes from cold start, then resumes every tab in a fresh
+  process for coordinate clicks, typing and pixel-verified screenshots. It also
+  tests a real JS dialog and closes all targets before reusing the same daemon.
+- Measured on macOS: 100 concurrent clients, 100 distinct tabs and screenshots,
+  one daemon, 5.21 seconds for the synthetic workflow. This is not a benchmark
+  of 100 heavy websites or proof of Windows/Linux runtime behavior.
+- Real-profile smoke test: logged-in Hacker News navigation, extraction and
+  screenshot succeeded. Two simultaneous CLI processes then captured separate
+  tabs and clicked a synthetic page through the same daemon; the visible Chrome
+  tab ID was unchanged before/after. All task-created tabs were closed afterward.
+
+No dependency or lockfile changes. No automatic installation, release, daemon
+replacement or PR merge is part of this proposal. When deploying, upgrade both
+the CLI and the persistent daemon once after its active tasks finish. Existing
+pre-routing daemons cannot implement new target-scoped requests, and starting
+another daemon per agent is not a migration strategy.

--- a/docs/shared-browser.md
+++ b/docs/shared-browser.md
@@ -41,6 +41,18 @@ tab. Screenshots get unique default filenames. Only an explicit user request
 should invoke `activate_tab()`. Agents retain full raw CDP access, including
 explicit session IDs for advanced iframe/Target-domain operations.
 
+Page helpers fail with an actionable error until the process selects a target;
+they do not inherit the daemon's startup tab. Existing multi-invocation scripts
+must retain a target ID and select it in each invocation. `list_tabs()` and
+browser-wide CDP commands remain usable without a page selection.
+
+Attached sessions enable CDP focus emulation once so hidden pages can render
+and process wheel input. This does not activate Chrome's visible tab. Agents
+can disable it through raw CDP; selecting a cached session preserves their
+override. Unsupported providers are logged, not replaced with another browser.
+`switch_tab()` does not take an implicit recording screenshot. Explicit
+screenshots and requested recordings remain available.
+
 The same helpers module is not a per-thread context: independent CLI processes
 are the supported concurrent-agent boundary. An orchestrator using one Python
 process can use explicit CDP session IDs or separate worker processes.
@@ -68,6 +80,11 @@ Remote CDP endpoints use the same routing and single-flight startup per name.
 Browser Use Cloud provisioning needs stored authentication or an API key;
 arbitrary `BU_CDP_WS`/`BU_CDP_URL` endpoints have their own authentication rules.
 Separate remote browsers remain opt-in for independent identities/lifetimes.
+
+`drain_events(all_targets=True)` reads the separate connection-wide buffer,
+including browser-level and independently attached raw-session events. Draining
+either queue does not consume the other. These bounded buffers are not a
+lossless event bus; advanced agents can filter the raw events themselves.
 
 ## Approval and connection lifetime
 

--- a/install.md
+++ b/install.md
@@ -14,11 +14,12 @@ uv tool install --python 3.12 --upgrade --force browser-harness
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness"
 browser-harness skill > "${CODEX_HOME:-$HOME/.codex}/skills/browser-harness/SKILL.md"
 browser-harness <<'PY'
-print(page_info())
+print(list_tabs())
 PY
 ```
 
-If `page_info()` prints, configure recording consent below, then stop.
+If `list_tabs()` prints, configure recording consent below, then stop. Browser
+work selects a target with `switch_tab(id)` or `new_tab(url)` first.
 
 `--python 3.12` prevents uv from selecting old releases that support older Python versions. `--upgrade --force` replaces any previous `browser-harness` tool install with the latest stable release. It does not uninstall unrelated commands such as `browser-use-Browser` or `browser-use-Terminal`.
 
@@ -49,7 +50,8 @@ In Chrome:
 
 1. Open `chrome://inspect/#remote-debugging`.
 2. Tick "Allow remote debugging for this browser instance".
-3. Retry `page_info()`.
+3. Run the connection check above, or leave its original process running if it
+   is already waiting for approval; do not start another connection.
 
 If that reports `permission-blocked` on macOS, handle the per-connection Allow
 sheet without bringing Chrome to the foreground:
@@ -82,7 +84,7 @@ Then use it by name:
 
 ```bash
 BU_NAME=r7k2 browser-harness <<'PY'
-print(page_info())
+print(list_tabs())
 PY
 ```
 

--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -6,28 +6,24 @@ When Chrome opens fresh, the only CDP `type: "page"` targets are `chrome://inspe
 
 The daemon's `attach_first_page()` handles this by creating an `about:blank` tab when no real pages exist. If you still end up on an invisible tab, use `switch_tab()` to attach to the real tab. Call `activate_tab()` only when the user explicitly asks Chrome to visibly show it.
 
-## Startup sequence
+## Shared connection
 
-1. Check if a daemon is already running with `daemon_alive()`
-2. If stale sockets exist but daemon is dead, clean them up
-3. List open tabs with `list_tabs()` to see what's available
-4. `ensure_real_tab()` attaches to a real page
-5. `switch_tab(target_id)` attaches without changing the visible Chrome tab; use `activate_tab(target_id)` only for a user-requested visible switch
+The CLI starts or reuses the default background connection automatically.
+Multiple agents use the same daemon and separate tab IDs, not separate daemon
+names. Do not remove socket/PID files yourself: another caller may be starting
+the connection or waiting for Chrome's approval.
 
-```python
-if not daemon_alive():
-    import os, ipc
-    ipc.cleanup_endpoint("default")
-    pid = ipc.pid_path("default")
-    if pid.exists(): pid.unlink()
-    ensure_daemon()
+For a new task, print and retain `new_tab(url)`'s target ID. For later calls,
+`switch_tab(target_id)` selects that exact tab for this script without changing
+the visible Chrome tab or another agent's selection. If the user explicitly
+asks to work in an existing tab, inspect `list_tabs()` and select its ID. A
+matching URL alone is not proof that the tab is unused by another task.
 
-tabs = list_tabs()
-for t in tabs:
-    print(t["url"][:60])
-
-tab = ensure_real_tab()
-```
+Run `browser-harness --doctor` for connection trouble. A closed tab, slow
+command, or truncated output does not mean the shared connection needs
+restarting. A timed-out mutation may already have happened: inspect its result
+before deciding what to do next. For a local Allow prompt, keep the original
+command running and follow the platform-specific instructions in `SKILL.md`.
 
 ## Bringing Chrome to front
 
@@ -39,14 +35,15 @@ subprocess.run(["osascript", "-e", 'tell application "Google Chrome" to activate
 ```
 
 For normal agent work, do not activate Chrome. Screenshots and CDP input work
-on the attached background tab; activate only for a page that demonstrably
-pauses visibility-dependent rendering while hidden.
+on the attached background tab. Rendering trouble is not permission to
+foreground Chrome; try temporary focus emulation as described in `SKILL.md`,
+then report any remaining limitation.
 
 ## Navigating
 
-Prefer navigating an existing tab over `new_tab()`. Harness-created tabs open in the background.
+Reuse a tab owned by this task. Harness-created tabs open in the background.
 
 ```python
-tab = ensure_real_tab()
+switch_tab("TARGET_ID_RETAINED_BY_THIS_TASK")
 goto_url("https://example.com")
 ```

--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -8,11 +8,14 @@ Use **CDP for control**, **UI automation for user-visible order**.
 tabs = list_tabs()                    # includes chrome:// pages too
 real_tabs = list_tabs(include_chrome=False)
 tid = new_tab("https://example.com")  # create + attach in the background
-switch_tab(tid)                       # attach harness, move the horse marker
-activate_tab(tid)                     # optional: explicitly show it in Chrome
+switch_tab(tid)                       # select for this CLI process only
 print(current_tab())
 print(page_info())
 ```
+
+Agents on different tabs can run this concurrently through the default daemon.
+Retain the target ID and call `switch_tab(id)` at the start of each later CLI
+invocation. Only a user-requested visible switch should call `activate_tab(id)`.
 
 What CDP is good at:
 - attach to a tab

--- a/interaction-skills/tabs.md
+++ b/interaction-skills/tabs.md
@@ -65,10 +65,12 @@ Typical tools:
 ## Rules that held up in practice
 
 - `switch_tab()` intentionally does **not** change Chrome's visible tab.
-- Static screenshots and normal CDP input work on the attached background tab.
+- Attach enables focus emulation so background rendering and wheel input work.
+  Raw CDP can override it for visibility/focus tests; reselecting the same
+  session does not reset the override.
 - `activate_tab()` is only for a user-requested visible switch. Rendering or
-  input trouble is not permission to foreground Chrome; use background CDP and
-  temporary focus emulation first.
+  input trouble is not permission to foreground Chrome. Inspect before retrying
+  an input that timed out: it may still execute after the page resumes.
 - `Target.activateTarget` is the CDP-side "show this tab".
 - `list_tabs()` includes `chrome://newtab/` by default; ask for `include_chrome=False` when you want only real pages.
 - `chrome://omnibox-popup.top-chrome/` can appear as a fake page target; ignore it for user-facing tab lists.

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -530,14 +530,20 @@ def ensure_daemon(wait=None, name=None, env=None):
         # CDP WS to Chrome is dead — probe with a real CDP call and require "result".
         # Must go through ipc.connect so this works on Windows (TCP loopback) too;
         # raw AF_UNIX here would fail on every warm call and churn the daemon.
-        for last in (False, True):
+        try:
+            s, token = ipc.connect(name or NAME, timeout=3.0)
             try:
-                s, token = ipc.connect(name or NAME, timeout=3.0)
                 resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
                 if "result" in resp: return
-            except Exception:
-                pass
-            if not last: time.sleep(0.5)
+            finally:
+                s.close()
+        except TimeoutError as e:
+            # A busy browser is not evidence its transport is dead. Restarting
+            # here would interrupt every agent and raise another Allow prompt.
+            raise RuntimeError("browser health check timed out; the shared daemon was left running") from e
+        except OSError:
+            # A closed IPC transport can be recovered through the normal path.
+            pass
         browser_kind = daemon_browser_kind(name)
         if browser_kind in {"cloud", None}:
             # A stale Cloud daemon still owns a billable browser. Its shutdown
@@ -564,13 +570,13 @@ def ensure_daemon(wait=None, name=None, env=None):
             stderr_sink = open(ipc.log_path(name or NAME), "ab")
         except OSError:
             stderr_sink = subprocess.DEVNULL
-        if local:
+        try:
+            # One connection per name, including when agents share a remote
+            # endpoint. Publish the child before releasing the spawn lock.
             with _spawn_lock(name, timeout=startup_wait) as lock:
                 if lock.fd is None:
                     raise RuntimeError("daemon-starting: another browser-harness daemon is still starting; retry later")
                 if daemon_alive(name):
-                    if stderr_sink is not subprocess.DEVNULL:
-                        stderr_sink.close()
                     return
                 pending_pid = _parked_daemon_pid(name) or _starting_daemon_pid(name)
                 if pending_pid:
@@ -582,13 +588,9 @@ def ensure_daemon(wait=None, name=None, env=None):
                     )
                     _publish_pid(ipc.pid_path(name or NAME), p.pid)
                     pending_pid = p.pid
-        else:
-            p = subprocess.Popen(
-                [sys.executable, "-m", "browser_harness.daemon"],
-                env=e, stdout=subprocess.DEVNULL, stderr=stderr_sink, **ipc.spawn_kwargs(),
-            )
-        if stderr_sink is not subprocess.DEVNULL:
-            stderr_sink.close()
+        finally:
+            if stderr_sink is not subprocess.DEVNULL:
+                stderr_sink.close()
         spawned = time.monotonic()
         deadline = spawned + startup_wait
         hinted = not local

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -414,7 +414,11 @@ class _PatientCDPClient(CDPClient):
         import websockets
         if self.ws is not None:
             raise RuntimeError("Client is already started")
-        connect_kwargs = {"max_size": self.max_ws_frame_size, "open_timeout": LOCAL_HANDSHAKE_TIMEOUT}
+        # A sleeping laptop or busy local Chrome is not a dead connection.
+        # Keep TCP/WS close detection, without a timed ping failure creating a
+        # replacement connection (and another approval). Remote clients keep
+        # their normal network keepalive policy.
+        connect_kwargs = {"max_size": self.max_ws_frame_size, "open_timeout": LOCAL_HANDSHAKE_TIMEOUT, "ping_interval": None}
         if self.additional_headers:
             connect_kwargs["additional_headers"] = self.additional_headers
         self.ws = await websockets.connect(self.url, **connect_kwargs)
@@ -435,8 +439,13 @@ class Daemon:
         self._recoveries_idle.set()
         self._shutting_down = False
         self._session_replacements = {}
+        self.target_sessions = {}
+        self.session_targets = {}
+        self._target_attach_tasks = {}
         self.events = deque(maxlen=BUF)
+        self.events_by_target = {}
         self.dialog = None
+        self.dialogs_by_target = {}
         self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self, replaces_session=None, enable_domains=True):
@@ -476,6 +485,7 @@ class Daemon:
             ))["sessionId"]
             self._record_session_replacement(replaces_session, self.session)
             self.target_id = tid
+            self._remember_target_session(tid, self.session)
             log(f"attached {tid} ({page.get('url','')[:80]}) session={self.session}")
             if enable_domains:
                 await self._enable_default_domains(self.session)
@@ -509,6 +519,7 @@ class Daemon:
         ))["sessionId"]
         self._record_session_replacement(replaces_session, self.session)
         self.target_id = pages[0]["targetId"]
+        self._remember_target_session(self.target_id, self.session)
         log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
         if take_over:
             try:
@@ -541,11 +552,10 @@ class Daemon:
     async def _enable_default_domains(self, session_id):
         """Enable Page/DOM/Runtime/Network on a CDP session.
 
-        Used by both initial attach and set_session (called after switch_tab/
-        new_tab). Without this, helpers that depend on Network.* events —
-        notably wait_for_network_idle() — silently stop receiving events
-        after a tab switch, because each fresh CDP session starts with all
-        domains disabled.
+        Used by initial attach, legacy set_session, and each daemon-owned target
+        session. Without this, helpers that depend on Network.* events — notably
+        wait_for_network_idle() — silently stop receiving events after a tab
+        switch, because each fresh CDP session starts with all domains disabled.
 
         Runs the four enables in parallel via gather so the worst-case time is
         bounded by a single CDP round trip rather than four sequential ones —
@@ -561,6 +571,51 @@ class Daemon:
             except Exception as e:
                 log(f"enable {d} on {session_id}: {e}")
         await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
+
+    def _remember_target_session(self, target_id, session_id):
+        previous = self.target_sessions.get(target_id)
+        if previous and previous != session_id:
+            self.session_targets.pop(previous, None)
+        self.target_sessions[target_id] = session_id
+        self.session_targets[session_id] = target_id
+
+    def _forget_target_session(self, target_id, session_id=None):
+        current = self.target_sessions.get(target_id)
+        if session_id is not None and current != session_id:
+            return
+        if current:
+            self.session_targets.pop(current, None)
+        self.target_sessions.pop(target_id, None)
+
+    async def _ensure_target_session(self, target_id):
+        """Return the daemon-owned CDP session for one page target."""
+        if self._shutting_down:
+            raise RuntimeError("daemon is shutting down")
+        task = self._target_attach_tasks.get(target_id)
+        # The mapping is published before domain enables so their events can
+        # be routed. Wait for that initialization before using the session.
+        if task is not None:
+            return await asyncio.shield(task)
+        existing = self.target_sessions.get(target_id)
+        if existing:
+            return existing
+        if task is None:
+            async def attach():
+                try:
+                    session_id = (await self.cdp.send_raw(
+                        "Target.attachToTarget", {"targetId": target_id, "flatten": True}
+                    ))["sessionId"]
+                    self._remember_target_session(target_id, session_id)
+                    await self._enable_default_domains(session_id)
+                    return session_id
+                finally:
+                    self._target_attach_tasks.pop(target_id, None)
+
+            task = asyncio.create_task(attach())
+            # Consume failures even if every waiting IPC caller was cancelled.
+            task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+            self._target_attach_tasks[target_id] = task
+        return await asyncio.shield(task)
 
     def _record_session_replacement(self, stale_session, replacement_session):
         """Remember which recovered session still controls the same tab."""
@@ -597,7 +652,7 @@ class Daemon:
         """Cancel active stale-session handlers and wait a bounded time."""
         current = asyncio.current_task()
         tasks = [
-            task for task in self._recovery_tasks
+            task for task in self._recovery_tasks | set(self._target_attach_tasks.values())
             if task is not current and not task.done()
         ]
         for task in tasks:
@@ -624,13 +679,40 @@ class Daemon:
         )))
 
     def _record_event(self, method, params, session_id=None):
-        self.events.append({"method": method, "params": params, "session_id": session_id})
+        target_id = self.session_targets.get(session_id)
+        event = {
+            "method": method,
+            "params": params,
+            "session_id": session_id,
+            "target_id": target_id,
+        }
+        self.events.append(event)
+        if target_id:
+            self.events_by_target.setdefault(target_id, deque(maxlen=BUF)).append(event)
         if method == "Page.javascriptDialogOpening":
-            self.dialog = params
+            if target_id:
+                self.dialogs_by_target[target_id] = params
+            if not session_id or target_id == self.target_id:
+                self.dialog = params
         elif method == "Page.javascriptDialogClosed":
-            self.dialog = None
+            if target_id:
+                self.dialogs_by_target.pop(target_id, None)
+            if not session_id or target_id == self.target_id:
+                self.dialog = None
+        elif method == "Target.targetDestroyed":
+            destroyed_target_id = params.get("targetId")
+            self.dialogs_by_target.pop(destroyed_target_id, None)
+            self.events_by_target.pop(destroyed_target_id, None)
+            self._forget_target_session(destroyed_target_id)
+        elif method == "Target.detachedFromTarget":
+            detached_session_id = params.get("sessionId")
+            detached_target_id = self.session_targets.get(detached_session_id)
+            if detached_target_id:
+                self._forget_target_session(detached_target_id, detached_session_id)
+                self.events_by_target.pop(detached_target_id, None)
+                self.dialogs_by_target.pop(detached_target_id, None)
         elif method in ("Page.loadEventFired", "Page.domContentEventFired"):
-            self._schedule_tab_marker(self.session)
+            self._schedule_tab_marker(session_id or self.session)
 
     async def start(self):
         self.stop = asyncio.Event()
@@ -655,12 +737,18 @@ class Daemon:
                     "browser-harness did not retry or create another connection"
                 )
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
-        await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):
             self._record_event(method, params, session_id)
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
+        try:
+            await self.cdp.send_raw("Target.setDiscoverTargets", {"discover": True})
+        except Exception as e:
+            # Some scoped remote relays expose attachments but not discovery.
+            # detachedFromTarget still cleans up the sessions we own.
+            log(f"target discovery unavailable: {e}")
+        await self.attach_first_page()
 
     async def handle(self, req):
         # Token guard for Windows TCP loopback: any local process can otherwise
@@ -676,67 +764,71 @@ class Daemon:
         # signaling — protects against SIGTERM-by-stale-pid-file after PID reuse.
         if meta == "ping":        return {"pong": True, "pid": os.getpid(), "browser_kind": BROWSER_KIND}
         if meta == "drain_events":
-            out = list(self.events); self.events.clear()
+            target_id = req.get("target_id") or self.target_id
+            if target_id:
+                out = list(self.events_by_target.pop(target_id, ()))
+                self.events = deque(
+                    (event for event in self.events if event.get("target_id") != target_id),
+                    maxlen=BUF,
+                )
+            else:
+                out = list(self.events); self.events.clear()
+                self.events_by_target.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
         if meta == "current_tab":
-            # Resolve the attached page's target info server-side. Helpers can't
-            # send Target.getTargetInfo themselves: daemon strips session_id for
-            # any Target.* method (browser-level call), and without a targetId
-            # Chrome silently returns the *browser* target.
+            # Legacy/default selection. Target-aware clients request the exact
+            # target themselves; never infer one from the visible Chrome tab.
             if not self.target_id:
                 return {"error": "not_attached"}
             try:
                 info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
-            except Exception:
-                return {"error": "cdp_disconnected"}
+            except Exception as e:
+                return {"error": f"default tab unavailable: {e}; select a target with switch_tab() or new_tab()"}
             return {"targetId": info.get("targetId"), "url": info.get("url", ""), "title": info.get("title", "")}
         if meta == "connection_status":
-            if not self.target_id:
-                return {"error": "not_attached"}
             try:
-                info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": self.target_id}))["targetInfo"]
+                targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
             except Exception:
                 return {"error": "cdp_disconnected"}
+            # Closing a tab does not close the browser WebSocket. Diagnostics
+            # must not tell agents to restart an otherwise shared connection.
+            info = next((t for t in targets if t["targetId"] == self.target_id), None)
             page = None
-            if is_real_page(info):
+            if info and is_real_page(info):
                 page = {
                     "targetId": info.get("targetId"),
                     "title": info.get("title") or "(untitled)",
                     "url": info.get("url") or "",
                 }
-            return {"target_id": self.target_id, "session_id": self.session, "page": page}
+            return {"target_id": self.target_id if info else None, "session_id": self.session if info else None, "page": page}
         if meta == "set_session":
             async with self._session_state_lock:
-                old_session = self.session
                 self.session = req.get("session_id")
                 self.target_id = req.get("target_id") or self.target_id
                 new_session = self.session
-            # Run the old-session Network.disable (defense in depth — keeps
-            # background-tab traffic out of the global event buffer; the
-            # consumer-side filter in wait_for_network_idle is the actual
-            # correctness gate) in parallel with the four enables on the new
-            # session. Different sessions, independent CDP requests. Keeps
-            # the synchronous reply under the helper's 5s IPC read timeout
-            # even on a remote daemon — sequentially these would have stacked
-            # to ~22s worst case.
-            tasks = []
-            if old_session and old_session != new_session:
-                async def disable_old():
-                    try:
-                        await asyncio.wait_for(
-                            self.cdp.send_raw("Network.disable", session_id=old_session),
-                            timeout=2,
-                        )
-                    except Exception: pass
-                tasks.append(disable_old())
-            tasks.append(self._enable_default_domains(new_session))
-            await asyncio.gather(*tasks)
+                if new_session and self.target_id:
+                    self._remember_target_session(self.target_id, new_session)
+            # Backward compatibility for older helpers that still move the
+            # daemon-wide default. Never disable domains on the old session:
+            # a target-aware client may still be using that tab concurrently.
+            await self._enable_default_domains(new_session)
             # 🐴 tab-marker title prefix is purely cosmetic — fire-and-forget so
             # it doesn't add to the synchronous IPC budget.
             self._schedule_tab_marker(new_session)
             return {"session_id": new_session}
-        if meta == "pending_dialog": return {"dialog": self.dialog}
+        if meta == "prepare_target":
+            target_id = req.get("target_id")
+            if not target_id:
+                return {"error": "target_id is required"}
+            try:
+                session_id = await self._ensure_target_session(target_id)
+            except Exception as e:
+                return {"error": str(e)}
+            return {"session_id": session_id, "target_id": target_id}
+        if meta == "pending_dialog":
+            target_id = req.get("target_id")
+            return {"dialog": self.dialogs_by_target.get(target_id) if target_id else self.dialog}
         if meta == "shutdown":
             # Flip the barrier synchronously with recovery registration, then
             # cancel/drain existing handlers. In particular, a CDP replay that
@@ -762,9 +854,19 @@ class Daemon:
 
         method = req["method"]
         params = req.get("params") or {}
-        # Browser-level Target.* calls must not use a session (stale or otherwise).
-        # For everything else, explicit session in req wins; else default.
-        sid = None if method.startswith("Target.") else (req.get("session_id") or self.session)
+        target_id = req.get("target_id")
+        # Browser-wide commands must not use a target session (stale or otherwise).
+        # For everything else, explicit session in req wins, then the request's
+        # target, then the legacy daemon default.
+        try:
+            sid = (
+                req.get("session_id") or (
+                    None if method.startswith(("Target.", "Browser."))
+                    else (await self._ensure_target_session(target_id) if target_id else self.session)
+                )
+            )
+        except Exception as e:
+            return {"error": str(e)}
         try:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
@@ -774,6 +876,24 @@ class Daemon:
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):
                     return {"error": msg}
+                if target_id:
+                    recovery_task = self._begin_recovery()
+                    if recovery_task is None:
+                        return {"error": "daemon is shutting down"}
+                    try:
+                        self._forget_target_session(target_id, sid)
+                        replacement_session = await self._ensure_target_session(target_id)
+                        if self.target_id == target_id:
+                            self._record_session_replacement(self.session, replacement_session)
+                            self.session = replacement_session
+                        try:
+                            return {"result": await self.cdp.send_raw(
+                                method, params, session_id=replacement_session
+                            )}
+                        except Exception as retry_error:
+                            return {"error": str(retry_error)}
+                    finally:
+                        self._finish_recovery(recovery_task)
                 recovery_task = self._begin_recovery()
                 if recovery_task is None:
                     return {"error": "daemon is shutting down"}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -557,20 +557,25 @@ class Daemon:
         wait_for_network_idle() — silently stop receiving events after a tab
         switch, because each fresh CDP session starts with all domains disabled.
 
-        Runs the four enables in parallel via gather so the worst-case time is
+        Runs domain and focus initialization in parallel so the worst-case time is
         bounded by a single CDP round trip rather than four sequential ones —
         important on the set_session path, where the helper's IPC socket has
         a 5s read timeout.
         """
-        async def enable_one(d):
+        async def enable_one(method, params=None):
             try:
                 await asyncio.wait_for(
-                    self.cdp.send_raw(f"{d}.enable", session_id=session_id),
+                    self.cdp.send_raw(method, params, session_id=session_id),
                     timeout=4,
                 )
             except Exception as e:
-                log(f"enable {d} on {session_id}: {e}")
-        await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
+                log(f"{method} on {session_id}: {e}")
+        await asyncio.gather(
+            *(enable_one(f"{d}.enable") for d in ("Page", "DOM", "Runtime", "Network")),
+            # Hidden tabs otherwise pause animation frames and even wheel input.
+            # This does not activate Chrome; agents can override it through CDP.
+            enable_one("Emulation.setFocusEmulationEnabled", {"enabled": True}),
+        )
 
     def _remember_target_session(self, target_id, session_id):
         previous = self.target_sessions.get(target_id)
@@ -764,16 +769,13 @@ class Daemon:
         # signaling — protects against SIGTERM-by-stale-pid-file after PID reuse.
         if meta == "ping":        return {"pong": True, "pid": os.getpid(), "browser_kind": BROWSER_KIND}
         if meta == "drain_events":
-            target_id = req.get("target_id") or self.target_id
+            target_id = req.get("target_id")
             if target_id:
                 out = list(self.events_by_target.pop(target_id, ()))
-                self.events = deque(
-                    (event for event in self.events if event.get("target_id") != target_id),
-                    maxlen=BUF,
-                )
             else:
+                # Independent queue for browser events, raw sessions and legacy
+                # clients. Reading it must not consume another agent's tab queue.
                 out = list(self.events); self.events.clear()
-                self.events_by_target.clear()
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
         if meta == "current_tab":
@@ -883,7 +885,9 @@ class Daemon:
                     try:
                         self._forget_target_session(target_id, sid)
                         replacement_session = await self._ensure_target_session(target_id)
-                        if self.target_id == target_id:
+                        # No await between comparison and publication: a legacy
+                        # selection made during domain initialization must win.
+                        if self.target_id == target_id and self.session == sid and self.target_sessions.get(target_id) == replacement_session:
                             self._record_session_replacement(self.session, replacement_session)
                             self.session = replacement_session
                         try:

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -3,7 +3,7 @@
 Core helpers live here. Agent-editable helpers live in
 BH_AGENT_WORKSPACE/agent_helpers.py.
 """
-import base64, importlib.util, json, math, os, time, urllib.request
+import base64, importlib.util, json, math, os, tempfile, time, urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -44,6 +44,10 @@ DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS = 5.0
 # their IPC socket alive within the caller's existing 90-second process budget.
 SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS = 60.0
 
+# One CLI process only needs to remember its tab. The daemon owns and reuses the
+# CDP session for that target over its single browser-level WebSocket.
+_TARGET_ID = None
+
 
 class _IPCResponseTimeout(TimeoutError):
     pass
@@ -65,19 +69,49 @@ def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
             ) from e
     finally:
         c.close()
-    if "error" in r: raise RuntimeError(r["error"])
+    if "error" in r:
+        if req.get("meta") == "prepare_target" and r["error"] == "'method'":
+            # Pre-routing daemons treat an unknown meta command as raw CDP.
+            raise RuntimeError(
+                "this daemon predates per-tab routing; restart it once after "
+                "its active tasks finish, then select your tab again"
+            )
+        raise RuntimeError(r["error"])
     return r
 
 
 def cdp(method, session_id=None, _response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS, **params):
     """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1)."""
+    if not session_id and not method.startswith(("Target.", "Browser.")):
+        _selected_target()
     return _send(
-        {"method": method, "params": params, "session_id": session_id},
+        {
+            "method": method,
+            "params": params,
+            "session_id": session_id,
+            "target_id": _TARGET_ID,
+        },
         response_timeout=_response_timeout,
     ).get("result", {})
 
 
-def drain_events():  return _send({"meta": "drain_events"})["events"]
+def drain_events():
+    """Drain events for this CLI process's selected tab only."""
+    return _send({"meta": "drain_events", "target_id": _selected_target()})["events"]
+
+
+def _selected_target():
+    # Legacy scripts inherit the default once; another client cannot move it
+    # between two calls in this process. Concurrent tasks should select their
+    # own tab explicitly with new_tab()/switch_tab().
+    if _TARGET_ID is None:
+        current_tab()
+    return _TARGET_ID
+
+
+def _set_client_tab(target_id):
+    global _TARGET_ID
+    _TARGET_ID = target_id
 
 
 def _js_snippet(expression, limit=160):
@@ -162,7 +196,10 @@ def page_info():
     If a native dialog (alert/confirm/prompt/beforeunload) is open, returns
     {dialog: {type, message, ...}} instead — the page's JS thread is frozen
     until the dialog is handled (see interaction-skills/dialogs.md)."""
-    dialog = _send({"meta": "pending_dialog"}).get("dialog")
+    dialog = _send({
+        "meta": "pending_dialog",
+        "target_id": _selected_target(),
+    }).get("dialog")
     if dialog:
         return {"dialog": dialog}
     expression = "JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})"
@@ -177,7 +214,7 @@ def click_at_xy(x, y, button="left", clicks=1):
         try:
             from PIL import Image, ImageDraw
             dpr = js("window.devicePixelRatio") or 1
-            path = capture_screenshot(str(ipc._TMP / f"debug_click_{_debug_click_counter}.png"))
+            path = capture_screenshot()
             img = Image.open(path)
             draw = ImageDraw.Draw(img)
             px, py = int(x * dpr), int(y * dpr)
@@ -331,7 +368,6 @@ def scroll(x, y, dy=-300, dx=0):
 def capture_screenshot(path=None, full=False, max_dim=None):
     """Save a PNG of the current viewport. Set max_dim=1800 on a 2× display to
     keep the file under the 2000px-per-side limit some image-aware LLMs enforce."""
-    path = path or str(ipc._TMP / "shot.png")
     try:
         r = cdp(
             "Page.captureScreenshot",
@@ -343,7 +379,16 @@ def capture_screenshot(path=None, full=False, max_dim=None):
         raise RuntimeError(
             f"Page.captureScreenshot timed out after {SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS:g}s"
         ) from e
-    open(path, "wb").write(base64.b64decode(r["data"]))
+    data = base64.b64decode(r["data"])
+    if path is None:
+        # Separate agents (and successive screenshots) must not overwrite a
+        # file another agent is still reading or showing to the user.
+        fd, path = tempfile.mkstemp(prefix="shot-", suffix=".png", dir=ipc._TMP)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+    else:
+        with open(path, "wb") as f:
+            f.write(data)
     if max_dim:
         from PIL import Image
         img = Image.open(path)
@@ -377,7 +422,16 @@ def list_tabs(include_chrome=True):
     return out
 
 def current_tab():
-    r = _send({"meta": "current_tab"})
+    if _TARGET_ID is None:
+        r = _send({"meta": "current_tab"})
+        _set_client_tab(r["targetId"])
+    else:
+        info = cdp("Target.getTargetInfo", targetId=_TARGET_ID)["targetInfo"]
+        r = {
+            "targetId": info["targetId"],
+            "url": info.get("url", ""),
+            "title": info.get("title", ""),
+        }
     return {
         "targetId": r["targetId"],
         "target_id": r["targetId"],
@@ -417,33 +471,20 @@ def switch_tab(target, activate=False):
     target_id = _target_id(target)
     # Unmark old tab. Horse emoji is a surrogate pair in JS UTF-16 strings (2 code units),
     # plus the trailing space = 3 code units, so slice(3) cleanly removes the prefix.
-    try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
-    except Exception: pass
+    if _TARGET_ID:
+        try: cdp("Runtime.evaluate", expression="if(document.title.startsWith('\U0001F434 '))document.title=document.title.slice(3)")
+        except Exception: pass
     if activate:
         activate_tab(target_id)
-    sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
-    _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
+    prepared = _send({"meta": "prepare_target", "target_id": target_id})
+    _set_client_tab(target_id)
     _mark_tab()
-    return sid
+    return prepared["session_id"]
 
 def new_tab(url="about:blank"):
     # Always create blank, then goto: passing url to createTarget races with
     # attach, so the brief about:blank is "complete" by the time the caller
     # polls and wait_for_load() returns before navigation actually starts.
-    if url != "about:blank":
-        try:
-            cur = current_tab()
-            cur_url = cur.get("url") or ""
-            # Reuse attached tab when it's blank
-            if (
-                cur_url in ("", "about:blank", "data:text/html,")
-                or cur_url.startswith("about:blank#")
-                or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
-            ):
-                goto_url(url)
-                return cur.get("targetId") or cur.get("target_id")
-        except Exception:
-            pass
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     switch_tab(tid)
     if url != "about:blank":
@@ -538,10 +579,10 @@ def wait_for_network_idle(timeout=10.0, idle_ms=500):
     deadline = time.time() + timeout
     last_activity = time.time()
     inflight = set()
-    active_session = _send({"meta": "session"}).get("session_id")
+    active_target = _selected_target()
     while time.time() < deadline:
         for e in drain_events():
-            if e.get("session_id") != active_session:
+            if e.get("target_id") != active_target:
                 continue
             method = e.get("method", "")
             params = e.get("params", {})

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -82,6 +82,8 @@ def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
 
 def cdp(method, session_id=None, _response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS, **params):
     """Raw CDP. cdp('Page.navigate', url='...'), cdp('DOM.getDocument', depth=-1)."""
+    if session_id is not None and not isinstance(session_id, str):
+        raise TypeError("session_id must be a string; pass CDP parameters as keywords, e.g. cdp('DOM.getDocument', depth=-1)")
     if not session_id and not method.startswith(("Target.", "Browser.")):
         _selected_target()
     return _send(
@@ -95,17 +97,14 @@ def cdp(method, session_id=None, _response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_
     ).get("result", {})
 
 
-def drain_events():
-    """Drain events for this CLI process's selected tab only."""
-    return _send({"meta": "drain_events", "target_id": _selected_target()})["events"]
+def drain_events(all_targets=False):
+    """Drain this tab's events, or the separate browser/raw-session queue."""
+    return _send({"meta": "drain_events", "target_id": None if all_targets else _selected_target()})["events"]
 
 
 def _selected_target():
-    # Legacy scripts inherit the default once; another client cannot move it
-    # between two calls in this process. Concurrent tasks should select their
-    # own tab explicitly with new_tab()/switch_tab().
     if _TARGET_ID is None:
-        current_tab()
+        raise RuntimeError("no tab selected in this process; call switch_tab(target_id) or new_tab(url) first. Use list_tabs() to inspect existing tabs.")
     return _TARGET_ID
 
 
@@ -422,21 +421,12 @@ def list_tabs(include_chrome=True):
     return out
 
 def current_tab():
-    if _TARGET_ID is None:
-        r = _send({"meta": "current_tab"})
-        _set_client_tab(r["targetId"])
-    else:
-        info = cdp("Target.getTargetInfo", targetId=_TARGET_ID)["targetInfo"]
-        r = {
-            "targetId": info["targetId"],
-            "url": info.get("url", ""),
-            "title": info.get("title", ""),
-        }
+    info = cdp("Target.getTargetInfo", targetId=_selected_target())["targetInfo"]
     return {
-        "targetId": r["targetId"],
-        "target_id": r["targetId"],
-        "url": r["url"],
-        "title": r["title"],
+        "targetId": info["targetId"],
+        "target_id": info["targetId"],
+        "url": info.get("url", ""),
+        "title": info.get("title", ""),
     }
 
 def _mark_tab():

--- a/src/browser_harness/recorder.py
+++ b/src/browser_harness/recorder.py
@@ -30,7 +30,7 @@ from . import paths
 # inspection-heavy sessions without adding visual beats.
 ACTIONS = {
     "goto_url", "click_at_xy", "type_text", "fill_input", "press_key",
-    "scroll", "dispatch_key", "upload_file", "new_tab", "switch_tab",
+    "scroll", "dispatch_key", "upload_file", "new_tab", "activate_tab",
     "close_tab", "ensure_real_tab",
     "wait", "wait_for_load", "wait_for_element", "wait_for_network_idle",
 }

--- a/src/browser_harness/run.py
+++ b/src/browser_harness/run.py
@@ -38,8 +38,7 @@ Read SKILL.md for the default workflow and examples.
 
 Typical usage:
   browser-harness <<'PY'
-  ensure_real_tab()
-  print(page_info())
+  print(list_tabs())  # select an exact target with switch_tab(id), or use new_tab(url)
   PY
 
 Helpers are pre-imported. The daemon auto-starts and connects to the running browser.
@@ -71,7 +70,7 @@ Commands:
 
 USAGE = """Usage:
   browser-harness <<'PY'
-  print(page_info())
+  print(list_tabs())
   PY
 """
 

--- a/tests/integration/test_shared_browser.py
+++ b/tests/integration/test_shared_browser.py
@@ -1,0 +1,155 @@
+"""Opt-in live CDP stress test using only a disposable Chrome profile.
+
+BH_TEST_CHROME=/path/to/chrome BH_TEST_AGENTS=100 uv run --with pytest \
+    python -m pytest tests/integration/test_shared_browser.py -q -s
+"""
+import asyncio
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+from urllib.parse import quote
+
+import pytest
+from PIL import Image
+
+
+@pytest.mark.skipif(not os.environ.get("BH_TEST_CHROME"), reason="set BH_TEST_CHROME to opt in")
+def test_independent_processes_share_one_browser_connection():
+    count = int(os.environ.get("BH_TEST_AGENTS", "10"))
+    with tempfile.TemporaryDirectory(prefix="bh-multi-", dir=None if os.name == "nt" else "/tmp") as folder:
+        root = Path(folder)
+        profile = root / "chrome"
+        with (root / "chrome.log").open("wb") as log:
+            chrome = subprocess.Popen([
+                os.environ["BH_TEST_CHROME"], "--headless=new", "--remote-debugging-port=0",
+                f"--user-data-dir={profile}", "--no-first-run", "--no-default-browser-check",
+                "--disable-extensions", "--disable-background-networking", "--window-size=800,600",
+                "about:blank",
+            ], stdout=subprocess.DEVNULL, stderr=log)
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("BU_", "BH_"))}
+        env.update(BH_HOME=str(root / "home"), BH_RUNTIME_DIR=str(root / "run"),
+                   BH_TMP_DIR=str(root / "shots"), BH_RECORD="0", BH_TAB_MARKER="0",
+                   BH_TELEMETRY="0", BH_DOMAIN_SKILLS="0")
+        try:
+            deadline = time.monotonic() + 20
+            port_file = profile / "DevToolsActivePort"
+            while not port_file.exists():
+                assert chrome.poll() is None, (root / "chrome.log").read_text()
+                assert time.monotonic() < deadline, "Chrome startup timed out"
+                time.sleep(0.05)
+            port, endpoint = port_file.read_text().splitlines()[:2]
+            env["BU_CDP_WS"] = f"ws://127.0.0.1:{port}{endpoint}"
+
+            async def cli(script):
+                p = await asyncio.create_subprocess_exec(
+                    sys.executable, "-m", "browser_harness.run", env=env,
+                    stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                try:
+                    out, err = await asyncio.wait_for(p.communicate(script.encode()), timeout=180)
+                except BaseException:
+                    if p.returncode is None:
+                        p.kill()
+                    await p.wait()
+                    raise
+                assert p.returncode == 0, err.decode() + out.decode()
+                return json.loads(out.decode().strip().splitlines()[-1])
+
+            async def run():
+                started = time.monotonic()
+
+                async def create(i):
+                    html = (f'<body style="margin:0;background:rgb({i % 256},100,150)">'
+                            '<button style="position:absolute;left:0;top:0;width:100px;height:40px" '
+                            f'onclick="window.clicks++">agent-{i}</button>'
+                            '<input style="position:absolute;left:0;top:50px;width:200px;height:40px">'
+                            f'<script>window.owner={i};window.clicks=0</script>')
+                    return await cli(f'''
+import json
+from browser_harness.helpers import _send
+tid = new_tab({("data:text/html," + quote(html))!r})
+assert wait_for_load()
+assert js("window.owner") == {i}
+print(json.dumps({{"target":tid,"pid":_send({{"meta":"ping"}})["pid"]}}))
+''')
+
+                # Cold-start burst; every creator exits before the next phase.
+                tabs = await asyncio.gather(*(create(i) for i in range(count)))
+                assert len({t["target"] for t in tabs}) == count
+                pids = {t["pid"] for t in tabs}
+                assert len(pids) == 1, f"multiple daemons: {pids}"
+
+                async def act(i, tab):
+                    return await cli(f'''
+import json
+from browser_harness.helpers import _send
+switch_tab({tab["target"]!r})
+click_at_xy(40, 20)
+click_at_xy(50, 70)
+type_text("agent-{i}")
+state = js("({{owner:window.owner, clicks:window.clicks, text:document.querySelector('input').value}})")
+assert state == {{"owner":{i},"clicks":1,"text":"agent-{i}"}}, state
+shot = capture_screenshot()
+assert current_tab()["targetId"] == {tab["target"]!r}
+print(json.dumps({{"shot":shot,"pid":_send({{"meta":"ping"}})["pid"]}}))
+''')
+                results = await asyncio.gather(*(act(i, t) for i, t in enumerate(tabs)))
+                assert {r["pid"] for r in results} == pids
+                assert len({r["shot"] for r in results}) == count
+                for i, r in enumerate(results):
+                    with Image.open(r["shot"]) as image:
+                        assert image.convert("RGB").getpixel((300, 200)) == (i % 256, 100, 150)
+                if count > 1:
+                    await cli(f'''
+import json, time
+switch_tab({tabs[0]["target"]!r})
+# Chrome suppresses background alerts. This is the disposable HEADLESS browser,
+# not the user's visible Chrome; activate only to exercise a real modal dialog.
+activate_tab({tabs[0]["target"]!r})
+cdp("Runtime.evaluate", expression="setTimeout(() => alert('only-tab-zero'), 10)", userGesture=True)
+time.sleep(0.2)
+print(json.dumps(page_info()))
+''')
+                    status = await cli(f'''
+import json
+switch_tab({tabs[1]["target"]!r})
+print(json.dumps(page_info()))
+''')
+                    assert "dialog" not in status
+                    await cli(f'''
+import json
+switch_tab({tabs[0]["target"]!r})
+assert page_info()["dialog"]["message"] == "only-tab-zero"
+cdp("Page.handleJavaScriptDialog", accept=True)
+print(json.dumps(True))
+''')
+                # Closing even the startup default must not replace the daemon.
+                cleanup = await cli('''
+import json
+from browser_harness.helpers import _send
+for t in list_tabs(): close_tab(t)
+assert "error" not in _send({"meta":"connection_status"})
+print(json.dumps(_send({"meta":"ping"})["pid"]))
+''')
+                fresh = await create(count)
+                assert {cleanup, fresh["pid"]} == pids
+                print(json.dumps({"agents": count, "daemons": len(pids), "distinct_tabs": count,
+                                  "distinct_screenshots": count, "seconds": round(time.monotonic()-started, 2)}))
+
+            asyncio.run(run())
+        finally:
+            # Only the owned test daemon in this isolated runtime directory.
+            subprocess.run([sys.executable, "-c",
+                            "from browser_harness.admin import restart_daemon; restart_daemon()"],
+                           env=env, capture_output=True, timeout=20)
+            chrome.terminate()
+            try:
+                chrome.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                chrome.kill()
+                chrome.wait(timeout=5)

--- a/tests/integration/test_shared_browser.py
+++ b/tests/integration/test_shared_browser.py
@@ -32,7 +32,7 @@ def test_independent_processes_share_one_browser_connection():
             ], stdout=subprocess.DEVNULL, stderr=log)
         env = {k: v for k, v in os.environ.items() if not k.startswith(("BU_", "BH_"))}
         env.update(BH_HOME=str(root / "home"), BH_RUNTIME_DIR=str(root / "run"),
-                   BH_TMP_DIR=str(root / "shots"), BH_RECORD="0", BH_TAB_MARKER="0",
+                   BH_TMP_DIR=str(root / "shots"), BH_RECORD="0", BH_TAB_MARKER=os.environ.get("BH_TEST_TAB_MARKER", "1"),
                    BH_TELEMETRY="0", BH_DOMAIN_SKILLS="0")
         try:
             deadline = time.monotonic() + 20
@@ -64,11 +64,13 @@ def test_independent_processes_share_one_browser_connection():
                 started = time.monotonic()
 
                 async def create(i):
-                    html = (f'<body style="margin:0;background:rgb({i % 256},100,150)">'
+                    html = (f'<body style="margin:0;height:2000px;background:rgb({i % 256},100,150)">'
                             '<button style="position:absolute;left:0;top:0;width:100px;height:40px" '
                             f'onclick="window.clicks++">agent-{i}</button>'
                             '<input style="position:absolute;left:0;top:50px;width:200px;height:40px">'
-                            f'<script>window.owner={i};window.clicks=0</script>')
+                            f'<script>window.owner={i};window.clicks=0;window.framesSeen=0;'
+                            'function tick(){window.framesSeen++;requestAnimationFrame(tick)};'
+                            'requestAnimationFrame(tick)</script>')
                     return await cli(f'''
 import json
 from browser_harness.helpers import _send
@@ -83,6 +85,17 @@ print(json.dumps({{"target":tid,"pid":_send({{"meta":"ping"}})["pid"]}}))
                 assert len({t["target"] for t in tabs}) == count
                 pids = {t["pid"] for t in tabs}
                 assert len(pids) == 1, f"multiple daemons: {pids}"
+                # A later CLI must not silently inherit any other task's tab.
+                await cli('''
+import json
+try:
+    click_at_xy(40, 20)
+except RuntimeError as error:
+    assert "no tab selected" in str(error)
+else:
+    raise AssertionError("unselected action must fail")
+print(json.dumps(True))
+''')
 
                 async def act(i, tab):
                     return await cli(f'''
@@ -94,6 +107,11 @@ click_at_xy(50, 70)
 type_text("agent-{i}")
 state = js("({{owner:window.owner, clicks:window.clicks, text:document.querySelector('input').value}})")
 assert state == {{"owner":{i},"clicks":1,"text":"agent-{i}"}}, state
+frames = js("window.framesSeen")
+scroll(150, 150, dy=300)
+wait(0.1)
+assert js("scrollY") > 0, "background wheel input stalled"
+assert js("window.framesSeen") > frames, "background animation frames stalled"
 shot = capture_screenshot()
 assert current_tab()["targetId"] == {tab["target"]!r}
 print(json.dumps({{"shot":shot,"pid":_send({{"meta":"ping"}})["pid"]}}))
@@ -108,9 +126,7 @@ print(json.dumps({{"shot":shot,"pid":_send({{"meta":"ping"}})["pid"]}}))
                     await cli(f'''
 import json, time
 switch_tab({tabs[0]["target"]!r})
-# Chrome suppresses background alerts. This is the disposable HEADLESS browser,
-# not the user's visible Chrome; activate only to exercise a real modal dialog.
-activate_tab({tabs[0]["target"]!r})
+# Focus emulation permits this background dialog without visible activation.
 cdp("Runtime.evaluate", expression="setTimeout(() => alert('only-tab-zero'), 10)", userGesture=True)
 time.sleep(0.2)
 print(json.dumps(page_info()))
@@ -144,12 +160,14 @@ print(json.dumps(_send({"meta":"ping"})["pid"]))
             asyncio.run(run())
         finally:
             # Only the owned test daemon in this isolated runtime directory.
-            subprocess.run([sys.executable, "-c",
-                            "from browser_harness.admin import restart_daemon; restart_daemon()"],
-                           env=env, capture_output=True, timeout=20)
-            chrome.terminate()
             try:
-                chrome.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                chrome.kill()
-                chrome.wait(timeout=5)
+                subprocess.run([sys.executable, "-c",
+                                "from browser_harness.admin import restart_daemon; restart_daemon()"],
+                               env=env, capture_output=True, timeout=20)
+            finally:
+                chrome.terminate()
+                try:
+                    chrome.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    chrome.kill()
+                    chrome.wait(timeout=5)

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -193,6 +193,14 @@ def test_prepare_target_attaches_once_without_changing_daemon_default():
     }
     assert enabled == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
     assert [method for method, _params, _session in d.cdp.calls].count("Target.attachToTarget") == 1
+    assert [call for call in d.cdp.calls if call[0] == "Emulation.setFocusEmulationEnabled"] == [
+        ("Emulation.setFocusEmulationEnabled", {"enabled": True}, "session-for-agent-target")
+    ]
+    asyncio.run(d.handle({"method":"Emulation.setFocusEmulationEnabled", "target_id":"agent-target", "params":{"enabled":False}}))
+    asyncio.run(d.handle({"meta":"prepare_target", "target_id":"agent-target"}))
+    assert [call[1] for call in d.cdp.calls if call[0] == "Emulation.setFocusEmulationEnabled"] == [
+        {"enabled":True}, {"enabled":False}
+    ], "reselecting a cached target must preserve the agent's override"
     assert not [
         call for call in d.cdp.calls
         if call[0] == "Network.disable" and call[2] == "daemon-default-session"
@@ -285,18 +293,26 @@ def test_target_scoped_event_drain_does_not_consume_another_agents_events():
     assert [event["params"]["requestId"] for event in second["events"]] == ["b"]
 
 
-def test_default_event_drain_does_not_consume_another_targets_events():
+def test_global_event_drain_preserves_raw_events_and_independent_tab_queues():
     d = _fresh_daemon()
     d.target_id = "default-target"
     d.session_targets = {"default-session": "default-target", "other-session": "other-target"}
     d._record_event("Network.requestWillBeSent", {"requestId": "default"}, "default-session")
     d._record_event("Network.requestWillBeSent", {"requestId": "other"}, "other-session")
+    d._record_event("Browser.downloadWillBegin", {})
+    d._record_event("Target.attachedToTarget", {})
+    d._record_event("Network.requestWillBeSent", {}, "raw-iframe")
 
     default = asyncio.run(d.handle({"meta": "drain_events"}))
     other = asyncio.run(d.handle({"meta": "drain_events", "target_id": "other-target"}))
 
-    assert [event["params"]["requestId"] for event in default["events"]] == ["default"]
+    assert len(default["events"]) == 5
+    assert default["events"][-1]["session_id"] == "raw-iframe"
     assert [event["params"]["requestId"] for event in other["events"]] == ["other"]
+    assert asyncio.run(d.handle({"meta":"drain_events"}))["events"] == []
+    d._record_event("Network.responseReceived", {}, "other-session")
+    asyncio.run(d.handle({"meta":"drain_events", "target_id":"other-target"}))
+    assert len(asyncio.run(d.handle({"meta":"drain_events"}))["events"]) == 1
 
 
 def test_pending_dialog_is_scoped_to_the_requesting_target():
@@ -363,7 +379,7 @@ def test_enable_default_domains_swallows_errors_per_domain():
     class _PartialFailureCDP(_FakeCDP):
         async def send_raw(self, method, params=None, session_id=None):
             self.calls.append((method, params, session_id))
-            if method == "DOM.enable":
+            if method in ("DOM.enable", "Emulation.setFocusEmulationEnabled"):
                 raise RuntimeError("simulated DOM failure")
             return {}
 
@@ -377,6 +393,7 @@ def test_enable_default_domains_swallows_errors_per_domain():
     assert "DOM.enable" in attempted  # attempted, but raised
     assert "Runtime.enable" in attempted
     assert "Network.enable" in attempted
+    assert "Emulation.setFocusEmulationEnabled" in attempted
 
 
 def test_set_session_keeps_old_target_domains_enabled():
@@ -434,7 +451,7 @@ def test_set_session_runs_enables_in_parallel():
         # in-flight. Cap iterations to avoid hanging if parallelization breaks.
         for _ in range(50):
             await asyncio.sleep(0)
-            if d.cdp.in_flight >= 4:
+            if d.cdp.in_flight >= 5:
                 break
         peak = d.cdp.max_concurrent
         d.cdp.release.set()
@@ -442,8 +459,8 @@ def test_set_session_runs_enables_in_parallel():
         return peak, d.cdp.calls
 
     peak, calls = asyncio.run(run())
-    assert peak == 4, (
-        f"set_session must run four enables concurrently "
+    assert peak == 5, (
+        f"set_session must run domain and focus enables concurrently "
         f"(observed peak in-flight = {peak}). Sequential await would peak at 1."
     )
     methods = sorted({m for (m, _p, _s) in calls})

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -146,11 +146,7 @@ def test_tab_marker_disabled_on_page_load_events(monkeypatch, value):
 
 
 def test_set_session_enables_all_four_default_domains_on_new_session():
-    """Regression: switch_tab() / new_tab() in helpers.py route through the
-    `set_session` IPC, which previously only enabled Page on the new
-    session. With Network disabled, wait_for_network_idle() silently stops
-    receiving events after a tab switch. Initial attach enables all four
-    (Page, DOM, Runtime, Network); set_session must enable the same set."""
+    """Legacy set_session must retain domain parity with initial attach."""
     d = _fresh_daemon()
     new_session = "session-AFTER-switch"
 
@@ -170,6 +166,177 @@ def test_set_session_enables_all_four_default_domains_on_new_session():
     )
     assert d.session == new_session
     assert d.target_id == "target-2"
+
+
+def test_prepare_target_attaches_once_without_changing_daemon_default():
+    d = daemon.Daemon()
+    d.cdp = _AttachCDP()
+    d.session = "daemon-default-session"
+    d.target_id = "daemon-default-target"
+
+    result = asyncio.run(d.handle({
+        "meta": "prepare_target",
+        "target_id": "agent-target",
+    }))
+    again = asyncio.run(d.handle({
+        "meta": "prepare_target",
+        "target_id": "agent-target",
+    }))
+
+    assert result == {"session_id": "session-for-agent-target", "target_id": "agent-target"}
+    assert again == result
+    assert d.session == "daemon-default-session"
+    assert d.target_id == "daemon-default-target"
+    enabled = {
+        method for method, _params, session_id in d.cdp.calls
+        if session_id == "session-for-agent-target" and method.endswith(".enable")
+    }
+    assert enabled == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
+    assert [method for method, _params, _session in d.cdp.calls].count("Target.attachToTarget") == 1
+    assert not [
+        call for call in d.cdp.calls
+        if call[0] == "Network.disable" and call[2] == "daemon-default-session"
+    ]
+
+
+def test_concurrent_prepare_target_calls_share_one_attachment():
+    class _SlowAttachCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Target.attachToTarget":
+                await asyncio.sleep(0)
+                return {"sessionId": "shared-session"}
+            return {}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _SlowAttachCDP()
+        requests = [
+            d.handle({"meta": "prepare_target", "target_id": "shared-target"}),
+            d.handle({"meta": "prepare_target", "target_id": "shared-target"}),
+        ]
+        return d, await asyncio.gather(*requests)
+
+    d, results = asyncio.run(run())
+
+    expected = {"session_id": "shared-session", "target_id": "shared-target"}
+    assert results == [expected, expected]
+    assert [call[0] for call in d.cdp.calls].count("Target.attachToTarget") == 1
+
+
+def test_concurrent_clients_keep_commands_on_their_target_sessions():
+    class _ConcurrentCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            await asyncio.sleep(0)
+            return {"value": f"{session_id}:{params['expression']}"}
+
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = _ConcurrentCDP()
+        d.session = "daemon-default-session"
+        d.target_sessions = {"target-a": "session-a", "target-b": "session-b"}
+        d.session_targets = {"session-a": "target-a", "session-b": "target-b"}
+        return d, await asyncio.gather(
+            d.handle({
+                "method": "Runtime.evaluate",
+                "params": {"expression": "agent-a"},
+                "target_id": "target-a",
+            }),
+            d.handle({
+                "method": "Runtime.evaluate",
+                "params": {"expression": "agent-b"},
+                "target_id": "target-b",
+            }),
+        )
+
+    d, results = asyncio.run(run())
+
+    assert results == [
+        {"result": {"value": "session-a:agent-a"}},
+        {"result": {"value": "session-b:agent-b"}},
+    ]
+    assert d.session == "daemon-default-session"
+
+
+def test_browser_domain_commands_bypass_the_selected_target_session():
+    d = _fresh_daemon()
+    d._remember_target_session("agent-target", "agent-session")
+
+    asyncio.run(d.handle({
+        "method": "Browser.getVersion",
+        "params": {},
+        "target_id": "agent-target",
+    }))
+
+    assert d.cdp.calls == [("Browser.getVersion", {}, None)]
+
+
+def test_target_scoped_event_drain_does_not_consume_another_agents_events():
+    d = _fresh_daemon()
+    d.session_targets = {"session-a": "target-a", "session-b": "target-b"}
+    d._record_event("Network.requestWillBeSent", {"requestId": "a"}, "session-a")
+    d._record_event("Network.requestWillBeSent", {"requestId": "b"}, "session-b")
+
+    first = asyncio.run(d.handle({"meta": "drain_events", "target_id": "target-a"}))
+    second = asyncio.run(d.handle({"meta": "drain_events", "target_id": "target-b"}))
+
+    assert [event["params"]["requestId"] for event in first["events"]] == ["a"]
+    assert [event["params"]["requestId"] for event in second["events"]] == ["b"]
+
+
+def test_default_event_drain_does_not_consume_another_targets_events():
+    d = _fresh_daemon()
+    d.target_id = "default-target"
+    d.session_targets = {"default-session": "default-target", "other-session": "other-target"}
+    d._record_event("Network.requestWillBeSent", {"requestId": "default"}, "default-session")
+    d._record_event("Network.requestWillBeSent", {"requestId": "other"}, "other-session")
+
+    default = asyncio.run(d.handle({"meta": "drain_events"}))
+    other = asyncio.run(d.handle({"meta": "drain_events", "target_id": "other-target"}))
+
+    assert [event["params"]["requestId"] for event in default["events"]] == ["default"]
+    assert [event["params"]["requestId"] for event in other["events"]] == ["other"]
+
+
+def test_pending_dialog_is_scoped_to_the_requesting_target():
+    d = _fresh_daemon()
+    d.session_targets = {"session-a": "target-a", "session-b": "target-b"}
+    d._record_event("Page.javascriptDialogOpening", {"message": "A"}, "session-a")
+    d._record_event("Page.javascriptDialogOpening", {"message": "B"}, "session-b")
+
+    a = asyncio.run(d.handle({"meta": "pending_dialog", "target_id": "target-a"}))
+    b = asyncio.run(d.handle({"meta": "pending_dialog", "target_id": "target-b"}))
+
+    assert a == {"dialog": {"message": "A"}}
+    assert b == {"dialog": {"message": "B"}}
+
+
+def test_pending_dialog_survives_a_later_command_for_the_same_target():
+    d = _fresh_daemon()
+    d.session_targets["old-session"] = "same-target"
+    d._record_event("Page.javascriptDialogOpening", {"message": "Still open"}, "old-session")
+
+    result = asyncio.run(d.handle({
+        "meta": "pending_dialog",
+        "target_id": "same-target",
+    }))
+
+    assert result == {"dialog": {"message": "Still open"}}
+
+
+def test_target_destroyed_cleans_cached_target_state():
+    d = _fresh_daemon()
+    d._remember_target_session("agent-target", "agent-session")
+    d._record_event("Network.requestWillBeSent", {"requestId": "a"}, "agent-session")
+    d._record_event("Page.javascriptDialogOpening", {"message": "A"}, "agent-session")
+
+    d._record_event("Target.targetDestroyed", {"targetId": "agent-target"})
+
+    assert "agent-session" not in d.session_targets
+    assert "agent-target" not in d.target_sessions
+    assert "agent-target" not in d.events_by_target
+    assert "agent-target" not in d.dialogs_by_target
 
 
 def test_set_session_falls_back_to_existing_target_id_when_not_provided():
@@ -212,14 +379,12 @@ def test_enable_default_domains_swallows_errors_per_domain():
     assert "Network.enable" in attempted
 
 
-def test_set_session_disables_network_on_old_session_before_enabling_new():
-    """When switching tabs, the previous session's Network domain must be
-    disabled so background tabs (polling, SSE, etc.) stop emitting events
-    into the global buffer that wait_for_network_idle reads. Initial attach
-    has no `old_session` so this disable doesn't fire then."""
+def test_set_session_keeps_old_target_domains_enabled():
+    """A legacy client moving the default must not disrupt target-aware clients."""
     d = _fresh_daemon()
     d.session = "session-OLD"
     d.target_id = "target-OLD"
+    d._remember_target_session("target-OLD", "session-OLD")
 
     asyncio.run(d.handle({
         "meta": "set_session",
@@ -227,49 +392,17 @@ def test_set_session_disables_network_on_old_session_before_enabling_new():
         "target_id": "target-NEW",
     }))
 
-    disabled = [
-        (method, sid) for (method, _params, sid) in d.cdp.calls
-        if method == "Network.disable"
-    ]
-    assert disabled == [("Network.disable", "session-OLD")], (
-        f"Network.disable must fire on the old session before re-enabling on "
-        f"the new one. Got: {disabled}"
-    )
-
-    # Sanity: the new session still gets Network.enable.
+    assert not [call for call in d.cdp.calls if call[0] == "Network.disable"]
+    assert d.target_sessions["target-OLD"] == "session-OLD"
     enabled_on_new = {
         method for (method, _p, sid) in d.cdp.calls
         if sid == "session-NEW" and method.endswith(".enable")
     }
-    assert "Network.enable" in enabled_on_new
+    assert enabled_on_new == {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}
 
 
-def test_set_session_does_not_disable_network_when_no_previous_session():
-    """First set_session call (e.g. very early in startup before any attach)
-    has no old_session — the Network.disable path must be skipped."""
-    d = _fresh_daemon()
-    d.session = None  # no prior attach
-
-    asyncio.run(d.handle({
-        "meta": "set_session",
-        "session_id": "session-FIRST",
-        "target_id": "target-FIRST",
-    }))
-
-    disables = [m for (m, _p, _s) in d.cdp.calls if m == "Network.disable"]
-    assert disables == [], (
-        f"Network.disable must not fire when there's no previous session "
-        f"to disable. Got: {disables}"
-    )
-
-
-def test_set_session_runs_disable_and_enables_in_parallel():
-    """The four Domain.enable calls (plus Network.disable on the old session)
-    must run concurrently via asyncio.gather, not sequentially. With the old
-    sequential code, helpers.switch_tab() would block in _send() for up to
-    ~22s on a slow/remote daemon while the helper's IPC socket has a 5s
-    read timeout, causing client-side socket timeouts. Verifying that all
-    five CDP calls reach send_raw before any returns proves parallelization."""
+def test_set_session_runs_enables_in_parallel():
+    """Legacy set_session keeps the four domain enables concurrent."""
     class _ConcurrencyProbeCDP:
         def __init__(self):
             self.calls = []
@@ -290,7 +423,6 @@ def test_set_session_runs_disable_and_enables_in_parallel():
     async def run():
         d = daemon.Daemon()
         d.cdp = _ConcurrencyProbeCDP()
-        d.session = "session-OLD"  # ensures Network.disable on old fires
         d.cdp.release = asyncio.Event()
 
         handle_task = asyncio.create_task(d.handle({
@@ -302,8 +434,7 @@ def test_set_session_runs_disable_and_enables_in_parallel():
         # in-flight. Cap iterations to avoid hanging if parallelization breaks.
         for _ in range(50):
             await asyncio.sleep(0)
-            # 5 = Network.disable on OLD + 4 enables on NEW.
-            if d.cdp.in_flight >= 5:
+            if d.cdp.in_flight >= 4:
                 break
         peak = d.cdp.max_concurrent
         d.cdp.release.set()
@@ -311,62 +442,12 @@ def test_set_session_runs_disable_and_enables_in_parallel():
         return peak, d.cdp.calls
 
     peak, calls = asyncio.run(run())
-    assert peak == 5, (
-        f"set_session must run disable + 4 enables concurrently via gather "
-        f"(observed peak in-flight = {peak}; expected 5 = 1 disable on OLD + "
-        f"4 enables on NEW). Sequential await would peak at 1."
-    )
-    # Sanity: the right calls were made.
-    methods = sorted({m for (m, _p, _s) in calls})
-    assert "Network.disable" in methods
-    assert {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}.issubset(methods)
-
-
-def test_set_session_first_attach_runs_four_enables_in_parallel():
-    """When there's no previous session, the disable path is skipped — only
-    the four enables run, still in parallel."""
-    class _ConcurrencyProbeCDP:
-        def __init__(self):
-            self.calls = []
-            self.in_flight = 0
-            self.max_concurrent = 0
-            self.release = None
-
-        async def send_raw(self, method, params=None, session_id=None):
-            self.calls.append((method, params, session_id))
-            self.in_flight += 1
-            self.max_concurrent = max(self.max_concurrent, self.in_flight)
-            try:
-                await self.release.wait()
-            finally:
-                self.in_flight -= 1
-            return {}
-
-    async def run():
-        d = daemon.Daemon()
-        d.cdp = _ConcurrencyProbeCDP()
-        d.session = None  # no previous session
-        d.cdp.release = asyncio.Event()
-
-        handle_task = asyncio.create_task(d.handle({
-            "meta": "set_session",
-            "session_id": "session-FIRST",
-            "target_id": "target-FIRST",
-        }))
-        for _ in range(50):
-            await asyncio.sleep(0)
-            if d.cdp.in_flight >= 4:
-                break
-        peak = d.cdp.max_concurrent
-        d.cdp.release.set()
-        await handle_task
-        return peak
-
-    peak = asyncio.run(run())
     assert peak == 4, (
-        f"first set_session must run 4 enables concurrently "
-        f"(observed peak = {peak}). No Network.disable should fire."
+        f"set_session must run four enables concurrently "
+        f"(observed peak in-flight = {peak}). Sequential await would peak at 1."
     )
+    methods = sorted({m for (m, _p, _s) in calls})
+    assert {"Page.enable", "DOM.enable", "Runtime.enable", "Network.enable"}.issubset(methods)
 
 
 def test_current_tab_meta_passes_attached_target_id():
@@ -845,3 +926,30 @@ def test_explicit_stale_session_is_not_redirected():
     assert d.cdp.calls == [
         ("Runtime.evaluate", {"expression": "1"}, "explicit-stale-session")
     ]
+
+
+def test_stale_target_session_reattaches_to_the_same_target():
+    class _StaleTargetCDP(_FakeCDP):
+        async def send_raw(self, method, params=None, session_id=None):
+            self.calls.append((method, params, session_id))
+            if method == "Runtime.evaluate" and session_id == "stale-session":
+                raise RuntimeError("Session with given id not found")
+            if method == "Target.attachToTarget":
+                return {"sessionId": "replacement-session"}
+            if method == "Runtime.evaluate" and session_id == "replacement-session":
+                return {"value": "same-target"}
+            return {}
+
+    d = daemon.Daemon()
+    d.cdp = _StaleTargetCDP()
+    d._remember_target_session("agent-target", "stale-session")
+
+    result = asyncio.run(d.handle({
+        "method": "Runtime.evaluate",
+        "params": {"expression": "1"},
+        "target_id": "agent-target",
+    }))
+
+    assert result == {"result": {"value": "same-target"}}
+    assert d.target_sessions["agent-target"] == "replacement-session"
+    assert d.session_targets["replacement-session"] == "agent-target"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -9,6 +9,11 @@ from PIL import Image
 from browser_harness import helpers
 
 
+@pytest.fixture(autouse=True)
+def _reset_client_tab(monkeypatch):
+    monkeypatch.setattr(helpers, "_TARGET_ID", "test-target")
+
+
 def _run(fake_png, width, height, **kwargs):
     fake = lambda method, **_: {"data": fake_png(width, height)}
     with patch("browser_harness.helpers.cdp", side_effect=fake), tempfile.TemporaryDirectory() as d:
@@ -61,6 +66,7 @@ def test_screenshot_uses_long_response_timeout_without_forwarding_it_to_cdp(fake
         "method": "Page.captureScreenshot",
         "params": {"format": "png", "captureBeyondViewport": False},
         "session_id": None,
+        "target_id": "test-target",
     }
     assert send.call_args.kwargs == {
         "response_timeout": helpers.SCREENSHOT_IPC_RESPONSE_TIMEOUT_SECONDS
@@ -317,9 +323,9 @@ def test_wait_for_network_idle_waits_for_inflight_request():
     # even though >idle_ms elapses between requestWillBeSent and loadingFinished.
     # An event-silence-only implementation would return True at iter2 (wrong).
     events_seq = [
-        [{"method": "Network.requestWillBeSent", "params": {"requestId": "req1"}}],
+        [{"target_id": "test-target", "method": "Network.requestWillBeSent", "params": {"requestId": "req1"}}],
         [],   # >500ms elapsed — old impl returns True here; new must NOT
-        [{"method": "Network.loadingFinished",   "params": {"requestId": "req1"}}],
+        [{"target_id": "test-target", "method": "Network.loadingFinished",   "params": {"requestId": "req1"}}],
         [],   # idle_ms after loadingFinished → return True
     ]
     idx = 0
@@ -358,7 +364,7 @@ def test_wait_for_network_idle_returns_false_on_timeout():
     # Continuous rWS keeps inflight non-empty → idle check short-circuits every iteration.
     # time.time() is only called for while-check and rWS last_activity (not idle check).
     def fake_send(req):
-        return {"events": [{"method": "Network.requestWillBeSent", "params": {"requestId": "r"}}]}
+        return {"events": [{"target_id": "test-target", "method": "Network.requestWillBeSent", "params": {"requestId": "r"}}]}
 
     with patch("browser_harness.helpers._send", side_effect=fake_send), \
          patch("browser_harness.helpers.time") as mock_time:
@@ -377,12 +383,8 @@ def test_wait_for_network_idle_returns_false_on_timeout():
 
 
 
-def test_wait_for_network_idle_filters_events_to_active_session():
-    """Background tabs (e.g. a polling page the agent switched away from) keep
-    emitting Network events into the daemon's global buffer. The wait must
-    filter by session_id of the currently-attached tab — otherwise it would
-    see the background tab's traffic and either fail to return idle or wait
-    on the wrong tab's requests."""
+def test_wait_for_network_idle_filters_events_to_active_target():
+    """Traffic on another target must not hold up this target's idle wait."""
     active = "session-ACTIVE"
     background = "session-BACKGROUND"
 
@@ -391,8 +393,8 @@ def test_wait_for_network_idle_filters_events_to_active_session():
     # active session sees no traffic and the idle window can elapse.
     events_seq = [
         [
-            {"session_id": background, "method": "Network.requestWillBeSent", "params": {"requestId": "bg1"}},
-            {"session_id": background, "method": "Network.loadingFinished",   "params": {"requestId": "bg1"}},
+            {"target_id": "other-target", "session_id": background, "method": "Network.requestWillBeSent", "params": {"requestId": "bg1"}},
+            {"target_id": "other-target", "session_id": background, "method": "Network.loadingFinished",   "params": {"requestId": "bg1"}},
         ],
         [],  # second drain — quiet on both sessions; idle window should fire here
     ]
@@ -439,21 +441,57 @@ def test_mark_tab_can_be_disabled(monkeypatch, value):
     assert calls == []
 
 
+def test_cdp_routes_calls_with_the_cli_target(monkeypatch):
+    requests = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", "target-agent-a")
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request, response_timeout=helpers.DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS:
+            requests.append(request) or {"result": {}},
+    )
+
+    helpers.cdp("Page.captureScreenshot")
+    helpers.cdp("Target.getTargets")
+
+    assert requests == [
+        {
+            "method": "Page.captureScreenshot",
+            "params": {},
+            "session_id": None,
+            "target_id": "target-agent-a",
+        },
+        {
+            "method": "Target.getTargets",
+            "params": {},
+            "session_id": None,
+            "target_id": "target-agent-a",
+        },
+    ]
+
+
 def test_switch_tab_keeps_visible_tab_unchanged_by_default(monkeypatch):
     calls = []
 
     def fake_cdp(method, **kwargs):
         calls.append((method, kwargs))
-        if method == "Target.attachToTarget":
-            return {"sessionId": "session-new"}
         return {}
 
     monkeypatch.setattr(helpers, "cdp", fake_cdp)
-    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request: calls.append(("ipc", request)) or {"session_id": "session-new"},
+    )
     monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
 
     assert helpers.switch_tab({"target_id": "target-new"}) == "session-new"
     assert not any(method == "Target.activateTarget" for method, _ in calls)
+    assert ("ipc", {
+        "meta": "prepare_target",
+        "target_id": "target-new",
+    }) in calls
+    assert helpers._TARGET_ID == "target-new"
 
 
 def test_switch_tab_can_explicitly_activate_visible_tab(monkeypatch):
@@ -461,12 +499,14 @@ def test_switch_tab_can_explicitly_activate_visible_tab(monkeypatch):
 
     def fake_cdp(method, **kwargs):
         calls.append((method, kwargs))
-        if method == "Target.attachToTarget":
-            return {"sessionId": "session-new"}
         return {}
 
     monkeypatch.setattr(helpers, "cdp", fake_cdp)
-    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request: calls.append(("ipc", request)) or {"session_id": "session-new"},
+    )
     monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
 
     assert helpers.switch_tab("target-new", activate=True) == "session-new"
@@ -480,12 +520,14 @@ def test_new_tab_creates_and_attaches_in_background(monkeypatch):
         calls.append((method, kwargs))
         if method == "Target.createTarget":
             return {"targetId": "target-new"}
-        if method == "Target.attachToTarget":
-            return {"sessionId": "session-new"}
         return {}
 
     monkeypatch.setattr(helpers, "cdp", fake_cdp)
-    monkeypatch.setattr(helpers, "_send", lambda request: calls.append(("ipc", request)) or {})
+    monkeypatch.setattr(
+        helpers,
+        "_send",
+        lambda request: calls.append(("ipc", request)) or {"session_id": "session-new"},
+    )
     monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
 
     assert helpers.new_tab() == "target-new"
@@ -493,8 +535,46 @@ def test_new_tab_creates_and_attaches_in_background(monkeypatch):
     assert not any(method == "Target.activateTarget" for method, _ in calls)
 
 
-def test_new_tab_reuses_an_empty_data_document(monkeypatch):
+def test_first_new_tab_does_not_reuse_the_daemon_default_tab(monkeypatch):
     calls = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", None)
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "agent-owned-target"}
+        return {}
+
+    monkeypatch.setattr(helpers, "current_tab", lambda: pytest.fail("must not inspect shared default"))
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+    monkeypatch.setattr(helpers, "_send", lambda request: {"session_id": "agent-owned-session"})
+    monkeypatch.setattr(helpers, "_mark_tab", lambda: None)
+
+    assert helpers.new_tab("https://example.com") == "agent-owned-target"
+    assert ("Target.createTarget", {"url": "about:blank", "background": True}) in calls
+
+
+def test_current_tab_stays_on_the_cli_process_target(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", "target-agent-a")
+
+    def fake_cdp(method, **params):
+        calls.append((method, params))
+        return {"targetInfo": {
+            "targetId": params["targetId"],
+            "url": "https://a.example/",
+            "title": "Agent A",
+        }}
+
+    monkeypatch.setattr(helpers, "cdp", fake_cdp)
+
+    assert helpers.current_tab()["targetId"] == "target-agent-a"
+    assert calls == [("Target.getTargetInfo", {"targetId": "target-agent-a"})]
+
+
+def test_new_tab_never_reuses_a_selected_blank_tab(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", "target-placeholder")
     monkeypatch.setattr(
         helpers,
         "current_tab",
@@ -504,11 +584,16 @@ def test_new_tab_reuses_an_empty_data_document(monkeypatch):
     monkeypatch.setattr(
         helpers,
         "cdp",
-        lambda method, **kwargs: calls.append((method, kwargs)) or {},
+        lambda method, **kwargs: calls.append((method, kwargs)) or {"targetId": "fresh-target"},
     )
 
-    assert helpers.new_tab("https://example.com") == "target-placeholder"
-    assert calls == [("goto_url", "https://example.com")]
+    monkeypatch.setattr(helpers, "switch_tab", lambda target: calls.append(("switch_tab", target)))
+    assert helpers.new_tab("https://example.com") == "fresh-target"
+    assert calls == [
+        ("Target.createTarget", {"url": "about:blank", "background": True}),
+        ("switch_tab", "fresh-target"),
+        ("goto_url", "https://example.com"),
+    ]
 
 
 # --- press_key physical key identity (#685) ---

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -1,7 +1,16 @@
 import base64
 import json
+from unittest.mock import Mock
 
 from browser_harness import helpers, recorder
+
+
+def test_tab_selection_never_waits_for_a_recording_frame(monkeypatch):
+    capture = Mock(side_effect=AssertionError("selection must not capture"))
+    monkeypatch.setattr(recorder, "_capture", capture)
+    monkeypatch.setenv("BH_RECORD", "1")
+    recorder.observe("switch_tab", ("tab",), {}, 0.01)
+    capture.assert_not_called()
 
 
 class _FakeCDP:

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -69,6 +69,7 @@ def test_dropped_frame_is_recorded_and_never_raises(tmp_path, monkeypatch):
     def _timeout(_conn, _token, _req):
         raise TimeoutError("timed out")
 
+    monkeypatch.setattr(helpers, "_TARGET_ID", "recorded-target")
     monkeypatch.setattr(helpers.ipc, "connect", lambda _name, timeout=None: (_Socket(), None))
     monkeypatch.setattr(helpers.ipc, "request", _timeout)
     monkeypatch.setattr(helpers, "js", lambda expression: {})

--- a/tests/unit/test_shared_browser.py
+++ b/tests/unit/test_shared_browser.py
@@ -176,19 +176,52 @@ def test_default_screenshots_are_unique_and_preserved(monkeypatch, fake_png, tmp
     assert first.read_bytes() == original == second.read_bytes()
 
 
-def test_implicit_target_is_pinned_once_not_daemon_global(monkeypatch):
-    requests = []
+@pytest.mark.parametrize("operation", [helpers.current_tab, helpers.page_info, helpers.drain_events,
+    lambda: helpers.cdp("Runtime.evaluate", expression="1"),
+    lambda: helpers.click_at_xy(10, 10), lambda: helpers.close_tab()])
+def test_missing_target_fails_before_any_ipc(monkeypatch, operation):
     monkeypatch.setattr(helpers, "_TARGET_ID", None)
+    monkeypatch.setattr(helpers, "_send", lambda *a, **kw: pytest.fail("must not inherit the daemon default"))
+    with pytest.raises(RuntimeError, match="no tab selected.*switch_tab"):
+        operation()
 
-    def send(req, **kwargs):
-        requests.append(req)
-        if req.get("meta") == "current_tab":
-            return {"targetId": "initial", "url": "about:blank", "title": ""}
-        return {"result": {}}
 
+def test_raw_and_browser_access_needs_no_page_selection(monkeypatch):
+    monkeypatch.setattr(helpers, "_TARGET_ID", None)
+    send = Mock(return_value={"result": {}, "events": []})
     monkeypatch.setattr(helpers, "_send", send)
-    helpers.cdp("Runtime.evaluate", expression="1")
-    helpers.cdp("Page.captureScreenshot")
-    assert requests[0] == {"meta": "current_tab"}
-    assert len(requests) == 3
-    assert [r["target_id"] for r in requests[1:]] == ["initial", "initial"]
+    helpers.cdp("Browser.getVersion")
+    helpers.cdp("Runtime.evaluate", session_id="raw", expression="1")
+    assert helpers.drain_events(all_targets=True) == []
+    assert send.call_args.args[0] == {"meta": "drain_events", "target_id": None}
+    with pytest.raises(TypeError, match="parameters as keywords"):
+        helpers.cdp("DOM.getDocument", {"depth": -1})
+
+
+def test_target_recovery_cannot_overwrite_newer_legacy_selection():
+    async def run():
+        d = daemon.Daemon()
+        d.target_id, d.session = "page", "old"
+        d._remember_target_session("page", "old")
+        initializing, finish = asyncio.Event(), asyncio.Event()
+        async def send(method, params=None, session_id=None):
+            if method == "Target.attachToTarget":
+                return {"sessionId": "recovery"}
+            if session_id == "old":
+                raise RuntimeError("Session with given id not found.")
+            return {}
+        async def enable(session):
+            if session == "recovery":
+                initializing.set()
+                await finish.wait()
+        d.cdp = Mock(send_raw=send)
+        d._enable_default_domains = enable
+        d._schedule_tab_marker = Mock()
+        request = asyncio.create_task(d.handle({"method":"Runtime.evaluate", "target_id":"page"}))
+        await asyncio.wait_for(initializing.wait(), 1)
+        await d.handle({"meta":"set_session", "target_id":"page", "session_id":"newer"})
+        finish.set()
+        assert "result" in await asyncio.wait_for(request, 1)
+        assert d.session == d.target_sessions["page"] == "newer"
+        assert d.session_targets[d.session] == "page"
+    asyncio.run(run())

--- a/tests/unit/test_shared_browser.py
+++ b/tests/unit/test_shared_browser.py
@@ -1,0 +1,194 @@
+"""Connection/target invariants for independent CLI processes sharing Chrome."""
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from browser_harness import admin, daemon, helpers
+
+
+def test_initializing_target_is_not_used_early_or_cancelled_by_one_client():
+    async def run():
+        d = daemon.Daemon()
+        d.cdp = Mock(send_raw=AsyncMock(return_value={"sessionId": "session"}))
+        enabling, finish = asyncio.Event(), asyncio.Event()
+
+        async def enable(_session):
+            enabling.set()
+            await finish.wait()
+
+        d._enable_default_domains = enable
+        first = asyncio.create_task(d._ensure_target_session("tab"))
+        await enabling.wait()
+        second = asyncio.create_task(d._ensure_target_session("tab"))
+        await asyncio.sleep(0)
+        assert not second.done(), "cached attachment must wait for domain initialization"
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        finish.set()
+        assert await second == "session"
+        assert d.cdp.send_raw.await_count == 1
+        assert d._target_attach_tasks == {}
+
+    asyncio.run(run())
+
+
+def test_shutdown_drains_pending_attachments():
+    async def run():
+        d = daemon.Daemon()
+        attaching = asyncio.Event()
+
+        async def send(*_args, **_kwargs):
+            attaching.set()
+            await asyncio.Event().wait()
+
+        d.cdp = Mock(send_raw=send)
+        request = asyncio.create_task(d._ensure_target_session("tab"))
+        await attaching.wait()
+        d._shutting_down = True
+        assert await d._cancel_and_drain_recoveries()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(request, timeout=1)
+        assert d._target_attach_tasks == {}
+
+    asyncio.run(run())
+
+
+def test_closed_default_tab_does_not_make_connection_unhealthy():
+    d = daemon.Daemon()
+    d.target_id = "closed-tab"
+    d.session = "closed-session"
+    d.cdp = Mock(send_raw=AsyncMock(return_value={"targetInfos": []}))
+    assert asyncio.run(d.handle({"meta": "connection_status"})) == {
+        "target_id": None, "session_id": None, "page": None,
+    }
+    d.cdp.send_raw.assert_awaited_once_with("Target.getTargets")
+
+
+def test_explicit_raw_session_is_preserved_for_target_domain():
+    d = daemon.Daemon()
+    d.cdp = Mock(send_raw=AsyncMock(return_value={}))
+    result = asyncio.run(d.handle({
+        "method": "Target.setAutoAttach", "session_id": "iframe-session",
+        "params": {"autoAttach": True, "waitForDebuggerOnStart": False, "flatten": True},
+    }))
+    assert result == {"result": {}}
+    assert d.cdp.send_raw.call_args.kwargs["session_id"] == "iframe-session"
+
+
+def test_detachment_releases_target_buffers():
+    d = daemon.Daemon()
+    d._remember_target_session("tab", "session")
+    d._record_event("Page.javascriptDialogOpening", {"message": "example"}, "session")
+    d._record_event("Target.detachedFromTarget", {"sessionId": "session"})
+    assert not d.target_sessions
+    assert not d.session_targets
+    assert not d.events_by_target
+    assert not d.dialogs_by_target
+
+
+def test_start_subscribes_to_target_lifecycle_before_attaching(monkeypatch):
+    client = Mock()
+    client.start = AsyncMock()
+    client._event_registry.handle_event = AsyncMock()
+    events = []
+
+    async def send(method, params):
+        events.append(method)
+        assert params == {"discover": True}
+        # Prove discovery is already tapped, not just that it was sent.
+        await client._event_registry.handle_event("Target.targetCreated", {})
+
+    client.send_raw = send
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    monkeypatch.setattr(daemon, "get_ws_url", lambda: "ws://127.0.0.1:9222/test")
+    monkeypatch.setattr(daemon, "CDPClient", lambda _: client)
+    d = daemon.Daemon()
+
+    async def attach():
+        assert len(d.events) == 1
+        events.append("attach")
+
+    d.attach_first_page = attach
+    asyncio.run(d.start())
+    assert events == ["Target.setDiscoverTargets", "attach"]
+
+
+def test_local_websocket_has_no_approval_or_ping_deadline(monkeypatch):
+    import websockets
+
+    connect = AsyncMock(return_value=Mock())
+    monkeypatch.setattr(websockets, "connect", connect)
+    client = daemon._PatientCDPClient("ws://127.0.0.1:9222/test")
+    client._handle_messages = AsyncMock()
+    asyncio.run(client.start())
+    assert connect.call_args.kwargs["open_timeout"] is None
+    assert connect.call_args.kwargs["ping_interval"] is None
+
+
+def test_scoped_remote_without_discovery_can_still_start(monkeypatch):
+    client = Mock(start=AsyncMock(), send_raw=AsyncMock(side_effect=RuntimeError("unsupported")))
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    monkeypatch.setattr(daemon, "get_ws_url", lambda: "ws://127.0.0.1:9222/test")
+    monkeypatch.setattr(daemon, "CDPClient", lambda _: client)
+    d = daemon.Daemon()
+    d.attach_first_page = AsyncMock()
+    asyncio.run(d.start())
+    d.attach_first_page.assert_awaited_once()
+
+
+def test_old_daemon_has_actionable_upgrade_error_without_restart(monkeypatch):
+    sock = Mock()
+    monkeypatch.setattr(helpers.ipc, "connect", lambda *a, **kw: (sock, None))
+    monkeypatch.setattr(helpers.ipc, "request", lambda *a: {"error": "'method'"})
+    with pytest.raises(RuntimeError, match="predates per-tab routing"):
+        helpers._send({"meta": "prepare_target", "target_id": "tab"})
+    sock.close.assert_called_once()
+
+
+@pytest.mark.parametrize("timeout", [False, True])
+def test_health_probe_closes_socket_and_never_restarts_on_timeout(monkeypatch, timeout):
+    sock = Mock()
+    monkeypatch.setattr(admin, "daemon_alive", lambda _: True)
+    monkeypatch.setattr(admin.ipc, "connect", lambda *a, **kw: (sock, None))
+    request = Mock(side_effect=TimeoutError() if timeout else None, return_value={"result": {}})
+    monkeypatch.setattr(admin.ipc, "request", request)
+    monkeypatch.setattr(admin, "restart_daemon", lambda *a: pytest.fail("unexpected restart"))
+    monkeypatch.setattr(admin, "stop_remote_daemon", lambda *a: pytest.fail("unexpected stop"))
+    if timeout:
+        with pytest.raises(RuntimeError, match="left running"):
+            admin.ensure_daemon()
+    else:
+        admin.ensure_daemon()
+    assert request.call_count == 1
+    sock.close.assert_called_once()
+
+
+def test_default_screenshots_are_unique_and_preserved(monkeypatch, fake_png, tmp_path):
+    monkeypatch.setattr(helpers.ipc, "_TMP", tmp_path)
+    monkeypatch.setattr(helpers, "cdp", lambda *a, **kw: {"data": fake_png(10, 10)})
+    first = Path(helpers.capture_screenshot())
+    original = first.read_bytes()
+    second = Path(helpers.capture_screenshot())
+    assert first != second
+    assert first.read_bytes() == original == second.read_bytes()
+
+
+def test_implicit_target_is_pinned_once_not_daemon_global(monkeypatch):
+    requests = []
+    monkeypatch.setattr(helpers, "_TARGET_ID", None)
+
+    def send(req, **kwargs):
+        requests.append(req)
+        if req.get("meta") == "current_tab":
+            return {"targetId": "initial", "url": "about:blank", "title": ""}
+        return {"result": {}}
+
+    monkeypatch.setattr(helpers, "_send", send)
+    helpers.cdp("Runtime.evaluate", expression="1")
+    helpers.cdp("Page.captureScreenshot")
+    assert requests[0] == {"meta": "current_tab"}
+    assert len(requests) == 3
+    assert [r["target_id"] for r in requests[1:]] == ["initial", "initial"]


### PR DESCRIPTION
## Outcome

Many independent agent processes can operate different tabs through **one persistent browser connection**, using the user's real Chrome and logged-in sessions. Agents only retain a target ID; there is no agent registry, global browser lane, per-agent daemon, or new dependency.

Builds on #746 (`cbe5bc7`) without merging it. Keeps the background-first behavior merged in #759.

## Changes

- `new_tab()` creates a fresh background tab; `switch_tab(id)` selects it for the current CLI process only. Commands, events and dialogs route by target over the shared WebSocket.
- Single-flight target attachment, lifecycle cleanup, exact-target recovery, and preservation of explicit raw CDP session IDs.
- Unique screenshot paths prevent concurrent agents from overwriting each other's output.
- Preserve the shared daemon on a health-check timeout; close probe sockets (same fix as #754). Disable timed WebSocket pings for local Chrome; remote keepalive is unchanged. Use the existing startup lock for shared remote endpoints too.
- Update skill guidance: remember a tab ID, omit per-agent `BU_NAME`, stay in the background, never silently take over another tab, and distinguish Cloud auth from arbitrary remote CDP auth.

Only three runtime modules change. The remaining changes are instructions, tests, and the design/review document.

## Evidence

- 278 unit tests pass; skill validation and `git diff --check` pass.
- Seven targeted regression tests fail against #746's current head and pass here.
- Live integration: **100 concurrent CLI processes, 100 separate tabs, 100 pixel-verified screenshots, one daemon**. Synthetic workflow completed in 5.05 seconds (another run: 5.21 seconds). Includes fresh processes resuming tabs, coordinate clicks, typing, dialog isolation, and closing every tab before reusing the same connection.
- Real-profile smoke: logged-in Hacker News navigation/extraction/screenshot; concurrent independent CLI processes controlled two tabs with the same daemon PID and left Chrome's visible tab unchanged. Test tabs and the test daemon were cleaned up; existing shared daemons were not stopped.
- Linux/Windows transport paths remain supported, but native integration was run on macOS, not on those operating systems. This is not a capacity promise for 100 heavy websites.

Run the opt-in integration test with `BH_TEST_CHROME=/path/to/chrome BH_TEST_AGENTS=100 uv run --with pytest python -m pytest tests/integration/test_shared_browser.py -q -s`. It creates only a disposable profile and uses no Cloud credentials.

## Approval boundary and rollout

Chrome requires approval **per new WebSocket connection**, not per agent. This removes per-agent approval while the shared connection lives; it cannot preserve a socket across Chrome termination/reboot. The local approval handshake already has no default expiry. macOS uses existing `mac-approve`; Windows/Linux users may approve once for the shared connection. No new auto-approval watcher or security-setting bypass is added.

An extension is a plausible future transport for reducing reconnect consent, but adds installation/permissions/native bridging and does not expose every CDP domain. It is not implemented here.

The [design, diagram, Chrome research and review of #746/#754/#734/#748/#751/#723/#725/#747](https://github.com/browser-use/browser-harness/blob/feat/shared-browser-targets/docs/shared-browser.md) explain the tradeoffs.

No release/install or automatic replacement of live user daemons. Deploy the CLI and restart its persistent daemon once after existing tasks finish; a pre-routing daemon cannot implement the new target-scoped protocol.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets many independent agents operate different tabs through one persistent browser connection using the user's real Chrome. Agents now keep only a target ID instead of sharing the daemon's single mutable current tab, so concurrent tasks no longer need to serialize browser operations or spin up separate daemons.

- `new_tab()` always creates a fresh background tab; `switch_tab(id)` selects it for the current CLI process only.
- Commands, events, and dialogs route by target over the shared WebSocket, with single-flight attachment, lifecycle cleanup, and exact-target recovery.
- Tab selection never waits for or triggers a recording frame, so it stays responsive in the background.
- Screenshots get unique paths so concurrent agents can't overwrite each other's output.
- A health-check timeout no longer kills the shared daemon, and timed WebSocket pings are disabled for local Chrome.
- Skill guidance now tells agents to remember a tab ID, omit `BU_NAME`, and never silently take over another agent's tab.

**Migration**

- Restart the persistent daemon once after its active tasks finish; a pre-routing daemon can't handle target-scoped requests.
- Chrome approval is per connection, not per agent, so a restarted Chrome may require one new approval shared by all agents.

<sup>Written for commit e285724fabac1cd7cc949a0038013d80055a7aab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

