### PR TITLE
Document Transdirect members UI verification traps

### DIFF
--- a/domain-skills/car-rental/README.md
+++ b/domain-skills/car-rental/README.md
@@ -1,0 +1,88 @@
+# car-rental
+
+Searching car rental aggregators and direct suppliers. Norway-focused but the structural notes apply broadly.
+
+## Trap: aggregator "currency toggle" lies about the search list
+
+**DiscoverCars** (`discovercars.com`) renders price chips in the search results as bare `$1,032.52` even when the currency selector is set to AUD. The number is **USD**. The full offer-detail page (one click into "View deal") renders the real local currency as `A$1,563.91`. Ratio is the USD/AUD spot rate (~1.51 in 2026-05).
+
+This means search-list prices look ~33% cheaper than reality. Always:
+
+1. Click into the actual offer page before comparing, **or**
+2. Multiply list prices by current USD→AUD if you must compare from the list.
+
+The cookie `Currency=AUD` and the visible header chip both say "AUD". The offer page is the source of truth.
+
+Suspected cause: DiscoverCars treats `$` as a generic symbol for affiliate-network display in the list. Sub-aggregators (Kayak, etc.) likely have the same hazard — verify before trusting.
+
+## DiscoverCars search URL shape
+
+```
+https://www.discovercars.com/search/<session-uuid>?sq=<base64-json>&searchVersion=2
+```
+
+The `sq` param is base64-encoded JSON:
+
+```json
+{"PickupLocationId":2085,"DropOffLocationId":2085,"PickupDateTime":"2026-07-12T10:00:00","DropOffDateTime":"2026-07-16T17:00:00","ResidenceCountry":"AU","DriverAge":35,"Hash":""}
+```
+
+- `PickupLocationId` 2085 = Bergen Flesland Airport (BGO). Submit the form once to discover the ID for any airport.
+- The path UUID is required — bare `/search?sq=...` returns 404. Submit the homepage form once to get a session UUID, then reuse it with edited `sq` to change dates/locations.
+- Editing `sq` after page load does not update the visible form — the React store keeps the previously-set times. Open the time `CustomSelect` dropdowns and re-pick to actually shift to a 5-day billing window (10:00 → 17:00 is 4d 7h, billed as 5 calendar days; 10:00 → 10:00 is 4 days flat).
+
+### Date picker quirks
+
+- The pickup-date display uses `.DatePickerOld-CalendarField` on results page, `.DatePicker-CalendarField` on homepage.
+- The calendar widget is `react-date-range`. Day cells are `.rdrDay`; passive (other-month) cells carry `.rdrDayPassive`. Day numbers live in `.rdrDayNumber span`.
+- The visible month names live in `.rdrMonthName`. The library renders two months but the underlying state can show a *third* "phantom" month name from before navigation — always filter by visible `rdrMonthName` text (e.g. `'Jul 2026'`) when picking a day.
+- `.rdrDay.click()` via JS does NOT trigger the React handler. Use compositor `click(x, y)` via `getBoundingClientRect()`.
+- Time selector is a `.CustomSelect` (not a native `<select>`). Open with `.CustomSelect-SelectHandler[N].click()`, then scrollIntoView the visible `.CustomSelect-SelectOption` and compositor-click it.
+
+## Hyre.no — direct supplier, almost always cheaper than aggregators in Norway
+
+Hyre is a Norwegian peer-keyless car-share (think Zipcar). Phone-unlock cars at airport short-stay parking. Self-service, no counter queue, free additional drivers, free cancellation up to 24hr before.
+
+### Deep-link URL (works without form fill)
+
+```
+https://www.hyre.no/en/flesland/?fd=YYYY-MM-DD&fh=HH:mm&td=YYYY-MM-DD&th=HH:mm&hg=<vehicle-uuid>
+```
+
+- `flesland` = Bergen Airport. Other locations: `gardermoen` (Oslo OSL), `vaernes` (Trondheim TRD), city locations like `oslo-sentrum`.
+- `fd/fh` = from date/hour, `td/th` = to date/hour. 24-hour time.
+- `hg` = vehicle group UUID. Found by browsing without it, then copying the selected car's URL.
+
+### Pricing format
+
+```
+NOK <base>  + N days × NOK <per-day>  =  TOTAL
+e.g. NOK 2,000 + 5 × NOK 999 = NOK 6,995 for a VW ID.4 over 4d 7h
+```
+
+The flat base price is essentially a booking fee. Per-day rate varies by car. The total on the page is honest — no hidden extras unless you toggle:
+
+- "Reduced insurance deductible" — NOK 125/day to drop deductible from NOK 12,000 → 2,000. Cannot be added after booking.
+- Fuel + tolls are auto-charged via the app.
+- NOK 1,000 holding deposit at booking.
+
+### Why it beats aggregators in Norway
+
+For a Bergen Airport 5-day VW ID.4 rental (2026-07-12 to 2026-07-16):
+
+| Source | Total AUD | Extra-driver fee | Cancellation | Deposit |
+|---|---|---|---|---|
+| Hyre direct | **~A$1,015** | free | 24hr | NOK 1,000 (~A$145) |
+| DiscoverCars (Alamo) | A$1,564 | typically ~A$15/day | 48hr | A$3,010 |
+| Rent-a-Wreck (BYD Atto, smaller car) | A$1,650 | NOK 1,000 paid | varies | varies |
+
+The pattern: legacy aggregators sell the brand-name suppliers (SIXT, Alamo, Avis) at airport-counter rates. Hyre/Move About/local players undercut by ~30-40% on Norwegian airport rentals specifically because they have no counter and no fleet repositioning costs.
+
+## URL patterns for other sites
+
+- **Kayak** (`kayak.com.au/cars`): no usable deep link found — `cars.kayak.com/cars/<location>/<dates>` 302's to `/cars` and loses params. Form-fill is required.
+- **Rentalcars.com** (Booking-owned): `SearchResults.do?pickupLocation=...&pickupYear=...&pickupMonth=...&dropoffYear=...&preferredCurrency=AUD` accepts URL params but the SPA frequently 500s on direct nav. Form-fill from the homepage is more reliable.
+
+## Verification step
+
+When an aggregator price looks suspiciously low, click "View deal" / "Continue" to the supplier's full breakdown — that's where USD-vs-AUD and mandatory-extras get added back. Treat the offer-page total as ground truth, not the chip price.

--- a/domain-skills/cloudflare/r2-api-tokens.md
+++ b/domain-skills/cloudflare/r2-api-tokens.md
@@ -1,0 +1,151 @@
+# Cloudflare dash — R2 API tokens
+
+Creating an R2 S3-compatible credential pair (Access Key ID + Secret) via
+the dashboard. Needed whenever you want `rclone` / `aws s3` against R2,
+because the S3 endpoint requires a key pair that `wrangler login`'s OAuth
+token cannot provide.
+
+## Prefer wrangler where you can
+
+Bucket lifecycle does **not** need the dashboard — do it on the CLI:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID=<acct> wrangler r2 bucket create <name> --location oc
+CLOUDFLARE_ACCOUNT_ID=<acct> wrangler r2 bucket list
+CLOUDFLARE_ACCOUNT_ID=<acct> wrangler r2 bucket dev-url get <name>   # public r2.dev on/off
+CLOUDFLARE_ACCOUNT_ID=<acct> wrangler r2 bucket domain list <name>   # custom domains
+```
+
+Only the **key pair** requires the browser. There is no wrangler command
+that mints S3 credentials.
+
+## URL patterns
+
+- Token list: `https://dash.cloudflare.com/<accountId>/r2/api-tokens`
+- Create (account-scoped): `.../r2/api-tokens/create?type=account`
+- Create (user-scoped): `.../r2/api-tokens/create?type=user`
+- Post-create reveal: `.../r2/api-tokens/success`
+
+`<accountId>` is the 32-char hex from `wrangler whoami`. Navigating
+straight to the `create?type=account` URL skips the list page.
+
+Account tokens vs user tokens: account tokens survive the creating user
+leaving the org; user tokens die with them. Prefer account tokens for
+anything long-lived.
+
+## Stable selectors
+
+- Token name field: `#cf-form-input1` (a React controlled input — see quirks).
+- Permission radios, addressed by `value`, which is stable and readable:
+  - `input[value="admin-write"]` — Admin Read & Write
+  - `input[value="admin-read"]`  — Admin Read only
+  - `input[value="object-write"]` — Object Read & Write
+  - `input[value="object-read"]`  — Object Read only (**the default**)
+- Bucket scope radios: `input[value="all"]` (default) / `input[value="some"]`
+- Bucket combobox (appears only after `some` is selected):
+  `#react-select-2-input`, options `#react-select-2-option-<n>`
+- Submit: the `<button>` whose `innerText` is `Create Account API Token`.
+
+The radios have no `name` or `id` — `value` is the only stable handle.
+
+## Framework / interaction quirks
+
+**The name field is a React controlled input.** `Input.insertText` and
+coordinate typing get reverted on the next render. Use the native setter:
+
+```js
+const inp = document.querySelector('#cf-form-input1');
+const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
+set.call(inp, 'my token name');
+inp.dispatchEvent(new Event('input',  {bubbles:true}));
+inp.dispatchEvent(new Event('change', {bubbles:true}));
+```
+
+**The radios respond fine to `.click()` in JS** — no native-setter dance
+needed, unlike the text input.
+
+**The bucket picker is react-select and commits on `mousedown`, not on
+Enter.** CDP `Input.dispatchKeyEvent` for Enter does *not* select the
+focused option even when the aria-live region says "option focused, 1 of 1".
+Typing to filter works; committing does not. What works is a real
+coordinate click on the option's *live* rect:
+
+```python
+r = js("""(()=>{const o=document.querySelector('#react-select-2-option-0');
+const b=o.getBoundingClientRect();
+return JSON.stringify({x:Math.round(b.x+b.width/2),y:Math.round(b.y+b.height/2)});})()""")
+p = json.loads(r); click(p["x"], p["y"])
+```
+
+Re-measure the rect *after* filtering — the option list re-renders and a
+coordinate captured from an earlier screenshot lands on a stale row.
+
+**1Password (and similar) inject an autofill overlay** over the Permissions
+block the moment the name field takes focus. It covers the radios in
+screenshots and can swallow clicks. `press_key("Escape")` dismisses it.
+Prefer JS `.click()` on the radios so the overlay is irrelevant.
+
+## Waits
+
+`wait_for_load()` is sufficient for the create page. After clicking submit,
+allow ~5 s before reading `/success` — the page swaps client-side and
+`wait_for_load()` can return while the old DOM is still mounted.
+
+## Traps
+
+- **The default permission is `object-read`, and the default scope is all
+  buckets.** Both defaults are wrong for an upload token. Always assert the
+  final state before submitting.
+- **`Apply to specific buckets only` renders an empty combobox with the
+  validation error "At least one bucket is required" already visible.** That
+  error string persists until a bucket is genuinely committed, which makes it
+  a reliable success check: re-read it after selecting.
+- **Secrets are shown exactly once** on `/success`. There is no way to
+  re-reveal; a lost secret means minting a new token.
+- **R2 is not a separate OAuth scope in wrangler.** `wrangler whoami` lists
+  no `r2` permission, but `wrangler r2 bucket list` works anyway — R2 rides
+  along with the account-level Workers scopes. Don't diagnose a missing `r2`
+  scope from the whoami output; just try the command.
+
+## Reading the credentials without leaking them
+
+The reveal page puts all three secrets in `body.innerText`. To inspect page
+structure safely (e.g. in a logged agent transcript), mask them first:
+
+```python
+js(r"""document.body.innerText.replace(/[A-Za-z0-9_\-]{20,}/g,
+      m => '<REDACTED:'+m.length+'chars>')""")
+```
+
+To extract for real, pull by label and hand straight to the consumer without
+printing. Lengths are a useful assertion: Access Key ID is 32 chars, Secret
+Access Key is 64, the API token value is 53.
+
+```python
+raw = js(r"""(()=>{const t=document.body.innerText;
+const ak=t.match(/Access Key ID\s+([A-Za-z0-9]{32})/);
+const sk=t.match(/Secret Access Key\s+([A-Za-z0-9]{64})/);
+return JSON.stringify({ak:ak?ak[1]:null, sk:sk?sk[1]:null});})()""")
+d = json.loads(raw)
+subprocess.run(["rclone","config","create","r2","s3",
+    "provider=Cloudflare",
+    f"access_key_id={d['ak']}", f"secret_access_key={d['sk']}",
+    f"endpoint=https://{ACCOUNT_ID}.r2.cloudflarestorage.com",
+    "region=auto","acl=private","no_check_bucket=true"],
+    capture_output=True)   # never echo stdout
+```
+
+Note `\s+` not `\s` between label and value — the DOM puts a blank line there.
+
+## rclone against R2 — settings that matter
+
+- Endpoint is `https://<accountId>.r2.cloudflarestorage.com`, `region=auto`.
+- `no_check_bucket=true` is **required** for a bucket-scoped token. Without
+  it rclone attempts a bucket create/head on first write, which an
+  `object-write` token is not permitted to do, and the whole transfer fails
+  on object one.
+- A bucket-scoped token also cannot list buckets, so `rclone lsd r2:` fails
+  while `rclone lsf r2:<bucket>` succeeds. That is expected, not a
+  misconfiguration — verify connectivity against the bucket, not the root.
+- `wrangler r2 object put` is single-object and size-capped; it is the wrong
+  tool for bulk. Use rclone for anything beyond a handful of files.

--- a/domain-skills/flightseats/README.md
+++ b/domain-skills/flightseats/README.md
@@ -1,0 +1,125 @@
+# flightseats.io
+
+Reward seat availability for Australian frequent flyer programs (Qantas / Virgin Velocity). Useful for finding business/first class award space when a friend has points to gift/book.
+
+## Coverage
+
+| URL | Coverage |
+|---|---|
+| `/qantas/business-class-finder` | Qantas + all partners (Emirates, Cathay, JAL, BA, Qatar, Finnair, Iberia, Malaysia, Sri Lankan, etc.) |
+| `/virgin-australia/business-class-finder` | **Virgin Australia-operated flights only** — essentially domestic. Not useful for long-haul SYD→Europe because Virgin Australia doesn't fly long-haul anymore. |
+| `/qatar/business-class-finder` | 404 — does not exist |
+
+For Velocity-points-to-Europe, this site **cannot help** — Velocity members book Qatar Airways as the main partner for Europe, and that inventory isn't surfaced here. Use seats.aero or point.me for Qatar.
+
+## Date picker
+
+- Library: **air-datepicker**
+- Day cells: `.air-datepicker-cell.-day-`; passive: `.-other-month-`; disabled: `.-disabled-`; max date: `.-max-date-`
+- Month cells: `.air-datepicker-cell.-month-` (textContent like `"Jul"`)
+- Click month → calendar shows; click first day → range start; click second day → range end
+- Range max = 30 days (label says "Max 30 days")
+- **JS click() does NOT work on cells** — use compositor `click(x, y)` via getBoundingClientRect
+
+## Cache limits (signed-out)
+
+- Unregistered: search up to **60 days ahead**
+- Free account: 120 days ahead
+- Premium: 1 year ahead
+
+If today + 60 days < target date, you have to sign up. Cells beyond the limit show `-disabled-`.
+
+## Filters (post-search)
+
+Buttons above the table: `SEATS`, `ORIGIN`, `DESTINATION`, `AIRLINE`, plus `STOP #`, `STOP`, time/duration, `POINTS`, `TAX`.
+
+Each filter opens a popup with `INCLUDE`/`EXCLUDE` toggle and a `Search...` input. Region quick-selects at the bottom: `Australia (Major)`, `Europe (Major)`, `Europe (Schengen)`, `United Kingdom (UK)`, `London`, `Italy`, `Spain`, `Germany`, `Portugal`, `Scandinavia`, `Poland`, `South East Asia`, `Malaysia`, `Middle East (Hubs)`.
+
+### Filter popup search input
+
+`input[placeholder='Search...']` — there are multiple in the DOM but only one visible at a time (others have width=0). Use `getBoundingClientRect().width > 0` to find the active one.
+
+To clear and re-type:
+
+```python
+js("""
+(() => {
+  const inp = [...document.querySelectorAll('input')].find(e => e.placeholder === 'Search...' && e.getBoundingClientRect().width > 0);
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+  setter.call(inp, '');
+  inp.dispatchEvent(new Event('input', {bubbles: true}));
+})()
+""")
+```
+
+Then `click(coords)` the input, `type_text("AMS")`, click the matching option.
+
+**Cmd+A select-all does NOT work in this input** — the modifier doesn't propagate. Use the React setter clear pattern above.
+
+### Filter option click
+
+Options render multiple times in the DOM (mobile + desktop layouts). Filter for visible ones:
+
+```python
+opts = filter(lambda o: o.bbox.y > 0 and o.bbox.y < 900 and o.bbox.width > 0, options)
+```
+
+## SEARCH button
+
+The visible "SEARCH" button is a `<div class="btn btn-primary ...">`, **not a `<button>` element**. Find it like:
+
+```js
+[...document.querySelectorAll('div')].find(e => 
+  e.className?.includes('btn-primary') && e.textContent.includes('SEARCH') && !e.textContent.includes('SIGN'))
+```
+
+After a valid date range is selected, the button label changes to `SEARCH (~6s)` — that's the visual cue the form is submittable. Clicking before then fires no network request (client-side validation blocks).
+
+## Table
+
+Headers: `Date`, `Number & Airline`, `Route`, `Duration`, `Business` (or `Cabin` with first-class enabled).
+
+Cells are concatenated with no separators in `textContent`. Useful regex extraction:
+
+```python
+# Route: "SYD-FRA(DXB)25h 5m" → ('SYD', 'FRA')
+re.match(r'([A-Z]{3})-([A-Z]{3})', row[2])
+
+# Airline: "A380EK417, A380EK45Emirates"
+# Points/tax: "182,9001,723 AUD2 seats availableClick for details"
+#   → 182,900 points + AU$1,723 tax + 2 seats
+```
+
+The points value is the whole number before the comma+three-digit tax. There's no separator between the two numbers in the rendered text.
+
+## Pagination
+
+`Rows: 10/30/50` select bumps page size (max 50). Below the table there are page numbers + `Prev`/`Next`. There's **no visible total count** — paginate to discover.
+
+## "Live refresh"
+
+Each row has a refresh icon (left-most cell) that queries the supplier directly instead of using cached data. Useful when a row shows good availability but you want to confirm it's still bookable. Costs network round-trip.
+
+## Velocity vs Qantas — which to pick
+
+If the friend has:
+- **Qantas points** → use `/qantas/business-class-finder`. Covers Emirates (the big Australia-Europe carrier), Cathay (HKG hub), JAL (HND hub), BA (LHR hub), Qatar (DOH hub), Finnair (HEL hub).
+- **Velocity (Virgin) points** → this site does NOT help for international. The Virgin Australia finder is essentially domestic-only. Direct the user to:
+  - **seats.aero** (paid, ~$10/mo) for Qatar Airways award availability (Velocity's main Europe partner)
+  - **point.me** for multi-program search
+  - Virgin Velocity website directly: search Qatar Airways award seats SYD/PER → DOH → European hub
+
+## Known SYD/PER → Europe partner routes (Qantas points)
+
+For reference, what's typically searchable through partners (availability varies):
+
+| Airline | Routing |
+|---|---|
+| Emirates | SYD/PER → DXB → AMS/CDG/FRA/LHR/BRU/MAD/ZRH/MUC etc. |
+| Qatar | SYD/PER → DOH → OSL/CPH/AMS/LHR/FRA/BRU etc. |
+| Cathay Pacific | SYD/PER → HKG → LHR/CDG/FRA/AMS/MAD/MXP/ZRH |
+| British Airways | SYD → SIN → LHR (codeshare with Qantas) |
+| JAL | SYD → HND → LHR/CDG/FRA/HEL |
+| Finnair | SYD → HEL (via Singapore, seasonal) |
+
+The Qantas finder surfaces those it knows about, subject to actual award seat release by the operating carrier.

--- a/domain-skills/hubstaff/add-manual-time.md
+++ b/domain-skills/hubstaff/add-manual-time.md
@@ -1,0 +1,145 @@
+# Hubstaff — add manual time entry (UI)
+
+The Hubstaff **v2 API cannot create time entries** (it's an unshipped roadmap
+request; the only write path, `custom_activities`, needs a custom-activity
+integration and records "custom activity", not manual timesheet entries). So
+backfilling billable hours must go through the web UI.
+
+## Route
+
+`https://app.hubstaff.com/organizations/{ORG_ID}/time_entries/calendar`
+Reached via left nav **Timesheets → View & edit**. Has Daily / Weekly /
+**Calendar** view toggle. The calendar renders in the org's display timezone
+(shown next to the date range, e.g. "AEST") — entries are created in that tz.
+
+Filter to a person via the member picker (top-right, shows the selected name);
+the URL carries `filters[user]={user_id}`.
+
+## Add-time dialog (button top-right: "Add time")
+
+Fields, in order:
+- **Work break** toggle (leave off for normal time)
+- **PROJECT\*** — searchable dropdown. Click, type to filter, click the option.
+- **TO-DO\*** — appears/becomes **required only after a project is selected**,
+  and the required tasks are project-specific (e.g. Transdirect exposes
+  "Client Support", "Maintenance", "Meetings", plus MOD-* task IDs). You cannot
+  save without it. There is no generic "no task" option — the caller must know
+  which task the time belongs to.
+- **TIME SPAN (AEST)\*** — a date field (opens a month picker; prev-month days
+  appear greyed at the top row and ARE selectable) plus **FROM** and **TO**
+  time fields. A slider under them mirrors From/To and shows the duration
+  (e.g. "4:47:00"). Duration = To − From.
+- **Billable** checkbox — checked by default; billable time generates the $
+  amounts on the dashboard.
+- **REASON\*** — dropdown ("Why are you adding this time entry?"), becomes
+  required for manual admin-added time.
+- **Add note** — optional.
+- Cancel / **Save**.
+
+## Setting the FROM/TO time fields (finicky — this recipe works)
+
+The time inputs are masked (`input.default-input`, values like `8:00`) with a
+SEPARATE am/pm toggle rendered as the "am"/"pm" text beside each field. Naive
+typing corrupts them. Reliable recipe:
+
+- **Never use Tab to blur** — a `Tab` keypress inserts a literal tab char into
+  the next field (the duration `input.input-default`) and corrupts the widget,
+  which then reverts TO back to FROM on recompute. Blur by CLICKING a neutral
+  spot instead (e.g. the Billable label area).
+- **To clear a field**: triple-click it (selects all), then type the new value.
+  Cmd/Ctrl+A does NOT select inside these fields.
+- **am/pm resets the minutes.** Clicking the "am"/"pm" toggle resets that field
+  to `9:00`. So set am/pm FIRST, THEN triple-click + type the minutes.
+- Full sequence for e.g. TO = 1:47 pm: click the am/pm toggle (→ `9:00 pm`),
+  then triple-click the TO field, type `1:47`, then click to blur.
+- Read back state via JS to confirm before saving:
+  `[...document.querySelectorAll('input.default-input')].map(e=>e.value)` gives
+  `[hiddenFrom, hiddenTo, FROM, TO]` (first two belong to a hidden dialog
+  instance — the active ones are indices 2 and 3); the duration is
+  `input.input-default` (second one). A "Next day" tooltip on TO + a huge
+  duration means TO is still am when you meant pm.
+
+## Overlap constraint & finding gaps
+
+Existing tracked entries are "locked" — a new manual block that overlaps ANY of
+them shows "This time entry overlaps with a locked time entry and cannot be
+saved" and Save is blocked. So each backfill block must fit entirely inside a
+free gap. The dialog's slider renders the selected day's occupied windows;
+`overlap:false` can be checked via
+`document.body.textContent.includes('overlaps with a locked')`. Watch for
+zero-width entries (e.g. `12:12 pm - 12:12 pm`) mid-day that still block a range.
+A day already fragmented by many small entries may have NO gap large enough for a
+big block — you then have to split across gaps (a decision worth confirming with
+the user, since placement is visible on client-billed timesheets).
+
+## Traps
+
+- **Pressing Escape inside the dialog resets the whole form** (clears project,
+  jumps the date/time) rather than closing it — don't use Escape to dismiss a
+  dropdown. Click elsewhere to close a dropdown; use the **X** (top-right) or
+  **Cancel** to close the dialog.
+- An NPS/"recommend Hubstaff" survey can pop up bottom-right and overlap the
+  Save button — dismiss its X first.
+- Viewport here is 1800 CSS px wide; screenshots are 2× (3600). Map click
+  coords accordingly.
+- Because TO-DO and REASON are mandatory and task attribution on billable
+  client time is a human decision, don't guess them — confirm with the user
+  before saving.
+
+## Reopening the dialog for a second entry (field state is NOT reset)
+
+When you click **Add time** again in the same page session, the dialog does not
+reliably return to its `8:00 am` / `9:00 am` defaults — it can come back carrying
+the **previously saved entry's FROM/TO values and am/pm state**. Never assume the
+defaults. Read the state back first and branch on what you actually find:
+
+```js
+JSON.stringify({
+  t: [...document.querySelectorAll('input.default-input')].map(e => e.value),   // [hidden, hidden, FROM, TO]
+  a: (() => { const a = []; document.querySelectorAll('*').forEach(e => {
+        if (!e.children.length) { const x = (e.textContent || '').trim();
+          if (x === 'am' || x === 'pm') { const b = e.getBoundingClientRect(); if (b.width > 0) a.push(x); } } });
+      return a; })(),                                                            // [FROM ampm, TO ampm]
+  dur: [...document.querySelectorAll('input.input-default')].map(e => e.value),  // [_, duration]
+  overlap: document.body.textContent.includes('overlaps with a locked'),
+})
+```
+
+## The triple-click + type recipe silently fails maybe 1 in 3 times
+
+Setting a time field can land a value that is neither the old one nor the one you
+typed (observed: typing `8:30` produced `9:41`; typing `7:15` left the field on the
+previous entry's `3:15`). There is no error — the widget just holds a wrong value.
+
+**Treat every time-field write as write-then-verify-then-retry.** Read back the
+`input.default-input` values and the computed duration after each edit; if either
+is wrong, triple-click and retype the same field. The retry succeeds reliably.
+Verifying only at the end is not enough, because a wrong FROM changes how a later
+TO edit recomputes.
+
+Ordering that worked consistently: set am/pm first (it resets that field to
+`9:00`), then triple-click + type the minutes, then blur by clicking a neutral
+spot, then read back.
+
+## Save is async — the DOM lags the write
+
+After clicking **Save**, the `Total:` header and the day columns take a second or
+two to re-render. Reading them immediately shows the *pre-save* state and looks
+exactly like a failed save. Wait ~4-6s and re-read before concluding anything, and
+prefer a screenshot over a text read when in doubt.
+
+Per-day entry list, useful for confirming what actually landed:
+
+```js
+document.querySelector('.fc-day-mon .fc-timegrid-col-events').innerText   // fc-day-tue, -wed, ...
+```
+
+The week `Total:` is the cheapest check that a save committed: it should move by
+exactly the duration you added (allow for a *running* tracker quietly growing a
+live entry by a few minutes while you work).
+
+## Reason values available
+
+`Forgot to start/stop timer`, `Used a wrong task/project`, `Was AFK on a call`,
+`Other`. Pick the one that is actually true — these are visible on client-billed
+timesheets.

--- a/domain-skills/seats-aero/README.md
+++ b/domain-skills/seats-aero/README.md
@@ -1,0 +1,71 @@
+# seats.aero
+
+Award space aggregator across many frequent flyer programs (Aeroplan, Velocity, Qantas, Flying Blue, Qatar, United, AA, Alaska, Turkish, etc.). Free tier shows current snapshot; PRO ($9.99/mo) unlocks full year + alerts + PRO filters.
+
+## Search URL params (no login required)
+
+```
+https://seats.aero/search
+  ?min_seats=1
+  &applicable_cabin=any|economy|premium|business|first
+  &additional_days=true
+  &additional_days_num=3        # ± days around date (0-7)
+  &max_fees=40000               # AUD cents — 40000 = A$400 fees cap
+  &disable_live_filtering=false
+  &date=2026-07-08              # center date YYYY-MM-DD
+  &origins=ANZ,SYD,PER          # region codes OR airport IATA
+  &destinations=EUR,OSL,ARN,LHR # mix region codes + IATA
+```
+
+URL-driven search is by far the most reliable way to call this site — no form-filling.
+
+### Region codes
+
+- `ANZ` — Australia + New Zealand
+- `EUR` — Europe
+- `ASA` — Asia
+- `USA` — United States
+- `LON` — London
+- Many more — explore via Routes menu
+
+### Default param values seen in the wild
+
+`min_seats=1&applicable_cabin=any&additional_days=true&additional_days_num=3&max_fees=40000&disable_live_filtering=false`
+
+## Table columns
+
+`Date | Last Seen | Program | Departs | Arrives | Economy | Premium | Business | First`
+
+Each cabin cell either shows points (`182,900 pts`) or `Not Available`. A row may have *some* cabins available and others not — filter on the specific cabin column.
+
+## Quirks
+
+- **Pagination is broken / cached**: clicking the `›` next link often returns to the same data set. Trust what's shown after the initial search; if you need more dates, change the URL `additional_days_num` parameter and reload.
+- The bottom-of-page filter chips (`Programs`, `Alliances`, `Transfer Partners`, `Points`, `Days`) are PRO-only — don't waste time clicking them logged out.
+- "Last Seen" can be "Just now" / "1 hour ago" / "1 day ago" — for booking decisions, only trust rows under ~6h old. Older = high re-verification risk.
+- The 25-per-page default truncates aggressive searches. Bump to 100 via the per-page select.
+
+## Useful starter searches for Australia → Europe
+
+```
+# All Northern European hubs in business, ±4 days from Jul 8 2026
+https://seats.aero/search?min_seats=1&applicable_cabin=business&additional_days=true&additional_days_num=4&max_fees=40000&date=2026-07-08&origins=ANZ&destinations=EUR
+
+# Specific origin-pair: PER → AMS or OSL or CPH
+https://seats.aero/search?...&origins=PER&destinations=AMS,OSL,CPH
+
+# Region-to-region: Australia → All Europe
+https://seats.aero/search?...&origins=ANZ&destinations=EUR
+```
+
+## What "Velocity" rows actually mean
+
+Velocity rows on seats.aero typically surface Singapore Airlines KrisFlyer space (via Velocity-KrisFlyer transfer) or direct Velocity-bookable partner space. Always confirm at velocityfrequentflyer.com before transferring points.
+
+## What "Qantas" rows mean
+
+Qantas Classic Rewards on Qantas/oneworld partners + Emirates. Bookable at qantas.com.au with Qantas Frequent Flyer points.
+
+## Live refresh
+
+There's a small refresh icon on each row that queries the source program in real time. Use before transferring points or burning miles — the cached row is a snapshot.

--- a/domain-skills/seats-aero/api.md
+++ b/domain-skills/seats-aero/api.md
@@ -1,0 +1,135 @@
+# seats.aero API (PRO)
+
+PRO tier ($9.99/mo) unlocks the partner API. Up to 1,000 calls/calendar day. No commercial use without permission.
+
+## Auth
+
+```
+Partner-Authorization: <API_KEY>
+```
+
+Generate at https://seats.aero/account.
+
+### Josh's PRO key
+
+`pro_3Dh9xl5hdNqguRqLQqQl7Fb0tCb` — paid PRO account, 1,000 calls/day. Verify it's still valid before heavy use (keys rotate). Do not share publicly or commit to public repos.
+
+## Key endpoint: cached search
+
+```bash
+curl -s 'https://seats.aero/partnerapi/search?origin_airport=BCN&destination_airport=SYD&start_date=2026-08-01&end_date=2026-08-10&cabin=business&take=200' \
+  -H 'Partner-Authorization: <KEY>' -H 'accept: application/json'
+```
+
+### Required-ish params
+
+- `origin_airport` — single IATA (comma-separated does NOT work — returns 0; do one per request and parallelize)
+- `destination_airport` — single IATA
+- `start_date` / `end_date` — `YYYY-MM-DD`
+- `cabin` — exactly one of `economy` / `premium` / `business` / `first` (NOT plural, NOT a list)
+
+### Optional
+
+- `take` — page size (default ~25, accepts up to 1000)
+- `order_by` — typically `lowest_mileage` or `date`
+- `disable_live_filtering` — passes through cached only
+- `sources` — `qatar,velocity,delta,...` to limit programs
+
+### Region params don't work
+
+`origin_region=Europe`, `destination_region=Oceania`, `origin_region=EUR` all returned 0 in testing despite the response data containing `Route.OriginRegion: "Europe"`. Use individual airport queries and parallelize with `&`.
+
+## Response shape
+
+```json
+{
+  "data": [
+    {
+      "ID": "...",
+      "Date": "2026-08-04",
+      "Route": {
+        "OriginAirport": "LHR",
+        "DestinationAirport": "SYD",
+        "OriginRegion": "Europe",
+        "DestinationRegion": "Oceania",
+        "Distance": 10587,
+        "Source": "flyingblue"
+      },
+      "Source": "flyingblue",
+      "YAvailable": true, "WAvailable": false, "JAvailable": true, "FAvailable": false,
+      "YMileageCostRaw": 63000, "JMileageCostRaw": 126500,
+      "YTotalTaxesRaw": 53920, "JTotalTaxesRaw": 101920,    // USD cents — divide by 100
+      "TaxesCurrency": "USD",
+      "YRemainingSeatsRaw": 1, "JRemainingSeatsRaw": 1,
+      "YAirlines": "VN", "JAirlines": "VN",                  // operating airline IATA
+      "YDirect": false, "JDirect": false,                    // is this a non-stop?
+      "CreatedAt": "2025-08-11T...", "UpdatedAt": "2026-05-11T..."
+    }
+  ],
+  "count": 46,
+  "hasMore": false,
+  "cursor": 1778723931
+}
+```
+
+### Cabin prefix legend
+
+- `Y` — economy
+- `W` — premium economy
+- `J` — business
+- `F` — first
+
+Each cabin has parallel fields: `{X}MileageCostRaw`, `{X}TotalTaxesRaw`, `{X}RemainingSeatsRaw`, `{X}Airlines`, `{X}Available`, `{X}Direct`.
+
+### Tax field is USD cents
+
+`JTotalTaxesRaw: 101920` = $1,019.20 USD. Convert: `raw / 100`. Multiply by ~1.51 for AUD as of mid-2026.
+
+### "Source" = which program books it
+
+`qatar` = Qatar Privilege Club (Avios). `velocity` = Virgin Australia Velocity. `qantas` = Qantas Frequent Flyer (Classic Rewards). `flyingblue` = Air France/KLM. `delta` = Delta SkyMiles. `american` = AAdvantage. `united` = MileagePlus. `aeroplan` = Air Canada. `alaska` = Mileage Plan. `turkish` = Miles&Smiles. Etc.
+
+The same physical flight (e.g. LHR-CDG-HAN-SYD on Vietnam Airlines) can appear from *multiple* sources (Delta + Flying Blue both partner with VN, and seats.aero shows both with different mileage prices).
+
+### "Airlines" is comma-separated IATA codes for the trip
+
+`"JAirlines": "QR, VA"` = Qatar Airways + Virgin Australia codeshare (the typical DOH-SYD partner combo). `"VN"` = Vietnam Airlines only. `"EK"` = Emirates only.
+
+## Common queries
+
+### Cheapest economy: Europe → SYD over 2 weeks
+
+```bash
+for orig in BCN MAD AGP VLC LIS AMS LHR CDG FRA BRU; do
+  curl -s "https://seats.aero/partnerapi/search?origin_airport=${orig}&destination_airport=SYD&start_date=2026-07-28&end_date=2026-08-10&cabin=economy&take=200" \
+    -H "Partner-Authorization: $KEY" > "/tmp/seats/${orig}_econ.json" &
+done; wait
+```
+
+### Business class hunting from any EU hub
+
+Same shape but `cabin=business`. Expect very sparse results — most EU→AUS biz reward space comes from a handful of cached routes (mostly LHR, ZRH, IST).
+
+### Sample known patterns (Jul 2026)
+
+- **Qatar (qatar source) BCN/CDG/LHR → SYD economy**: 54k–90k pts, $0 fees (Qatar doesn't pass through YQ on awards via Privilege Club). 9 seats typical, very generous.
+- **Delta → Vietnam Airlines LHR-SYD biz**: 90k SkyMiles + ~$327 fees. 1 seat. Outstanding deal if you can grab it.
+- **Qantas → Emirates ZRH/FRA → SYD biz**: ~183k QFF pts + ~$1,000 fees. Emirates has high YQ.
+- **Aeroplan partner LHR-SYD biz**: 485k pts + ~$609 fees. Lots of seats (6–9) but expensive in points.
+- **Velocity QR+VA codeshare AMS/FRA/LHR-SYD economy**: 80k pts + $443–604 fees. 2–4 seats per day, very consistent inventory.
+
+## Rate limits
+
+1,000 calls/day on PRO. A "fan out to 20 origins" run uses 20 calls. Cheap.
+
+## Gotchas
+
+- **`origin_airport` does NOT accept lists** — splits into separate requests required. The web UI looks like it accepts lists but the API doesn't.
+- **`origin_region` returns 0** despite the response containing region fields.
+- **`cabin` must be singular** — `business,economy` returns `invalid_cabin` error.
+- **0 results for a route doesn't mean no seats exist** — only that seats.aero doesn't currently track that route in the queried programs. e.g. MAD-SYD biz returns 0 from every source, but Qatar Privilege Club genuinely has biz space on MAD-DOH-SYD that the cache doesn't surface (because it's stitched, not a single route). For stitched availability use the airline's own website.
+- **Tax values in `TaxesCurrency: USD`** even though the website displays AUD. Don't trust the AUD on the web UI — pull `JTotalTaxesRaw` and convert yourself.
+
+## When the API misses things
+
+The API tracks **published award space** that's been ingested. It doesn't synthesize itineraries. If your routing involves a positioning leg (e.g. MAD→DOH cash + DOH→SYD on points), search the long-haul leg only and book the short leg in cash separately.

--- a/domain-skills/tplink-router/dhcp-reservations.md
+++ b/domain-skills/tplink-router/dhcp-reservations.md
@@ -1,0 +1,80 @@
+# TP-Link router admin (VX420-G2v, Archer-family UI)
+
+Web UI at `http://192.168.1.1`. Session is cookie-based; the user must log in — never
+type router credentials.
+
+## Page structure
+
+- Two top tabs: **Basic** / **Advanced**. Almost everything useful is under Advanced.
+- DHCP reservations: **Advanced → Network → LAN Settings**. The page holds four
+  stacked sections: DHCP Server, Client List, Address Reservation, Condition Pool.
+- Left menu items are `div`/`li`, not `<a>`. `element.click()` works for menu
+  navigation, but the *submenu* only renders after clicking the parent group
+  (e.g. "Network") — read the DOM again before looking for "LAN Settings".
+
+## The trap that costs the most time
+
+**The page body does not scroll.** `page_info()` reports `ph == h` and `scrollY`
+is always `0`; an inner panel scrolls instead. So:
+
+- `scroll(x, y, dy=...)` on the body does nothing.
+- Fixed pixel coordinates are never stable across iterations.
+- `element.scrollIntoView({block:'center'})` *does* work (it scrolls the inner
+  container) — but read `getBoundingClientRect()` in a **separate** `js()` call
+  afterwards. Combining scroll + rect-read in one call returns pre-scroll
+  coordinates and every subsequent click misses.
+
+## The other trap: the Add control
+
+`Add` / `Delete` are `div.add-icon-wrap` containing `span.add-icon` (the glyph)
+and `label.table-icon-text` (the word). The click handler is bound to the
+**icon span only**. Clicking the wrapper's centre — which is what
+`getBoundingClientRect()` on the wrapper gives you — lands between the two
+children and silently does nothing.
+
+```python
+ICON = "document.querySelectorAll('.add-icon-wrap')[0].querySelector('.add-icon')"
+# click the centre of ICON, not of .add-icon-wrap
+```
+
+Verify the form actually opened before filling — the reservation form contains a
+`Scan` button, so its presence is a reliable open/closed signal:
+
+```python
+SCAN = "(()=>[...document.querySelectorAll('button,input')]" \
+       ".filter(e=>e.offsetParent&&/scan/i.test(e.value||e.innerText||'')).length)()"
+```
+
+## Filling the reservation form
+
+MAC and IP are split into separate octet inputs (6 + 4), unnamed and unlabelled.
+Locate them relative to the `Scan` button: the six inputs *before* it are the MAC,
+the four *after* it are the IP. Set values through the native setter and dispatch
+`input`/`change`/`blur`, or the framework ignores them:
+
+```python
+const p = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set;
+p.call(el, v);
+el.dispatchEvent(new Event('input',{bubbles:true}));
+el.dispatchEvent(new Event('change',{bubbles:true}));
+```
+
+Then click `OK`. Each saved row grows the table ~42px and pushes `OK` below the
+fold on later iterations — re-check the rect and `scrollIntoView` when it returns
+null.
+
+## Reading the full client list
+
+The Client List paginates at 5 rows. Rather than clicking through pages, the
+**DHCP Server page's own table** renders every lease at once — query all `tr`
+and filter rows that contain both a MAC-shaped and an IP-shaped cell.
+
+## Useful identification detail
+
+- Tuya/ESP smart bulbs appear with client name `lwip0` (the LwIP stack) or
+  `ESP_xxxxxx`. That is often the only way to tell bulbs from other IoT gear.
+- These devices frequently **do not answer ICMP**, so a ping sweep undercounts
+  them badly. Probe TCP 6668 (Tuya local) with a ≥3s timeout instead.
+- Some Tuya device IDs embed the MAC as their last 12 hex characters (older
+  numeric-style IDs). Newer `bf...`-prefixed IDs do **not** — do not assume it,
+  and beware `bf...` IDs whose tail happens to be valid hex.

--- a/domain-skills/transdirect/members.md
+++ b/domain-skills/transdirect/members.md
@@ -1,0 +1,22 @@
+# Transdirect React members area
+
+Use only the environment and member account authorized for the task. A local URL does not establish which backend it uses; confirm its configured API target before creating records. Do not infer that legacy PHP members routes and the React app share a session.
+
+## Navigation and controls
+
+- React routes include `/orders`, `/bookings`, `/billing`, `/stats`, and `/settings/addresses`. `/book?new=1` creates a fresh booking draft and redirects to `/book/<draft-id>`.
+- Desktop navigation labels the dashboard **Dashboard**; the mobile bottom navigation labels it **Home**. A desktop-only link is a poor readiness check on a phone viewport.
+- Booking addresses use **Ship From** and **Ship To** sections. Orders use **From (Sender)** and **To (Recipient)** with **Edit sender** and **Edit recipient** controls.
+- Custom locality, state, and street-type controls expose `combobox` roles and options. Read current options instead of treating them as native selects. A warehouse-hours option can include both its readable time and its 24-hour hint in the accessible name.
+- The Referrals screen uses tabs for **Past Referrals** and **Permalinks**.
+- Empty billing accounts may have no pagination controls. Assert pagination only when the account actually has enough records.
+
+## Verification traps
+
+- Draft creation and a displayed quote do not prove booking completion. Require the visible confirmation screen, then verify the requested follow-on action such as reopening or cloning.
+- When explicitly authorized to test in a preview environment, select the **Demo** courier and **Use test payment**. Verify that test payment is selected before confirming. Do not substitute another courier or a real payment method if these controls are unavailable.
+- Courier quotes have desktop rows and mobile cards in the DOM at the same time. Scope quote selection to the visible layout before asserting `aria-selected`.
+- Terms and warranty text can contain buttons opening informational dialogs. Operate the checkbox control when accepting an authorized test declaration.
+- A cached saved-address or package row is weaker evidence than persistence. Reopen or reload and confirm the edited data, accounting for the app's persistent query cache.
+- Rapid partial-address entry deserves explicit coverage: enter Unit before No. and Street, then check all fields after save and reopen.
+- Vite can report a lazy page as failing to load when a dependency request returns **Outdated Optimize Dep**. Inspect the failed dependency response before attributing that development-server error to the page or backend.


### PR DESCRIPTION
Add reusable guidance for the React members area: semantic navigation and form controls, empty-account behavior, preview booking verification, persistent-cache readback, and Vite lazy-route diagnostics. No account details, credentials, internal API payloads, or environment identifiers are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reusable browser-automation and verification guidance for eight external services as new `domain-skills` documents. The Hubstaff guide also now covers dialog state reuse, flaky time-field writes, and async save lag.

- Covers car rental aggregators, Cloudflare R2 API token creation, flightseats.io, Hubstaff manual time entry, seats.aero search plus PRO API, TP-Link router DHCP reservations, and the Transdirect React members area.
- Records stable selectors, framework interaction quirks, and verification traps.
- The `seats-aero/api.md` key is now a placeholder; no live credential remains in the diff.

<sup>Written for commit 0db69a90a972a65748fdcbc0362c2a4d4ab90a0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

