### PR TITLE
docs: Supabase SQL editor and Vercel traffic inspection notes

### DIFF
--- a/domain-skills/partsouq/vin-lookup.md
+++ b/domain-skills/partsouq/vin-lookup.md
@@ -1,0 +1,39 @@
+# partsouq.com — OEM parts lookup by VIN (live EPC mirror)
+
+Validated 2026-08-12 (Toyota/Lexus, brand-new 2026 VIN resolved perfectly).
+
+## The one URL that matters
+
+```
+https://partsouq.com/en/search/all?q=<17-char VIN>
+```
+
+Redirects straight into the manufacturer EPC catalog for that exact vehicle
+(region/year/model/modelcode, e.g. `GYU15L-BWXGBA`), with production date, color
+code, trim code shown. No login needed for browsing.
+
+## Search inside the vehicle
+
+The vehicle page has a "Search in vehicle" box — accepts part names, 5-digit
+Toyota base codes (e.g. `44250`), or callouts. Results give full part numbers
+with qty + production-date applicability windows and link to the exploded
+diagram (figure) pages.
+
+## Why this beats the alternatives
+
+- **Toyota TIS (techinfo.toyota.com) does NOT include the parts catalog** on
+  standard subscriptions — `t3Portal/resources/jsp/partscatalog/index.jsp`
+  just errors ("There was an error in the page you requested"). Don't chase it.
+- US dealer e-commerce sites (RevolutionParts network: lexuspartsnow,
+  parts.<dealer>.com) lag months behind on new models — their VIN decoders
+  reject brand-new VINs ("unable to process") and new-model catalogs may list
+  accessories only. They also 403 non-browser fetchers (WebFetch/curl); they
+  load fine in a real browser.
+- PartSouq's EPC data is near-live (had a 2026 PHV weeks after production).
+
+## Traps
+
+- Diagram footnote `N01` callouts = parts not supplied individually.
+- Fitment differs across trims of the same model line (e.g. TX500h rack =
+  44250-0E230, TX550h+ rack = 44250-0E220) — always resolve via the VIN, not
+  the model name.

--- a/domain-skills/supabase/dashboard.md
+++ b/domain-skills/supabase/dashboard.md
@@ -1,0 +1,49 @@
+# Supabase dashboard — SQL editor and permission inspection
+
+## Navigation and identity
+
+- Organization projects: `/dashboard/org/{organization_id}`.
+- Project home: `/dashboard/project/{project_ref}`. Confirm the project name,
+  branch/environment and visible project URL before any database action.
+- SQL editor: follow the **SQL Editor** navigation link. The project also has
+  a top-bar button with the same name, so use the link role when disambiguating.
+- A signed-in organization tab can coexist with an older tab still showing the
+  sign-in page. Inspect current user tabs before concluding login failed.
+
+## Editor mechanics
+
+The SQL editor exposes a textbox named **Editor content**, but it is a code
+editor, not an ordinary full-document textarea. Its accessible value can contain
+only the window around the cursor. Generic textarea replacement can leave a
+prefix from the old SQL, producing a concatenated invalid query.
+
+For replacement, focus the editor, send the platform Select All shortcut,
+Backspace, then insert the new SQL as text/paste. Read the rendered code before
+Run. Do not rely on the textbox value alone to verify the entire query. Avoid
+framework/model mutation workarounds.
+
+- **Run** executes SQL; inspect the Results panel afterward.
+- Successful DDL can show **Success. No rows returned**. Follow with independent
+  read-only checks; a success message is not a substitute for verification.
+- Results are a virtualized ARIA grid. A label saying 20 rows can coexist with
+  fewer rendered rows. Do not infer missing records from the DOM window. For
+  permission assertions, prefer a bounded aggregate query returning one row.
+- The editor can automatically append a result limit (typically 100). Read the
+  displayed SQL error before changing a valid query to work around that limit.
+
+## Safe audit patterns
+
+Read catalog metadata first (pg_class, pg_namespace, pg_proc and privilege
+functions), not sensitive business rows. SQL ownership/permission changes need
+explicit task authorization, exact scope and transaction/verification plans.
+
+`has_table_privilege(role, table, 'SELECT,INSERT')` means **any listed privilege**,
+not all: use separate checks joined with AND to prove full backend CRUD. For
+proving denial, checking that none of a combined list is granted is appropriate.
+
+Public API HEAD with count can verify read access without returning row bodies.
+A positive count proves rows are visible; an empty result alone cannot establish
+whether a table has effective RLS. Admin RLS/grant inspection resolves that.
+
+Never include keys, tokens, customer data, project identifiers or organization
+state in reusable skills or public issue reports.

--- a/domain-skills/vercel/observability.md
+++ b/domain-skills/vercel/observability.md
@@ -1,0 +1,38 @@
+# Vercel — project identity, visitor analytics and request traffic
+
+## Resolve the actual project first
+
+- Team overview: `/{team_slug}`.
+- Project overview: `/{team_slug}/{project_slug}`.
+- A repository can be linked to multiple Vercel projects. Match the live domain
+  on the project's Production Deployment card, not just a similar project name.
+- The production card shows its source commit. A newer failed deployment does
+  not replace the live commit. Record web and separately hosted backend revisions
+  independently.
+
+## Visitor analytics versus operational traffic
+
+- Project **Analytics** links to the visitor dashboard. An **Enable** button and
+  **Demo Data** label mean the sample chart is not measured visitor activity.
+- Project **Observability → Edge Requests** provides operational request counts
+  even when visitor analytics is not enabled.
+- The edge-request view supports **Routes**, **Paths**, and **Bot Name** groupings.
+  Inspect the exact time range and environment (e.g. Production).
+- Page hits, sign-in route requests, function invocations and edge requests are
+  not counts of people, successful sign-ins or conversions. The requesting agent,
+  bots, scanners, static assets and prefetches may contribute.
+- Named-bot counts do not imply the unclassified remainder is human.
+- Longer lookback choices can be gated behind an observability plan. Do not
+  enable/upgrade a paid feature just to answer a traffic question.
+
+## UI traps
+
+- **Edge Requests** may be both a sidebar link and a card link with identical
+  destinations. Scope to the known navigation region or disambiguate the links.
+- Client-side navigation may return a stale previous-page snapshot immediately
+  after clicking. Check URL/next state rather than repeating the click blindly.
+- A deployment's **Logs** page may show runtime request logs, not build logs.
+  No runtime entries does not explain why a build failed.
+
+Keep account names, customer domains, project IDs and traffic measurements out
+of reusable public skills.

--- a/domain-skills/zillow/scraping.md
+++ b/domain-skills/zillow/scraping.md
@@ -431,3 +431,32 @@ If you need property data without scraping Zillow or Redfin at scale:
 - **Zillow total count can exceed 800 but pagination caps at page ~20.** Zillow caps search results at around 800 listings even if `totalResultCount` shows 1037. Narrow by ZIP code, neighborhood, or price range to stay within bounds.
 
 - **URL filter syntax for Zillow:** Beds: `3-_beds` prefix; price: `0-1800000_price` suffix; ZIP: use `{zip}_rb` instead of city slug. Test by building the URL in a browser and copying the pattern.
+
+## Photo galleries for a specific address (the /homedetails/ 403 workaround)
+
+Field-tested 2026-07-31. Task: "download all listing photos" for one address when
+`/homedetails/` is PX-walled (curl AND `--headless=new` both get the captcha page).
+
+**Don't fight Zillow — the same MLS gallery is syndicated everywhere.** Ranked by yield:
+
+1. **Movoto — best source, full gallery, no bot wall.** Find the listing URL via a web
+   search for `"<address>" movoto` (their slug embeds an internal ID you can't guess).
+   The listing page (`/for-sale/` variant for sold homes) embeds every gallery image as
+   `https://pi.movoto.com/p/101/<MLS#>_0_<hash>.jpeg` — plain curl with a Chrome UA
+   returns all of them (a 54-photo gallery came back complete). ~1150px is the stored
+   size; there is no larger variant on that CDN.
+2. **Redfin CDN sequential probe — covers only, not the gallery.** Sold-home pages
+   render just photo 1, but the CDN pattern `ssl.cdn-redfin.com/photo/27/bigphoto/
+   <last3-of-MLS>/<MLS#>_<n>.jpg` answers HEAD requests. In practice only `_0`/`_1`
+   exist for sold listings — the rest 404. Don't waste time probing 0-60.
+3. **Compass/Coldwell Banker — server-render one photo only.** Sold-listing galleries
+   lazy-load behind auth'd XHR; `--virtual-time-budget` headless rendering still yields
+   only `img_0`. The `/m/<hash>_img_<n>_<suffix>/origin.jpg` suffix is per-image and
+   not enumerable.
+4. **Estately** — dead for sold homes (redirects to city search). **Wayback** — listing
+   pages are almost never archived (CDX returns empty).
+
+Traps: Redfin's `stingray` API 403s from datacenter IPs even when page HTML fetches
+fine; Movoto search-page HTML also contains *other* listings' `pi.movoto.com` URLs —
+filter by the target MLS number, then dedupe by image dimensions (small 480/960
+variants of the cover ship alongside the 1150px set).


### PR DESCRIPTION
Adds reusable dashboard notes from hands-on browser inspection: Supabase code-editor replacement/virtualized results and safe permission checks; Vercel project/deployment identity, real analytics versus demo data, and request-versus-visitor distinctions. No credentials, customer data, account-specific identifiers, or run narration included. Documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reusable browser-inspection notes for Supabase, Vercel, and PartSouq dashboards, and documents a Zillow photo-gallery workaround for PX-walled listing pages. Documentation only; no credentials, customer data, or account identifiers included.

**Key coverage**
- Supabase: SQL editor is a code editor, not a textarea; results are a virtualized grid, so verify with bounded aggregate queries.
- Vercel: distinguish visitor analytics from edge-request counts; demo data is not measured traffic.
- PartSouq: near-live OEM EPC lookup by VIN beats Toyota TIS and dealer sites for new models.
- Zillow: Movoto CDN serves the full MLS gallery when `/homedetails/` is PX-walled.

<sup>Written for commit bf08938ca6c520c79d2b4ddabd3fb13faeb345b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

