### PR TITLE
docs: clarify raw CDP keyword parameters

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -191,6 +191,9 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
+  Pass CDP parameters as keywords: `cdp("Input.insertText", text="hello")`.
+  The second positional argument is a session ID, not a parameters dictionary.
+  When targeting an explicit session, use `session_id="..."` alongside the keywords.
 
 ## Recordings and Videos
 


### PR DESCRIPTION
Shows the working keyword form for raw CDP calls in SKILL.md. Clarifies that the second positional argument is a session ID, and shows explicit session_id targeting. This is documentation only; runtime params-dict support remains separate in #417.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies raw CDP usage in `SKILL.md` by documenting the keyword parameter form and the meaning of the second positional argument.

- Shows `cdp("Domain.method", keyword="value")` as the working parameter form.
- Notes the second positional argument is a session ID, not a parameters dictionary.
- Documents explicit `session_id="..."` targeting.

<sup>Written for commit 7103d22b6961dfdd484e80eff41469fe3bafbef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

