### PR TITLE
P0: keep tab ownership across recovery and daemon restart

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -80,7 +80,13 @@ approval prompt is acceptable. It creates another controller and dedicated tab
 in the same local Chrome profile, not another Chrome profile or process.
 
 If the default daemon becomes stale, use its built-in reattachment/recovery
-first. A command timeout, truncated output, site change, closed tab, or new task
+first. Recovery and daemon restart keep the saved target ID. `TabLost` means
+the selected tab disappeared, the browser changed, or the saved binding is
+unreadable. Inspect `list_tabs()` and explicitly `switch_tab(targetId)` or
+`new_tab()`; an interrupted action is never replayed on a different tab.
+Named local daemon shutdown still closes its owned tab, so a later restart
+requires explicit tab selection if that was the saved target.
+A command timeout, truncated output, site change, closed tab, or new task
 is not a reason to create another daemon. Run `browser-harness --doctor` and
 restart or replace the default daemon only when it is actually dead or cannot
 recover.
@@ -186,7 +192,8 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Clicking: AX node -> box center -> `click_at_xy(x, y)` -> verify with a targeted `js(...)`/`page_info()` check.
 - Fall back to raw HTML via `js(...)` only when the AX tree lacks the element (canvas, exotic widgets); screenshot when layout or imagery matters.
 - After navigation, call `wait_for_load()`.
-- If the current tab is stale or internal, call `ensure_real_tab()`.
+- For an internal page, explicitly choose a working tab with `ensure_real_tab()`.
+  For `TabLost`, inspect and select the intended target explicitly before acting.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.

--- a/src/browser_harness/_tab_binding.py
+++ b/src/browser_harness/_tab_binding.py
@@ -1,0 +1,56 @@
+"""Private, per-daemon target binding. Never persist CDP credentials or URLs."""
+import hashlib
+import json
+import os
+import tempfile
+from urllib.parse import urlsplit
+
+
+class TabLost(RuntimeError):
+    def __init__(self, reason):
+        super().__init__(f"TabLost: {reason}; use list_tabs() and switch_tab(targetId), or new_tab(), explicitly")
+
+
+def browser_key(url, remote_id=None):
+    parsed = urlsplit(url)
+    identity = f"cloud:{remote_id}" if remote_id else f"{parsed.scheme}://{parsed.hostname}:{parsed.port}{parsed.path}"
+    return hashlib.sha256(identity.encode()).hexdigest()
+
+
+class TabBinding:
+    def __init__(self, path, key):
+        self.path, self.key = path, key
+
+    def load(self):
+        try:
+            data = json.loads(self.path.read_text())
+        except FileNotFoundError:
+            return None
+        except (OSError, ValueError):
+            raise TabLost("saved tab binding cannot be read") from None
+        if not isinstance(data, dict) or data.get("version") != 1:
+            raise TabLost("saved tab binding is invalid")
+        if data.get("browser") != self.key:
+            raise TabLost("the browser changed since the saved tab was selected")
+        if not isinstance(data.get("target"), str) or not data["target"]:
+            raise TabLost("saved target is invalid")
+        if data.get("owned") is not None and not isinstance(data["owned"], str):
+            raise TabLost("saved owned target is invalid")
+        return data
+
+    def save(self, target, owned):
+        data = {"version": 1, "browser": self.key, "target": target, "owned": owned}
+        # mkstemp creates mode 0600. Replace atomically: a crash must not leave
+        # a truncated binding that looks like a first-ever attachment.
+        fd, tmp = tempfile.mkstemp(prefix=self.path.name + ".", dir=self.path.parent)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, self.path)
+        finally:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from . import _ipc as ipc
 from . import auth
 from . import paths
+from ._tab_binding import TabBinding, TabLost, browser_key
 from cdp_use.client import CDPClient
 
 
@@ -427,6 +428,8 @@ class Daemon:
         self.session = None
         self.target_id = None
         self.dedicated_target_id = None
+        self._binding = None
+        self._binding_error = None
         self._dedicated_target_lock = asyncio.Lock()
         self._session_state_lock = asyncio.Lock()
         self._active_recoveries = 0
@@ -440,8 +443,17 @@ class Daemon:
         self.stop = None  # asyncio.Event, set inside start()
 
     async def attach_first_page(self, replaces_session=None, enable_domains=True):
-        """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
+        """Choose a page once; every subsequent attachment keeps that exact target."""
+        selected_before_discovery = self.target_id
         targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+        if self.target_id != selected_before_discovery:
+            # Another first attachment may have created a tab after our snapshot.
+            targets = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
+        if self.target_id:
+            page = next((t for t in targets if t["targetId"] == self.target_id and t["type"] == "page"), None)
+            if page is None:
+                raise TabLost(f"selected target {self.target_id} disappeared")
+            return await self._attach_page(page, replaces_session, enable_domains)
         # Named daemons (BU_NAME != "default") share one browser with other
         # daemons — attaching to the first page makes parallel daemons fight
         # over a single tab (navigations clobber each other). Give each named
@@ -453,12 +465,9 @@ class Daemon:
             if BROWSER_KIND == "local":
                 await self._close_inspect_tabs(targets)
             pages_by_id = {t["targetId"]: t for t in targets if t["type"] == "page"}
-            # A stale CDP session does not necessarily mean its tab disappeared.
-            # Reattach to the current tab first, then the daemon's dedicated tab.
-            page = pages_by_id.get(self.target_id) or pages_by_id.get(self.dedicated_target_id)
+            page = pages_by_id.get(self.dedicated_target_id)
             if page is None:
-                # Two stale IPC requests can recover concurrently. Recheck
-                # inside a narrow lock so they share one replacement tab.
+                # Concurrent first attachments share one dedicated tab.
                 async with self._dedicated_target_lock:
                     refreshed = (await self.cdp.send_raw("Target.getTargets"))["targetInfos"]
                     pages_by_id = {t["targetId"]: t for t in refreshed if t["type"] == "page"}
@@ -470,16 +479,7 @@ class Daemon:
                         self.dedicated_target_id = tid
                         log(f"named daemon {NAME}: created dedicated tab ({tid})")
                         page = {"targetId": tid, "url": "about:blank", "type": "page"}
-            tid = page["targetId"]
-            self.session = (await self.cdp.send_raw(
-                "Target.attachToTarget", {"targetId": tid, "flatten": True}
-            ))["sessionId"]
-            self._record_session_replacement(replaces_session, self.session)
-            self.target_id = tid
-            log(f"attached {tid} ({page.get('url','')[:80]}) session={self.session}")
-            if enable_domains:
-                await self._enable_default_domains(self.session)
-            return page
+            return await self._attach_page(page, replaces_session, enable_domains)
 
         pages = [t for t in targets if is_real_page(t)]
         if not pages:
@@ -504,12 +504,7 @@ class Daemon:
             ))["targetId"]
             log(f"no real pages found, created about:blank ({tid})")
             pages = [{"targetId": tid, "url": "about:blank", "type": "page"}]
-        self.session = (await self.cdp.send_raw(
-            "Target.attachToTarget", {"targetId": pages[0]["targetId"], "flatten": True}
-        ))["sessionId"]
-        self._record_session_replacement(replaces_session, self.session)
-        self.target_id = pages[0]["targetId"]
-        log(f"attached {pages[0]['targetId']} ({pages[0].get('url','')[:80]}) session={self.session}")
+        await self._attach_page(pages[0], replaces_session, enable_domains=False)
         if take_over:
             try:
                 await self.cdp.send_raw("Page.navigate", {"url": "about:blank"}, session_id=self.session)
@@ -521,6 +516,24 @@ class Daemon:
         if enable_domains:
             await self._enable_default_domains(self.session)
         return pages[0]
+
+    def _persist_tab(self, target_id):
+        if self._binding is not None:
+            self._binding.save(target_id, self.dedicated_target_id)
+
+    async def _attach_page(self, page, replaces_session=None, enable_domains=True):
+        target_id = page["targetId"]
+        self._persist_tab(target_id)
+        session = (await self.cdp.send_raw(
+            "Target.attachToTarget", {"targetId": target_id, "flatten": True}
+        ))["sessionId"]
+        self.session, self.target_id = session, target_id
+        self._binding_error = None
+        self._record_session_replacement(replaces_session, session)
+        log(f"attached {target_id} session={session}")
+        if enable_domains:
+            await self._enable_default_domains(session)
+        return page
 
     async def _close_inspect_tabs(self, targets):
         """Close chrome://inspect tabs left open by the permission recovery flow"""
@@ -655,7 +668,16 @@ class Daemon:
                     "browser-harness did not retry or create another connection"
                 )
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
-        await self.attach_first_page()
+        self._binding = TabBinding(ipc.pid_path(NAME).with_suffix(".tab.json"), browser_key(url, REMOTE_ID))
+        try:
+            saved = self._binding.load()
+            if saved:
+                self.target_id, self.dedicated_target_id = saved["target"], saved.get("owned")
+            await self.attach_first_page()
+        except TabLost as e:
+            # Keep the control plane available for explicit tab selection.
+            self._binding_error = str(e)
+            log(self._binding_error)
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):
             self._record_event(method, params, session_id)
@@ -708,9 +730,15 @@ class Daemon:
             return {"target_id": self.target_id, "session_id": self.session, "page": page}
         if meta == "set_session":
             async with self._session_state_lock:
+                target_id = req.get("target_id") or self.target_id
+                try:
+                    self._persist_tab(target_id)
+                except OSError:
+                    return {"error": "TabBindingWriteFailed: selection unchanged; saved binding could not be written"}
                 old_session = self.session
                 self.session = req.get("session_id")
-                self.target_id = req.get("target_id") or self.target_id
+                self.target_id = target_id
+                self._binding_error = None
                 new_session = self.session
             # Run the old-session Network.disable (defense in depth — keeps
             # background-tab traffic out of the global event buffer; the
@@ -762,6 +790,8 @@ class Daemon:
 
         method = req["method"]
         params = req.get("params") or {}
+        if self._binding_error and not method.startswith("Target.") and not req.get("session_id"):
+            return {"error": self._binding_error}
         # Browser-level Target.* calls must not use a session (stale or otherwise).
         # For everything else, explicit session in req wins; else default.
         sid = None if method.startswith("Target.") else (req.get("session_id") or self.session)
@@ -803,6 +833,8 @@ class Daemon:
                             )}
                         except Exception as retry_error:
                             return {"error": str(retry_error)}
+                except TabLost as lost:
+                    return {"error": str(lost)}
                 finally:
                     self._finish_recovery(recovery_task)
             return {"error": msg}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -430,6 +430,7 @@ class Daemon:
         self.dedicated_target_id = None
         self._binding = None
         self._binding_error = None
+        self._detached_sessions = deque(maxlen=32)
         self._dedicated_target_lock = asyncio.Lock()
         self._session_state_lock = asyncio.Lock()
         self._active_recoveries = 0
@@ -637,6 +638,8 @@ class Daemon:
         )))
 
     def _record_event(self, method, params, session_id=None):
+        if method == "Target.detachedFromTarget" and params.get("sessionId"):
+            self._detached_sessions.append(params["sessionId"])
         self.events.append({"method": method, "params": params, "session_id": session_id})
         if method == "Page.javascriptDialogOpening":
             self.dialog = params
@@ -796,7 +799,14 @@ class Daemon:
         # For everything else, explicit session in req wins; else default.
         sid = None if method.startswith("Target.") else (req.get("session_id") or self.session)
         try:
-            return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
+            if sid in self._detached_sessions:
+                raise RuntimeError("Session with given id not found")
+            result = await self.cdp.send_raw(method, params, session_id=sid)
+            if method == "Target.closeTarget" and params.get("targetId") == self.target_id and result.get("success"):
+                # Chrome may acknowledge close before emitting the detach event.
+                # Never send the next page command into that closing session.
+                self._binding_error = str(TabLost(f"selected target {self.target_id} was closed"))
+            return {"result": result}
         except Exception as e:
             msg = str(e)
             if "Session with given id not found" in msg and sid:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -705,6 +705,8 @@ class Daemon:
             return {"events": out}
         if meta == "session":     return {"session_id": self.session}
         if meta == "current_tab":
+            if self._binding_error:
+                return {"error": self._binding_error}
             # Resolve the attached page's target info server-side. Helpers can't
             # send Target.getTargetInfo themselves: daemon strips session_id for
             # any Target.* method (browser-level call), and without a targetId

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -422,7 +422,16 @@ def switch_tab(target, activate=False):
     if activate:
         activate_tab(target_id)
     sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
-    _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
+    try:
+        _send({"meta": "set_session", "session_id": sid, "target_id": target_id})
+    except RuntimeError as exc:
+        # A timeout has an unknown outcome. Detach only after an explicit
+        # rejection before the daemon committed the new selection.
+        if not str(exc).startswith("TabBindingWriteFailed:"):
+            raise
+        try: cdp("Target.detachFromTarget", sessionId=sid)
+        except Exception: pass
+        raise
     _mark_tab()
     return sid
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -553,8 +553,8 @@ def test_named_reattach_keeps_selected_tab_when_it_still_exists(monkeypatch):
     assert d.session == "session-for-selected-tab"
 
 
-def test_named_reattach_creates_replacement_only_when_tab_is_gone(monkeypatch):
-    """If the user closes the dedicated tab, the daemon creates one replacement."""
+def test_named_reattach_fails_when_tab_is_gone(monkeypatch):
+    """A closed selected tab must never redirect an outstanding action."""
     monkeypatch.setattr(daemon, "NAME", "worker-a")
     monkeypatch.setattr(daemon, "REMOTE_ID", None)
     monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
@@ -563,16 +563,17 @@ def test_named_reattach_creates_replacement_only_when_tab_is_gone(monkeypatch):
 
     asyncio.run(d.attach_first_page())
     d.cdp.targets = [t for t in d.cdp.targets if t["targetId"] != "created-1"]
-    asyncio.run(d.attach_first_page())
+    with pytest.raises(daemon.TabLost, match="disappeared"):
+        asyncio.run(d.attach_first_page())
 
-    assert d.cdp.created == 2
+    assert d.cdp.created == 1
     assert d.cdp.closed == []
-    assert d.target_id == "created-2"
-    assert d.dedicated_target_id == "created-2"
+    assert d.target_id == "created-1"
+    assert d.dedicated_target_id == "created-1"
 
 
-def test_concurrent_named_reattach_creates_one_replacement(monkeypatch):
-    """Concurrent recovery after a user closes the tab shares one replacement."""
+def test_concurrent_named_first_attach_creates_one_tab(monkeypatch):
+    """Concurrent first attachments share one dedicated tab."""
     class _ConcurrentAttachCDP(_AttachCDP):
         def __init__(self):
             super().__init__()

--- a/tests/unit/test_tab_binding.py
+++ b/tests/unit/test_tab_binding.py
@@ -1,0 +1,146 @@
+import asyncio
+import json
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+from browser_harness import daemon
+from browser_harness import helpers
+from browser_harness._tab_binding import TabBinding, TabLost, browser_key
+
+
+class Browser:
+    def __init__(self, targets):
+        self.targets = targets
+        self.calls = []
+        async def event(*args):
+            pass
+        self._event_registry = SimpleNamespace(handle_event=event)
+
+    async def start(self):
+        pass
+
+    async def send_raw(self, method, params=None, session_id=None):
+        self.calls.append((method, params, session_id))
+        if method == "Target.getTargets":
+            return {"targetInfos": [{"targetId": t, "type": "page", "url": "https://example.test"} for t in self.targets]}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-" + params["targetId"]}
+        if session_id == "stale":
+            raise RuntimeError("Session with given id not found")
+        return {}
+
+
+@pytest.fixture
+def setup_browser(tmp_path, monkeypatch):
+    browser = Browser(["owned", "other"])
+    monkeypatch.setattr(daemon, "NAME", "default")
+    monkeypatch.setattr(daemon, "BROWSER_KIND", "cdp")
+    monkeypatch.setattr(daemon, "REMOTE_ID", None)
+    monkeypatch.setattr(daemon, "get_ws_url", lambda: "ws://localhost:9222/devtools/browser/id?token=secret")
+    monkeypatch.setattr(daemon, "CDPClient", lambda url: browser)
+    monkeypatch.setattr(daemon, "log", lambda msg: None)
+    monkeypatch.setattr(daemon.ipc, "pid_path", lambda name: tmp_path / "daemon.pid")
+    monkeypatch.setenv("BH_TAB_MARKER", "0")
+    return browser, tmp_path / "daemon.tab.json"
+
+
+def test_restart_and_recovery_keep_selected_target_despite_reordering(setup_browser):
+    browser, path = setup_browser
+    async def run():
+        first = daemon.Daemon()
+        await first.start()
+        await first.handle({"meta": "set_session", "session_id": "selected", "target_id": "other"})
+        second = daemon.Daemon()
+        await second.start()
+        assert second.target_id == "other"
+        second.session = "stale"
+        assert await second.handle({"method": "Input.dispatchMouseEvent", "params": {"type": "mousePressed"}}) == {"result": {}}
+        assert browser.calls[-1][2] == "session-other"
+    asyncio.run(run())
+    assert "secret" not in path.read_text()
+    assert "localhost" not in path.read_text()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("fault", ["closed", "changed-browser", "corrupt"])
+def test_lost_binding_keeps_control_plane_and_requires_explicit_selection(setup_browser, monkeypatch, fault):
+    browser, path = setup_browser
+    async def run():
+        first = daemon.Daemon()
+        await first.start()
+        if fault == "closed":
+            browser.targets = ["other"]
+        elif fault == "changed-browser":
+            monkeypatch.setattr(daemon, "get_ws_url", lambda: "ws://localhost:9222/devtools/browser/new")
+        else:
+            path.write_text("broken")
+        browser.calls.clear()
+        second = daemon.Daemon()
+        await second.start()
+        assert not any(m == "Target.attachToTarget" for m, _, _ in browser.calls)
+        result = await second.handle({"method": "Input.dispatchMouseEvent", "params": {"type": "mousePressed"}})
+        assert result["error"].startswith("TabLost:")
+        assert not any(m == "Input.dispatchMouseEvent" for m, _, _ in browser.calls)
+        assert "result" in await second.handle({"method": "Target.getTargets"})
+        await second.handle({"meta": "set_session", "session_id": "session-other", "target_id": "other"})
+        assert await second.handle({"method": "Runtime.evaluate"}) == {"result": {}}
+        assert json.loads(path.read_text())["target"] == "other"
+    asyncio.run(run())
+
+
+def test_recovery_never_falls_back_to_owned_tab(setup_browser, monkeypatch):
+    browser, _ = setup_browser
+    monkeypatch.setattr(daemon, "NAME", "worker")
+    d = daemon.Daemon()
+    d.cdp, d.target_id, d.dedicated_target_id, d.session = browser, "closed-selection", "owned", "stale"
+    result = asyncio.run(d.handle({"method": "Input.dispatchMouseEvent", "params": {"type": "mousePressed"}}))
+    assert "TabLost" in result["error"]
+    assert not any(m in {"Target.attachToTarget", "Target.createTarget"} for m, _, _ in browser.calls)
+
+
+def test_failed_atomic_save_retains_previous_binding_and_selection(setup_browser, monkeypatch):
+    browser, path = setup_browser
+    async def run():
+        d = daemon.Daemon()
+        await d.start()
+        before = path.read_bytes()
+        def fail(*args):
+            raise OSError("disk full")
+        monkeypatch.setattr("browser_harness._tab_binding.os.replace", fail)
+        result = await d.handle({"meta": "set_session", "target_id": "other", "session_id": "new"})
+        assert result["error"].startswith("TabBindingWriteFailed:")
+        assert (d.target_id, d.session) == ("owned", "session-owned")
+        assert path.read_bytes() == before
+        assert list(path.parent.glob("daemon.tab.json.*")) == []
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("data", [[], {"version": 2}, {"version": 1, "browser": "key", "target": None}, {"version": 1, "browser": "key", "target": "tab", "owned": 3}])
+def test_invalid_binding_is_not_treated_as_first_attach(tmp_path, data):
+    path = tmp_path / "tab.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(TabLost):
+        TabBinding(path, "key").load()
+
+
+def test_browser_identity_ignores_rotating_credentials():
+    assert browser_key("wss://a:b@host:443/browser/id?key=one") == browser_key("wss://x:y@host:443/browser/id?key=two")
+    assert browser_key("wss://host/a", "cloud-1") == browser_key("wss://host/b", "cloud-1")
+    assert browser_key("wss://host/a") != browser_key("wss://host/b")
+
+
+@pytest.mark.parametrize("failure,detach", [(RuntimeError("TabBindingWriteFailed: disk full"), True), (helpers._IPCResponseTimeout("unknown outcome"), False)])
+def test_switch_detaches_only_after_explicit_binding_rejection(monkeypatch, failure, detach):
+    calls = []
+    def cdp(method, **params):
+        calls.append(method)
+        return {"sessionId": "new"}
+    def fail(req):
+        raise failure
+    monkeypatch.setattr(helpers, "cdp", cdp)
+    monkeypatch.setattr(helpers, "_send", fail)
+    with pytest.raises(type(failure)):
+        helpers.switch_tab("selected")
+    assert ("Target.detachFromTarget" in calls) is detach

--- a/tests/unit/test_tab_binding.py
+++ b/tests/unit/test_tab_binding.py
@@ -144,3 +144,42 @@ def test_switch_detaches_only_after_explicit_binding_rejection(monkeypatch, fail
     with pytest.raises(type(failure)):
         helpers.switch_tab("selected")
     assert ("Target.detachFromTarget" in calls) is detach
+
+
+def test_observed_detach_recovers_without_sending_into_dead_session(setup_browser):
+    browser, _ = setup_browser
+    async def run():
+        d = daemon.Daemon()
+        await d.start()
+        old = d.session
+        original = browser.send_raw
+        async def send(method, params=None, session_id=None):
+            result = await original(method, params, session_id)
+            return {"sessionId": "recovered"} if method == "Target.attachToTarget" else result
+        browser.send_raw = send
+        d._record_event("Target.detachedFromTarget", {"sessionId": old})
+        browser.calls.clear()
+        await d.handle({"method": "Runtime.evaluate"})
+        methods = [m for m, _, _ in browser.calls]
+        assert methods[0] == "Target.getTargets"
+        assert methods.index("Target.attachToTarget") < methods.index("Runtime.evaluate")
+    asyncio.run(run())
+
+
+def test_acknowledged_close_rejects_next_action_before_detach_event(setup_browser):
+    browser, _ = setup_browser
+    async def run():
+        d = daemon.Daemon()
+        await d.start()
+        original = browser.send_raw
+        async def send(method, params=None, session_id=None):
+            if method == "Target.closeTarget":
+                return {"success": True}
+            return await original(method, params, session_id)
+        browser.send_raw = send
+        await d.handle({"method": "Target.closeTarget", "params": {"targetId": "owned"}})
+        browser.calls.clear()
+        result = await d.handle({"method": "Input.dispatchMouseEvent"})
+        assert "TabLost" in result["error"]
+        assert browser.calls == []
+    asyncio.run(run())

--- a/tests/unit/test_tab_binding.py
+++ b/tests/unit/test_tab_binding.py
@@ -183,3 +183,36 @@ def test_acknowledged_close_rejects_next_action_before_detach_event(setup_browse
         assert "TabLost" in result["error"]
         assert browser.calls == []
     asyncio.run(run())
+
+
+def test_new_tab_after_close_ack_creates_once_without_navigating_closing_target(setup_browser, monkeypatch):
+    browser, _ = setup_browser
+    d = daemon.Daemon()
+    asyncio.run(d.start())
+    original = browser.send_raw
+    async def send(method, params=None, session_id=None):
+        result = await original(method, params, session_id)
+        if method == "Target.getTargetInfo":
+            return {"targetInfo": {"targetId": "owned", "url": "", "title": ""}}
+        if method == "Target.closeTarget":
+            return {"success": True}
+        if method == "Target.createTarget":
+            return {"targetId": "fresh"}
+        return result
+    browser.send_raw = send
+    def ipc(req, **kwargs):
+        result = asyncio.run(d.handle(req))
+        if "error" in result:
+            raise RuntimeError(result["error"])
+        return result
+    monkeypatch.setattr(helpers, "_send", ipc)
+    helpers.close_tab("owned")
+    with pytest.raises(RuntimeError, match="TabLost"):
+        helpers.current_tab()
+    browser.calls.clear()
+    assert helpers.new_tab("https://example.test/recovery") == "fresh"
+    assert sum(m == "Target.createTarget" for m, _, _ in browser.calls) == 1
+    assert [(p, s) for m, p, s in browser.calls if m == "Page.navigate"] == [
+        ({"url": "https://example.test/recovery"}, "session-fresh")]
+    assert d.target_id == "fresh"
+    assert d._binding_error is None


### PR DESCRIPTION
Stale-session recovery must replay an action only on its original target. Persist the selected target across daemon restarts. A lost target, changed browser, or invalid binding raises `TabLost`, while explicit tab selection remains available.

Persist a versioned, atomic, private target binding and browser fingerprint. Store no URL, token or CDP credentials. Keep existing recovery locks, replacement mapping, explicit-session behavior and owned-tab shutdown cleanup. Failed binding writes retain the old selection; an ambiguous IPC timeout does not detach a potentially committed session. Relates to #596 without modifying that branch.

When Chrome acknowledges a target close before emitting detach, reject implicit page actions immediately. `current_tab()` now exposes that known loss instead of returning the closing target's empty URL. Consequently `new_tab(url)` creates one fresh target and navigates it. Navigation failures themselves are not a reason to repeat a navigation in another tab.

Proof: 289 standalone unit/integration tests pass. Coverage includes restart/reordering/deletion, browser replacement, malformed bindings, atomic-write failure, concurrent recovery/selection/shutdown, close-before-detach, and explicit recovery.

Compatibility / rollout: first attachment is unchanged when no binding exists. Missing tabs and current_tab on a known lost binding fail visibly. Explicit-session CDP remains exact. Named-local shutdown still closes its owned tab; a later restart may require explicit selection. Reload deliberately; running user daemons were not restarted.

Rollback: revert and deliberately reload. Older daemons ignore the binding file. Before upgrading again, stop the daemon and clear its own .tab.json if the old version changed selection, then explicitly choose the intended target. No profile/customer-data migration.

Combined validation: initial fixed candidate `0ea704f` passes 343 unit/integration tests; six disposable headless-Chrome click tests, four CLI/browser probes and package builds pass. Latest candidate `78aaadc`, adding Cloud health protection, passes 347 unit/integration tests. Counts cover different scopes and must not be added. Integration must preserve the tested conflict resolutions, including the detached-session tracking `deque` import.

Completed full paired rerun: **main 79/106 (74.5%); candidate 82/106 (77.4%), +2.83 percentage points**. 15 candidate wins, 12 losses; exact paired McNemar p=0.701. [Main workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999817407), [candidate workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999818855). Main `eba1021`, candidate `0ea704f`, platform `4104d41`; all 106 internal-bench-hard tasks; one attempt per task/arm; GPT-5.5 medium; Laith/GPT-5.5; matched options/dependencies/budgets. Actual initial viewport is 1280×960; reported DPR, IP/fingerprint and live sites remain variable. Resizing is enabled in both arms; do not compare causally to the older default-provider 85/106 vs 78/106 run.

Raw scores retain one ungraded candidate judge-startup timeout (`4t60pl`). Excluding only that pair: main 78/105, candidate 82/105. A separate candidate agent timeout (`trp0j4`) has a substantive failing judgment and stays included. Several flips expose inconsistent grading of coverage/access limitations. No scores were overridden. This run does not isolate an individual PR's effect or establish an uplift.

The full candidate predates separate Cloud health protection #773 and platform ownership enforcement browser-use/new-eval-platform#17. Latest `78aaadc` on platform `6bfa066` has a separate two-task matched follow-up: 1/2 in both arms; candidate Maps returns 40 qualifying leads, Apartments.com remains blocked. All four follow-up stops are confirmed. No live strict-health failure occurs there, so forced local failure/recovery tests establish the guard. No full 106-task comparison on the latest health fix.

Draft. Current-head automated checks pass; no human reviews or review threads. The harness has no automated unit-test workflow, so unit-test evidence above is local. No merge or production deployment. All 212 full-rerun artifacts confirm Cloud stop. A separate aborted setup cohort is excluded; 17 started tasks there lack confirmed stop evidence, requested 60-minute lifetimes have elapsed, and final provider state is unverified.
