### PR TITLE
P0: surface navigation failures without retrying in another tab

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -186,6 +186,8 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Clicking: AX node -> box center -> `click_at_xy(x, y)` -> verify with a targeted `js(...)`/`page_info()` check.
 - Fall back to raw HTML via `js(...)` only when the AX tree lacks the element (canvas, exotic widgets); screenshot when layout or imagery matters.
 - After navigation, call `wait_for_load()`.
+- `goto_url()` raises on Chrome navigation errors. A download handoff keeps
+  `isDownload` in the result; it does not mean the file has finished downloading.
 - If the current tab is stale or internal, call `ensure_real_tab()`.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -150,7 +150,14 @@ def _is_illegal_return_error(exc):
 
 # --- navigation / page ---
 def goto_url(url):
+    """Navigate; raise on Chrome navigation errors. Downloads retain the CDP result."""
     r = cdp("Page.navigate", url=url)
+    if r.get("errorText") and not r.get("isDownload"):
+        # Chrome's error code is useful; the requested URL may contain secrets.
+        import re
+        code = re.search(r"\bnet::ERR_[A-Z0-9_]+\b", str(r["errorText"]))
+        reason = code.group(0) if code else "Chrome reported a navigation error"
+        raise RuntimeError(f"Navigation failed: {reason}")
     if os.environ.get("BH_DOMAIN_SKILLS") != "1":
         return r
     d = (AGENT_WORKSPACE / "domain-skills" / (urlparse(url).hostname or "").removeprefix("www.").split(".")[0])
@@ -433,17 +440,18 @@ def new_tab(url="about:blank"):
     if url != "about:blank":
         try:
             cur = current_tab()
+        except Exception:
+            cur = None
+        if cur is not None:
             cur_url = cur.get("url") or ""
-            # Reuse attached tab when it's blank
             if (
                 cur_url in ("", "about:blank", "data:text/html,")
                 or cur_url.startswith("about:blank#")
                 or cur_url.startswith(("chrome://newtab", "chrome://new-tab-page", "edge://newtab", "about:newtab"))
             ):
+                # A failed navigation must not be retried in a second tab.
                 goto_url(url)
                 return cur.get("targetId") or cur.get("target_id")
-        except Exception:
-            pass
     tid = cdp("Target.createTarget", url="about:blank", background=True)["targetId"]
     switch_tab(tid)
     if url != "about:blank":

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -143,7 +143,7 @@ def browser_new_tab(url: str = "about:blank"):
 
 @_tool
 def browser_goto(url: str):
-    """Navigate the current tab to `url`. Returns the navigation result."""
+    """Navigate to `url`; errors raise. Success and downloads return the CDP navigation result."""
     return goto_url(url)
 
 

--- a/tests/unit/test_navigation_errors.py
+++ b/tests/unit/test_navigation_errors.py
@@ -1,0 +1,51 @@
+import asyncio
+import json
+
+import pytest
+
+from browser_harness import helpers
+
+
+@pytest.mark.parametrize("error", ["net::ERR_NAME_NOT_RESOLVED", "net::ERR_CONNECTION_REFUSED", "net::ERR_ABORTED", "private URL https://secret.test/?token=secret"])
+def test_navigation_errors_raise_without_exposing_url(monkeypatch, error):
+    monkeypatch.setattr(helpers, "cdp", lambda *args, **kwargs: {"errorText": error, "frameId": "frame"})
+    with pytest.raises(RuntimeError, match="Navigation failed") as exc:
+        helpers.goto_url("https://user:secret@example.test/?token=secret")
+    assert "secret" not in str(exc.value)
+    if error.startswith("net::ERR_"):
+        assert error in str(exc.value)
+
+
+@pytest.mark.parametrize("result", [{"frameId": "f", "loaderId": "l"}, {"frameId": "f"}, {"frameId": "f", "isDownload": True, "errorText": "net::ERR_ABORTED"}])
+def test_success_same_document_and_download_keep_raw_shape(monkeypatch, result):
+    monkeypatch.delenv("BH_DOMAIN_SKILLS", raising=False)
+    monkeypatch.setattr(helpers, "cdp", lambda *args, **kwargs: result)
+    assert helpers.goto_url("https://example.test/#section") is result
+
+
+def test_new_tab_does_not_repeat_failed_navigation(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helpers, "current_tab", lambda: {"targetId": "blank", "url": "about:blank"})
+    def cdp(method, **kwargs):
+        calls.append(method)
+        return {"errorText": "net::ERR_CONNECTION_REFUSED"}
+    monkeypatch.setattr(helpers, "cdp", cdp)
+    with pytest.raises(RuntimeError, match="ERR_CONNECTION_REFUSED"):
+        helpers.new_tab("http://example.test")
+    assert calls == ["Page.navigate"]
+
+
+def test_mcp_navigation_failure_is_a_tool_error_and_download_is_success(monkeypatch):
+    pytest.importorskip("mcp")
+    import mcp_server
+    from mcp_types import CallToolRequestParams
+    monkeypatch.setattr(mcp_server, "ensure_daemon", lambda: None)
+    result = {"errorText": "net::ERR_ABORTED"}
+    monkeypatch.setattr(helpers, "cdp", lambda *args, **kwargs: result)
+    params = CallToolRequestParams(name="browser_goto", arguments={"url": "https://example.test/file"})
+    failed = asyncio.run(mcp_server.SERVER._handle_call_tool(None, params))
+    assert failed.is_error is True
+    result["isDownload"] = True
+    success = asyncio.run(mcp_server.SERVER._handle_call_tool(None, params))
+    assert success.is_error is False
+    assert json.loads(success.content[0].text) == result


### PR DESCRIPTION
`goto_url()` currently returns Chrome's `errorText` as a successful helper result. Raise a sanitized navigation error instead, and let the existing MCP ToolError wrapper carry it to clients. Successful and same-document results keep their CDP shape; an explicit `isDownload` handoff remains successful.

Also narrow `new_tab()`'s exception handler: a failed navigation in a reused blank tab must not be swallowed and retried in a second tab. Raw `cdp("Page.navigate", ...)` remains unchanged.

Relates to #695. This smaller alternative retains the successful return schema, adds no landing-URL round trip, and distinguishes download handoff from an unexplained `ERR_ABORTED`.

Validation: `uv run --extra mcp --with pytest python -m pytest tests/unit tests/integration -q` — 282 passed. Covers DNS/refused/aborted navigation, sanitized errors, successful/same-document/download shapes, no duplicate navigation, and actual MCP tool-error/success responses. `git diff --check` passes. Combined browser and eval evidence is below.

Compatibility / rollout: callers that inspect returned `errorText` must catch `RuntimeError` instead. An `isDownload` result is a handoff, not proof the file completed. This helper change needs a new CLI/MCP process; no automatic daemon restart or customer-data migration. Rollback is a commit revert; success schemas and raw CDP are unchanged.

Combined validation: initial fixed candidate `0ea704f` passes 343 unit/integration tests; six disposable headless-Chrome click tests, four CLI/browser probes and package builds pass. Latest candidate `78aaadc`, adding Cloud health protection, passes 347 unit/integration tests. Counts cover different scopes and must not be added. Integration must preserve the tested conflict resolutions, including the detached-session tracking `deque` import.

Completed full paired rerun: **main 79/106 (74.5%); candidate 82/106 (77.4%), +2.83 percentage points**. 15 candidate wins, 12 losses; exact paired McNemar p=0.701. [Main workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999817407), [candidate workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999818855). Main `eba1021`, candidate `0ea704f`, platform `4104d41`; all 106 internal-bench-hard tasks; one attempt per task/arm; GPT-5.5 medium; Laith/GPT-5.5; matched options/dependencies/budgets. Actual initial viewport is 1280×960; reported DPR, IP/fingerprint and live sites remain variable. Resizing is enabled in both arms; do not compare causally to the older default-provider 85/106 vs 78/106 run.

Raw scores retain one ungraded candidate judge-startup timeout (`4t60pl`). Excluding only that pair: main 78/105, candidate 82/105. A separate candidate agent timeout (`trp0j4`) has a substantive failing judgment and stays included. Several flips expose inconsistent grading of coverage/access limitations. No scores were overridden. This run does not isolate an individual PR's effect or establish an uplift.

The full candidate predates separate Cloud health protection #773 and platform ownership enforcement browser-use/new-eval-platform#17. Latest `78aaadc` on platform `6bfa066` has a separate two-task matched follow-up: 1/2 in both arms; candidate Maps returns 40 qualifying leads, Apartments.com remains blocked. All four follow-up stops are confirmed. No live strict-health failure occurs there, so forced local failure/recovery tests establish the guard. No full 106-task comparison on the latest health fix.

Draft. Current-head automated checks pass; no human reviews or review threads. The harness has no automated unit-test workflow, so unit-test evidence above is local. No merge or production deployment. All 212 full-rerun artifacts confirm Cloud stop. A separate aborted setup cohort is excluded; 17 started tasks there lack confirmed stop evidence, requested 60-minute lifetimes have elapsed, and final provider state is unverified.
