### PR TITLE
P0: isolate event readers and track requests before consumption

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -191,6 +191,8 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
+- For network diagnostics, `read_events(cursor)` gives each reader independent
+  bounded history. Check `dropped`/`truncated`; see `interaction-skills/network-requests.md`.
 
 ## Recordings and Videos
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -191,8 +191,9 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
-- For network diagnostics, `read_events(cursor)` gives each reader independent
-  bounded history. Check `dropped`/`truncated`; see `interaction-skills/network-requests.md`.
+- For network diagnostics, start with `batch = read_events()`, then continue with
+  `batch = read_events(batch["cursor"])`. Each reader has independent bounded history.
+  Check `dropped`/`truncated`; see `interaction-skills/network-requests.md`.
 
 ## Recordings and Videos
 

--- a/interaction-skills/network-requests.md
+++ b/interaction-skills/network-requests.md
@@ -1,3 +1,32 @@
 # Network Requests
 
-Document how to watch or infer network activity when page state is ambiguous, especially for submit flows, downloads, and SPA actions that succeed without obvious DOM changes.
+Each event reader keeps its own cursor. Reading does not consume another reader's
+history or affect request tracking:
+
+```python
+batch = read_events()  # up to 500 retained events
+cursor = batch["cursor"]
+print(batch["dropped"], batch["events"])
+# Later, in this reader; persist cursor yourself across CLI invocations.
+batch = read_events(cursor, session_id=None)
+cursor = batch["cursor"]
+```
+
+`dropped` counts overwritten events since the cursor (across all sessions).
+Events larger than 16 KiB retain method/session and set `truncated: true` with
+empty params. Check both before drawing conclusions. A daemon restart raises
+`EventCursorExpired`; explicitly start a new reader. `drain_events()` retains its
+legacy shared-reader behavior, but no longer deletes the retained history.
+MCP exposes the same cursor interface as `browser_read_events`.
+
+`wait_for_network_idle()` tracks requests as they arrive, including redirects
+and failed loads. It returns `True` after no pending requests and a quiet window,
+or `False` on timeout. It raises if the session changes or coverage is unknown.
+Coverage requires Network enabled before a top-level navigation. Requests that
+started before attachment cannot be reconstructed reliably. After attachment or
+recovery, navigate explicitly or use a specific DOM condition instead. Tracking
+more than 4096 concurrent requests fails closed; reattach and navigate to reset.
+
+For form submission, verify the actual result in the UI. Network quiet is not
+proof that a save succeeded. Do not print headers, cookies, or full event payloads
+when a status/method summary answers the question.

--- a/interaction-skills/network-requests.md
+++ b/interaction-skills/network-requests.md
@@ -18,6 +18,8 @@ empty params. Check both before drawing conclusions. A daemon restart raises
 `EventCursorExpired`; explicitly start a new reader. `drain_events()` retains its
 legacy shared-reader behavior, but no longer deletes the retained history.
 MCP exposes the same cursor interface as `browser_read_events`.
+Pass the returned cursor unchanged, not `0`, a reader name, or `drain_events()`.
+Malformed cursors raise `ValueError` before IPC; they do not mean the daemon restarted.
 
 `wait_for_network_idle()` tracks requests as they arrive, including redirects
 and failed loads. It returns `True` after no pending requests and a quiet window,
@@ -26,6 +28,8 @@ Coverage requires Network enabled before a top-level navigation. Requests that
 started before attachment cannot be reconstructed reliably. After attachment or
 recovery, navigate explicitly or use a specific DOM condition instead. Tracking
 more than 4096 concurrent requests fails closed; reattach and navigate to reset.
+Repeated `Network.enable` preserves tracking. `Network.disable` creates a coverage
+gap; reattach and navigate before using network idle again.
 
 For form submission, verify the actual result in the UI. Network quiet is not
 proof that a save succeeded. Do not print headers, cookies, or full event payloads

--- a/src/browser_harness/_events.py
+++ b/src/browser_harness/_events.py
@@ -1,0 +1,78 @@
+"""Bounded event history and request state, updated before any reader runs."""
+from collections import deque
+import json
+import time
+import uuid
+
+
+class EventHistory:
+    def __init__(self, capacity=500, max_event_bytes=16384):
+        self.events = deque(maxlen=capacity)
+        self.max_event_bytes = max_event_bytes
+        self.generation = uuid.uuid4().hex
+        self.sequence = 0
+        self.legacy_sequence = 0
+
+    def append(self, event):
+        self.sequence += 1
+        if len(json.dumps(event, ensure_ascii=True).encode()) > self.max_event_bytes:
+            event = {"method": event["method"], "session_id": event["session_id"], "params": {}, "truncated": True}
+        self.events.append((self.sequence, event))
+
+    def read(self, cursor=None, session_id=None):
+        sequence = 0
+        if cursor is not None:
+            if not isinstance(cursor, dict) or cursor.get("generation") != self.generation:
+                raise RuntimeError("EventCursorExpired: daemon changed; start a new reader with cursor=None")
+            sequence = cursor.get("sequence")
+            if type(sequence) is not int or not 0 <= sequence <= self.sequence:
+                raise ValueError("invalid event cursor sequence")
+        oldest = self.events[0][0] if self.events else self.sequence + 1
+        return {
+            "events": [{**event, "sequence": seq} for seq, event in self.events
+                       if seq > sequence and (session_id is None or event["session_id"] == session_id)],
+            "cursor": {"generation": self.generation, "sequence": self.sequence},
+            "dropped": max(0, oldest - sequence - 1),
+        }
+
+    def drain(self):
+        result = [event for seq, event in self.events if seq > self.legacy_sequence]
+        self.legacy_sequence = self.sequence
+        return result
+
+
+class RequestState:
+    """One active session. Unknown coverage must never be reported as idle."""
+    def __init__(self, session_id=None, max_requests=4096):
+        self.session_id = session_id
+        self.pending = set()
+        self.max_requests = max_requests
+        self.enabled = False
+        self.navigation_seen = False
+        self.error = None
+        self.last_activity = time.monotonic()
+
+    def record(self, method, params, session_id):
+        if session_id != self.session_id or session_id is None:
+            return
+        frame = params.get("frame", {})
+        if method == "Page.frameNavigated" and frame.get("id") and not frame.get("parentId") and self.enabled:
+            self.navigation_seen = True
+        if not method.startswith("Network."):
+            return
+        self.last_activity = time.monotonic()
+        request_id = params.get("requestId")
+        if method == "Network.requestWillBeSent" and request_id:
+            if len(self.pending) >= self.max_requests and request_id not in self.pending:
+                self.error = "request tracking overflow"
+            else:
+                # Redirects reuse the same request ID; they are one pending load.
+                self.pending.add(request_id)
+        elif method in ("Network.loadingFinished", "Network.loadingFailed"):
+            self.pending.discard(request_id)
+
+    def snapshot(self):
+        known = self.enabled and self.navigation_seen and self.error is None
+        return {"session_id": self.session_id, "known": known, "inflight": len(self.pending),
+                "quiet_ms": max(0, (time.monotonic() - self.last_activity) * 1000),
+                "reason": self.error or (None if known else "network coverage incomplete; navigate after attachment or wait for a DOM condition")}

--- a/src/browser_harness/_events.py
+++ b/src/browser_harness/_events.py
@@ -5,6 +5,17 @@ import time
 import uuid
 
 
+def validate_cursor(cursor):
+    """Reject malformed/oversized cursors before IPC and distinguish stale readers."""
+    if cursor is None:
+        return
+    if (not isinstance(cursor, dict) or cursor.keys() != {"generation", "sequence"}
+            or not isinstance(cursor["generation"], str) or len(cursor["generation"]) != 32
+            or any(c not in "0123456789abcdef" for c in cursor["generation"])
+            or type(cursor["sequence"]) is not int or not 0 <= cursor["sequence"] < 2**63):
+        raise ValueError("Invalid event cursor: start with batch = read_events(), then pass batch['cursor']; not an event list or reader name")
+
+
 class EventHistory:
     def __init__(self, capacity=500, max_event_bytes=16384):
         self.events = deque(maxlen=capacity)
@@ -20,9 +31,10 @@ class EventHistory:
         self.events.append((self.sequence, event))
 
     def read(self, cursor=None, session_id=None):
+        validate_cursor(cursor)
         sequence = 0
         if cursor is not None:
-            if not isinstance(cursor, dict) or cursor.get("generation") != self.generation:
+            if cursor["generation"] != self.generation:
                 raise RuntimeError("EventCursorExpired: daemon changed; start a new reader with cursor=None")
             sequence = cursor.get("sequence")
             if type(sequence) is not int or not 0 <= sequence <= self.sequence:

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -695,7 +695,9 @@ class Daemon:
             if req.get("session_id") != self.session:
                 return {"error": "network wait session changed; start a new wait explicitly"}
             ws = getattr(self.cdp, "ws", None)
-            if ws is None or ws.state != 1:  # websockets.protocol.State.OPEN
+            reader = getattr(self.cdp, "_message_handler_task", None)
+            if ws is None or ws.state != 1 or (reader is not None and reader.done()):
+                # State.OPEN == 1; an open socket with a stopped reader is not coverage.
                 self.network.error = "browser connection lost"
             return self.network.snapshot()
         if meta == "session":     return {"session_id": self.session}

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,12 +1,12 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
 import asyncio, json, os, platform, socket, sys, time, urllib.error, urllib.request
 from urllib.parse import urlparse
-from collections import deque
 from pathlib import Path
 
 from . import _ipc as ipc
 from . import auth
 from . import paths
+from ._events import EventHistory, RequestState
 from cdp_use.client import CDPClient
 
 
@@ -435,7 +435,8 @@ class Daemon:
         self._recoveries_idle.set()
         self._shutting_down = False
         self._session_replacements = {}
-        self.events = deque(maxlen=BUF)
+        self.events = EventHistory(BUF)
+        self.network = RequestState()
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
 
@@ -552,13 +553,19 @@ class Daemon:
         important on the set_session path, where the helper's IPC socket has
         a 5s read timeout.
         """
+        if session_id == self.session and self.network.session_id != session_id:
+            self.network = RequestState(session_id)
         async def enable_one(d):
             try:
                 await asyncio.wait_for(
                     self.cdp.send_raw(f"{d}.enable", session_id=session_id),
                     timeout=4,
                 )
+                if d == "Network" and self.network.session_id == session_id:
+                    self.network.enabled = True
             except Exception as e:
+                if d == "Network" and self.network.session_id == session_id:
+                    self.network.error = "Network.enable failed"
                 log(f"enable {d} on {session_id}: {e}")
         await asyncio.gather(*(enable_one(d) for d in ("Page", "DOM", "Runtime", "Network")))
 
@@ -624,6 +631,11 @@ class Daemon:
         )))
 
     def _record_event(self, method, params, session_id=None):
+        self.network.record(method, params, session_id)
+        if method == "Target.detachedFromTarget" and params.get("sessionId") == self.network.session_id:
+            self.network.error = "session detached"
+        if method == "Target.targetDestroyed" and params.get("targetId") == self.target_id:
+            self.network.error = "tab closed"
         self.events.append({"method": method, "params": params, "session_id": session_id})
         if method == "Page.javascriptDialogOpening":
             self.dialog = params
@@ -655,12 +667,12 @@ class Daemon:
                     "browser-harness did not retry or create another connection"
                 )
             raise RuntimeError(f"CDP WS handshake failed: {e} -- click Allow in Chrome if prompted, then retry")
-        await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event
         async def tap(method, params, session_id=None):
             self._record_event(method, params, session_id)
             return await orig(method, params, session_id)
         self.cdp._event_registry.handle_event = tap
+        await self.attach_first_page()
 
     async def handle(self, req):
         # Token guard for Windows TCP loopback: any local process can otherwise
@@ -676,8 +688,16 @@ class Daemon:
         # signaling — protects against SIGTERM-by-stale-pid-file after PID reuse.
         if meta == "ping":        return {"pong": True, "pid": os.getpid(), "browser_kind": BROWSER_KIND}
         if meta == "drain_events":
-            out = list(self.events); self.events.clear()
-            return {"events": out}
+            return {"events": self.events.drain()}
+        if meta == "read_events":
+            return self.events.read(req.get("cursor"), req.get("session_id"))
+        if meta == "network_status":
+            if req.get("session_id") != self.session:
+                return {"error": "network wait session changed; start a new wait explicitly"}
+            ws = getattr(self.cdp, "ws", None)
+            if ws is None or ws.state != 1:  # websockets.protocol.State.OPEN
+                self.network.error = "browser connection lost"
+            return self.network.snapshot()
         if meta == "session":     return {"session_id": self.session}
         if meta == "current_tab":
             # Resolve the attached page's target info server-side. Helpers can't
@@ -712,6 +732,8 @@ class Daemon:
                 self.session = req.get("session_id")
                 self.target_id = req.get("target_id") or self.target_id
                 new_session = self.session
+                if self.network.session_id != new_session:
+                    self.network = RequestState(new_session)
             # Run the old-session Network.disable (defense in depth — keeps
             # background-tab traffic out of the global event buffer; the
             # consumer-side filter in wait_for_network_idle is the actual
@@ -765,11 +787,15 @@ class Daemon:
         # Browser-level Target.* calls must not use a session (stale or otherwise).
         # For everything else, explicit session in req wins; else default.
         sid = None if method.startswith("Target.") else (req.get("session_id") or self.session)
+        if method in ("Network.disable", "Network.enable") and sid == self.network.session_id:
+            self.network.error = "network subscription changed; reattach and navigate before waiting for idle"
         try:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}
         except Exception as e:
             msg = str(e)
             if "Session with given id not found" in msg and sid:
+                if sid == self.network.session_id:
+                    self.network.error = "session lost"
                 # Explicit session callers asked for that exact session; do not
                 # silently redirect them to the daemon's current tab.
                 if req.get("session_id"):

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -789,7 +789,9 @@ class Daemon:
         # Browser-level Target.* calls must not use a session (stale or otherwise).
         # For everything else, explicit session in req wins; else default.
         sid = None if method.startswith("Target.") else (req.get("session_id") or self.session)
-        if method in ("Network.disable", "Network.enable") and sid == self.network.session_id:
+        # Repeated enable is idempotent: it must not poison existing coverage.
+        # Disable creates a gap even if an earlier enable reply arrives later.
+        if method == "Network.disable" and sid == self.network.session_id:
             self.network.error = "network subscription changed; reattach and navigate before waiting for idle"
         try:
             return {"result": await self.cdp.send_raw(method, params, session_id=sid)}

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -79,6 +79,13 @@ def cdp(method, session_id=None, _response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_
 
 def drain_events():  return _send({"meta": "drain_events"})["events"]
 
+def read_events(cursor=None, session_id=None):
+    """Read bounded history without consuming it. Retain cursor; check dropped/truncated.
+
+    Each caller owns its cursor. A daemon restart expires old cursors explicitly.
+    """
+    return _send({"meta": "read_events", "cursor": cursor, "session_id": session_id})
+
 
 def _js_snippet(expression, limit=160):
     snippet = expression.strip().replace("\n", "\\n")
@@ -524,38 +531,24 @@ def wait_for_element(selector, timeout=10.0, visible=False):
     return False
 
 def wait_for_network_idle(timeout=10.0, idle_ms=500):
-    """Wait until all in-flight requests finish and no Network.* events arrive for idle_ms ms.
+    """Wait for tracked requests to finish and Network events to stay quiet.
 
-    Useful after form submits, SPA route transitions, and any action that triggers
-    XHR/fetch without a visible DOM change. Builds on drain_events() — no daemon changes.
-    Returns True if idle window reached, False on timeout.
-
-    Events are filtered to the active session — a previously-attached background
-    tab (e.g. a polling/SSE page the agent switched away from) keeps emitting
-    Network events into the daemon's global event buffer; without this filter
-    they would poison the idle check on the current tab.
+    True on idle, False on timeout. Unknown coverage or a tab/session change
+    raises: navigate after attachment to establish coverage, or wait for a DOM
+    condition instead. Reading events never changes request tracking.
     """
-    deadline = time.time() + timeout
-    last_activity = time.time()
-    inflight = set()
+    if not all(isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v) and v >= 0 for v in (timeout, idle_ms)):
+        raise ValueError("timeout and idle_ms must be finite non-negative numbers")
+    started = time.monotonic()
+    deadline = started + timeout
     active_session = _send({"meta": "session"}).get("session_id")
-    while time.time() < deadline:
-        for e in drain_events():
-            if e.get("session_id") != active_session:
-                continue
-            method = e.get("method", "")
-            params = e.get("params", {})
-            if method == "Network.requestWillBeSent":
-                inflight.add(params.get("requestId"))
-                last_activity = time.time()
-            elif method in ("Network.loadingFinished", "Network.loadingFailed"):
-                inflight.discard(params.get("requestId"))
-                last_activity = time.time()
-            elif method.startswith("Network."):
-                last_activity = time.time()
-        if not inflight and (time.time() - last_activity) * 1000 >= idle_ms:
+    while time.monotonic() < deadline:
+        state = _send({"meta": "network_status", "session_id": active_session})
+        if not state.get("known"):
+            raise RuntimeError(f"Network idle unknown: {state.get('reason', 'reload daemon to update event tracking')}")
+        if not state["inflight"] and min(state["quiet_ms"], (time.monotonic() - started) * 1000) >= idle_ms:
             return True
-        time.sleep(0.1)
+        time.sleep(max(0, min(0.1, deadline - time.monotonic())))
     return False
 
 def js(expression, target_id=None):

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from . import _ipc as ipc
 from . import paths
+from ._events import validate_cursor as _validate_event_cursor
 
 
 CORE_DIR = Path(__file__).resolve().parent
@@ -82,8 +83,10 @@ def drain_events():  return _send({"meta": "drain_events"})["events"]
 def read_events(cursor=None, session_id=None):
     """Read bounded history without consuming it. Retain cursor; check dropped/truncated.
 
-    Each caller owns its cursor. A daemon restart expires old cursors explicitly.
+    Start with batch = read_events(), then read_events(batch['cursor']).
+    Each caller owns its cursor. A daemon restart expires valid old cursors explicitly.
     """
+    _validate_event_cursor(cursor)
     return _send({"meta": "read_events", "cursor": cursor, "session_id": session_id})
 
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -41,6 +41,7 @@ from browser_harness.helpers import (
     new_tab,
     page_info,
     press_key,
+    read_events,
     scroll,
     start_recording,
     stop_recording,
@@ -251,6 +252,12 @@ def browser_wait_for_element(
     """Wait for an element matching `selector` to appear. Set `visible=True` to
     also require it to be rendered."""
     return {"ok": wait_for_element(selector, timeout=timeout, visible=visible)}
+
+
+@_tool
+def browser_read_events(cursor: dict | None = None, session_id: str | None = None):
+    """Read bounded event history without consuming it. Retain cursor; check dropped/truncated."""
+    return read_events(cursor=cursor, session_id=session_id)
 
 
 @_tool

--- a/tests/unit/test_event_history.py
+++ b/tests/unit/test_event_history.py
@@ -131,6 +131,13 @@ def test_closed_websocket_cannot_report_idle():
     assert state["reason"] == "browser connection lost"
 
 
+def test_stopped_reader_on_open_websocket_cannot_report_idle():
+    d = ready_daemon()
+    d.cdp._message_handler_task = SimpleNamespace(done=lambda: True)
+    state = asyncio.run(d.handle({"meta": "network_status", "session_id": "active"}))
+    assert state["known"] is False
+
+
 def test_wait_unknown_status_and_stale_daemon_raise(monkeypatch):
     monkeypatch.setattr(helpers, "_send", lambda req: {"session_id": "s"} if req.get("meta") == "session" else {})
     with pytest.raises(RuntimeError, match="Network idle unknown"):

--- a/tests/unit/test_event_history.py
+++ b/tests/unit/test_event_history.py
@@ -1,0 +1,137 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from browser_harness import daemon, helpers
+from browser_harness._events import EventHistory, RequestState
+
+
+def event(method="Network.requestWillBeSent", request="r", session="active"):
+    return {"method": method, "params": {"requestId": request}, "session_id": session}
+
+
+def test_independent_readers_and_legacy_drain_keep_same_history():
+    history = EventHistory()
+    cursor = history.read()["cursor"]
+    history.append(event())
+    first = history.read(cursor)
+    assert history.drain() == [event()]
+    assert history.drain() == []
+    assert history.read(cursor) == first
+    assert history.read(first["cursor"])["events"] == []
+    history.append(event("Network.loadingFinished"))
+    assert [e["sequence"] for e in history.read(first["cursor"])["events"]] == [2]
+
+
+def test_overflow_reports_exact_gap_and_payload_truncation():
+    history = EventHistory(capacity=2, max_event_bytes=200)
+    cursor = history.read()["cursor"]
+    for i in range(4):
+        history.append(event(request=str(i)))
+    result = history.read(cursor)
+    assert result["dropped"] == 2
+    assert [e["sequence"] for e in result["events"]] == [3, 4]
+    history.append({"method": "Runtime.consoleAPICalled", "params": {"args": ["x" * 1000]}, "session_id": "active"})
+    last = history.read(result["cursor"])["events"][0]
+    assert last["truncated"] is True
+    assert last["params"] == {}
+    assert len(history.events) == 2
+
+
+def test_cursor_restart_validation_and_session_filter():
+    first, second = EventHistory(), EventHistory()
+    with pytest.raises(RuntimeError, match="EventCursorExpired"):
+        second.read(first.read()["cursor"])
+    for sequence in [-1, 9, True, "0"]:
+        with pytest.raises(ValueError):
+            first.read({"generation": first.generation, "sequence": sequence})
+    first.append(event(session="background"))
+    first.append(event(session="active"))
+    result = first.read(session_id="active")
+    assert len(result["events"]) == 1
+    assert result["events"][0]["session_id"] == "active"
+    assert result["cursor"]["sequence"] == 2
+
+
+def ready_daemon():
+    d = daemon.Daemon()
+    d.cdp = SimpleNamespace(ws=SimpleNamespace(state=1))
+    d.session = "active"
+    d.network = RequestState("active")
+    d.network.enabled = True
+    d._record_event("Page.frameNavigated", {"frame": {"id": "root"}}, "active")
+    return d
+
+
+@pytest.mark.parametrize("completion", ["Network.loadingFinished", "Network.loadingFailed"])
+def test_inflight_survives_readers_ring_overflow_and_redirects(completion):
+    async def run():
+        d = ready_daemon()
+        d.events = EventHistory(capacity=2)
+        d._record_event(**event())
+        d._record_event("Network.requestWillBeSent", {"requestId": "r", "redirectResponse": {"status": 302}}, "active")
+        await d.handle({"meta": "drain_events"})
+        for _ in range(4):
+            d._record_event("Runtime.consoleAPICalled", {}, "background")
+        assert (await d.handle({"meta": "network_status", "session_id": "active"}))["inflight"] == 1
+        d._record_event(completion, {"requestId": "r"}, "background")
+        assert d.network.snapshot()["inflight"] == 1
+        d._record_event(completion, {"requestId": "r"}, "active")
+        assert d.network.snapshot()["inflight"] == 0
+    asyncio.run(run())
+
+
+def test_unknown_coverage_and_tracking_overflow_fail_closed():
+    tracker = RequestState("s", max_requests=1)
+    tracker.record("Page.frameNavigated", {"frame": {"id": "root"}}, "s")
+    tracker.enabled = True
+    assert tracker.snapshot()["known"] is False
+    tracker.record("Page.frameNavigated", {"frame": {"id": "iframe", "parentId": "root"}}, "s")
+    assert tracker.snapshot()["known"] is False
+    tracker.record("Page.frameNavigated", {"frame": {"id": "root"}}, "s")
+    assert tracker.snapshot()["known"] is True
+    tracker.record("Network.requestWillBeSent", {"requestId": "one"}, "s")
+    tracker.record("Network.requestWillBeSent", {"requestId": "two"}, "s")
+    tracker.record("Network.loadingFinished", {"requestId": "one"}, "s")
+    assert tracker.snapshot()["inflight"] == 0
+    assert tracker.snapshot()["known"] is False
+    assert tracker.snapshot()["reason"] == "request tracking overflow"
+
+
+def test_detach_and_tab_switch_invalidate_waiter():
+    async def run():
+        d = ready_daemon()
+        d._record_event("Target.detachedFromTarget", {"sessionId": "active"})
+        assert d.network.snapshot()["known"] is False
+        d.session = "new-session"
+        response = await d.handle({"meta": "network_status", "session_id": "active"})
+        assert "session changed" in response["error"]
+    asyncio.run(run())
+
+
+def test_network_enable_failure_is_not_idle(monkeypatch):
+    class Broken:
+        async def send_raw(self, method, **kwargs):
+            if method == "Network.enable":
+                raise RuntimeError("disconnected")
+            return {}
+    monkeypatch.setattr(daemon, "log", lambda msg: None)
+    d = ready_daemon()
+    d.cdp = Broken()
+    asyncio.run(d._enable_default_domains("active"))
+    assert d.network.snapshot()["known"] is False
+
+
+def test_closed_websocket_cannot_report_idle():
+    d = ready_daemon()
+    d.cdp.ws.state = 3
+    state = asyncio.run(d.handle({"meta": "network_status", "session_id": "active"}))
+    assert state["known"] is False
+    assert state["reason"] == "browser connection lost"
+
+
+def test_wait_unknown_status_and_stale_daemon_raise(monkeypatch):
+    monkeypatch.setattr(helpers, "_send", lambda req: {"session_id": "s"} if req.get("meta") == "session" else {})
+    with pytest.raises(RuntimeError, match="Network idle unknown"):
+        helpers.wait_for_network_idle()

--- a/tests/unit/test_event_history.py
+++ b/tests/unit/test_event_history.py
@@ -142,3 +142,67 @@ def test_wait_unknown_status_and_stale_daemon_raise(monkeypatch):
     monkeypatch.setattr(helpers, "_send", lambda req: {"session_id": "s"} if req.get("meta") == "session" else {})
     with pytest.raises(RuntimeError, match="Network idle unknown"):
         helpers.wait_for_network_idle()
+
+
+@pytest.mark.parametrize("cursor", [0, "reader-name", [], [{"payload": "x" * 100_000}],
+    {}, {"generation": "x" * 100_000, "sequence": 0},
+    {"generation": "a" * 32, "sequence": 0, "events": "x" * 100_000},
+    {"generation": "a" * 32, "sequence": True}])
+def test_invalid_cursor_fails_before_ipc_without_claiming_restart(monkeypatch, cursor):
+    def unexpected_send(req):
+        pytest.fail("invalid cursor reached IPC")
+    monkeypatch.setattr(helpers, "_send", unexpected_send)
+    for read in (helpers.read_events, EventHistory().read):
+        with pytest.raises(ValueError, match="Invalid event cursor") as error:
+            read(cursor)
+        assert "daemon changed" not in str(error.value)
+        assert len(str(error.value)) < 250
+
+
+def test_helper_cursor_roundtrip_and_real_restart(monkeypatch):
+    history = EventHistory()
+    monkeypatch.setattr(helpers, "_send", lambda req: history.read(req["cursor"], req["session_id"]))
+    batch = helpers.read_events()
+    history.append(event())
+    assert helpers.read_events(batch["cursor"])["events"][0]["sequence"] == 1
+    history = EventHistory()
+    with pytest.raises(RuntimeError, match="EventCursorExpired"):
+        helpers.read_events(batch["cursor"])
+
+
+def test_redundant_enable_preserves_pending_requests_and_idle_recovery():
+    async def run():
+        d = ready_daemon()
+        async def send(*args, **kwargs):
+            return {}
+        d.cdp.send_raw = send
+        d._record_event(**event())
+        assert await d.handle({"method": "Network.enable"}) == {"result": {}}
+        d._record_event("Page.frameNavigated", {"frame": {"id": "root"}}, "active")
+        state = d.network.snapshot()
+        assert state["known"] is True
+        assert state["inflight"] == 1
+        d._record_event(**event("Network.loadingFinished"))
+        assert d.network.snapshot()["inflight"] == 0
+    asyncio.run(run())
+
+
+def test_disable_remains_unknown_even_when_delayed_enable_finishes_later():
+    async def run():
+        d = ready_daemon()
+        entered, release = asyncio.Event(), asyncio.Event()
+        async def send(method, *args, **kwargs):
+            if method == "Network.enable":
+                entered.set()
+                await release.wait()
+            return {}
+        d.cdp.send_raw = send
+        enable = asyncio.create_task(d.handle({"method": "Network.enable"}))
+        await entered.wait()
+        await d.handle({"method": "Network.disable"})
+        assert d.network.snapshot()["known"] is False
+        release.set()
+        await enable
+        d._record_event("Page.frameNavigated", {"frame": {"id": "root"}}, "active")
+        assert d.network.snapshot()["known"] is False
+    asyncio.run(run())

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -293,135 +293,36 @@ def test_wait_for_element_non_visible_uses_simple_check():
 
 # --- wait_for_network_idle ---
 
-def test_wait_for_network_idle_returns_true_when_no_events():
-    call_count = 0
-
-    def fake_send(req):
-        nonlocal call_count
-        call_count += 1
-        return {"events": []}
-
-    with patch("browser_harness.helpers._send", side_effect=fake_send), \
-         patch("browser_harness.helpers.time") as mock_time:
-        start = 1000.0
-        # first call: not idle yet; second call: idle window elapsed
-        mock_time.time.side_effect = [start, start, start, start + 0.6, start + 0.6]
-        mock_time.sleep = lambda _: None
-        result = helpers.wait_for_network_idle(timeout=5.0, idle_ms=500)
-
-    assert result is True
-
-
-def test_wait_for_network_idle_waits_for_inflight_request():
-    # Verifies inflight tracking: must not return True until loadingFinished,
-    # even though >idle_ms elapses between requestWillBeSent and loadingFinished.
-    # An event-silence-only implementation would return True at iter2 (wrong).
-    events_seq = [
-        [{"method": "Network.requestWillBeSent", "params": {"requestId": "req1"}}],
-        [],   # >500ms elapsed — old impl returns True here; new must NOT
-        [{"method": "Network.loadingFinished",   "params": {"requestId": "req1"}}],
-        [],   # idle_ms after loadingFinished → return True
-    ]
-    idx = 0
-
-    def fake_send(req):
-        nonlocal idx
-        evs = events_seq[min(idx, len(events_seq) - 1)]
-        idx += 1
-        return {"events": evs}
-
-    with patch("browser_harness.helpers._send", side_effect=fake_send), \
-         patch("browser_harness.helpers.time") as mock_time:
-        start = 1000.0
-        # inflight non-empty → short-circuit skips time.time() in idle check for iter1/iter2
-        mock_time.time.side_effect = [
-            start, start,       # deadline + last_activity init
-            start + 0.1,        # iter1 while-check
-            start + 0.1,        # iter1 rWS last_activity update
-                                # iter1 idle-check: inflight non-empty → short-circuit
-            start + 0.7,        # iter2 while-check (>500ms since rWS but request still in flight)
-                                # iter2 idle-check: inflight non-empty → short-circuit
-            start + 0.8,        # iter3 while-check
-            start + 0.8,        # iter3 lF last_activity update
-            start + 0.8,        # iter3 idle-check: 0ms < 500 → not idle
-            start + 1.4,        # iter4 while-check
-            start + 1.4,        # iter4 idle-check: 600ms >= 500 → True
-        ]
-        mock_time.sleep = lambda _: None
-        result = helpers.wait_for_network_idle(timeout=5.0, idle_ms=500)
-
-    assert result is True
-    assert idx == 4  # did not short-circuit at iter2 despite silence > idle_ms
-
-
-def test_wait_for_network_idle_returns_false_on_timeout():
-    # Continuous rWS keeps inflight non-empty → idle check short-circuits every iteration.
-    # time.time() is only called for while-check and rWS last_activity (not idle check).
-    def fake_send(req):
-        return {"events": [{"method": "Network.requestWillBeSent", "params": {"requestId": "r"}}]}
-
-    with patch("browser_harness.helpers._send", side_effect=fake_send), \
-         patch("browser_harness.helpers.time") as mock_time:
-        start = 1000.0
-        mock_time.time.side_effect = [
-            start, start,       # deadline + last_activity init
-            start + 0.1,        # iter1 while-check (in deadline)
-            start + 0.1,        # iter1 rWS last_activity update
-                                # iter1 idle-check: inflight non-empty → short-circuit
-            start + 20.0,       # iter2 while-check (past deadline → exit)
-        ]
-        mock_time.sleep = lambda _: None
-        result = helpers.wait_for_network_idle(timeout=10.0, idle_ms=500)
-
-    assert result is False
-
-
-
-def test_wait_for_network_idle_filters_events_to_active_session():
-    """Background tabs (e.g. a polling page the agent switched away from) keep
-    emitting Network events into the daemon's global buffer. The wait must
-    filter by session_id of the currently-attached tab — otherwise it would
-    see the background tab's traffic and either fail to return idle or wait
-    on the wrong tab's requests."""
-    active = "session-ACTIVE"
-    background = "session-BACKGROUND"
-
-    # First /drain_events/ payload: rWS + lF on the BACKGROUND session that we
-    # must ignore, plus zero events on the active session. With filtering, the
-    # active session sees no traffic and the idle window can elapse.
-    events_seq = [
-        [
-            {"session_id": background, "method": "Network.requestWillBeSent", "params": {"requestId": "bg1"}},
-            {"session_id": background, "method": "Network.loadingFinished",   "params": {"requestId": "bg1"}},
-        ],
-        [],  # second drain — quiet on both sessions; idle window should fire here
-    ]
-    drain_idx = 0
-
-    def fake_send(req):
-        nonlocal drain_idx
-        if req.get("meta") == "session":
-            return {"session_id": active}
-        if req.get("meta") == "drain_events":
-            evs = events_seq[min(drain_idx, len(events_seq) - 1)]
-            drain_idx += 1
-            return {"events": evs}
-        return {}
-
-    with patch("browser_harness.helpers._send", side_effect=fake_send), \
-         patch("browser_harness.helpers.time") as mock_time:
-        start = 1000.0
-        # No inflight on active session → idle check uses time.time().
-        mock_time.time.side_effect = [start, start, start, start + 0.6, start + 0.6]
-        mock_time.sleep = lambda _: None
-        result = helpers.wait_for_network_idle(timeout=5.0, idle_ms=500)
-
-    assert result is True, (
-        "wait_for_network_idle must return True even when the BACKGROUND "
-        "session is busy, as long as the ACTIVE session is idle. Without the "
-        "session filter, the background rWS/lF pair would have updated "
-        "last_activity and prevented the idle window from elapsing."
-    )
+@pytest.mark.parametrize("busy_until,background,expected", [(0, False, True), (0.8, False, True), (100, False, False), (0, True, True)])
+def test_wait_for_network_idle_uses_retained_request_state(monkeypatch, busy_until, background, expected):
+    from browser_harness import daemon
+    from browser_harness._events import RequestState
+    from types import SimpleNamespace
+    import asyncio
+    now = [0.0]
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(helpers.time, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
+    d = daemon.Daemon()
+    d.cdp = SimpleNamespace(ws=SimpleNamespace(state=1))
+    d.session = "active"
+    d.network = RequestState("active")
+    d.network.enabled = True
+    d._record_event("Page.frameNavigated", {"frame": {"id": "root"}}, "active")
+    sid = "background" if background else "active"
+    if busy_until or background:
+        d._record_event("Network.requestWillBeSent", {"requestId": "pending"}, sid)
+    d.events.drain()  # Another reader already consumed the request start.
+    finished = [False]
+    def send(req):
+        assert req["meta"] != "drain_events"
+        if not finished[0] and now[0] >= busy_until:
+            d._record_event("Network.loadingFinished", {"requestId": "pending"}, sid)
+            finished[0] = True
+        return asyncio.run(d.handle(req))
+    monkeypatch.setattr(helpers, "_send", send)
+    assert helpers.wait_for_network_idle(timeout=2, idle_ms=500) is expected
+    if expected:
+        assert now[0] >= (0.5 if background else busy_until + 0.5)
 
 
 @pytest.mark.parametrize("value", ["0", "false", "NO", "off"])


### PR DESCRIPTION
Reading diagnostics must not consume request starts and make a pending request appear idle. Record request lifetime when CDP events arrive, and give each diagnostic reader an independent cursor.

Flow: CDP event → request state + bounded history → independent readers. Retain 500 events, cap event payloads at 16 KiB, report dropped/truncated data, and expire valid cursors after daemon restart. Legacy `drain_events()` retains its shared-reader interface without deleting the retained history. MCP uses the same cursor interface. Request tracking retains at most 4096 inflight IDs, including redirects and failures. Unknown coverage or a lost connection/session raises instead of reporting idle.

Trace-driven fixes: reject malformed/oversized cursors before IPC with the exact valid usage, rather than falsely reporting a daemon restart. Repeating `Network.enable` preserves tracking and pending requests; `Network.disable` still invalidates coverage. A delayed enable reply cannot undo that invalidation.

Proof: 295 standalone unit/integration tests pass, covering independent/legacy readers, overflow, malformed cursors, restart expiry, redirects, failures, lost sockets/sessions, and enable/disable ordering.

Compatibility / rollout: valid cursor and legacy-drain formats are unchanged. Bad cursor inputs now fail locally. Unknown coverage raises; explicitly navigate after attachment/recovery or wait for a DOM condition. Reattach and navigate after Network.disable. New IPC operations require a deliberate daemon reload; running user daemons were not restarted.

Rollback: revert and deliberately reload. Old daemons support legacy drain but not cursor reads; do not mix new cursor clients with old daemons. Cursor state is in memory/client-owned; no persisted event-data migration or customer-data changes.

Combined validation: initial fixed candidate `0ea704f` passes 343 unit/integration tests; six disposable headless-Chrome click tests, four CLI/browser probes and package builds pass. Latest candidate `78aaadc`, adding Cloud health protection, passes 347 unit/integration tests. Counts cover different scopes and must not be added. Integration must preserve the tested conflict resolutions, including the detached-session tracking `deque` import.

Completed full paired rerun: **main 79/106 (74.5%); candidate 82/106 (77.4%), +2.83 percentage points**. 15 candidate wins, 12 losses; exact paired McNemar p=0.701. [Main workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999817407), [candidate workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999818855). Main `eba1021`, candidate `0ea704f`, platform `4104d41`; all 106 internal-bench-hard tasks; one attempt per task/arm; GPT-5.5 medium; Laith/GPT-5.5; matched options/dependencies/budgets. Actual initial viewport is 1280×960; reported DPR, IP/fingerprint and live sites remain variable. Resizing is enabled in both arms; do not compare causally to the older default-provider 85/106 vs 78/106 run.

Raw scores retain one ungraded candidate judge-startup timeout (`4t60pl`). Excluding only that pair: main 78/105, candidate 82/105. A separate candidate agent timeout (`trp0j4`) has a substantive failing judgment and stays included. Several flips expose inconsistent grading of coverage/access limitations. No scores were overridden. This run does not isolate an individual PR's effect or establish an uplift.

The full candidate predates separate Cloud health protection #773 and platform ownership enforcement browser-use/new-eval-platform#17. Latest `78aaadc` on platform `6bfa066` has a separate two-task matched follow-up: 1/2 in both arms; candidate Maps returns 40 qualifying leads, Apartments.com remains blocked. All four follow-up stops are confirmed. No live strict-health failure occurs there, so forced local failure/recovery tests establish the guard. No full 106-task comparison on the latest health fix.

Draft. Current-head automated checks pass; no human reviews or review threads. The harness has no automated unit-test workflow, so unit-test evidence above is local. No merge or production deployment. All 212 full-rerun artifacts confirm Cloud stop. A separate aborted setup cohort is excluded; 17 started tasks there lack confirmed stop evidence, requested 60-minute lifetimes have elapsed, and final provider state is unverified.
