### PR TITLE
P1: wait for a page condition with one bounded deadline

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -186,6 +186,11 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Clicking: AX node -> box center -> `click_at_xy(x, y)` -> verify with a targeted `js(...)`/`page_info()` check.
 - Fall back to raw HTML via `js(...)` only when the AX tree lacks the element (canvas, exotic widgets); screenshot when layout or imagery matters.
 - After navigation, call `wait_for_load()`.
+- For an async UI change, wait for the actual condition: `wait_until("location.pathname === '/done'")`,
+  `wait_until("document.body.innerText.includes('Saved')")`, or
+  `wait_until("!document.querySelector('[role=progressbar]')", timeout=10)`.
+  It returns `True` or raises on timeout/JS/session error. It stays on the original
+  session; use read-only expressions. Existing `wait_for_*` Boolean results stay unchanged.
 - If the current tab is stale or internal, call `ensure_real_tab()`.
 - Use `js(...)` for DOM inspection or extraction when coordinates are the wrong tool.
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.

--- a/src/browser_harness/_ipc.py
+++ b/src/browser_harness/_ipc.py
@@ -1,5 +1,5 @@
 """Daemon IPC plumbing. AF_UNIX socket on POSIX, TCP loopback on Windows."""
-import asyncio, json, os, re, secrets, socket, subprocess, sys
+import asyncio, json, os, re, secrets, socket, subprocess, sys, time
 from pathlib import Path
 
 from . import paths
@@ -86,20 +86,29 @@ def connect(name, timeout=1.0):
     if not IS_WINDOWS:
         # uv-Python on Windows lacks socket.AF_UNIX, so this branch must be gated.
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.settimeout(timeout); s.connect(str(_sock_path(name))); return s, None
+        try:
+            s.settimeout(timeout); s.connect(str(_sock_path(name))); return s, None
+        except BaseException:
+            s.close()
+            raise
     port, token = _read_port_file(name)
     if port is None: raise FileNotFoundError(str(port_path(name)))
     s = socket.create_connection(("127.0.0.1", port), timeout=timeout)
     s.settimeout(timeout); return s, token
 
 
-def request(c, token, req):
+def request(c, token, req, *, deadline=None):
     """One-shot send + recv + parse on an open socket. Injects token on Windows.
     Returns the parsed JSON response. Caller closes the socket."""
     if token: req = {**req, "token": token}
     c.sendall((json.dumps(req) + "\n").encode())
     data = b""
     while not data.endswith(b"\n"):
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("request deadline exceeded")
+            c.settimeout(remaining)
         chunk = c.recv(1 << 16)
         if not chunk: break
         data += chunk

--- a/src/browser_harness/helpers.py
+++ b/src/browser_harness/helpers.py
@@ -49,12 +49,17 @@ class _IPCResponseTimeout(TimeoutError):
     pass
 
 
-def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS):
-    c, token = ipc.connect(NAME, timeout=IPC_CONNECT_TIMEOUT_SECONDS)
+def _send(req, response_timeout=DEFAULT_IPC_RESPONSE_TIMEOUT_SECONDS, *, deadline=None):
+    def remaining(limit):
+        budget = limit if deadline is None else min(limit, deadline - time.monotonic())
+        if budget <= 0:
+            raise _IPCResponseTimeout("request deadline exceeded")
+        return budget
+    c, token = ipc.connect(NAME, timeout=remaining(IPC_CONNECT_TIMEOUT_SECONDS))
     try:
-        c.settimeout(response_timeout)
+        c.settimeout(remaining(response_timeout))
         try:
-            r = ipc.request(c, token, req)
+            r = ipc.request(c, token, req, **({"deadline": deadline} if deadline is not None else {}))
         except TimeoutError as e:
             # Carry the detail on the exception itself. Raising the bare class
             # left str(exc) empty, so every caller that reported the error had
@@ -522,6 +527,38 @@ def wait_for_element(selector, timeout=10.0, visible=False):
         if js(check): return True
         time.sleep(0.3)
     return False
+
+def wait_until(js_condition, timeout=10.0):
+    """Wait for a read-only JS expression to become truthy on this exact session.
+
+    Returns True; raises TimeoutError on expiry and surfaces JS/session errors.
+    Use an expression, not a statement block. Existing Boolean waits are unchanged.
+    """
+    if not isinstance(js_condition, str) or not js_condition.strip():
+        raise ValueError("js_condition must be a non-empty JavaScript expression")
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("timeout must be a finite positive number of seconds")
+    deadline = time.monotonic() + timeout
+    expression = f"(async () => Boolean(await ({js_condition})))()"
+    try:
+        session = _send({"meta": "session"}, response_timeout=timeout, deadline=deadline).get("session_id")
+        if not session:
+            raise RuntimeError("wait_until requires an attached tab")
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError()
+            result = _send({
+                "method": "Runtime.evaluate", "session_id": session,
+                "params": {"expression": expression, "returnByValue": True,
+                           "awaitPromise": True, "timeout": remaining * 1000},
+            }, response_timeout=remaining, deadline=deadline)["result"]
+            if _runtime_value(result, js_condition):
+                return True
+            time.sleep(max(0, min(0.1, deadline - time.monotonic())))
+    except TimeoutError as exc:
+        raise TimeoutError(f"wait_until timed out after {timeout:g}s; condition: {_js_snippet(js_condition)}") from exc
+
 
 def wait_for_network_idle(timeout=10.0, idle_ms=500):
     """Wait until all in-flight requests finish and no Network.* events arrive for idle_ms ms.

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -50,6 +50,7 @@ from browser_harness.helpers import (
     wait,
     wait_for_element,
     wait_for_load,
+    wait_until,
 )
 
 SERVER = MCPServer("browser-harness")
@@ -251,6 +252,12 @@ def browser_wait_for_element(
     """Wait for an element matching `selector` to appear. Set `visible=True` to
     also require it to be rendered."""
     return {"ok": wait_for_element(selector, timeout=timeout, visible=visible)}
+
+
+@_tool
+def browser_wait_until(js_condition: str, timeout: float = 10.0):
+    """Wait for a read-only JavaScript expression on the original tab. Timeout and JS errors raise."""
+    return {"ok": wait_until(js_condition, timeout=timeout)}
 
 
 @_tool

--- a/tests/unit/test_wait_until.py
+++ b/tests/unit/test_wait_until.py
@@ -1,0 +1,107 @@
+import asyncio
+
+import pytest
+
+from browser_harness import helpers
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("nan"), True, "1", None])
+def test_invalid_timeout_never_contacts_browser(monkeypatch, timeout):
+    monkeypatch.setattr(helpers, "_send", lambda *a, **k: pytest.fail("unexpected IPC"))
+    with pytest.raises(ValueError):
+        helpers.wait_until("true", timeout)
+
+
+@pytest.mark.parametrize("condition", ["", "  ", None, 1])
+def test_invalid_condition(condition):
+    with pytest.raises(ValueError):
+        helpers.wait_until(condition)
+
+
+def test_wait_is_pinned_and_uses_one_monotonic_budget(monkeypatch):
+    now, calls = [0.0], []
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(helpers.time, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
+    monkeypatch.setattr(helpers.time, "time", lambda: pytest.fail("wall clock used"))
+    def send(req, response_timeout, deadline):
+        calls.append((req, response_timeout, deadline))
+        if req.get("meta") == "session":
+            now[0] += 0.2
+            return {"session_id": "original"}
+        assert req["session_id"] == "original"
+        return {"result": {"result": {"value": len(calls) == 3}}}
+    monkeypatch.setattr(helpers, "_send", send)
+    assert helpers.wait_until("document.title === 'Done'", timeout=1) is True
+    assert [c[2] for c in calls] == [1, 1, 1]
+    assert calls[1][1] == pytest.approx(0.8)
+    assert calls[2][1] == pytest.approx(0.7)
+    assert calls[2][0]["params"]["timeout"] == pytest.approx(700)
+
+
+@pytest.mark.parametrize("failure", ["false", "hung", "session", "js"])
+def test_wait_failures_are_not_reported_as_success(monkeypatch, failure):
+    now = [0.0]
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(helpers.time, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
+    def send(req, **kwargs):
+        if req.get("meta") == "session":
+            return {"session_id": "original"}
+        if failure == "hung":
+            raise helpers._IPCResponseTimeout("never-settled promise")
+        if failure == "session":
+            raise RuntimeError("Session with given id not found")
+        if failure == "js":
+            return {"result": {"exceptionDetails": {"text": "ReferenceError: missing"}}}
+        return {"result": {"result": {"value": False}}}
+    monkeypatch.setattr(helpers, "_send", send)
+    error, match = (TimeoutError, "wait_until timed out after 0.25s") if failure in {"false", "hung"} else (RuntimeError, "Session|JavaScript")
+    with pytest.raises(error, match=match):
+        helpers.wait_until("missing", timeout=0.25)
+    assert now[0] <= 0.25
+
+
+def test_ipc_connect_and_response_share_deadline(monkeypatch):
+    now, budgets = [10.0], []
+    class Connection:
+        def settimeout(self, value):
+            budgets.append(value)
+        def close(self):
+            pass
+    def connect(name, timeout):
+        budgets.append(timeout)
+        now[0] += 0.3
+        return Connection(), None
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(helpers.ipc, "connect", connect)
+    monkeypatch.setattr(helpers.ipc, "request", lambda *args, **kwargs: {"session_id": "s"})
+    helpers._send({"meta": "session"}, response_timeout=1, deadline=10.5)
+    assert budgets == pytest.approx([0.5, 0.2])
+
+
+def test_partial_responses_do_not_restart_deadline(monkeypatch):
+    now, budgets = [0.0], []
+    class Connection:
+        def settimeout(self, value):
+            budgets.append(value)
+        def sendall(self, value):
+            pass
+        def recv(self, size):
+            now[0] += 0.3
+            return b" "
+    monkeypatch.setattr(helpers.ipc.time, "monotonic", lambda: now[0])
+    with pytest.raises(TimeoutError, match="deadline exceeded"):
+        helpers.ipc.request(Connection(), None, {}, deadline=0.5)
+    assert budgets == pytest.approx([0.5, 0.2])
+
+
+def test_mcp_wait_timeout_is_tool_error(monkeypatch):
+    pytest.importorskip("mcp")
+    import mcp_server
+    from mcp_types import CallToolRequestParams
+    monkeypatch.setattr(mcp_server, "ensure_daemon", lambda: None)
+    def timeout(*args, **kwargs):
+        raise TimeoutError("wait_until timed out")
+    monkeypatch.setattr(mcp_server, "wait_until", timeout)
+    result = asyncio.run(mcp_server.SERVER._handle_call_tool(None, CallToolRequestParams(name="browser_wait_until", arguments={"js_condition": "false"})))
+    assert result.is_error is True
+    assert "wait_until timed out" in result.content[0].text


### PR DESCRIPTION
A loaded document does not prove a SPA finished rendering. Add one `wait_until(js_condition, timeout=10)` helper and matching MCP tool for the actual URL/text/DOM condition the task needs.

Use a monotonic deadline shared by session lookup, connection, IPC reads, and evaluation. Validate finite positive timeouts, cap Chrome evaluation by the remaining budget, pin the original session, and surface JS/session failures. Return `True` on success; raise a descriptive timeout on expiry. Existing Boolean wait APIs are unchanged. Timed-out socket connects are closed.

Validation: `uv run --extra mcp --with pytest python -m pytest tests/unit tests/integration -q` — 292 passed. Covers changing/false predicates, JS error, hanging evaluation, lost session, invalid arguments, the shared connection/response budget, partial responses, and MCP errors. `git diff --check` passes. Combined browser and eval evidence is below.

Compatibility / rollout: additive helper/tool; existing scripts and daemon protocol still work. Restart the MCP process to load its new tool. Conditions must be read-only expressions. The caller's timeout does not guarantee cancellation of a page-owned asynchronous promise. Explicit session pinning intentionally does not jump to a replacement tab.

Rollback: revert the commit and remove new helper calls from scripts. No persisted data/config migration, provider change, or automatic daemon restart.

Combined validation: initial fixed candidate `0ea704f` passes 343 unit/integration tests; six disposable headless-Chrome click tests, four CLI/browser probes and package builds pass. Latest candidate `78aaadc`, adding Cloud health protection, passes 347 unit/integration tests. Counts cover different scopes and must not be added. Integration must preserve the tested conflict resolutions, including the detached-session tracking `deque` import.

Completed full paired rerun: **main 79/106 (74.5%); candidate 82/106 (77.4%), +2.83 percentage points**. 15 candidate wins, 12 losses; exact paired McNemar p=0.701. [Main workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999817407), [candidate workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999818855). Main `eba1021`, candidate `0ea704f`, platform `4104d41`; all 106 internal-bench-hard tasks; one attempt per task/arm; GPT-5.5 medium; Laith/GPT-5.5; matched options/dependencies/budgets. Actual initial viewport is 1280×960; reported DPR, IP/fingerprint and live sites remain variable. Resizing is enabled in both arms; do not compare causally to the older default-provider 85/106 vs 78/106 run.

Raw scores retain one ungraded candidate judge-startup timeout (`4t60pl`). Excluding only that pair: main 78/105, candidate 82/105. A separate candidate agent timeout (`trp0j4`) has a substantive failing judgment and stays included. Several flips expose inconsistent grading of coverage/access limitations. No scores were overridden. This run does not isolate an individual PR's effect or establish an uplift.

The full candidate predates separate Cloud health protection #773 and platform ownership enforcement browser-use/new-eval-platform#17. Latest `78aaadc` on platform `6bfa066` has a separate two-task matched follow-up: 1/2 in both arms; candidate Maps returns 40 qualifying leads, Apartments.com remains blocked. All four follow-up stops are confirmed. No live strict-health failure occurs there, so forced local failure/recovery tests establish the guard. No full 106-task comparison on the latest health fix.

Draft. Current-head automated checks pass; no human reviews or review threads. The harness has no automated unit-test workflow, so unit-test evidence above is local. No merge or production deployment. All 212 full-rerun artifacts confirm Cloud stop. A separate aborted setup cohort is excluded; 17 started tasks there lack confirmed stop evidence, requested 60-minute lifetimes have elapsed, and final provider state is unverified.
