### PR TITLE
P1: let the MCP HTTP tool work without Chrome

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -7,7 +7,7 @@ Run:
     uv run python -m mcp_server
 
 The server starts on stdio and exposes one MCP tool per browser-harness
-helper. Each tool ensures the daemon is running, calls the existing helper,
+helper. Browser tools ensure the daemon is running, call the existing helper,
 and returns JSON text. Helper failures use MCP's tool-error channel.
 """
 import functools
@@ -113,19 +113,23 @@ def _stderr_stdout():
         sys.stdout = saved
 
 
-def _tool(fn):
+def _tool(fn=None, *, requires_browser=True):
     """Wrap a helper so it is exposed as an MCP tool and returns JSON text.
 
-    Ensures the daemon is up, runs the helper, and converts operational failures
+    Ensures the daemon is up when required, runs the helper, and converts operational failures
     (including daemon startup failures) into MCP tool errors. Tool name and
     description are taken from the wrapped function so the schema matches the
     parameter annotations.
     """
 
+    if fn is None:
+        return functools.partial(_tool, requires_browser=requires_browser)
+
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         try:
-            ensure_daemon()
+            if requires_browser:
+                ensure_daemon()
             with _stderr_stdout():
                 result = fn(*args, **kwargs)
             return _dump(result)
@@ -272,7 +276,7 @@ def browser_upload_file(selector: str, path: str):
     return {"ok": True}
 
 
-@_tool
+@_tool(requires_browser=False)
 def browser_http_get(url: str, timeout: float = 20.0, headers: dict | None = None):
     """HTTP GET `url` (browser-less). Returns the response body. Optional
     `headers` dict for authentication or custom request headers."""

--- a/tests/unit/test_mcp_http.py
+++ b/tests/unit/test_mcp_http.py
@@ -1,0 +1,58 @@
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+pytest.importorskip("mcp")
+from mcp_types import CallToolRequestParams
+import mcp_server
+
+
+def call(name, **arguments):
+    return asyncio.run(mcp_server.SERVER._handle_call_tool(None, CallToolRequestParams(name=name, arguments=arguments)))
+
+
+def test_http_works_without_a_browser_and_preserves_headers(monkeypatch):
+    seen = []
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            seen.append(self.headers.get("X-Test"))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"fixture response")
+        def log_message(self, *args):
+            pass
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    monkeypatch.delenv("BROWSER_USE_API_KEY", raising=False)
+    def no_browser():
+        raise RuntimeError("Chrome unavailable")
+    monkeypatch.setattr(mcp_server, "ensure_daemon", no_browser)
+    try:
+        result = call("browser_http_get", url=f"http://127.0.0.1:{server.server_port}", timeout=2, headers={"X-Test": "preserved"})
+        assert result.is_error is False
+        assert json.loads(result.content[0].text) == {"text": "fixture response"}
+        assert seen == ["preserved"]
+        browser_result = call("browser_page_info")
+        assert browser_result.is_error is True
+        assert "Chrome unavailable" in browser_result.content[0].text
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join()
+
+
+def test_http_options_and_failures_reach_existing_helper(monkeypatch):
+    seen = []
+    monkeypatch.setattr(mcp_server, "ensure_daemon", lambda: pytest.fail("HTTP started Chrome"))
+    def fail(url, headers, timeout):
+        seen.append((url, headers, timeout))
+        raise TimeoutError("HTTP timed out")
+    monkeypatch.setattr(mcp_server, "http_get", fail)
+    result = call("browser_http_get", url="https://example.test", headers={"Accept": "application/json"}, timeout=0.5)
+    assert result.is_error is True
+    assert "HTTP timed out" in result.content[0].text
+    assert seen == [("https://example.test", {"Accept": "application/json"}, 0.5)]


### PR DESCRIPTION
`browser_http_get` advertises browser-independent HTTP but its MCP wrapper currently starts Chrome first. Make browser startup an explicit decorator option and opt only this existing HTTP tool out.

The underlying `http_get()` transport, proxy choice, headers, and timeout are unchanged. Browser tools still call `ensure_daemon()`. Both browser and HTTP failures still use MCP ToolError. The general Python CLI continues its existing startup behavior; this change does not parse scripts or refactor the runner.

Validation: `uv run --extra mcp --with pytest python -m pytest tests/unit tests/integration -q` — 275 passed. A real local HTTP server succeeds with headers preserved while Chrome startup is forced to fail; a browser tool still fails startup. HTTP options and timeout errors reach the existing helper/tool-error channel. `git diff --check` passes.

Compatibility / rollout: restart the MCP process to load the wrapper. Tool schemas and result shapes are unchanged. No browser daemon restart, persisted-data change, or transport migration. Rollback is a commit revert and MCP restart.

The paired Codex CLI eval does not exercise this MCP-only path; the local MCP tests above are its direct evidence.

Combined validation: initial fixed candidate `0ea704f` passes 343 unit/integration tests; six disposable headless-Chrome click tests, four CLI/browser probes and package builds pass. Latest candidate `78aaadc`, adding Cloud health protection, passes 347 unit/integration tests. Counts cover different scopes and must not be added. Integration must preserve the tested conflict resolutions, including the detached-session tracking `deque` import.

Completed full paired rerun: **main 79/106 (74.5%); candidate 82/106 (77.4%), +2.83 percentage points**. 15 candidate wins, 12 losses; exact paired McNemar p=0.701. [Main workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999817407), [candidate workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999818855). Main `eba1021`, candidate `0ea704f`, platform `4104d41`; all 106 internal-bench-hard tasks; one attempt per task/arm; GPT-5.5 medium; Laith/GPT-5.5; matched options/dependencies/budgets. Actual initial viewport is 1280×960; reported DPR, IP/fingerprint and live sites remain variable. Resizing is enabled in both arms; do not compare causally to the older default-provider 85/106 vs 78/106 run.

Raw scores retain one ungraded candidate judge-startup timeout (`4t60pl`). Excluding only that pair: main 78/105, candidate 82/105. A separate candidate agent timeout (`trp0j4`) has a substantive failing judgment and stays included. Several flips expose inconsistent grading of coverage/access limitations. No scores were overridden. This run does not isolate an individual PR's effect or establish an uplift.

The full candidate predates separate Cloud health protection #773 and platform ownership enforcement browser-use/new-eval-platform#17. Latest `78aaadc` on platform `6bfa066` has a separate two-task matched follow-up: 1/2 in both arms; candidate Maps returns 40 qualifying leads, Apartments.com remains blocked. All four follow-up stops are confirmed. No live strict-health failure occurs there, so forced local failure/recovery tests establish the guard. No full 106-task comparison on the latest health fix.

Draft. Current-head automated checks pass; no human reviews or review threads. The harness has no automated unit-test workflow, so unit-test evidence above is local. No merge or production deployment. All 212 full-rerun artifacts confirm Cloud stop. A separate aborted setup cohort is excluded; 17 started tasks there lack confirmed stop evidence, requested 60-minute lifetimes have elapsed, and final provider state is unverified.
