### PR TITLE
P1: add a tested recipe for checking nodes before clicking

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -184,6 +184,10 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 
 - Prefer to find elements with the accessibility tree, not screenshots: `cdp("Accessibility.getFullAXTree")["nodes"]` has every element's role, name, and `backendDOMNodeId` — filter in Python before printing (it is thousands of nodes). Coordinates: `q = cdp("DOM.getBoxModel", backendNodeId=n)["model"]["content"]; x, y = sum(q[0::2])/4, sum(q[1::2])/4` (viewport px, ready for `click_at_xy`; negative/oversized means scroll first).
 - Clicking: AX node -> box center -> `click_at_xy(x, y)` -> verify with a targeted `js(...)`/`page_info()` check.
+- For offscreen, covered, or changing DOM controls, use the
+  [checked-click recipe](interaction-skills/checked-clicks.md) from this checkout
+  (or the same path in the browser-harness GitHub repository):
+  keep the target/session, scroll, recheck the node and hit-test, click once, verify the effect.
 - Fall back to raw HTML via `js(...)` only when the AX tree lacks the element (canvas, exotic widgets); screenshot when layout or imagery matters.
 - After navigation, call `wait_for_load()`.
 - If the current tab is stale or internal, call `ensure_real_tab()`.

--- a/interaction-skills/checked-clicks.md
+++ b/interaction-skills/checked-clicks.md
@@ -1,0 +1,93 @@
+# Check a node before clicking
+
+Use this when a normal DOM control is offscreen, covered, or has changed since
+the last observation. Keep the target and backend node ID from the same fresh
+AX snapshot. Re-observe after navigation or a re-render.
+
+Copy this small recipe into `agent-workspace/agent_helpers.py` when needed.
+It uses an explicit CDP session for every operation. It rejects detached,
+renamed, disabled, hidden, covered, iframe, and shadow-root nodes. A failed
+check sends no mouse input. Raw coordinate clicks remain useful for canvas.
+
+```python
+def checked_click(session_id, backend_node_id, expected_role, expected_name):
+    def send(method, **params):
+        return cdp(method, session_id=session_id, **params)
+
+    obj = send("DOM.resolveNode", backendNodeId=backend_node_id)["object"]["objectId"]
+    try:
+        send("DOM.scrollIntoViewIfNeeded", backendNodeId=backend_node_id)
+        nodes = send("Accessibility.getPartialAXTree", backendNodeId=backend_node_id,
+                     fetchRelatives=False)["nodes"]
+        node = next((n for n in nodes if n.get("backendDOMNodeId") == backend_node_id), None)
+        if (not node or node.get("ignored") or
+                node.get("role", {}).get("value") != expected_role or
+                node.get("name", {}).get("value") != expected_name):
+            raise RuntimeError("Node changed; take a fresh AX snapshot")
+        result = send("Runtime.callFunctionOn", objectId=obj, returnByValue=True,
+                      functionDeclaration="""function() {
+            if (!this.isConnected) return {error: 'Node detached'};
+            if (window !== window.top || this.ownerDocument !== document ||
+                this.getRootNode() !== document)
+                return {error: 'Recipe supports the top document only'};
+            if (this.matches(':disabled') || this.closest('[aria-disabled="true"], [inert]'))
+                return {error: 'Node disabled'};
+            if (!this.checkVisibility({checkOpacity:true, checkVisibilityCSS:true}))
+                return {error: 'Node hidden'};
+            const r = this.getBoundingClientRect();
+            const x = r.x + r.width/2, y = r.y + r.height/2;
+            if (r.width <= 0 || r.height <= 0 || x < 0 || y < 0 ||
+                x >= innerWidth || y >= innerHeight) return {error: 'Node outside viewport'};
+            const hit = document.elementFromPoint(x, y);
+            if (!hit || (hit !== this && !this.contains(hit))) return {error: 'Node covered'};
+            return {x, y};
+        }""")
+        if result.get("exceptionDetails"):
+            raise RuntimeError("Click check failed; inspect the page before retrying")
+        point = result.get("result", {}).get("value")
+        if not point or "error" in point:
+            raise RuntimeError((point or {}).get("error", "Click check returned no point"))
+        # Always attempt release if press was sent; preserve the original error.
+        try:
+            send("Input.dispatchMouseEvent", type="mousePressed", button="left",
+                 clickCount=1, x=point["x"], y=point["y"])
+        except BaseException:
+            try:
+                send("Input.dispatchMouseEvent", type="mouseReleased", button="left",
+                     clickCount=1, x=point["x"], y=point["y"])
+            except BaseException:
+                pass
+            raise
+        send("Input.dispatchMouseEvent", type="mouseReleased", button="left",
+             clickCount=1, x=point["x"], y=point["y"])
+    finally:
+        try:
+            send("Runtime.releaseObject", objectId=obj)
+        except Exception:
+            pass
+```
+
+Attach to the intended target, inspect, click once, then verify the actual
+effect through that same session. Example for a synchronous local control:
+
+```python
+target_id = current_tab()["targetId"]
+sid = cdp("Target.attachToTarget", targetId=target_id, flatten=True)["sessionId"]
+try:
+    nodes = cdp("Accessibility.getFullAXTree", session_id=sid)["nodes"]
+    matches = [n for n in nodes if n.get("role", {}).get("value") == "button"
+               and n.get("name", {}).get("value") == "Save"]
+    assert len(matches) == 1, "Choose the intended control explicitly"
+    checked_click(sid, matches[0]["backendDOMNodeId"], "button", "Save")
+    result = cdp("Runtime.evaluate", session_id=sid, returnByValue=True,
+                 expression="document.querySelector('#status')?.textContent === 'Saved'")
+    assert not result.get("exceptionDetails") and result["result"].get("value") is True
+finally:
+    cdp("Target.detachFromTarget", sessionId=sid)
+```
+
+For async effects, poll the specific postcondition on `sid` with a deadline.
+Do not repeat a click because its result is uncertain. Inspect the outcome first.
+The page can still change between the final hit test and mouse dispatch; this
+recipe reduces stale/covered clicks and does not make a click atomic. If a page
+animates or changes that quickly, wait for it to settle and re-observe.

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -55,7 +55,10 @@ def browser_cli():
             def run(code, timeout=20):
                 result = subprocess.run([sys.executable, "-m", "browser_harness.run"], input=code, text=True,
                                         capture_output=True, env=env, cwd=repo, timeout=timeout)
-                assert result.returncode == 0, result.stdout + result.stderr
+                if result.returncode:
+                    log = root / "tmp" / "bu.log"
+                    evidence = log.read_text()[-4000:] if log.exists() else "no daemon log"
+                    raise AssertionError(result.stdout + result.stderr + "\nDaemon log:\n" + evidence)
                 return result.stdout
             yield run
         finally:

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -1,0 +1,69 @@
+"""Opt-in real-browser tests. Always create an isolated disposable profile/daemon."""
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def browser_cli():
+    chrome = os.environ.get("BH_TEST_CHROME")
+    if not chrome:
+        pytest.skip("set BH_TEST_CHROME to run against a disposable headless Chrome")
+    repo = Path(__file__).resolve().parents[2]
+    with tempfile.TemporaryDirectory(prefix="bh-test-", dir="/tmp") as directory:
+        root = Path(directory)
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("BU_", "BH_", "BROWSER_HARNESS_"))}
+        env.update(BU_NAME="fixture", BH_HOME=str(root / "home"), BH_RUNTIME_DIR=str(root / "runtime"),
+                   BH_TMP_DIR=str(root / "tmp"), BH_AGENT_WORKSPACE=str(root / "workspace"),
+                   BH_TAB_MARKER="0", BH_RECORD="0", PYTHONPATH=str(repo / "src"))
+        browser = subprocess.Popen([chrome, "--headless=new", "--remote-debugging-port=0",
+                                    f"--user-data-dir={root / 'profile'}", "--no-first-run", "--no-default-browser-check", "about:blank"],
+                                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+        daemon_process = None
+        try:
+            port_file = root / "profile" / "DevToolsActivePort"
+            deadline = time.monotonic() + 15
+            while not port_file.exists():
+                if browser.poll() is not None or time.monotonic() > deadline:
+                    pytest.fail("disposable Chrome failed to start")
+                time.sleep(0.05)
+            port, path = port_file.read_text().splitlines()[:2]
+            env["BU_CDP_WS"] = f"ws://127.0.0.1:{port}{path}"
+            daemon_process = subprocess.Popen([sys.executable, "-m", "browser_harness.daemon"], env=env,
+                                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            sock_path = root / "runtime" / "bu.sock"
+            while True:
+                try:
+                    with socket.socket(socket.AF_UNIX) as sock:
+                        sock.settimeout(1)
+                        sock.connect(str(sock_path))
+                        sock.sendall(b'{"meta":"ping"}\n')
+                        if json.loads(sock.recv(4096)).get("pong"):
+                            break
+                except (OSError, ValueError):
+                    pass
+                if daemon_process.poll() is not None or time.monotonic() > deadline:
+                    pytest.fail("disposable harness daemon failed to start")
+                time.sleep(0.05)
+            def run(code, timeout=20):
+                result = subprocess.run([sys.executable, "-m", "browser_harness.run"], input=code, text=True,
+                                        capture_output=True, env=env, cwd=repo, timeout=timeout)
+                assert result.returncode == 0, result.stdout + result.stderr
+                return result.stdout
+            yield run
+        finally:
+            for process in (daemon_process, browser):
+                if process is not None and process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=5)

--- a/tests/browser/test_checked_click.py
+++ b/tests/browser/test_checked_click.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import re
+from urllib.parse import quote
+
+import pytest
+
+
+RECIPE = re.findall(r"```python\n(.*?)```", (Path(__file__).resolve().parents[2] / "interaction-skills/checked-clicks.md").read_text(), re.S)[0]
+PAGE = """<html><body><div style="height:1800px"></div>
+<button id="save" onclick="window.clicks++;document.querySelector('#status').textContent='Saved'">Save</button>
+<p id="status">Unsaved</p><script>window.clicks=0;</script></body></html>"""
+
+
+@pytest.mark.parametrize("change,error", [
+    ("", None),
+    ("document.body.insertAdjacentHTML('beforeend', '<div style=\"position:fixed;inset:0;z-index:99\"></div>')", "covered"),
+    ("document.querySelector('#save').remove()", "detached"),
+    ("document.querySelector('#save').outerHTML = '<button id=save onclick=window.clicks++>Save</button>'", "replaced"),
+    ("document.querySelector('#save').textContent = 'Delete'", "changed"),
+    ("document.querySelector('#save').disabled = true", "disabled"),
+])
+def test_checked_click_against_real_dom(browser_cli, change, error):
+    script = RECIPE + f'''
+goto_url({('data:text/html,' + quote(PAGE))!r})
+wait_for_load()
+sid = cdp("Target.attachToTarget", targetId=current_tab()["targetId"], flatten=True)["sessionId"]
+try:
+    nodes = cdp("Accessibility.getFullAXTree", session_id=sid)["nodes"]
+    node = next(n for n in nodes if n.get("role", {{}}).get("value") == "button" and n.get("name", {{}}).get("value") == "Save")
+    assert js("document.querySelector('#save').getBoundingClientRect().top > innerHeight")
+    if {bool(change)!r}:
+        js({change!r})
+    failed = False
+    try:
+        checked_click(sid, node["backendDOMNodeId"], "button", "Save")
+    except RuntimeError as exc:
+        failed = True
+        print(str(exc))
+    assert failed is {bool(error)!r}
+    assert js("window.clicks") == {0 if error else 1}
+    if not failed:
+        assert js("document.querySelector('#status').textContent") == "Saved"
+    print("verified")
+finally:
+    cdp("Target.detachFromTarget", sessionId=sid)
+'''
+    assert "verified" in browser_cli(script)


### PR DESCRIPTION
An AX node's box center can land on an overlay or a control that changed after observation. Add a small checked-click recipe for top-document DOM controls using existing CDP calls.

The recipe pins an explicit session, scrolls, refreshes the AX role/name, checks attachment/visibility/disabled state and the hit-test result, then dispatches one mouse click. It rejects frames and shadow-root nodes. The usage example verifies the actual effect on the same session. Raw coordinate APIs are unchanged.

Validation:

- `uv run --extra mcp --with pytest python -m pytest tests/unit tests/integration -q` — 273 passed.
- `BH_TEST_CHROME='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' uv run --extra mcp --with pytest python -m pytest tests/browser -q` — 6 passed against disposable headless Chrome through the actual CLI/daemon. Tests execute the exact Markdown recipe. Offscreen control scrolls and clicks once; overlay, detached/replaced/renamed, and disabled cases leave the click counter at zero.
- `git diff --check` passes. The fixture owns and cleans up its browser/profile/daemon; no normal user browser was touched.

Compatibility / risk: recipe and opt-in tests only; no new core API, ref registry, or default observation system. The page can change between hit test and input dispatch: this is not an atomic-click guarantee. If a click outcome is uncertain, inspect before repeating. The example is deliberately limited to the top document; frames/shadow DOM need a different probe.

Rollout/rollback: use or remove the task-local recipe. No daemon restart, install/config migration, or customer-data change.

Combined validation: initial fixed candidate `0ea704f` passes 343 unit/integration tests; six disposable headless-Chrome click tests, four CLI/browser probes and package builds pass. Latest candidate `78aaadc`, adding Cloud health protection, passes 347 unit/integration tests. Counts cover different scopes and must not be added. Integration must preserve the tested conflict resolutions, including the detached-session tracking `deque` import.

Completed full paired rerun: **main 79/106 (74.5%); candidate 82/106 (77.4%), +2.83 percentage points**. 15 candidate wins, 12 losses; exact paired McNemar p=0.701. [Main workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999817407), [candidate workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999818855). Main `eba1021`, candidate `0ea704f`, platform `4104d41`; all 106 internal-bench-hard tasks; one attempt per task/arm; GPT-5.5 medium; Laith/GPT-5.5; matched options/dependencies/budgets. Actual initial viewport is 1280×960; reported DPR, IP/fingerprint and live sites remain variable. Resizing is enabled in both arms; do not compare causally to the older default-provider 85/106 vs 78/106 run.

Raw scores retain one ungraded candidate judge-startup timeout (`4t60pl`). Excluding only that pair: main 78/105, candidate 82/105. A separate candidate agent timeout (`trp0j4`) has a substantive failing judgment and stays included. Several flips expose inconsistent grading of coverage/access limitations. No scores were overridden. This run does not isolate an individual PR's effect or establish an uplift.

The full candidate predates separate Cloud health protection #773 and platform ownership enforcement browser-use/new-eval-platform#17. Latest `78aaadc` on platform `6bfa066` has a separate two-task matched follow-up: 1/2 in both arms; candidate Maps returns 40 qualifying leads, Apartments.com remains blocked. All four follow-up stops are confirmed. No live strict-health failure occurs there, so forced local failure/recovery tests establish the guard. No full 106-task comparison on the latest health fix.

Draft. Current-head automated checks pass; no human reviews or review threads. The harness has no automated unit-test workflow, so unit-test evidence above is local. No merge or production deployment. All 212 full-rerun artifacts confirm Cloud stop. A separate aborted setup cohort is excluded; 17 started tasks there lack confirmed stop evidence, requested 60-minute lifetimes have elapsed, and final provider state is unverified.
