### PR TITLE
fix: launch Chrome after cold daemon exit

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -188,8 +188,8 @@ def _pending_pid_record(path):
     return pid if _is_daemon_process(pid) else None
 
 
-def _fingerprinted_pending_generation(path):
-    """Return (PID, start fingerprint) only while that generation is alive."""
+def _pending_generation_record(path):
+    """Return a validated (PID, start fingerprint) record without probing it."""
     try:
         record = json.loads(path.read_text())
         pid = record["pid"]
@@ -198,8 +198,17 @@ def _fingerprinted_pending_generation(path):
         return None
     if type(pid) is not int or not 0 < pid < (1 << 31) or fingerprint is None:
         return None
+    return (pid, fingerprint)
+
+
+def _fingerprinted_pending_generation(path):
+    """Return (PID, start fingerprint) only while that generation is alive."""
+    generation = _pending_generation_record(path)
+    if generation is None:
+        return None
+    pid, fingerprint = generation
     current = _process_start_time(pid)
-    return (pid, fingerprint) if current is not None and current == fingerprint else None
+    return generation if current is not None and current == fingerprint else None
 
 
 def _fingerprinted_pending_pid(path):
@@ -225,6 +234,40 @@ def _publish_pid(path, pid):
     tmp = path.with_name(f"{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
     tmp.write_text(value)
     os.replace(tmp, path)
+
+
+def _stop_pending_generation(
+    name, generation, wait=5.0, process_dead=False, process=None
+):
+    """Stop and clean one lock-protected pending daemon generation."""
+    import signal
+
+    pid, fingerprint = generation
+    if not process_dead and _process_start_time(pid) == fingerprint:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (ProcessLookupError, OSError, SystemError, OverflowError):
+            pass
+        if process is not None and process.pid == pid:
+            try:
+                process.wait(timeout=wait)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=wait)
+        deadline = time.monotonic() + wait
+        while _process_start_time(pid) == fingerprint and time.monotonic() < deadline:
+            time.sleep(0.05)
+        if _process_start_time(pid) == fingerprint:
+            raise RuntimeError(
+                f"daemon-stopping: pending browser-harness daemon {pid} did not exit; retry later"
+            )
+    ipc.cleanup_endpoint(name)
+    path = ipc.pid_path(name)
+    if _pending_generation_record(path) == generation:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def _parked_daemon_pid(name=None):
@@ -558,6 +601,8 @@ def ensure_daemon(wait=None, name=None, env=None):
     # default caller's deadline, so Browser Use cloud startup is unaffected.
     launched_browser = None
     opened_inspect = False
+    pending_pid = None
+    pending_generation = None
     for _ in range(3):
         e = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
         try:
@@ -582,6 +627,9 @@ def ensure_daemon(wait=None, name=None, env=None):
                     )
                     _publish_pid(ipc.pid_path(name or NAME), p.pid)
                     pending_pid = p.pid
+                pending_generation = _pending_generation_record(
+                    ipc.pid_path(name or NAME)
+                )
         else:
             p = subprocess.Popen(
                 [sys.executable, "-m", "browser_harness.daemon"],
@@ -601,7 +649,9 @@ def ensure_daemon(wait=None, name=None, env=None):
             if p is not None and p.poll() is not None:
                 pending_died = True
                 break
-            if p is None and pending_pid and _pending_pid_record(ipc.pid_path(name or NAME)) != pending_pid:
+            if p is None and pending_pid and (
+                _pending_pid_record(ipc.pid_path(name or NAME)) != pending_pid
+            ):
                 pending_died = True
                 break
             log_tail = _log_tail(name) or ""
@@ -633,11 +683,60 @@ def ensure_daemon(wait=None, name=None, env=None):
             # we observed. Another waiter may already have published a healthy
             # successor while this caller was leaving its wait loop.
             with _spawn_lock(name, timeout=1.0) as cleanup_lock:
-                if cleanup_lock.fd is not None and _pid_number(ipc.pid_path(name or NAME)) == pending_pid:
+                pid_path = ipc.pid_path(name or NAME)
+                current_generation = _pending_generation_record(pid_path)
+                owned_child_died = p is not None and p.poll() is not None
+                owns_dead_generation = (
+                    cleanup_lock.fd is not None
+                    and pending_generation is not None
+                    and (
+                        current_generation == pending_generation
+                        or (owned_child_died and not pid_path.exists())
+                    )
+                )
+                legacy_dead_generation = False
+                if (
+                    cleanup_lock.fd is not None
+                    and pending_generation is None
+                    and pending_pid
+                ):
                     try:
-                        ipc.pid_path(name or NAME).unlink()
-                    except FileNotFoundError:
+                        legacy_dead_generation = (
+                            pid_path.read_text().strip() == str(pending_pid)
+                            and _pending_pid_record(pid_path) is None
+                        )
+                    except OSError:
                         pass
+                if owns_dead_generation:
+                    _stop_pending_generation(
+                        name or NAME,
+                        pending_generation,
+                        process_dead=p is not None and p.poll() is not None,
+                    )
+                elif legacy_dead_generation:
+                    ipc.cleanup_endpoint(name or NAME)
+                    pid_path.unlink(missing_ok=True)
+                if owns_dead_generation or legacy_dead_generation:
+                    if not permission_wait and launched_browser is None and _chrome_not_running(msg):
+                        # Keep cleanup and browser launch in one critical section:
+                        # otherwise another caller can publish a successor that
+                        # restart_daemon() below would kill.
+                        launched_browser = _launch_browser()
+                        if launched_browser is None:
+                            raise RuntimeError(
+                                "chrome-not-running: no supported browser is running and none could be launched -- ask the user to open Chrome, then retry."
+                            )
+                        print(
+                            "browser-harness: Chrome isn't running — launching it. "
+                            'If Chrome shows an "Allow remote debugging?" popup, click Allow.',
+                            file=sys.stderr,
+                        )
+                        from .daemon import supported_browser_running
+
+                        boot_deadline = time.time() + 15
+                        while time.time() < boot_deadline and not supported_browser_running():
+                            time.sleep(0.3)
+
             if permission_wait:
                 # A denied/expired approval may already have dropped its sheet.
                 # Never auto-spawn a replacement here: that would immediately
@@ -646,6 +745,9 @@ def ensure_daemon(wait=None, name=None, env=None):
                     "permission-blocked: the pending Chrome connection ended before approval; "
                     "browser-harness did not retry or create another connection."
                 )
+            # Retry whether we launched Chrome or found that another caller had
+            # already replaced the dead generation. The next iteration joins
+            # that successor rather than stopping it.
             continue
         if local and msg.startswith("handshake-wait"):
             # Leave it running: this daemon's connection is what holds the popup
@@ -665,18 +767,34 @@ def ensure_daemon(wait=None, name=None, env=None):
                 "permission-blocked: Chrome did not approve the connection; browser-harness did not retry or create another connection."
             )
         if local and launched_browser is None and _chrome_not_running(msg):
-            # Chrome is closed — launch the browser and retry
-            restart_daemon(name)
-            launched_browser = _launch_browser()
-            if launched_browser is None:
-                raise RuntimeError(
-                    "chrome-not-running: no supported browser is running and none could be launched -- ask the user to open Chrome, then retry."
+            # A timeout (rather than an observed child exit) reaches this path.
+            # Serialize the same generation check used above so a concurrent
+            # caller's successor is never stopped by stale recovery work.
+            with _spawn_lock(name, timeout=1.0) as recovery_lock:
+                owns_generation = (
+                    recovery_lock.fd is not None
+                    and pending_generation is not None
+                    and _pending_generation_record(ipc.pid_path(name or NAME))
+                    == pending_generation
                 )
-            print("browser-harness: Chrome isn't running — launching it. If Chrome shows an \"Allow remote debugging?\" popup, click Allow.", file=sys.stderr)
-            from .daemon import supported_browser_running
-            boot_deadline = time.time() + 15
-            while time.time() < boot_deadline and not supported_browser_running():
-                time.sleep(0.3)
+                if not owns_generation:
+                    continue
+                _stop_pending_generation(
+                    name or NAME,
+                    pending_generation,
+                    process=p,
+                )
+                launched_browser = _launch_browser()
+                if launched_browser is None:
+                    raise RuntimeError(
+                        "chrome-not-running: no supported browser is running and none could be launched -- ask the user to open Chrome, then retry."
+                    )
+                print("browser-harness: Chrome isn't running — launching it. If Chrome shows an \"Allow remote debugging?\" popup, click Allow.", file=sys.stderr)
+                from .daemon import supported_browser_running
+
+                boot_deadline = time.time() + 15
+                while time.time() < boot_deadline and not supported_browser_running():
+                    time.sleep(0.3)
             continue
         if local and not opened_inspect and _needs_chrome_remote_debugging_prompt(msg):
             opened_inspect = True

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1130,6 +1130,59 @@ def test_ensure_daemon_returns_when_the_parked_daemon_finishes(tmp_path, monkeyp
     admin_mod.ensure_daemon(wait=5.0)  # returns, does not raise
 
 
+def test_ensure_daemon_launches_chrome_when_cold_child_exits(tmp_path, monkeypatch):
+    """A cold child may report chrome-not-running only as it exits."""
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    log_file.write_text("fatal: chrome-not-running: no supported browser is running")
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod.ipc, "spawn_kwargs", lambda: {})
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: None)
+    process_state = {"dead": False}
+    monkeypatch.setattr(
+        admin_mod,
+        "_process_start_time",
+        lambda pid: None if process_state["dead"] else f"start-{pid}",
+    )
+    monkeypatch.setattr(admin_mod, "restart_daemon", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_cleanup_unattached_browser_launch", lambda launch: None)
+    monkeypatch.setattr("browser_harness.daemon.supported_browser_running", lambda: True)
+
+    spawned = []
+
+    class Child:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def poll(self):
+            if self.pid == 4321:
+                process_state["dead"] = True
+                pid_file.unlink(missing_ok=True)
+                return 1
+            return None
+
+    def spawn(*args, **kwargs):
+        child = Child(4321 + len(spawned))
+        spawned.append(child)
+        return child
+
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", spawn)
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: len(spawned) >= 2)
+    launches = []
+    launched = (object(), tmp_path / "profile")
+    monkeypatch.setattr(admin_mod, "_launch_browser", lambda: launches.append(True) or launched)
+
+    admin_mod.ensure_daemon(wait=0.1)
+
+    assert launches == [True]
+    assert len(spawned) == 2
+
+
 def test_ensure_daemon_does_not_replace_pending_approval_that_exited(tmp_path, monkeypatch):
     """A failed approval attempt must not create another Chrome prompt."""
     from browser_harness import admin as admin_mod
@@ -1186,6 +1239,198 @@ def test_dead_pending_cleanup_does_not_unlink_successor(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError, match="did not retry or create another connection"):
         admin_mod.ensure_daemon(wait=0.1)
     assert pid_file.read_text() == "222"
+
+
+def test_cold_pending_cleanup_does_not_launch_over_successor(tmp_path, monkeypatch):
+    """A successor published before cleanup owns cold-browser recovery."""
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    pid_file.write_text("111")
+    log_file.write_text("fatal: chrome-not-running")
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod.ipc, "spawn_kwargs", dict)
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    alive = iter([False, False, False, True])
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: next(alive, True))
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: "start")
+
+    class Dead:
+        pid = 111
+
+        def poll(self):
+            pid_file.write_text("222")
+            return 1
+
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", lambda *a, **k: Dead())
+    monkeypatch.setattr(
+        admin_mod,
+        "_launch_browser",
+        lambda: (_ for _ in ()).throw(AssertionError("successor owns recovery")),
+    )
+
+    admin_mod.ensure_daemon(wait=0.1)
+
+    assert pid_file.read_text() == "222"
+
+
+def test_cold_timeout_does_not_restart_successor(tmp_path, monkeypatch):
+    """Timeout recovery must not stop a successor published after spawning."""
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod.ipc, "spawn_kwargs", dict)
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: False)
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: f"start-{pid}")
+
+    class Starting:
+        pid = 111
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", lambda *a, **k: Starting())
+
+    def successor_arrives(name=None):
+        pid_file.write_text("222")
+        return "fatal: chrome-not-running"
+
+    monkeypatch.setattr(admin_mod, "_log_tail", successor_arrives)
+    monkeypatch.setattr(
+        admin_mod,
+        "restart_daemon",
+        lambda name=None: (_ for _ in ()).throw(AssertionError("must not stop successor")),
+    )
+    monkeypatch.setattr(
+        admin_mod,
+        "_launch_browser",
+        lambda: (_ for _ in ()).throw(AssertionError("successor owns recovery")),
+    )
+
+    with pytest.raises(RuntimeError, match="didn't come up"):
+        admin_mod.ensure_daemon(wait=0)
+
+    assert pid_file.read_text() == "222"
+
+
+def test_cold_timeout_cancels_owned_generation_without_reentering_lock(tmp_path, monkeypatch):
+    """Owned timeout recovery stops its child without nested lock acquisition."""
+    from browser_harness import admin as admin_mod
+
+    pid_file = tmp_path / "daemon.pid"
+    log_file = tmp_path / "daemon.log"
+    log_file.write_text("fatal: chrome-not-running")
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name: pid_file)
+    monkeypatch.setattr(admin_mod.ipc, "log_path", lambda name: log_file)
+    monkeypatch.setattr(admin_mod.ipc, "spawn_kwargs", dict)
+    monkeypatch.setattr(admin_mod, "_is_local_chrome_mode", lambda env: True)
+    spawned = []
+    monkeypatch.setattr(admin_mod, "daemon_alive", lambda name=None: len(spawned) >= 2)
+    monkeypatch.setattr(admin_mod, "_parked_daemon_pid", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: None)
+    process_alive = {111: True}
+    monkeypatch.setattr(
+        admin_mod,
+        "_process_start_time",
+        lambda pid: f"start-{pid}" if process_alive.get(pid, True) else None,
+    )
+    monkeypatch.setattr("browser_harness.daemon.supported_browser_running", lambda: True)
+    monkeypatch.setattr(admin_mod, "_cleanup_unattached_browser_launch", lambda launch: None)
+    monkeypatch.setattr(
+        admin_mod,
+        "restart_daemon",
+        lambda name=None: (_ for _ in ()).throw(AssertionError("must not re-enter spawn lock")),
+    )
+
+    class Starting:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def wait(self, timeout=None):
+            process_alive[self.pid] = False
+
+        def poll(self):
+            return None
+
+    def spawn(*args, **kwargs):
+        child = Starting(111 + len(spawned))
+        spawned.append(child)
+        return child
+
+    monkeypatch.setattr(admin_mod.subprocess, "Popen", spawn)
+    killed = []
+
+    def kill(pid, sig):
+        killed.append((pid, sig))
+
+    monkeypatch.setattr(admin_mod.os, "kill", kill)
+    launches = []
+    monkeypatch.setattr(
+        admin_mod,
+        "_launch_browser",
+        lambda: launches.append(True) or (object(), tmp_path / "profile"),
+    )
+
+    admin_mod.ensure_daemon(wait=0.01)
+
+    assert killed and killed[0][0] == 111
+    assert launches == [True]
+
+
+def test_legacy_dead_child_chrome_marker_still_launches_browser(tmp_path, monkeypatch):
+    """A proven-dead legacy raw-PID generation remains recoverable."""
+    from browser_harness import admin as admin_mod
+
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text("111")
+    monkeypatch.setattr(admin_mod.ipc, "pid_path", lambda name=None: pid_path)
+    monkeypatch.setattr(admin_mod.ipc, "cleanup_endpoint", lambda name=None: None)
+    monkeypatch.setattr(admin_mod, "_starting_daemon_pid", lambda name=None: 111)
+    monkeypatch.setattr(admin_mod, "_pending_pid_record", lambda path: None)
+    monkeypatch.setattr(admin_mod, "_process_start_time", lambda pid: None)
+    monkeypatch.setattr(admin_mod, "_log_tail", lambda name=None: "error: chrome-not-running")
+
+    class ImmediateLock:
+        fd = 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        admin_mod, "_spawn_lock", lambda name=None, timeout=None: ImmediateLock()
+    )
+    monkeypatch.setattr("browser_harness.daemon.supported_browser_running", lambda: True)
+    monkeypatch.setattr(admin_mod.time, "sleep", lambda seconds: None)
+    launches = []
+    monkeypatch.setattr(
+        admin_mod,
+        "daemon_alive",
+        lambda name=None: bool(launches),
+    )
+    monkeypatch.setattr(
+        admin_mod,
+        "_launch_browser",
+        lambda: launches.append(True) or ("proc", None, None),
+    )
+    monkeypatch.setattr(admin_mod, "_cleanup_unattached_browser_launch", lambda *args: None)
+
+    admin_mod.ensure_daemon(wait=0.1)
+
+    assert launches == [True]
+    assert not pid_path.exists()
 
 
 def test_default_local_approval_has_no_deadline_without_affecting_remote():


### PR DESCRIPTION
## Problem

On a cold local start, the daemon can exit with `chrome-not-running` before publishing its IPC endpoint. `ensure_daemon()` handled `pending_died` by cleaning up and immediately retrying, so it spawned three doomed daemons without ever reaching the existing `BH_CHROME_PATH` recovery branch.

This reproduces browser-use/browser-harness 0.1.13 in Science Factory: the configured launcher is never invoked until Chrome is started manually.

## Fix

- retain the exact pending generation (PID + process-start fingerprint)
- when that generation exits with `chrome-not-running`, clean it and launch Chrome while holding the per-name spawn lock
- apply the same generation-safe serialization to timeout recovery
- never stop or overwrite a concurrently published successor
- preserve the existing no-retry behavior for Chrome permission/approval failures

## Tests

- regression for `chrome-not-running` emitted as the child exits
- concurrent successor protection for the child-exit and timeout paths
- same-generation cancellation without lock re-entry
- full unit suite: **258 passed, 1 skipped**
- `git diff --check`

The primary regression was observed RED before the fix. Independent review also identified and drove the successor-generation hardening.

Downstream report: https://github.com/hayman-labs/science-factory/issues/9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cold-start daemon recovery so Chrome is launched when the daemon exits with `chrome-not-running` before publishing its IPC endpoint. Previously `ensure_daemon()` cleaned up and retried immediately, spawning three doomed daemons without ever reaching the Chrome launch recovery path.

- Tracks the exact pending generation (PID plus process-start fingerprint) and uses it to clean up and launch Chrome under the spawn lock; proven-dead legacy raw-PID records keep the same recovery.
- Applies the same generation-safe serialization to timeout recovery so a concurrently published successor is never stopped or overwritten.
- Keeps the existing no-retry behavior for Chrome permission or approval failures.
- Adds regression tests for cold child exit, successor protection on both paths, legacy recovery, and same-generation cancellation without lock re-entry.

<sup>Written for commit 5852c392e0158942eba2ff939e3cc3d65f71cc09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

