### PR TITLE
Preserve recent daemon failure logs across restarts

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -225,6 +225,7 @@ def _start_log():
     # Keep the most recent MiB across restarts, including the original failure.
     # Truncate in place: admin already opened this inode as the child's stderr.
     with open(LOG, "a+b") as stream:
+        os.chmod(LOG, 0o600)
         if stream.tell() > 1024 * 1024:
             stream.seek(-1024 * 1024, os.SEEK_END)
             tail = stream.read()

--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -1,5 +1,6 @@
 """CDP WS holder + IPC relay (Unix socket on POSIX, TCP loopback on Windows). One daemon per BU_NAME."""
 import asyncio, json, os, platform, socket, sys, time, urllib.error, urllib.request
+import traceback
 from urllib.parse import urlparse
 from collections import deque
 from pathlib import Path
@@ -218,6 +219,19 @@ def supported_browser_running():
 
 def log(msg):
     open(LOG, "a", encoding="utf-8", errors="replace").write(f"{msg}\n")
+
+
+def _start_log():
+    # Keep the most recent MiB across restarts, including the original failure.
+    # Truncate in place: admin already opened this inode as the child's stderr.
+    with open(LOG, "a+b") as stream:
+        if stream.tell() > 1024 * 1024:
+            stream.seek(-1024 * 1024, os.SEEK_END)
+            tail = stream.read()
+            stream.seek(0)
+            stream.truncate()
+            stream.write(b"[earlier daemon log truncated]\n" + tail)
+    log(f"daemon starting pid={os.getpid()} utc={time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
 
 
 def _safe_connection_label(url):
@@ -879,13 +893,16 @@ if __name__ == "__main__":
     if already_running():
         print(f"daemon already running on {SOCK}", file=sys.stderr)
         sys.exit(0)
-    open(LOG, "w").close()
+    _start_log()
     _publish_own_pid()
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
         pass
     except Exception as e:
+        # Stack locations without locals or chained exception payloads. The
+        # existing final error stays last for admin's one-line diagnostic.
+        log("Traceback (most recent call last):\n" + "".join(traceback.format_tb(e.__traceback__)))
         log(f"fatal: {e}")
         sys.exit(1)
     finally:

--- a/tests/unit/test_daemon_log.py
+++ b/tests/unit/test_daemon_log.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from browser_harness import daemon
+
+
+def test_restart_retains_error_and_stderr_sink_when_history_is_trimmed(tmp_path, monkeypatch):
+    path = tmp_path / "daemon.log"
+    monkeypatch.setattr(daemon, "LOG", str(path))
+    path.write_bytes(b"old\n" * 300_000 + b"fatal: original browser failure\n")
+    # admin opens this descriptor before the child starts. Replacing the file
+    # would silently send stderr to the old inode.
+    with path.open("ab", buffering=0) as stderr:
+        daemon._start_log()
+        stderr.write(b"stderr: reconnect failed\n")
+        daemon._start_log()
+    data = path.read_text()
+    assert "fatal: original browser failure" in data
+    assert "stderr: reconnect failed" in data
+    assert data.count("daemon starting pid=") == 2
+    assert len(path.read_bytes()) < 1_050_000
+
+
+def test_real_entrypoint_preserves_failure_across_repeated_failed_starts(tmp_path):
+    # Only a fake CDP client is instantiated. No Chrome, cloud API, user daemon,
+    # credentials or real endpoint is accessed.
+    code = """
+import runpy
+from cdp_use.client import CDPClient
+from browser_harness import _ipc
+async def fail(self):
+    raise RuntimeError('local startup sentinel')
+CDPClient.start = fail
+_ipc.ping = lambda *a, **kw: False
+runpy.run_module('browser_harness.daemon', run_name='__main__')
+"""
+    env = {key: value for key, value in os.environ.items()
+           if not key.startswith(("BH_", "BU_", "BROWSER_USE_"))}
+    env.update(BH_HOME=str(tmp_path / "home"), BH_TMP_DIR=str(tmp_path / "logs"),
+               BH_RUNTIME_DIR=str(tmp_path / "ipc"), BH_AGENT_WORKSPACE=str(tmp_path / "workspace"),
+               BU_NAME="log-test", BU_CDP_WS="ws://127.0.0.1:1/devtools/browser/fake",
+               PYTHONPATH=str(Path(daemon.__file__).parents[1]))
+    for _ in range(2):
+        result = subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, timeout=10)
+        assert result.returncode == 1, result.stderr.decode()
+    logs = list((tmp_path / "logs").glob("*.log"))
+    assert len(logs) == 1
+    text = logs[0].read_text()
+    assert text.count("daemon starting pid=") == 2
+    assert text.count("fatal: CDP WS handshake failed: local startup sentinel") == 2
+    assert text.count("Traceback (most recent call last)") == 2

--- a/tests/unit/test_daemon_log.py
+++ b/tests/unit/test_daemon_log.py
@@ -1,4 +1,5 @@
 import os
+import stat
 from pathlib import Path
 import subprocess
 import sys
@@ -21,6 +22,8 @@ def test_restart_retains_error_and_stderr_sink_when_history_is_trimmed(tmp_path,
     assert "stderr: reconnect failed" in data
     assert data.count("daemon starting pid=") == 2
     assert len(path.read_bytes()) < 1_050_000
+    if os.name != "nt":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 def test_real_entrypoint_preserves_failure_across_repeated_failed_starts(tmp_path):


### PR DESCRIPTION
A failed daemon restart currently truncates the log and destroys the original browser failure. Retain the latest MiB across startups and append a UTC/PID startup marker. Fatal errors also record stack locations without locals or chained exception payloads; the existing error stays last for one-line diagnostics.

Trim in place so the stderr descriptor opened by the parent keeps writing to the same file. No rotation framework or extra files.

Proof: 275 standalone unit/integration tests pass on Python 3.12.11. New tests run the actual entrypoint through two failed starts and verify both errors/stacks remain. A large-log test verifies bounded retained history, owner-only permissions and stderr continuity through trimming.

Risk / rollout: logs now retain recent prior attempts, with owner-only file permissions (0600 on POSIX). Retention is capped at startup; an individual long-running process can still grow its log. Trimming can remove older evidence and is explicitly marked. Running daemons are unchanged until deliberately restarted. No profile or customer-data changes.

Rollback: revert and deliberately restart; the old startup behavior truncates the log. Save needed evidence before rollback. Draft; no merge or deployment.

Combined validation: initial fixed candidate `0ea704f` passes 343 unit/integration tests; six disposable headless-Chrome click tests, four CLI/browser probes and package builds pass. Latest candidate `78aaadc`, adding Cloud health protection, passes 347 unit/integration tests. Counts cover different scopes and must not be added. Integration must preserve the tested conflict resolutions, including the detached-session tracking `deque` import.

Completed full paired rerun: **main 79/106 (74.5%); candidate 82/106 (77.4%), +2.83 percentage points**. 15 candidate wins, 12 losses; exact paired McNemar p=0.701. [Main workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999817407), [candidate workflow](https://github.com/browser-use/new-eval-platform/actions/runs/33999818855). Main `eba1021`, candidate `0ea704f`, platform `4104d41`; all 106 internal-bench-hard tasks; one attempt per task/arm; GPT-5.5 medium; Laith/GPT-5.5; matched options/dependencies/budgets. Actual initial viewport is 1280×960; reported DPR, IP/fingerprint and live sites remain variable. Resizing is enabled in both arms; do not compare causally to the older default-provider 85/106 vs 78/106 run.

Raw scores retain one ungraded candidate judge-startup timeout (`4t60pl`). Excluding only that pair: main 78/105, candidate 82/105. A separate candidate agent timeout (`trp0j4`) has a substantive failing judgment and stays included. Several flips expose inconsistent grading of coverage/access limitations. No scores were overridden. This run does not isolate an individual PR's effect or establish an uplift.

The full candidate predates separate Cloud health protection #773 and platform ownership enforcement browser-use/new-eval-platform#17. Latest `78aaadc` on platform `6bfa066` has a separate two-task matched follow-up: 1/2 in both arms; candidate Maps returns 40 qualifying leads, Apartments.com remains blocked. All four follow-up stops are confirmed. No live strict-health failure occurs there, so forced local failure/recovery tests establish the guard. No full 106-task comparison on the latest health fix.

Draft. Current-head automated checks pass; no human reviews or review threads. The harness has no automated unit-test workflow, so unit-test evidence above is local. No merge or production deployment. All 212 full-rerun artifacts confirm Cloud stop. A separate aborted setup cohort is excluded; 17 started tasks there lack confirmed stop evidence, requested 60-minute lifetimes have elapsed, and final provider state is unverified.
