### PR TITLE
Preserve Cloud browsers after failed CDP health checks

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -178,6 +178,9 @@ When the task is done and a cloud browser is still running, ask directly: "Shoul
 
 Do not start a remote daemon and then keep using the default daemon. Use the same name for `BU_NAME`.
 
+A failed Cloud health check preserves the existing browser. Retry after it
+recovers; explicitly stop it when finished. Billing continues until stop or timeout.
+
 Cloud profile cookie sync reference: https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md.
 
 ## Page Workflow

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -533,20 +533,24 @@ def ensure_daemon(wait=None, name=None, env=None):
         for last in (False, True):
             try:
                 s, token = ipc.connect(name or NAME, timeout=3.0)
-                resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
+                try:
+                    resp = ipc.request(s, token, {"method": "Target.getTargets", "params": {}})
+                finally:
+                    s.close()
                 if "result" in resp: return
             except Exception:
                 pass
             if not last: time.sleep(0.5)
         browser_kind = daemon_browser_kind(name)
         if browser_kind in {"cloud", None}:
-            # A stale Cloud daemon still owns a billable browser. Its shutdown
-            # handler stops that browser before acknowledging, and stays alive
-            # when the Cloud stop fails so a later call can retry cleanup. Treat
-            # an unknown kind the same way: the health failure that made the
-            # daemon stale may also prevent classification, and replacing an
-            # unclassified daemon best-effort could orphan a Cloud browser.
-            stop_remote_daemon(name or NAME)
+            # A failed CDP probe can be temporary. Shutdown destroys the Cloud
+            # session; this caller may not have its transport to reconnect.
+            # Unknown kind may also own a Cloud browser. Leave cleanup explicit.
+            raise RuntimeError(
+                f"daemon {name or NAME!r} is unhealthy; existing browser preserved. "
+                f"Retry after it recovers, or explicitly stop_remote_daemon({name or NAME!r}) "
+                "when finished; the Cloud browser still bills until stopped or timed out."
+            )
         else:
             restart_daemon(name)
 

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -185,6 +185,43 @@ def test_require_existing_daemon_probes_cdp(monkeypatch):
     assert sock.closed is True
 
 
+@pytest.mark.parametrize("kind", ["cloud", None])
+@pytest.mark.parametrize("failure", ["timeout", "error"])
+def test_cloud_health_failure_preserves_browser_and_recovers_on_retry(monkeypatch, kind, failure):
+    sockets = []
+    healthy = False
+
+    def connect(_name, timeout):
+        sock = FakeSocket()
+        sockets.append(sock)
+        return sock, None
+
+    def request(_sock, _token, _request):
+        if healthy:
+            return {"result": {"targetInfos": []}}
+        if failure == "timeout":
+            raise TimeoutError("CDP temporarily stalled")
+        return {"error": "CDP temporarily stalled"}
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name: True)
+    monkeypatch.setattr(admin, "daemon_browser_kind", lambda _name: kind)
+    monkeypatch.setattr(admin.ipc, "connect", connect)
+    monkeypatch.setattr(admin.ipc, "request", request)
+    monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(admin, "stop_remote_daemon", lambda *_args: pytest.fail("health check destroyed the browser"))
+    monkeypatch.setattr(admin, "restart_daemon", lambda *_args: pytest.fail("health check replaced the daemon"))
+    monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: pytest.fail("health check started a replacement"))
+
+    with pytest.raises(RuntimeError, match="unhealthy.*preserved"):
+        admin.ensure_daemon(name="scoped")
+    assert len(sockets) == 2
+    assert all(sock.closed for sock in sockets)
+    healthy = True
+    admin.ensure_daemon(name="scoped")
+    assert len(sockets) == 3
+    assert all(sock.closed for sock in sockets)
+
+
 def test_strict_remote_stop_propagates_daemon_error(monkeypatch):
     sock = FakeSocket(response=b'{"error":"billing stop failed"}\n')
     monkeypatch.setattr(admin.ipc, "identify", lambda _name, timeout: 123)


### PR DESCRIPTION
A transient CDP health failure currently makes `ensure_daemon()` stop a live Cloud browser. The next CLI invocation then attempts local Chrome discovery without the original Cloud transport. During task `t4p501` in the matched rerun, retained logs show the Cloud stop followed by three `chrome-not-running` restarts while the agent was still working.

This change raises an actionable error for a Cloud or unclassified daemon after failed health probes. It preserves the browser, closes probe sockets, and lets a later CLI invocation reuse the same daemon if it recovers. Explicit Cloud stop and local-daemon recovery retain their existing behavior.

Proof: four regression cases fail before the patch and pass after it (timeout/error × Cloud/unknown kind). Standalone unit/integration suite: 275 passed, one optional-MCP skip. Combined P0/P1 candidate: 347 passed. A real CLI/Unix-IPC fixture fails closed, then succeeds against the same recovered endpoint, with zero shutdown requests; no real browser or Cloud API is used in that probe.

Risk: an unhealthy Cloud browser remains billable until explicit stop or its configured timeout. The error and skill state this. Unknown daemon kind also fails closed because it may own a Cloud browser. This prevents destructive recovery; it does not repair a permanently hung Chrome process. No persisted schema or public signature changes. Takes effect on the next CLI process; existing work is preserved. Reverting restores the destructive recovery path.

Evaluation: completed a separate matched follow-up on Maps (`t4p501`) and Apartments.com (`mly4ly`), one attempt per task/arm. Latest combined candidate `78aaadc` and main `eba1021` both score 1/2 on platform `6bfa066` with runner ownership enforced. Candidate Maps delivers 40 qualifying leads; Apartments.com remains access-blocked. All four Cloud stops are confirmed; each candidate task has exactly one daemon startup. None of the four live attempts hits the strict health-check failure branch, so this is workflow evidence, not isolated causal proof of this guard. The forced local regression and real CLI/IPC recovery probe establish the behavior.

Follow-up workflows: [main](https://github.com/browser-use/new-eval-platform/actions/runs/34001827634), [candidate](https://github.com/browser-use/new-eval-platform/actions/runs/34001828753). The separate 106-task/arm comparison uses candidate `0ea704f` and predates this fix. No full-cohort quality claim for this HEAD. Draft; no merge approval.
