### PR TITLE
docs: exact product-label capture for iHerb, Nordic and Thorne

### DIFF
--- a/agent-workspace/domain-skills/iherb/product-labels.md
+++ b/agent-workspace/domain-skills/iherb/product-labels.md
@@ -1,0 +1,49 @@
+# iHerb — exact product labels and lifecycle
+
+Observed on public, signed-out US/English product pages in September 2026.
+Use a plain fetch first; if it times out or returns an incomplete page, inspect
+the rendered product page. No account or cart operation is needed for labels.
+
+## Identity and layout
+
+- Product URLs use `/pr/<descriptive-slug>/<numeric-item-id>`. Slugs can change
+  on redirect, including an added `discontinued-item`, while the numeric ID stays
+  the same. Verify the final ID, selected package and UPC; a similar name is not
+  sufficient to substitute another item.
+- `#name` / `[data-testid="product-name"]` is the selected product heading.
+- `#product-specs-list` contains product code, UPC and package quantity.
+- A package selector can offer several counts or strengths. Retain the selected
+  variant's identity alongside any extracted facts or prices.
+
+## Supplement Facts: two observed layouts
+
+1. Active pages may have an already-visible `.supplement-facts-container` with a
+   table containing serving size, servings per container and labeled amounts.
+2. A discontinued page used a collapsed `[data-toggle-type="product-supplement-facts"]`
+   header and `#product-supplement-facts` body. Find the visible header's button
+   in the accessibility tree, scroll it into view, click, then verify that the
+   facts body is visible before extracting it.
+
+Do not require an accordion on every page. Do not try to click the zero-sized
+rectangle of a hidden body. After scrolling or expanding, allow layout to settle
+and verify the full table visually. Capture the facts container, not just its
+heading. Other ingredients may be in an adjacent block.
+
+## Discontinued-product and price traps
+
+- `.product-summary-unbuyable-message` can explicitly say the item is
+  discontinued and no longer available. `#product-action` may be empty in this
+  layout; it is not a reliable lifecycle source on its own.
+- The same page can prominently show a **Similar Recommendation** with a price.
+  That price belongs to another product, not the discontinued item.
+- Active buying panels can show subscription, one-time and promotional prices
+  together. Keep purchase type, package, currency/region and capture time
+  attached; do not treat the lowest visible number as the one-time price.
+- Page-wide text includes categories, recommendations and reviews. Searching the
+  entire body for an ingredient can falsely attribute another product's formula
+  to the selected item. Use its actual Supplement Facts and other ingredients.
+- A retailer discontinuation notice concerns that retailer listing; it does not
+  establish that the manufacturer discontinued the product globally.
+
+Preserve label wording and serving basis. A salt amount, an ingredient amount
+"as" a salt and a free-form amount are not automatically interchangeable.

--- a/agent-workspace/domain-skills/nordic/product-labels.md
+++ b/agent-workspace/domain-skills/nordic/product-labels.md
@@ -1,0 +1,19 @@
+# Nordic Naturals — Supplement Facts drawer
+
+Observed on `nordic.com` public product pages in September 2026.
+
+- Product route: `/products/<slug>/`; the selected Shopify variant may be in
+  `?variant=<id>`. Preserve that variant when recording the source.
+- A visible **Supplement Facts** button opens a right-hand drawer. Locate its
+  button by accessible name, click, and verify the open drawer before reading.
+- The open dialog is exposed as `[role="dialog"][aria-label="Supplement Facts"]`;
+  `#supplement-facts-dialog` contains the label HTML.
+- `button[aria-label="Close supplement facts sidebar"]` closes the drawer.
+- The label includes serving size, servings per container, amounts, ingredient
+  qualifiers and other ingredients. Read the whole label, not only the product
+  description or search-result snippet.
+
+Indexed or fetch-extracted text can omit this drawer's table. An absent table in
+a search result is not evidence of an empty label. Similarly named mushroom
+blends can have different formulas; a multi-product search snippet can mix them.
+Verify the exact product and selected variant before attributing ingredients.

--- a/agent-workspace/domain-skills/thorne/product-labels.md
+++ b/agent-workspace/domain-skills/thorne/product-labels.md
@@ -1,0 +1,31 @@
+# Thorne — rendered ingredients and future lifecycle notices
+
+Observed on public `thorne.com/products/dp/<slug>` pages in September 2026.
+
+## Rendering and labels
+
+A web extraction may contain only a generic product shell while the rendered
+Nuxt page shows the actual product. After a fetch-only result lacks the title or
+label, inspect the browser and verify the product heading and displayed SKU.
+
+- `[aria-label="Ingredients Information"]` identifies the ingredient navigation
+  button; `#ingredients` is the corresponding section.
+- `#transcript-ingredient-infodescription` contains the ingredient table.
+- `#button-ingredient-info` exposes Show More / Show Less and `aria-expanded`.
+  Verify the expanded state and visible table rather than assuming the first
+  click or navigation immediately completed scrolling.
+- Serving size and servings per container can sit above the table; other
+  ingredients can be its final row. Capture these together.
+- `#warnings` is separate from the ingredient section.
+
+## Lifecycle is not one boolean
+
+The observed product displayed **To be discontinued**, alongside disabled
+**Out of Stock - Pre-Order** buttons. That is a future discontinuation notice and
+an unavailable purchase control, not proof of completed discontinuation. Read
+both the notice and the control's actual disabled state. Do not click checkout
+or preorder merely to verify availability.
+
+Keep the manufacturer's ingredient wording literal. Label matching does not
+validate clinical effectiveness, dosing equivalence, product quality or broad
+marketing safety claims.


### PR DESCRIPTION
## Summary
- Add field-tested public product-label workflows for iHerb, Nordic Naturals and Thorne.
- Record two iHerb facts layouts, retired-page recommendation-price pitfalls, Nordic’s Supplement Facts drawer, and Thorne’s rendered ingredient table and future lifecycle notice.
- Keep exact package identity, label wording and purchase/lifecycle context separate.

## Verification
- Selectors and visible states observed in a real browser on public product pages.
- Documentation-only changes; git diff --check passed.
- No cookies, credentials, user data, coordinates, or application code included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation-only capture workflows for exact product labels on iHerb, Nordic Naturals, and Thorne public pages. The docs record how to reach and verify the real label and how to avoid pricing and lifecycle traps that surfaced during field testing.

- iHerb: covers two Supplement Facts layouts (visible container vs. collapsed accordion) and warns against confusing a Similar Recommendation price with the selected item's price.
- Nordic: notes that Supplement Facts open in a right-hand drawer, so fetched or indexed text alone can miss the table.
- Thorne: distinguishes a future "To be discontinued" notice from a completed discontinuation, and treats the rendered Nuxt page as authoritative over fetch-only extraction.

<sup>Written for commit 86f804beba2f87881935fd7a9db531606b20c81c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

