### PR TITLE
docs: NIH ODS fact-sheet capture and source-date distinctions

### DIFF
--- a/agent-workspace/domain-skills/ods/fact-sheets.md
+++ b/agent-workspace/domain-skills/ods/fact-sheets.md
@@ -1,0 +1,27 @@
+# NIH ODS — public fact-sheet capture
+
+Observed on `ods.od.nih.gov` in September 2026.
+
+- Fact-sheet URLs use `/factsheets/<Nutrient>-HealthProfessional/` and
+  `/factsheets/<Nutrient>-Consumer/`. Confirm the audience in the visible title.
+- Try ordinary HTTP first. A plain request returned 403 while the same public
+  page rendered normally in Chrome. Do not archive a denial body as the fact
+  sheet; a normal browser visit may provide the public article without login.
+- The rendered `article` contains the sheet, references, disclaimer and displayed
+  update date. `#fact-sheet` contains the substantive sections. If capturing DOM,
+  label it rendered article HTML, not the original HTTP response.
+- Locate sections by visible heading text, then use that heading's observed ID.
+  Numeric IDs such as `h18` are specific to a sheet's organization, not universal
+  identifiers for the same topic on every nutrient page.
+- Some headings have duplicate generated IDs (`heading-0`, etc.). Prefer the
+  actual heading element within the article rather than a global ID match.
+- Inline references include tooltip citation text in the DOM. Naive `textContent`
+  or static HTML-to-text extraction can repeat full citations inside paragraphs.
+  Keep the original capture, and distinguish displayed prose from tooltip text
+  before doing content-length checks or extracting sentences.
+- Record the article's **Updated** date separately from retrieval time. A fresh
+  capture does not mean the scientific content was updated that day.
+
+The site's linked source records and original publications still need their own
+identity and scope checks; the fact-sheet capture is not review of every cited
+paper. No account access or form submission is needed for this workflow.


### PR DESCRIPTION
## Summary
Add a small agent-generated domain note from public NIH ODS browsing: normal browser fallback after a failed plain fetch, article/section identity, duplicate heading IDs, tooltip citation text, and displayed update date versus retrieval time.

## Verification
Observed on the rendered public website. Documentation only; git diff --check passed. No user data, clinical recommendations, credentials, or raw coordinates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a domain note for capturing NIH ODS fact sheets so future captures correctly distinguish public article content from HTTP responses and avoid common extraction pitfalls.

- Notes that a plain HTTP request can return 403 while a normal browser visit renders the public page.
- Says to label captured DOM as rendered article HTML, not the original HTTP response.
- Explains that heading IDs like `h18` are sheet-specific, and duplicate generated IDs mean visible heading elements should be targeted instead.
- Flags that tooltip citation text can appear in `textContent` output and must be separated from displayed prose.
- Distinguishes the article's displayed Updated date from retrieval time; a fresh capture does not imply fresh scientific content.

<sup>Written for commit 19f36026e0cc5cd214eec4d09d1c4428531bd7cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

