### PR TITLE
docs(skills): add bulk9 reseller panel skill, fill in uploads skill

### DIFF
--- a/agent-workspace/domain-skills/bulk9/reseller-website-settings.md
+++ b/agent-workspace/domain-skills/bulk9/reseller-website-settings.md
@@ -130,6 +130,42 @@ serves. Adding is `#add-domain-form` with a single `domain` input.
   scope to `#slide3` when reading or writing the sell price, or you will pick
   up the wrong one.
 
+## Save order matters — Landing clobbers Signup
+
+Saving the **Landing** pane resets the Signup pane's stored values:
+`free_credit_on_signup` reverts to unchecked and `free_credits` / `sms_price`
+fall back to `0`. The reverse is not true — saving Signup leaves Landing
+intact. So when you are configuring both in one pass:
+
+> **Save Landing first, Signup last.**
+
+Verify after a full reload, not from the in-page DOM: re-`goto_url` the
+settings page, click through the panes, and read the values back. This bites
+silently — the Signup pane looks correct right up until the next Landing save.
+
+## Where the reseller's own cost lives
+
+The panel's hidden `sms_price` is *not* the reseller's current buy rate — it is
+one tier off a volume rate card. The real card is on
+`/reseller/wallet` under **Plan Details**, as a volume → per-SMS → amount table
+(with GST added separately at purchase). Read that page before reasoning about
+margin; the dashboard's "₹X wallet / N SMS" pair gives the effective rate the
+account is actually on.
+
+## Per-user rates (how volume slabs are honoured)
+
+The Signup pane sets one default rate for every new signup. Per-client rates are
+assigned separately at
+`/reseller/users/add-debit-credit/<userId>` ("Add Plan" in the Manage Users
+row). That form's `per_message_cost` pre-fills from the Signup pane's
+`sms_price`, and `expiry_date` pre-fills from `default_validity`. So a public
+slab table is delivered manually per client from this page — the landing page
+does not price orders by itself.
+
+Other useful reseller routes (the sidebar names differ from the paths):
+`/reseller/wallet`, `/reseller/users`, `/reseller/transactional-history`,
+`/reseller/dev-api`, `/reseller/settings`.
+
 ## Verification
 
 `page_info()['title']` on both the panel and the public site is

--- a/agent-workspace/domain-skills/bulk9/reseller-website-settings.md
+++ b/agent-workspace/domain-skills/bulk9/reseller-website-settings.md
@@ -1,0 +1,139 @@
+# bulk9 — reseller white-label website settings
+
+bulk9.com is a white-label bulk-SMS platform. A reseller account gets a
+Laravel panel at `https://bulk9.com/reseller/...` that drives a customer-facing
+site served on the reseller's own subdomain. This maps the
+`/reseller/website-settings` page, which is where that whole public site is
+authored.
+
+## URL patterns
+
+- Panel: `https://bulk9.com/reseller/website-settings`
+- After any save the app redirects to `?tab=slideN`, reloading the whole
+  page. The tab is restored from that query param, so a save is a full
+  round-trip — re-read the DOM afterwards, don't reuse stale node handles.
+- The public site lives at the reseller's own subdomain (CNAME → `bulk9.com`).
+  Routes on it: `/` (landing), `/login`, `/signup`.
+
+## Page structure
+
+Five Bootstrap tab panes, switched by `a[href="#slideN"]`:
+
+| Pane | Tab | Contents |
+|---|---|---|
+| `#slide1` | General Setting | display name, logo, favicon, panel colours, payment + contact rich text |
+| `#slide2` | Domain Setting | subdomain add/verify, domain list |
+| `#slide3` | Signup Setting | signup on/off, free credits, per-SMS price, validity |
+| `#slide4` | Landing Setting | the entire public landing page |
+| `#slide5` | Contact Query | read-only inbox of landing-page contact-form submissions |
+
+Each pane has its own save button and posts independently:
+
+- `#save-general-setting` (an `<a>`, not a button)
+- `#add-domain-form` → its own submit
+- `#save-signup-setting`
+- `#save-landing-setting` (an `<a>`)
+
+## The big trap: fields are not inside `<form>`
+
+Only `add-domain-form` and `signup-settings-form` are real forms. The General
+and Landing panes keep their inputs **outside** any `<form>` and the save
+anchors collect values by name at click time. So:
+
+- Don't try `form.submit()` or enumerate fields via `document.forms` — you
+  will find the CKEditor toolbars' internal forms and almost nothing else.
+- Enumerate by pane instead: `document.querySelectorAll('#slide4 input, ...')`.
+- Filter out `el.closest('.ck')`, or CKEditor's own toolbar inputs
+  ("Media URL" etc.) pollute every listing.
+
+## Conditional fields
+
+Most content fields do not exist in the DOM until their toggle is checked.
+Check the toggle, wait ~1s, *then* read or write the revealed inputs.
+
+- `#slide3`: `free_credits`, `sms_price`, `default_validity` appear only after
+  `input[name="free_credit_on_signup"]` is checked.
+- `#slide4`: each section is gated by its own checkbox — `show_about`,
+  `show_social_media`, `show_contact`, `show_pricing`, `show_payment`,
+  `show_client_logos`.
+
+## Landing Setting field map (`#slide4`)
+
+Plain inputs: `header_title`, `theme_color` (native colour picker),
+`about_title`, `help_line_number`, `support_email`,
+`twitter` / `instagram` / `linkedin` / `facebook` / `skype`.
+
+File inputs: `header_banner`, `about_us_banner`.
+
+CKEditor-backed textareas: `header_subtitle`, `about_description`,
+`contact_description`, `contact_address`, `pricing_description`,
+`payment_description`.
+
+Repeaters (array fields, each row has a `.remove-detail` button):
+
+- `#add-more-pricing` → `sms_quantity[]`, `per_sms_rate[]`, `amount[]`
+- `#add-more-payment` → `bank[]`, `ifsc[]`, `account_no[]`, `name[]`
+- `#add-logo` → client logo image rows
+
+## CKEditor 5, not a plain textarea
+
+The textareas are `display:none` and replaced by CKEditor 5. Setting
+`textarea.value` alone is silently discarded on save. Reach the editor
+through the DOM node CK created:
+
+```python
+js("""
+(() => {
+  const t = document.querySelector('#slide4 textarea[name="pricing_description"]');
+  const ed = t.nextElementSibling.querySelector('.ck-editor__editable');
+  const inst = ed.ckeditorInstance;          // CK5 exposes the editor here
+  inst.setData("<h3>Hello</h3>");
+  t.value = inst.getData();                  // keep the textarea in sync
+})()
+""")
+```
+
+The editor element is always inside `textarea.nextElementSibling`
+(`div.ck.ck-reset.ck-editor`). The table plugin is enabled, so
+`<figure class="table"><table>…` survives round-tripping; `<h3>`, `<ul>`,
+`<strong>`, `<br>` and HTML entities all survive too.
+
+## Rendering quirks on the public site
+
+- An enabled section with empty content still renders its chrome. Enabling
+  `show_pricing` with no `#add-more-pricing` rows renders a bare
+  `SMS Quantity | Per SMS Rate | Amount` header bar with no body — looks
+  broken. Either fill the repeater or leave the toggle off.
+- Same for `about_us_banner`: the About section always emits an `<img>`, so
+  with no upload you get a 0×0 broken image and a blank half-width column.
+- The landing sections centre their text. A `<ul>` in `payment_description`
+  renders bullets flush-left against centred text and reads as broken —
+  prefer `<p>` there. In `about_description` (a left-aligned column) `<ul>`
+  is fine.
+- The `amount[]` column is displayed with a `₹` prefix added by the site;
+  don't type the symbol into the field.
+
+## Domain setting
+
+Subdomains only — the hint text is "We accept only subdomain. Please create
+CNAME on your sub domain to → bulk9.com". The domains table shows a
+`Verification Status` column; it must read `Approved` before the public site
+serves. Adding is `#add-domain-form` with a single `domain` input.
+
+## Known platform bugs
+
+- `select[name="default_validity"]` has duplicate option values: the options
+  are `1,2,3,3,3` for *1–5 Years*. Anything above 3 Years is unselectable —
+  picking "4 Years" or "5 Years" stores 3.
+- There is a page-level hidden `input[name="sms_price"]` (the reseller's own
+  buy rate) that collides by name with the Signup pane's `sms_price`. Always
+  scope to `#slide3` when reading or writing the sell price, or you will pick
+  up the wrong one.
+
+## Verification
+
+`page_info()['title']` on both the panel and the public site is
+`🟢 <Page> - <display_name>`, so it flips to the new display name right after
+a successful General Setting save — the cheapest confirmation that a save
+landed. Beyond that, reload the public subdomain and diff `document.body.innerText`;
+the page height jumps substantially once landing sections are populated.

--- a/interaction-skills/uploads.md
+++ b/interaction-skills/uploads.md
@@ -1,1 +1,60 @@
 # Uploads
+
+Attach a local file to an `<input type="file">` without touching the OS file
+picker. Never click the "Choose File" button — that opens a native dialog the
+browser process owns and CDP cannot drive.
+
+## The one move
+
+`DOM.setFileInputFiles` sets the input's `FileList` directly and fires the
+`change` event the page is listening for.
+
+```python
+import os
+
+path = os.path.abspath("banner.png")          # must be absolute
+doc  = cdp("DOM.getDocument", depth=-1)
+node = cdp("DOM.querySelector",
+           nodeId=doc["root"]["nodeId"],
+           selector='input[name="about_us_banner"]')
+cdp("DOM.setFileInputFiles", files=[path], nodeId=node["nodeId"])
+```
+
+Then verify from the page's own point of view:
+
+```python
+js("""
+(() => {
+  const e = document.querySelector('input[name="about_us_banner"]');
+  return e.files.length + " " + (e.files[0] ? e.files[0].name : "-");
+})()
+""")
+```
+
+`files.length == 1` means the page really sees the file. A screenshot does
+not prove this — many sites style the native input away and show their own
+label, which does not update.
+
+## Details that bite
+
+- **Absolute paths only.** A relative path is resolved against the browser
+  process's cwd, not yours, and usually fails silently with `files.length == 0`.
+- **Multi-file inputs** take several entries: `files=[a, b, c]`. For a
+  single-file input, passing more than one is an error.
+- **The node must exist when you query it.** Inputs revealed by a toggle or
+  inside a lazily-rendered tab are not in the DOM yet — reveal them, wait,
+  then `DOM.querySelector`.
+- **Node ids go stale on navigation.** Any save that reloads the page
+  invalidates the `nodeId`. Re-run `DOM.getDocument` after every reload;
+  reusing an old id raises "No node with given id found".
+- **Hidden inputs still work.** `setFileInputFiles` does not require the
+  input to be visible, so the common "invisible input + styled label" pattern
+  needs no special handling — target the real input, ignore the label.
+- **Drag-and-drop dropzones** that never render an `<input type="file">` are
+  the exception; those need a synthetic `DataTransfer` in page JS instead.
+
+## Generating a file to upload
+
+Nothing stops you from creating the asset first — Pillow for images, a
+heredoc for text/CSV — then pointing `setFileInputFiles` at it. Write it to
+the scratchpad, not the repo.


### PR DESCRIPTION
## bulk9 domain skill

`bulk9.com` is a white-label bulk-SMS platform. A reseller account gets a Laravel panel at `/reseller/website-settings` that authors an entire customer-facing site served on the reseller's own subdomain. Two things there cost real steps to work out:

- **The General and Landing panes keep their inputs outside any `<form>`.** The obvious `document.forms` enumeration finds only CKEditor's internal toolbar forms and almost nothing else. You have to enumerate by tab pane and filter out `.ck` descendants.
- **The textareas are CKEditor 5 instances.** Setting `textarea.value` is silently discarded on save. The editor is reachable as `textarea.nextElementSibling.querySelector('.ck-editor__editable').ckeditorInstance`.

Also documents the section-toggle reveal pattern (most fields don't exist in the DOM until their checkbox is ticked), the array-field repeaters, and the sections that render visibly broken chrome when enabled but left empty.

Two platform bugs worth knowing before you trust a value round-tripped:

- `select[name="default_validity"]` has duplicate option values (`1,2,3,3,3` for *1–5 Years*), so anything above 3 Years silently stores 3.
- A page-level hidden `input[name="sms_price"]` collides by name with the signup pane's `sms_price`. Unscoped selectors read the wrong one.

## uploads interaction skill

`interaction-skills/uploads.md` was an empty stub. Filled it with the `DOM.setFileInputFiles` approach — clicking a file input opens a native dialog CDP cannot drive — plus the failure modes that make it look like a silent no-op: relative paths, stale node ids after a save-and-reload, and inputs not yet revealed by a toggle. Includes the `files.length` check, since a screenshot won't tell you whether the page actually saw the file.

No credentials, account state, or user-specific data in either file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a domain skill for bulk9's reseller website-settings panel and fills in the previously empty uploads interaction skill, so agents stop rediscovering the same pitfalls.

**New Features**
- The bulk9 skill maps all five tab panes and documents that General and Landing fields live outside any `<form>`, so discovery must be pane-scoped and filtered against CKEditor internals.
- Covers the CKEditor 5 reach-around, toggle-gated fields, array repeaters, and sections that render broken chrome when enabled but empty.
- Records two platform bugs: duplicate `default_validity` option values make >3 Years unselectable, and a hidden page-level `sms_price` collides with the signup pane's field.
- Saving the Landing pane silently resets the Signup pane's values, so save Landing first, Signup last, and verify after a full reload.
- The hidden `sms_price` is not the buy rate; the real volume rate card is on `/reseller/wallet`, and per-client rates are set at `/reseller/users/add-debit-credit/<userId>`.
- The uploads skill uses `DOM.setFileInputFiles` and documents failure modes that look like no-ops: relative paths, stale node ids after reloads, and unrevealed inputs.
- Verifying via `files.length == 1` beats screenshots, since styled inputs hide whether the page actually saw the file.

<sup>Written for commit 4a7a65208508035c920193084d79de3a19c05fe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

