### PR TITLE
x: reply-thread retrieval (login wall, fxtwitter, API v2 conversation_id)

### DIFF
--- a/domain-skills/breakoutprop/checkout-api.md
+++ b/domain-skills/breakoutprop/checkout-api.md
@@ -1,0 +1,31 @@
+# breakoutprop.com — checkout & promo API
+
+## URL patterns
+- Pricing: `https://www.breakoutprop.com/pricing` (tier toggle $5K–$200K; "Start Evaluation" anchors open `portal.breakoutprop.com/checkout?productId=<uuid>` in a NEW tab — the pricing tab does not navigate).
+- Checkout accepts `?promo=CODE` (or `code=`) as a URL param; the SPA reads it into the cart store (`pendingPromo`).
+- The portal checkout SPA can sit on a spinner indefinitely for a fresh logged-out session — use the API directly instead.
+
+## Private API (public, no auth needed)
+Base: `https://btg-prod-api.breakoutprop.com`
+
+- `GET /users/products` — full product catalog with UUIDs, sizes, costs, targets. Works logged out.
+- `GET /checkout/status`, `GET /checkout/headroom` — availability + funded-cap headroom.
+- `POST /checkout/validate` — the price-quote endpoint. Body:
+  ```json
+  {"items":[{"sku_id":"<productId uuid>","attributes":[],"quantity":1}],
+   "email":"required@example.com","platform":"BREAKOUT","profit_split":false,
+   "promo_code":"CODE"}
+  ```
+  Response: `validated_total`, `validated_subtotal`, `validated_discount_amount`,
+  `discount_percent`, `code_type` ("affiliate"), `discount_applied`, `promo_error`,
+  `discount_scope` ("all" | "none" | "needs_login"), `is_new_user`.
+  `email` is a required field (400 without it).
+- Other endpoints: `/checkout/session` (card), `/checkout/paypal-session`, `/checkout/confirmo-session` (crypto), `/checkout/finalize`, `/checkout/first-purchase-check`, `/checkout/prefill-email`, `/users/referral`.
+
+## Traps
+- **CORS**: `POST /checkout/validate` from a page-context `fetch` on the portal origin fails ("Failed to fetch" on preflight). Workaround: open a tab directly on `https://btg-prod-api.breakoutprop.com/checkout/status`, then `fetch('/checkout/validate', ...)` same-origin — no CORS at all.
+- **Cloudflare**: curl from a server IP gets the "Just a moment..." challenge on both portal assets and the API. Go through the browser.
+- Simple GETs to the API from any page context work fine (no preflight).
+
+## Promo code facts (verified 2026-08-31)
+- Every valid code is `code_type: "affiliate"` at exactly **2%** (DRAFT, INVEST, ASFX, WF8QS6, DQS380, KRAKEN all identical). Coupon-site claims of 20–50% are false; G2KB5D and BREAKOUT return "Invalid or expired code". There is no deeper public discount tier.

--- a/domain-skills/x/reading.md
+++ b/domain-skills/x/reading.md
@@ -27,3 +27,28 @@ Works for regular tweets. For article tweets it again returns only `article.prev
 
 - Tweet pages are the new `x-web` Rolldown/Relay app; bundles at `abs.twimg.com/x-web/x-web/assets/*.js`. Persisted GraphQL query ids live in per-route modules (`params:{id:\`...\`,name:\`OperationName\`}`); the endpoint template is in `environment-*.js` (`https://api.x.com/graphql/<id>/<name>`, GET with `?variables=` for queries).
 - `x.com/<user>` profile HTML fetches fine logged-out with a desktop UA and lists all bundle URLs — useful for scraping current query ids.
+
+## Reply threads (full conversation): logged-out page is walled — use the official API
+
+- Logged-out `x.com/<user>/status/<id>` renders the root plus ONE reply, then a fixed
+  "See all the replies / Continue to X" overlay. Scrolling loads nothing more. Don't fight it
+  with coordinate clicks; the wall is a login redirect.
+- `https://api.fxtwitter.com/<user>/status/<id>` gives the root tweet as clean JSON (text,
+  author, counts, media, quoted tweet) with no auth — but no replies.
+- For the replies, the reliable path is X API v2 recent search with a `conversation_id:` query.
+  Needs an app with user-context OAuth1 (or a bearer) on a paid/pay-per-use plan:
+
+  ```python
+  # GET https://api.x.com/2/tweets/search/recent
+  params = {"query": f"conversation_id:{ROOT_ID}", "max_results": 100,
+            "tweet.fields": "author_id,created_at,referenced_tweets,note_tweet,public_metrics",
+            "expansions": "author_id", "user.fields": "username"}
+  # page with meta.next_token until absent; ~1s between pages is enough
+  ```
+
+  - Recent search only covers the last 7 days. Older threads need the full-archive endpoint.
+  - Rebuild the tree from `referenced_tweets[type=replied_to].id`. Replies to a tweet that is
+    not in the result set (deleted, or older than the window) come back as orphans — keep them.
+  - Long posts arrive truncated in `text`; the full body is in `note_tweet.text`.
+  - Volume reference: a 54-visible-reply post returned 262 tweets across 3 pages once nested
+    replies were included.

--- a/domain-skills/x/reading.md
+++ b/domain-skills/x/reading.md
@@ -1,0 +1,29 @@
+# x.com — reading tweets & articles without login
+
+## Tweets: syndication API (no auth, fastest)
+
+`https://cdn.syndication.twimg.com/tweet-result?id=<TWEET_ID>&lang=en&token=<TOKEN>`
+
+Token formula (mirror of the JS embed code): `((id / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, '')`. In Python, emulate Number.toString(36) on the float (integer part base36 + ~12 fractional base36 digits), then strip `0` and `.`.
+
+Returns JSON: `text`, `user`, `created_at`, `favorite_count`, `entities`, `conversation_count`, and for article tweets an `article` object with `title`, `preview_text`, `rest_id` — but **never the full article body**.
+
+## Tweets: GraphQL guest token (no auth)
+
+1. `POST https://api.x.com/1.1/guest/activate.json` with the public web bearer
+   `Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA` → `guest_token`.
+2. `GET https://api.x.com/graphql/2ICDjqPd81tulZcYrtpTuQ/TweetResultByRestId?variables=...&features=...` with headers `Authorization: <bearer>`, `x-guest-token: <token>`. Needs the long `features` flag dict (copy a current one; missing flags return explicit errors naming the missing flag, so it's self-correcting).
+
+Works for regular tweets. For article tweets it again returns only `article.preview_text`.
+
+## X Articles (x.com/i/article/<id>): login-walled — use mirrors
+
+- Logged-out browser navigation to `/i/article/...` redirects to `x.com/i/jf/onboarding/web?...&mode=login`.
+- The article GraphQL op is `ArticleByTweetId` (persisted query id found in `abs.twimg.com/x-web/x-web/assets/article-by-tweet-id-*.js`; variables `{restId: "<tweet_id>"}`, endpoint `https://api.x.com/graphql/<id>/ArticleByTweetId`). It returns `plain_text` + DraftJS `content_state.blocks` — but **404s for guest tokens**, both raw and from page context. Auth cookies (`auth_token` + `ct0`) required. Don't burn time here.
+- **Fastest workaround: youmind.com mirrors viral X articles in full.** Web-search the article title + author handle; look for `youmind.com/landing/x-viral-articles/<slug>`. Plain `http_get` returns the entire article text in the HTML (no JS needed). Medium/plainenglish.io reposts also show up for viral posts.
+- Wayback Machine generally has **no** snapshots of `x.com/i/article/...` URLs.
+
+## Structure notes
+
+- Tweet pages are the new `x-web` Rolldown/Relay app; bundles at `abs.twimg.com/x-web/x-web/assets/*.js`. Persisted GraphQL query ids live in per-route modules (`params:{id:\`...\`,name:\`OperationName\`}`); the endpoint template is in `environment-*.js` (`https://api.x.com/graphql/<id>/<name>`, GET with `?variables=` for queries).
+- `x.com/<user>` profile HTML fetches fine logged-out with a desktop UA and lists all bundle URLs — useful for scraping current query ids.


### PR DESCRIPTION
Adds a section to domain-skills/x/reading.md on pulling a full reply thread.

- Logged-out status pages show root + one reply, then a hard "Continue to X" overlay; scrolling loads nothing.
- api.fxtwitter.com returns the root tweet as JSON with no auth (no replies).
- Replies: X API v2 recent search with `conversation_id:` — pagination, 7-day window, tree rebuild from `referenced_tweets`, orphan handling, `note_tweet` for long posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhXD2JFuZ6ZgZTvWveL89K

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds domain-skill reference docs for reading X (Twitter) tweets, articles, and full reply threads, and for the breakoutprop checkout and promo API.

**X (Twitter)**
- Documents the syndication API and GraphQL guest-token approach for fetching tweets without auth.
- Logged-out reply threads render only the root plus one reply; fxtwitter also returns just the root, so use X API v2 recent search with `conversation_id:` and rebuild the tree from `referenced_tweets`.
- Article bodies require the API v2 `tweet.fields=article` field or youmind.com mirrors as a logged-out fallback.

**breakoutprop checkout API**
- Documents the public checkout endpoints, including `POST /checkout/validate` with promo code handling.
- Notes the CORS workaround for the portal origin and the Cloudflare challenge when hitting the API from servers.

<sup>Written for commit 0f82f2653508c66a314a9f34f1ae3717a6806e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

