### PR TITLE
domain-skills/chatgpt: backend-API export of conversations & projects

### DIFF
--- a/domain-skills/chatgpt/export-conversations.md
+++ b/domain-skills/chatgpt/export-conversations.md
@@ -1,0 +1,50 @@
+# chatgpt.com — exporting conversations & projects via backend API
+
+Scraping chat DOM is the wrong tool here. The page's own backend API returns full
+conversation JSON, and the auth token is one fetch away.
+
+## Auth
+
+```js
+const s = await fetch('/api/auth/session', {credentials:'include'}).then(r=>r.json());
+const tok = s.accessToken;   // Bearer token for all /backend-api/* calls
+```
+
+`s.user` is null when logged out — poll this to detect login instead of reloading.
+Note: from a logged-out tab this endpoint can return anon even right after the user
+logs in elsewhere; reload the tab once before concluding they aren't logged in.
+
+## Projects ("g-p-" gizmos)
+
+Sidebar project chats link to `/g/g-p-<32hex>/c/<conv-uuid>` — sidebar items are NOT
+`<a>` tags until a project is expanded (click the project name first, then query
+`a[href*="/c/"]`).
+
+- Project metadata (name, custom instructions, author): `GET /backend-api/gizmos/g-p-<id>`
+- All conversations in a project (paginated by `cursor`):
+  `GET /backend-api/gizmos/g-p-<id>/conversations` → `{items: [{id, title, update_time}], cursor}`
+
+## Full conversation content
+
+`GET /backend-api/conversation/<uuid>` → `{title, create_time, mapping, current_node}`.
+
+- `mapping` is a node tree; the *active* thread = walk `current_node` → `parent` → … → root, then reverse.
+- Message content types worth handling:
+  - `text` — `content.parts[]` strings
+  - `multimodal_text` — parts mix strings and dicts; dict `content_type`s include
+    `audio_transcription` (**voice chats — the text is in `.text`**; skip
+    `audio_asset_pointer` / `real_time_user_audio_video_asset_pointer`) and image
+    asset pointers (`width`/`height` present)
+  - `thoughts`, `reasoning_recap` — model reasoning, usually skip
+- Filter `author.role` to `user`/`assistant` and drop messages with
+  `metadata.is_visually_hidden_from_conversation`.
+- Merge consecutive same-role turns — assistant answers often span several nodes.
+
+## Traps
+
+- Assistant text is littered with citation placeholders: `citeturnNsearchM` tokens
+  wrapped in Unicode private-use chars (U+E200 range). Strip
+  `/[-](?:cite|navlist|video)?[^-]*?[-]/g`.
+- The `js()` helper evaluates an *expression* — wrap multi-statement fetch code in
+  `(async () => { ... })()` or you silently get `None`.
+- Rate: ~1 req/sec on /backend-api/conversation was fine for 11 conversations (~6MB).


### PR DESCRIPTION
Adds a domain skill for exporting ChatGPT conversations and project ("g-p-" gizmo) chats via the page's own backend API instead of DOM scraping.

Learned while exporting an 11-conversation ChatGPT project (~6MB):

- Session-token auth via `/api/auth/session` (+ login-detection gotcha from a logged-out tab)
- Project metadata and paginated conversation listing via `/backend-api/gizmos/g-p-<id>/*`
- Full-content fetch via `/backend-api/conversation/<uuid>` and the `current_node` → parent walk for the active thread
- `multimodal_text` part handling — notably `audio_transcription` for voice chats, which otherwise export as empty
- Trap: citation placeholders (`citeturn…` wrapped in U+E200-range private-use chars) littering assistant text, with a strip regex
- Trap: the harness `js()` helper is expression-only — multi-statement fetch code needs an async IIFE or silently returns `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkTsc6n3S1imfzPWJsvzG8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a ChatGPT domain skill that exports conversations and project ("g-p-") chats via the page's backend API instead of DOM scraping.

**Details**
- Auth via `/api/auth/session` Bearer token; poll `s.user` for login and reload the tab once if logged out.
- Project metadata and paginated conversation listing live under `/backend-api/gizmos/g-p-<id>/*`.
- Full content comes from `/backend-api/conversation/<uuid>`; walk `current_node` → parent for the active thread.
- Handle `multimodal_text` parts — voice-chat text sits in `audio_transcription`, not the asset pointer.
- Strip citation placeholders (`citeturn…` in U+E200 private-use chars) from assistant text.
- `js()` is expression-only — wrap multi-statement fetch code in an async IIFE.

<sup>Written for commit 4b7e5bd418274f37ead042f27914b41eba42f25a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

