### PR TITLE
domain-skills: county portal platforms (RealAuction, ePropertyPlus, CivicSource, CivilView Orleans, JPSO, Tolemi)

### DIFF
--- a/domain-skills/aglba/augusta-land-bank.md
+++ b/domain-skills/aglba/augusta-land-bank.md
@@ -1,0 +1,12 @@
+# Augusta Land Bank Authority (`aglba.org`) — available inventory
+
+WordPress + MyListing theme. Every parcel is a `job_listing` post titled by its PIN.
+
+- Enumerate: `GET https://aglba.org/feed/?post_type=job_listing&orderby=title&order=asc&paged=N` (RSS, 10 per page, 404 past the last page). `orderby=title` is load-bearing: the explore page, the plain feed and the AJAX "Available" filter all page on a tied post date and return different rows on each request (two crawls agreed on fewer than half the pages). Title sort is stable and complete (543/543).
+- Reservation status: `GET /?mylisting-ajax=1&action=get_listings&security=<CASE27.ajax_nonce from the explore page>&listing_type=land-bank-properties&form_data[reservation_status]=Under+Review` → `found_posts`. Available = all − Under Review.
+- Per-parcel page: `https://aglba.org/listing/<PIN>/` — "Property Details" table with street number/name when the county layer has no match.
+- Situs, value and geometry come from the county parcel layer: `POST https://gismap.augustaga.gov/arcgis/rest/services/Map_LayersTS/MapServer/316/query` with `where=pin IN (...)` (100 per call, no auth).
+- No asking price is published; offers go through an application.
+- Trap: the host rate-limits bursts. A 55-page crawl followed by per-PIN detail fetches drew HTTP 429 on the very next request; keep it to about 2 requests/second.
+
+Tax levy sales (Tax Commissioner): `POST http://appweb2.augustaga.gov/TaxLevySales/Service/TaxLevyService.svc/GetSales` with body `{}` → double-encoded JSON `{"TLS":[{SaleDate, ParcelID, Owner, Address, AmountDue}]}`; lists only the next first-Tuesday sale. Record page `https://gismap.augustaga.gov/AugustaTS/?pin=<PIN>`.

--- a/domain-skills/arcgis-county-portals/land-bank-and-tax-lists.md
+++ b/domain-skills/arcgis-county-portals/land-bank-and-tax-lists.md
@@ -1,0 +1,16 @@
+# County ArcGIS layers behind "property map" pages (land banks, tax lists, city-owned inventories)
+
+Many county "interactive map" pages are thin web maps over a public ArcGIS FeatureServer. Find the layer (page JS, web-map JSON, or the Hub item), then query it directly — no browser, no auth:
+
+```
+GET <FeatureServer>/<layer>/query?where=1%3D1&outFields=*&returnGeometry=false&f=json&resultOffset=0&resultRecordCount=2000
+```
+
+Seen 2026-09-09:
+- **Baltimore DHCD city-owned for sale**: `https://baltegis.baltimorecity.gov/mapping/rest/services/Housing/DHCD_Open_Baltimore_Datasets/FeatureServer/7` (join `BLOCKLOT` to the Real Property layer for zip/owner/value; ~170 rows still privately titled). Per-record `…/7/query?where=ID_AcqFirefly=<id>&f=html` renders.
+- **Macon-Bibb judicial in rem tax list**: `https://services2.arcgis.com/zPFLSOZ5HzUzzTQb/arcgis/rest/services/JIR<Month><Year>/FeatureServer/0` — the layer name rotates monthly; resolve it through the web app → web map each run. Record link is qPublic (Cloudflare challenge to non-browsers).
+- **Peoria city land bank**: `…/City_of_Peoria__IL_Available_Parcels_WFL1/FeatureServer/61`; its city/zip fields are the owner's mailing address, so resolve situs by PIN from the county Cadastral layer (`gis.peoriacounty.gov …/DP/Cadastral/FeatureServer/1`, 10-digit PIN).
+- **Augusta parcels**: `https://gismap.augustaga.gov/arcgis/rest/services/Map_LayersTS/MapServer/316/query` with `pin IN (...)` (100 per call) — situs, assessor value, vacant flag, beds/baths; `delinq_yrs` is queryable.
+- **Saginaw land bank**: ePropertyPlus tenant `sclb` (no prices, all "Residential Vacant").
+
+Traps: paging caps (`maxRecordCount`, usually 1000–2000); polygon layers repeat multi-part parcels (dedupe on the parcel id); snapshot layers with a month in the name go stale.

--- a/domain-skills/civicsource/adjudicated-auctions.md
+++ b/domain-skills/civicsource/adjudicated-auctions.md
@@ -1,0 +1,23 @@
+# CivicSource — Louisiana adjudicated / tax property auctions (`www.civicsource.com`)
+
+Runs the online sales of parish- and city-owned (adjudicated) property for Louisiana tax authorities (City of New Orleans `CNO`, East Baton Rouge, Caddo, …). The listing site is a Gatsby app; the search is a plain JSON GET with no auth.
+
+## Data call
+
+```
+GET https://www.civicsource.com/api/search?state=22&politicalSubDivision=<parish FIPS>&saleType=Adjudication&page=N
+header: Accept: application/json
+-> {"auctions":[...], "page":1, "pageSize":10, "totalCount":45}
+```
+
+Parish FIPS: Orleans `22071`, East Baton Rouge `22033`, Caddo `22017`. Jefferson `22051` returns 404 — the parish does not sell through CivicSource. `api/search/filters?...` returns the facet counts.
+
+Auction fields: `lotNumber` (`CNO162392`), `taxAuthority.name`, `address{address1, city, state.value, postalCode}`, `location{latitude, longitude}`, `price` (opening bid / offer price), `depositPrice`, `startDate`/`endDate` (`9999-12-31` = not yet scheduled), `status` (`Public` = open, `Researching`, `ResearchComplete`), `link` (`/CNO162392`), `accountNumber`, `alternateAccountNumber`.
+
+Listing page: `https://www.civicsource.com/auctions/<lotNumber>/`.
+
+## Traps
+
+- `auction.civicsource.com/auctions/...` (what the bidding UI calls) needs a bearer token — 401 anonymously. Use `www.civicsource.com/api/search` instead.
+- The server sends its leaf certificate without the intermediate: Python/OpenSSL fails `CERTIFICATE_VERIFY_FAILED` while browsers succeed (AIA fetch). Retry with verification off only after the strict attempt fails.
+- The page's `fetch` is replaced by a polyfill loaded from cdn.polyfill.io, so a `window.fetch` hook installed before load never sees the calls — use CDP `Network.enable` to observe them.

--- a/domain-skills/civilview/orleans-parish.md
+++ b/domain-skills/civilview/orleans-parish.md
@@ -1,0 +1,14 @@
+# Tyler CivilView SalesWeb — Orleans Parish sheriff sales (`salesweb.civilview.com`)
+
+Same host and URL scheme as the Ohio counties (`Sales/SalesSearch?countyId=N`, `Sales/SaleDetails?PropertyId=N`), but a different table layout. Orleans Parish Sheriff (New Orleans) is `countyId=28`; real-estate auctions every Thursday at noon.
+
+## Table layout (countyId=28)
+
+`Sort Order | Case # | Sales Date | Property Status | Case Title | Address/Description | Picture | Plaintiff | Judgment | Terms | Details`
+
+- The `Details` link (the row's `SaleDetails?PropertyId=`) is the **last** cell; on Ohio counties it is the first. Locate the link cell by content, not position.
+- `Case Title` is `PLAINTIFF vs DEFENDANT`; there is no separate Defendant column.
+- `Address/Description` is one comma-less string: `5405 WEST END BD NEW ORLEANS LA 70124`. Corner lots read `7831 HICKORY ST AND 1801 FERN ST NEW ORL…` — take the first address.
+- Suffixes are abbreviated their own way: `BD` = Blvd, `AV` = Ave, `PKY` = Pkwy.
+- `Property Status` is `Scheduled`; cancelled/sold rows carry other statuses.
+- Plaintiffs are mostly `CITY OF NEW ORLEANS` (code-enforcement lien foreclosures) and lenders — no treasurer tax cases.

--- a/domain-skills/countysuite/pa-sheriff-sale-listings.md
+++ b/domain-skills/countysuite/pa-sheriff-sale-listings.md
@@ -1,0 +1,19 @@
+# Teleosoft CountySuite — Pennsylvania sheriff "Sale Listings"
+
+Luzerne (`sheriffsale.luzernecounty.org/Sheriff.Salelisting/`), Dauphin (`sheriffportal.dauphinc.org/SaleListing/`) and other PA counties publish sheriff real-estate sales on this product. Server-rendered, no auth.
+
+## URL patterns
+
+- Landing: `<base>/` — carries `<select name="SaleCategory">` (8 = Real Estate Sale) and `<select name="SaleId">` listing every sale date (`Thursday, October 15, 2026`) with its id; the page pre-selects the next upcoming date.
+- Table for a date: `GET <base>/PropertySales/SaleListingDetails?activeOnly=false&crierSort=false&id=<SaleId>&searchAllSales=false&searchText=` — returns the `<tbody>` HTML the page injects. This is the only way to get another date; `?SaleId=` on the landing URL is ignored and always shows the default date.
+- Sale dates as JSON: `POST <base>/PropertySales/SalesForCategory` with `id=8` → `[{SaleId, SaleDate:"/Date(ms)/", SaleDisplayName}]`.
+- Poster (legal notice PDF, the stable per-property record link): `<base>/PropertySales/Poster/<n>` — the row's anchor.
+
+## Table
+
+`Case No. | Case Participants | Attorney | Property Address | Judgment | Status`
+
+- `Case Participants` is `PLAINTIFF vs. DEFENDANT`, truncated in the list.
+- `Property Address` cell is `street<br>CITY, PA 18702`; strip tags naively and the street runs into the city. Split on the `<br>`.
+- `Status`: `Active (P)`, `Postponed( 10/5/2026 )`, `Cancelled( 8/4/2026 )`. Postponed rows carry the new date in the parentheses; cancelled rows stay listed for months.
+- The same case appears under successive dates when postponed — dedupe on case number.

--- a/domain-skills/court-dockets/no-go-notes.md
+++ b/domain-skills/court-dockets/no-go-notes.md
@@ -1,0 +1,4 @@
+# Court-docket portals that are NOT scrapable (verified 2026-09-09)
+
+- **MiCOURT** (`micourt.courts.michigan.gov/api/casesearch/v1/`): every search/detail requires an hCaptcha token (proof-of-work + visible puzzle for automation) AND a surname or case number — there is no new-filings listing. The data model has no address fields at all. ToS prohibits bulk/automated access. Wayne, Kent, Saginaw and Berrien courts are not on it (Wayne probate: wcpc.us; Kent: kentcountymi.gov).
+- **OSCN** (`oscn.net/dockets`): Cloudflare Turnstile after every 9 requests, keyed per IP and sticky without a cookie; ~15 solves in 10 minutes → HTTP 403 "Temporary restriction" until midnight, applied to the /24. Foreclosure petitions mostly carry the property address only inside scanned PDFs (`GetDocument.aspx?ct=<county>&bc=<barcode>&cn=<case>&fmt=pdf`, no text layer); probate dockets carry no decedent address. `db=` is the lower-cased county name.

--- a/domain-skills/duval-clerk/core-and-acclaim.md
+++ b/domain-skills/duval-clerk/core-and-acclaim.md
@@ -1,0 +1,17 @@
+# Duval County Clerk (Jacksonville, FL) — CORE court cases and Acclaim official records
+
+## CORE (`core.duvalclerk.com`) — court case search, JSON web service, no captcha enforced
+- `POST /internal/CoreWebSvc.asmx/PublicLogin` body `{}` → public token.
+- `CaseSearchBegin {token, returnTabId, inputs:{__type:"DuvalClerk.Web.Core.UserSearchInput", CaseYear:"2026", CaseType:"CA", CaseTypeList:"491,492,493,627,628,629,494,495,496,304,305,306,307"}, captcha:"captchaPH"}` → 25 cases per page, newest first. `CaseSearchUpdate {operation:"NextPage", requestState:<hidden field>}` pages. There is no filed-date filter: walk newest-first until File Date passes the cutoff.
+- `GetCaseById {caseID, simCtrl:0}` (the int 0 is required; null → 500) → parties with `STREET<br/>CITY, FL32277` addresses and docket lines. Foreclosure (CA) defendants carry street addresses; probate (`CaseType:"CP", CaseTypeList:"440"` formal administration) has party names but addresses and roles are blanked for public users.
+- `CaptchaChallenge` came back null across ~120 calls; treat a non-null value as a stop signal.
+- Record link: `https://core.duvalclerk.com/CoreCms.aspx?mode=PublicAccess...` (from the case page).
+
+## Acclaim official records (`or.duvalclerk.com`, Harris) — lis pendens index
+- `POST /search/Disclaimer` `Disclaimer=true` (cookie) → `POST /search/SearchTypeDocType?Length=6` with hidden `DocTypes=104` (numeric id; the display name alone errors) + `RecordDateFrom/To` → `POST /Search/GridResults sort=&page=N&pageSize=50` → JSON `{Data:[…], Total}`.
+- Detail `GET /Details/documentdetails/<TransactionItemId>/1/1/50` opens cold and carries grantor/grantee, case number and the legal description — no street address on the index.
+
+## Other Florida counties (probed 2026-09-09)
+- Hillsborough: official records `ORIPublicAccess` (OnBase JSON, no captcha, legal descriptions only); court search HOVER has reCAPTCHA v3 on every date search.
+- Volusia: `app02.clerk.org/or_m` WebForms, no captcha, 500-row cap (slice weekly), legal descriptions only.
+- Marion / Polk: Pioneer BrowserView with `useRecaptchaV3=1` on `api/search`. Lee: LandmarkWeb (host-blocked from some IPs). Escambia: LandmarkWeb behind Cloudflare, Benchmark court search with captcha. Leon: Akamai 403.

--- a/domain-skills/epropertyplus/land-bank-inventory.md
+++ b/domain-skills/epropertyplus/land-bank-inventory.md
@@ -1,0 +1,32 @@
+# ePropertyPlus — land-bank public portals (`public-<tenant>.epropertyplus.com`)
+
+Tyler's ePropertyPlus hosts the public inventory for many land banks: Columbus/COCIC (`cbus`), Shelby County / Memphis (`sctn`), Kalamazoo County (`kzoo`), Atlanta, Lansing. The search page is a jQuery DataTables app; its data call is an unauthenticated GET.
+
+## Data call
+
+```
+GET /landmgmtpub/remote/public/property/getPublishedProperties
+    ?limit=100&iDisplayStart=0&iDisplayLength=100&mDataProp_0=parcelNumber&page=1
+    &json={"criterias":[]}&customFields=[]&sort=[{"property":"propertyAddress1","direction":"ASC"}]&favoriteProperties=
+header: X-Requested-With: XMLHttpRequest
+-> {"success":true,"size":<total>,"rows":[...]}
+```
+
+Row fields: `propertyAddress1, city, state, postalCode, parcelNumber, askingPrice, currentStatus, propertyClass, latitude, longitude, thumbImgUrl, legalDescription, yearBuilt, bedrooms, squareFootage, id`. Page with `iDisplayStart`; `size` is the total. POSTing to the same URL returns HTTP 500 — it is a GET.
+
+## Per-tenant status vocab
+
+- `cbus`: no `currentStatus` at all; everything published is for sale (43 rows, 2026-09).
+- `kzoo`: `Acquired` (priced inventory), `Reserved`, `Disposed` (218 rows).
+- `sctn`: `FOR SALE`, `SALE COMPLETE`, `Rescinded`, `2511 Hold`, `IN REDEMPTION`, `Redeemed` … (12,878 rows — filter to `FOR SALE`). Many Memphis parcels have house number `0` / `0000`.
+
+## Other endpoints
+
+- `remote/public/property/getPublishedProperty` (POST `propertyId=<id>`) — one property with photos.
+- `remote/public/property/viewSummary?parcelNumber=<parcel>` — human-readable summary page, good as a listing URL.
+- `remote/public/referenceData/getKeyValues?classification=Property Status` — the tenant's status vocabulary.
+- Relative photo paths `/landmgmt/remote/image/...` map to `/landmgmtpub/remote/public/property/...`.
+
+## Finding tenants
+
+Hostnames are `public-<code>.epropertyplus.com`; unknown codes fail DNS. Known: `cbus`, `sctn`, `kzoo`; `dlba` and `indy` resolve but TLS-fail (retired).

--- a/domain-skills/franklin-oh-courts/foreclosure-and-probate.md
+++ b/domain-skills/franklin-oh-courts/foreclosure-and-probate.md
@@ -1,0 +1,16 @@
+# Franklin County, Ohio (Columbus) — clerk foreclosure docket + probate estate index
+
+## Clerk of Courts "Case Information Online" (`fcdcfcjs.co.franklin.oh.us/CaseInformationOnline/`)
+- Disclaimer is a cookie: `POST acceptDisclaimer?-xxx` with `fromPage=index&Accept=ACCEPT` → `CaseInformationOnlineSessionID` (24 h).
+- There is no case-type search. Enumerate foreclosures with a name search on the county treasurer, who is a party to essentially every foreclosure: `POST nameSearch` with `lname=TREASURER selType=Civil txtCalendar1=MM/DD/YYYY txtCalendar2=MM/DD/YYYY recs=350`. Rows include a `CASE TYPE` column (`FORECLOSURES`). 350 is a hard cap with no paging — split the date window.
+- Detail: `GET caseSearch?caseYear=26&caseType=CV&caseSeq=007629&reallySubmit=true`. No property field; the premises is the individual defendant's service address (skip institutions / courthouse addresses; docket service entries are the fallback).
+- Rate limit: HTTP 429 after ~8 fast requests, then about a minute of host block. Pace 3 s. ToS mentions bulk-mining detection.
+- Per-record links work, but a cold browser is bounced to the disclaimer, lands on the search page after accepting, and must reload the link once.
+
+## Probate Court general case index (`probatesearch.franklincountyohio.gov/netdata/`)
+- IBM Net.Data, no cookie or disclaimer. `PBODateInx.ndm/input?string=YYYYMMDD` lists cases opened that day (40 per page; "Next Cases >>" cursor is `input?stringf=YYYYMMDD<caseno>`).
+- `ESTATE_DETAIL?caseno=N;;` → decedent street/city/zip (the record link). `PBFidy.ndm/input?caseno=N;;` → fiduciary name, title, appointment/termination dates, attorney. Fiduciary mailing address is not published.
+- Case classes: FULL ADMINISTRATION and REAL ESTATE ONLY are the ones with property. The open-date index re-lists old estates that received a new docket entry — compare the open date.
+- `probate.franklincountyohio.gov` itself is Akamai-gated (403 to curl); the netdata host is not.
+
+Other Ohio counties use different vendors (Montgomery in-house, Summit clerkweb, Stark CJIS, Mahoning Tyler Odyssey, Hamilton in-house); only the treasurer-as-party trick transfers.

--- a/domain-skills/jpso/judicial-sales.md
+++ b/domain-skills/jpso/judicial-sales.md
@@ -1,0 +1,18 @@
+# Jefferson Parish Sheriff (LA) — judicial real-estate sales (`eservices2.jpso.com/JudpSale`)
+
+Covers Metairie, Kenner, Gretna, Harvey, Marrero, Westwego, Avondale, Waggaman and the rest of Jefferson Parish. Sales are Wednesdays.
+
+## URL patterns
+
+- List (current sale date): `GET /JudpSale/Home/RealEstate` — a plain HTML table plus a `<select name="SaleDateString">` listing every upcoming sale date and a `<select name="StartDate">`.
+- Other dates: `POST /JudpSale/Home/DateSelectorPartial` form-encoded `Type=RE&SaleDateString=M/D/YYYY&Keyword=` — returns that date's table. A GET on this URL is 404.
+- Detail: `/JudpSale/Home/SelectREProperty?CSSHNBR=<n>` — case, full case style, attorney, writ amount, appraisal flag, sale date.
+
+## Table
+
+`Case Number | Case Style | Sale Date | Address | Writ Amount | Appraisal`
+
+- `Case Style` is `PLAINTIFF VS DEFENDANT` (may be truncated in the list; the detail page has the full text).
+- `Address` is `1909 STAFFORD STREET GRETNA, LA` — street and city run together with no comma; split on the parish's municipality names (longest first). About two thirds of rows are `Address Not Available`.
+- `Writ Amount` is the judgment amount, not an opening bid.
+- Dates further than ~4 weeks out usually have no rows posted yet; the same writ can appear under more than one date, so dedupe on case number.

--- a/domain-skills/ms-sos-tax-forfeited/availability.md
+++ b/domain-skills/ms-sos-tax-forfeited/availability.md
@@ -1,0 +1,84 @@
+# Mississippi SoS — tax-forfeited land inventory
+
+The authoritative list of Mississippi parcels the State currently holds and will
+sell. Use it to answer "is this parcel actually still available?" — county tax
+rolls do not answer that, because a parcel stays printed in the county's report
+long after it has been bought.
+
+## Don't scrape the map
+
+`https://tflgis.sos.ms.gov/` is an ArcGIS JS 4.32 WebMap viewer. There is
+nothing useful in its HTML — the parcel list is fetched at runtime, and
+`curl` of the page yields no service URLs. Go to the FeatureServer instead.
+
+## The service
+
+```
+https://gisserver.its.ms.gov/arcgis/rest/services/Hosted/Active_Tax_Forfeited_Properties/FeatureServer/0
+```
+
+Standard ArcGIS REST. `/query` supports `where`, `outFields`, `resultOffset`,
+`resultRecordCount` (page size 1000), `returnCountOnly`, `returnGeometry=false`.
+
+**It requires a token** — an unauthenticated request returns
+`{"error":{"code":499,"message":"Token Required"}}`. The viewer obtains an
+anonymous portal token on load, so the cheapest way in is to run the query from
+inside the page:
+
+```python
+new_tab("https://tflgis.sos.ms.gov/")
+wait_for_load(); wait(10)          # the token appears with the first portal call
+out = js("""
+(async () => {
+  const t = performance.getEntriesByType('resource').map(r=>r.name)
+     .find(n => n.includes('portals/self') && n.includes('token='));
+  const token = decodeURIComponent(t.split('token=')[1].split('&')[0]);
+  const B = 'https://gisserver.its.ms.gov/arcgis/rest/services/Hosted/'
+          + 'Active_Tax_Forfeited_Properties/FeatureServer/0';
+  const r = await (await fetch(B + '/query?f=json&token=' + token
+      + '&where=' + encodeURIComponent("county='Hinds'")
+      + '&outFields=sosparno,parcel_number,ppin,legal_description,activeapplications'
+      + '&returnGeometry=false&resultRecordCount=1000&resultOffset=0')).json();
+  return JSON.stringify(r.features.map(f => f.attributes));
+})()
+""")
+```
+
+`js()` already awaits promises — do not pass `await_promise`, it is not a
+parameter.
+
+The WebMap definition itself lives at
+`gisportal.its.ms.gov/portal/sharing/rest/content/items/d74c6b741a83487e8ca56bc8ceafbd27/data`
+and also needs the token (403 without it). That is where the layer URL came
+from; re-read it if the layer ever moves.
+
+## Scale
+
+7,272 active parcels statewide; 2,359 in Hinds alone (Aug 2026).
+
+## Fields that matter
+
+| field | why |
+|---|---|
+| `sosparno` | county parcel number, usually hyphenated (`855-18`) — the join key |
+| `parcel_number` / `ppin` | same parcel, digits-only. Formats are inconsistent between records, so **normalise by stripping non-digits and match against all three** |
+| `legal_description` | carries `P# 613-260`; a fourth identifier form worth harvesting |
+| `parcel_status_description` | `Active` |
+| `activeapplications` | **someone is already applying to buy it.** Non-zero means contested — 455 of 2,359 Hinds parcels, and 215 of the 445 we were listing |
+| `county`, `municipality_name` | filter/label |
+
+There is no situs address field. Match on parcel identifiers, not addresses.
+
+## The trap this exists for
+
+A county tax roll keeps printing a parcel after it has been sold. Checking a
+2025 Hinds roll against this service: **63 of 508 parcels (12%) were no longer
+in the active inventory** — already gone, still printed. Listing them offers
+property that is not for sale.
+
+Two identifier caveats found the hard way:
+- `sosparno` is hyphenated for some records and not for others, so a string
+  compare misses most matches. Normalise to digits.
+- Build the key set from `sosparno`, `parcel_number`, `ppin` **and** the `P#`
+  inside `legal_description` — 2,359 records yield ~2,020 distinct identifier
+  forms, and any single field alone under-matches.

--- a/domain-skills/ms-sos-tax-forfeited/availability.md
+++ b/domain-skills/ms-sos-tax-forfeited/availability.md
@@ -82,3 +82,11 @@ Two identifier caveats found the hard way:
 - Build the key set from `sosparno`, `parcel_number`, `ppin` **and** the `P#`
   inside `legal_description` — 2,359 records yield ~2,020 distinct identifier
   forms, and any single field alone under-matches.
+
+## Update 2026-09-09 — the inventory is a plain ArcGIS query, no browser needed
+
+- `www.sos.ms.gov` is Akamai-gated (403 to non-browser clients), but the map app `https://tflgis.sos.ms.gov/` is not, and its HTML embeds an anonymous ArcGIS portal token in `<input id="tk" …>`.
+- Inventory: `GET https://gisserver.its.ms.gov/arcgis/rest/services/Hosted/Active_Tax_Forfeited_Properties/FeatureServer/0/query?f=json&token=<tk>&where=county='Hinds'&outFields=*&returnGeometry=false&resultOffset=N&resultRecordCount=2000` — standard ArcGIS paging. Contrary to the note above, the layer DOES carry situs fields: `street_line_1`, `city`, `zip`, `propertyaddress`, plus `market_value`, `sumoftaxfees`, `activeapplications`.
+- Multi-part parcels repeat rows: dedupe on `parcel_id`. Rows whose address ends in "(Lot)" are unimproved. `activeapplications > 0` means someone already applied.
+- Per-parcel page `https://www.sos.ms.gov/tfsearch/default.aspx?parcel_id=<id>` is a JS shell fed by `LandsSearch.asmx/ProcessSearchDetail` (browser-only); it renders address, owner, legal description, county market value and taxes owed.
+- The token-free `Hinds_Tax_Forfeit_Properties_May_2026` layer on the same server is a stale snapshot — don't use it.

--- a/domain-skills/propstream/cdp-list-id-capture.md
+++ b/domain-skills/propstream/cdp-list-id-capture.md
@@ -1,0 +1,81 @@
+# PropStream — virtual-scroll fix: capture list ID via CDP Network
+
+The PropStream sidebar Marketing-Lists tree uses **virtual scrolling**. Once an account has more than ~9–10 saved lists, a newly-created list is rendered below the visible viewport and the harness can't click it via DOM queries or coordinate clicks — `scrollIntoView` doesn't work because the off-screen DOM node has no bounding rect, and the sidebar's outer scroller has no `overflow:auto` ancestor that we can scroll programmatically.
+
+## Solution — bypass the sidebar entirely
+
+PropStream's saved-list URL pattern is `https://app.propstream.com/property/group/<numeric_id>`. The Save modal's `POST` returns the new list's ID. We capture that response via CDP Network domain and navigate directly to the list URL.
+
+## Implementation pattern
+
+```python
+from helpers import cdp, drain_events, click_at_xy, js
+
+def save_list_capture_id(modal_save_coords):
+    """Click the modal Save button and return the new list ID."""
+    # Enable network capture + drain backlog right before the click
+    cdp("Network.enable", {})
+    drain_events()
+
+    click_at_xy(*modal_save_coords)
+
+    # Poll until we see a 200 from a list-create endpoint
+    for _ in range(180):  # ~4.5 min max for large lists
+        time.sleep(1.5)
+        for e in drain_events():
+            if e.get("method") != "Network.responseReceived":
+                continue
+            p = e.get("params", {})
+            r = p.get("response") or {}
+            url = r.get("url", "")
+            if r.get("status") != 200:
+                continue
+            if not any(k in url for k in (
+                "/api/group", "/api/marketing-list",
+                "/api/property/group", "/groups",
+            )):
+                continue
+            # Fetch + parse the response body
+            body = cdp("Network.getResponseBody", {"requestId": p["requestId"]})
+            text = body.get("body", "")
+            if body.get("base64Encoded"):
+                import base64
+                text = base64.b64decode(text).decode("utf-8", "replace")
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            # PropStream returns {id: <int>} (or {data: {id: <int>}})
+            cand = payload.get("id")
+            if cand is None and isinstance(payload.get("data"), dict):
+                cand = payload["data"].get("id")
+            if isinstance(cand, int) and cand > 1000:
+                return cand
+    return None
+```
+
+## Once you have the ID
+
+```python
+from helpers import goto_url, wait_for_load
+goto_url(f"https://app.propstream.com/property/group/{list_id}")
+wait_for_load()
+# now the list is the active view — proceed with select-all + Export as
+# documented in export-cash-buyers.md from step 12 onward.
+```
+
+## Why this is more reliable than the sidebar path
+
+| Failure mode | Sidebar approach | This approach |
+|---|---|---|
+| List below the visible fold | `scrollIntoView` returns 0,0 because virtual node is unmounted — click misses | URL navigation works regardless of sidebar render state |
+| Search input not present (account has only 1–2 lists) | Sidebar search button doesn't render — heuristics fail | No dependency on sidebar |
+| User has many similarly-named lists | "Find by text" matches the wrong row | ID is unique by construction |
+| Welcome modal re-fires on every nav | Modal blocks the sidebar click | Modal still has to be dismissed but the list URL bypasses sidebar entirely |
+
+## Caveats
+
+- `Network.enable` is a per-tab session setting; call it after `switch_tab` to the PropStream tab, not before.
+- Drain the backlog (`drain_events()`) immediately before clicking Save — otherwise unrelated background API responses pollute the candidate list.
+- PropStream's list-create endpoint URL is currently undocumented; the regex in the implementation matches a generous set of paths. Re-confirm the actual URL via the CDP capture itself on first run.
+- For very large saves (≥5,000 records), the response can take up to a minute. The poll loop in the example above caps at ~4.5 minutes.

--- a/domain-skills/propstream/export-cash-buyers.md
+++ b/domain-skills/propstream/export-cash-buyers.md
@@ -1,0 +1,109 @@
+# PropStream — export cash-buyer list
+
+Drives PropStream's web app to filter by Cash Buyers in a target ZIP / city / county, save the result as a marketing list, then download the XLSX from the list page. Uses the account-holder's existing subscription — no extra credits charged unless the optional skip-trace toggle is checked.
+
+Verified live 2026-05-18: ZIP 63116 → 2,559 cash-buyer rows × 75 columns. **Last Sale Recording Date 100%**, Last Sale Amount 79%, equity / LTV / property type / APN ~95%+. Phones/emails are blank unless skip-trace is run separately.
+
+## URL patterns
+
+| Page | URL |
+|---|---|
+| Login | `https://login.propstream.com/?prompt=login` |
+| Search / map | `https://app.propstream.com/search` |
+| Saved-list / "My Properties" | `https://app.propstream.com/property/group/0` |
+
+## Pre-flight
+
+- Browser-harness daemon attached to the user's Chrome (`browser-harness --setup`).
+- User is logged into PropStream in the active Chrome profile.
+- **Do not auto-fill credentials.** If the active tab lands on `login.propstream.com/...`, stop and ask the user to log in.
+- On first visit to `/property/group/0` a "PropStream Updates" modal appears — click the **Close** link (default position ≈ y=738 in 1251×817 viewport).
+
+## Flow
+
+```text
+1. new_tab("https://app.propstream.com/search")
+2. Click the "Filters" toggle in the top toolbar
+     selector: text === "Filters" with width 80–120, near top-right of header
+     default coords (1251×817 viewport): (891, 24)
+3. The right-side panel opens to "Lead Lists". Click the "Cash Buyers" tile
+     selector: walk up from <p|span>Cash Buyers</p> to the parent DIV with
+               offsetWidth 150–250 (the clickable tile is the wider ancestor).
+     `.click()` works; coordinate click is unreliable because the tile spans
+     to the right edge of the viewport.
+4. Click the top-left location input and type the target query (ZIP, city, etc),
+   then press Enter:
+     selector: input[placeholder^="Enter County"]  at ≈ (230, 24)
+     query examples: "63116", "Saint Louis MO", "Cuyahoga County OH"
+5. Confirm the filter chip + scope changed: the top-right button now reads
+   "View N Properties" where N is the count for (ZIP × Cash Buyers).
+6. Click "View N Properties" to enter the list view. The panel changes to show
+   "N PROPERTIES" with an Actions dropdown.
+     coord ≈ (1176, 34)
+7. Click the master select-all checkbox at the top of the property cards
+     selector: first checkbox-class element with width ≈ 24, y near 199
+8. Click "Actions" → "Save" inside the right panel
+     Actions DIV at ≈ (1165, 199); Save row at ≈ (1155, 283)
+   The "Save" inside Actions opens an "Add to Marketing List" modal — NOT a
+   direct export. Direct Export from the search-results view does not exist.
+9. In the modal:
+     - Click the input "Select or Type to Create a New List" (≈ 615, 382)
+     - Type a unique list name (e.g. "cash-buyers-63116-test")
+     - Click the "(Create as New List)" suggestion that appears below
+     - Do NOT tick "Skip Trace Selected Properties" unless phone enrichment
+       is desired — that charges credits.
+     - Click "Save" button (≈ 699, 513). Wait for the loading spinner to clear
+       (1–10s depending on selection size).
+10. **Capture the new list's ID from the Save POST response** via CDP Network
+    (see [cdp-list-id-capture.md](cdp-list-id-capture.md)). This is the
+    reliable replacement for the old sidebar-clicking step, which fails when
+    the account has more than ~9 saved lists (virtual-scroll renders the
+    newly-saved list below the fold and `scrollIntoView` doesn't work).
+11. Navigate directly to the list:
+      goto_url(f"https://app.propstream.com/property/group/{list_id}")
+    Close the "PropStream Updates" welcome modal if present.
+12. Click the master select-all checkbox on the table header (≈ 422, 191).
+    The toolbar "Export" button transitions from disabled (opacity 0.5) to
+    enabled (opacity 1).
+13. Click "Export" (≈ 593, 151). The file downloads silently to ~/Downloads
+    as: `Property Export <list name>.xlsx`. No "save as" prompt appears.
+```
+
+## Output
+
+`~/Downloads/Property Export <list-name>.xlsx`
+
+75 columns. The ones that matter for cash-buyer ingestion:
+
+| Column | Coverage | Notes |
+|---|---|---|
+| Address / City / State / Zip / County / APN | 100% | Property identification |
+| Owner 1 First/Last Name | 43% / 100% | First is blank for entities |
+| Owner 2 First/Last Name | 18% / 21% | Joint ownership when present |
+| Mailing Address / City / State / Zip | 100% | Buyer's mailing — feeds dedup |
+| **Last Sale Recording Date** | **100%** | The cash-sale date |
+| **Last Sale Amount** | **79%** | The cash-sale price |
+| Total Open Loans | 98% | Cash-buyer confirmation (expect 0) |
+| Est. Equity / Est. LTV / Est. Value | 88-97% | Buyer balance-sheet signal |
+| Bedrooms / Bathrooms / Sqft / Year Built | 52-95% | Buy-box inference |
+| Do Not Mail | 99.6% | DNC compliance |
+| Phone 1-5 / Email 1-4 | 0% by default | Empty unless skip-trace was run |
+
+## Gotchas
+
+- **The Export button on the search results page does not exist.** The only place to export is the saved-list page (`/property/group/0` → click list name → Actions/Export). Save first, export second.
+- **Master select-all is required before Export enables.** Top-of-table checkbox at ≈ (422, 191). Without it the Export button shows opacity 0.5 / `disabled=true`.
+- **Two visible "Cash Buyers" labels collide.** After the filter applies, a chip appears at the top of the page (left of the search bar) reading "N Cash Buyers". Don't confuse it with the tile inside the filter panel. The chip's parent class begins `src-components-HeaderSearchItem` — that's *applied*, not a fresh tile.
+- **The "View N Properties" count changes when the filter toggles.** If you click the Cash Buyers tile twice, you toggle the filter off and the count jumps back up. Verify the chip is present before proceeding.
+- **PropStream Updates welcome modal** shows on `/property/group/0` once per session. Close it with a text-match click on "Close" (default ≈ 625, 738).
+- **Save spinner** can take 1–30 seconds depending on list size (2,559 took ~2s). Poll for the "Loading..." text in the header before continuing.
+- **Output format is XLSX, not CSV.** Parse with `pandas.read_excel` and `openpyxl`. The PropStream marketing docs call it "Export CSV" but the file extension is `.xlsx`.
+- **Skip Trace toggle in the save modal** costs credits per row. Leave unchecked unless phone enrichment is the explicit goal — phone columns will then populate in the exported file.
+- **Login wall**: agent must never type credentials. If redirected to `login.propstream.com`, stop and ask the user.
+
+## Replay (rough Python)
+
+Not yet packaged as a one-shot `Replay` block — the workflow is interactive
+enough (waits, modal dismiss, list naming) that the next iteration will turn
+this into a parameterized `propstream_export(query, list_name)` function. For
+now, follow the Flow above by hand with browser-harness.

--- a/domain-skills/propstream/export-preforeclosure.md
+++ b/domain-skills/propstream/export-preforeclosure.md
@@ -1,0 +1,50 @@
+# PropStream — export Pre-Foreclosure / NOD list
+
+Mirrors the cash-buyer flow exactly — only the **lead-list tile** changes. The output XLSX has the same 75-column shape; the semantic shift is from *cash buyers* (deal exits) to *motivated sellers* (deal sources).
+
+Verified live 2026-05-18: ZIP 63116 → 15 rows × 75 columns. 87% sale-date coverage. **Open loans avg 1.6, zero-loan count 0/15** — every pre-foreclosure record has an active mortgage, as expected.
+
+## URL patterns
+
+Same as [export-cash-buyers.md](export-cash-buyers.md).
+
+## Pre-flight
+
+Same as cash-buyers. Plus: be aware that the **PropStream Updates welcome modal** fires on *every* navigation between `/search` and `/property/group/0`, not just first visit. Dismiss it (Close link, default ≈ y=738) at every transition.
+
+## Flow
+
+Steps 1, 2, 4, 5 are identical to cash-buyers. The differences:
+
+```text
+3. Lead Lists tile → "Pre-Foreclosures" (instead of "Cash Buyers")
+     selector: <p|span>Pre-Foreclosures</p> → walk up to ancestor with offsetWidth 150–250
+6. View N Properties — for ZIP 63116, expect a much smaller N (15 vs 2,559 cash buyers)
+9. List name in the modal — use a distinct name like "pre-foreclosure-63116-<run>"
+```
+
+## Output
+
+`~/Downloads/Property Export pre-foreclosure-63116-test.xlsx`
+
+Same 75 columns. Key distinguishing fields for foreclosure ingestion:
+
+| Column | Coverage | Notes |
+|---|---|---|
+| **Foreclosure Factor** | High | PropStream's distress score |
+| **Lien Amount** | High | Outstanding lien total |
+| **Pre-Foreclosure Type / Recording Date / Auction Date** | High | Available in the Filter side-panel; not in the default export but accessible via "Customize Columns" before export |
+| **Total Open Loans** | 100% | Expect ≥1 for valid pre-foreclosure rows |
+| **Owner / Mailing Address** | 100% / 100% | Same as cash-buyers — direct outreach target |
+
+Note: the **default export columns are cash-buyer-oriented**. To get the pre-foreclosure-specific fields (Default Amount, Auction Date, Recording Date), customize columns before clicking Export. The customization control is in the toolbar near Export.
+
+## Gotchas
+
+- All cash-buyers gotchas apply.
+- **Welcome modal repeats on every nav** (didn't show up on first sample because the cash-buyers run happened all in one tab without leaving `/search`). Plan for dismissal between each export.
+- **Open-loan count is the inverse signal** vs cash buyers: cash-buyer ingest rejects rows with `Total Open Loans > 0`; pre-foreclosure ingest should *require* `Total Open Loans > 0` (otherwise it's not a pre-foreclosure).
+
+## Replay
+
+Not yet packaged. Same parameterization opportunity as cash-buyers — once `propstream_export(query, list_name, lead_list_tile)` exists, this becomes one function call with `lead_list_tile="Pre-Foreclosures"`.

--- a/domain-skills/propstream/export-vacant-equity-absentee.md
+++ b/domain-skills/propstream/export-vacant-equity-absentee.md
@@ -1,0 +1,76 @@
+# PropStream — multi-filter export (Vacant + High Equity + Absentee)
+
+Demonstrates **stacking multiple Lead-List tiles + at least one Owner-Info filter** in a single export run. The "easy deal" combo for wholesalers: a property that is *vacant* (nobody living there), *high-equity* (owner has skin in the game), and *absentee* (owner doesn't live nearby, so they're less attached / more willing to sell).
+
+Verified live 2026-05-18 on ZIP 63116 — partial validation: Vacant filter applied cleanly, exported 1,437 records (92% sale-date coverage). High Equity tile toggling proved state-sticky (see gotchas). Multi-tile mechanics work; the SOP below captures the deterministic sequence.
+
+## URL patterns
+
+Same as [export-cash-buyers.md](export-cash-buyers.md).
+
+## Flow
+
+```text
+1. new_tab("https://app.propstream.com/search")
+2. **HARD RESET FIRST.** Click "Clear All" before opening Filters. If filters
+   from a previous run are sticky in the session, tile clicks will TOGGLE
+   them (re-clicking turns them off). Clear All guarantees a known state.
+3. Enter the ZIP / city in the location bar (≈ 230, 24) and press Enter.
+   Wait for the "View N Properties" header to populate with the unfiltered
+   total. This is the baseline.
+4. Click "Filters" (≈ 891, 24). The Lead Lists panel opens.
+5. Click "Vacant" tile. Verify View N Properties drops to the Vacant count.
+   selector: <p|span>Vacant</p> → ancestor with offsetWidth 150–250 → click()
+6. Click "High Equity" tile. Verify View N Properties drops again — to the
+   *intersection*. If it does NOT drop further, the tile toggled the previous
+   filter off; check by looking at the count header chips at the top of the
+   page (you should see "N High Equity" highlighted, not "0 High Equity").
+7. Scroll down inside the filter panel to "Owner Information & Occupancy"
+   section → "Absentee Owner Location". Toggle "Out of State" and/or
+   "Out of County" (multi-select). The View N count narrows further.
+     selector strategy: find a text node "Absentee Owner Location" via
+     querySelectorAll then scrollIntoView; then locate "Out of State" text
+     within the same parent.
+8. Click "View N Properties" to load the list.
+9. Master select-all (≈ 865, 199).
+10. Actions (≈ 1165, 199) → Save (≈ 1155, 283).
+11. In modal: type "vacant-equity-absentee-<zip>-<run>" → click
+    "(Create as New List)" → click Save (≈ 699, 513) → wait for spinner.
+12. goto_url("https://app.propstream.com/property/group/0")
+13. Dismiss "PropStream Updates" welcome modal (click "Close" ≈ 625, 738).
+14. Click the sidebar magnifying-glass at ≈ (299, 453) → type list name into
+    "Enter Search Name" input that appears at ≈ (260, 497). The list filters
+    to the matching list, bringing it into view at ≈ (215, 610).
+15. Click the list at the new visible position.
+16. Master select-all on the list page (≈ 422, 191) → Export (≈ 593, 151).
+    File downloads silently to ~/Downloads.
+```
+
+## Output
+
+`~/Downloads/Property Export <list-name>.xlsx`
+
+Same 75-column shape. Useful distinguishing fields for the "easy deal" combo:
+
+| Column | What it tells you |
+|---|---|
+| Total Open Loans | Should be 0 most of the time (high-equity → free-and-clear or near-free) |
+| Est. Equity / Est. LTV | Confirms the high-equity filter |
+| Owner Occupied | Should be **No** (absentee filter) |
+| Mailing State vs State | Absentee = mailing state ≠ property state |
+| Vacant | (PropStream's vacancy flag — should be **Yes**) |
+
+## Gotchas — multi-filter specific
+
+- **Tile clicks TOGGLE**, they don't guarantee ON. If a filter was on from a previous interaction, clicking it again turns it OFF. Always do **Clear All before applying** the desired stack.
+- **Verify each step by reading View N Properties.** It should drop monotonically as filters narrow. If N stays the same or goes UP after a click, that click toggled OFF a previous filter — un-toggle it.
+- **Header count chips at the top of the page** (the "264 MLS | 15 Pre-Foreclosures | …" strip) are *unfiltered totals* for the current ZIP scope. They are not applied-filter indicators. The applied-filter signal is the "View N Properties" button at the top-right.
+- **Absentee Owner Location lives in "Owner Information & Occupancy"**, not in Lead Lists. You have to scroll the filter panel down. The Lead Lists section is the top-most; Owner Info is several sections below.
+- **PropStream Updates welcome modal** fires on every navigation to `/property/group/0`. Close it before any sidebar / table interaction.
+- **Marketing Lists sidebar is virtualized.** A newly-created list may be below the visible 9-or-so items and not reachable by scroll. Use the in-sidebar search (magnifying-glass icon next to "Marketing Lists" header) to filter the sidebar to your list name.
+
+## Replay
+
+Not yet packaged. The multi-filter combinatorics make a generic
+`propstream_export(query, list_name, lead_list_tiles=[...], owner_filters={...})`
+the natural next iteration of the harness skill.

--- a/domain-skills/realauction/ohio-sheriff-sales.md
+++ b/domain-skills/realauction/ohio-sheriff-sales.md
@@ -27,3 +27,14 @@ The first call uses `doR=1` (reset). Then repeat with `PageDir=1&doR=0` — the 
 - Only `AREA=W` returns the grid; `AREA=C` is the countdown strip.
 - `zaction=AUCTION&zmethod=UPDATE&VALUE=<aids>&LUDATE=` (what the page polls) is the bid-status refresher, not the listing.
 - The home page has no calendar link in its anchors (it's a JS menu); go to the calendar URL directly.
+
+## Florida: `<county>.realforeclose.com` and `<county>.realtaxdeed.com`
+
+Same app, same calendar and item-loader calls (the vendor is Realauction.com). Differences:
+
+- Two sites per county: `realforeclose.com` (mortgage foreclosures) and `realtaxdeed.com` (tax deeds). Not every county uses both — the calendar of an unused one is empty, not an error. Counties seen active 2026-09: Hillsborough, Duval, Pinellas, Polk, Volusia, Marion, Escambia, Lee, Orange, Broward, Miami-Dade, Palm Beach, Brevard, Pasco, Leon, Alachua, Manatee, Sarasota, Seminole, Osceola, St. Lucie, Bay, Charlotte, Hernando, Citrus, Clay.
+- Different token dictionary in `retHTML` (`@H`, `@F`, …). Don't decode tokens; read pairs by the `AD_LBL` / `AD_DTA` class names — every site uses those.
+- Labels: tax deed = `Auction Type` (TAXDEED), `Case #`, `Certificate #`, `Opening Bid`, `Parcel ID` (links to the property appraiser), `Property Address`, unlabeled `CITY, FL- 32207` row, `Assessed Value`. Foreclosure = `Auction Type` (FORECLOSURE), `Case #`, `Final Judgment Amount` (no opening bid), `Parcel ID`, `Property Address`, city row, `Assessed Value`.
+- Many tax-deed parcels have address `NO SITUS` or `0 <STREET>` (vacant land) — Marion is 95% of those.
+- The site returns HTTP 403 to non-browser user agents; send a normal Chrome UA.
+- Auction days can carry 200+ items; paging works the same (`doR=1` then `PageDir=1`).

--- a/domain-skills/realauction/ohio-sheriff-sales.md
+++ b/domain-skills/realauction/ohio-sheriff-sales.md
@@ -1,0 +1,29 @@
+# RealAuction — Ohio sheriff sales (`<county>.sheriffsaleauction.ohio.gov`)
+
+Franklin, Montgomery, Mahoning, Hamilton, Stark, Lucas, Lake, Summit, Geauga and most other Ohio counties run sheriff foreclosure sales on this ColdFusion app (vendor: Realauction.com). The auction grid is JS-rendered, but every data call is a plain GET that only needs the site's own session cookie. No browser needed.
+
+## URL patterns
+
+- Calendar: `index.cfm?zaction=USER&zmethod=CALENDAR` — current month. Other months: `&selCalDate={ts 'YYYY-MM-01 00:00:00'}` (URL-encode the braces/quotes).
+- Auction-day preview (sets `cfid` / `cftoken` cookies and the page state): `index.cfm?zaction=AUCTION&zmethod=PREVIEW&AuctionDate=MM/DD/YYYY`
+- Item loader (needs the cookies from the preview call): `index.cfm?zaction=AUCTION&zmethod=UPDATE&FNC=LOAD&AREA=W&PageDir=0&doR=1&AuctionDate=MM/DD/YYYY`
+- Item details: `index.cfm?zaction=auction&zmethod=details&AID=<aid>` — plaintiff/defendant only render for logged-in bidders; anonymous gets the shell.
+
+## Calendar markup
+
+One `<div tabindex='0' … class='CALBOX CALW5 CALSELF' dayid='09/18/2026'>` per day. Days with sales carry `<span class="CALACT">n</span> / <span class="CALSCH">m</span> FC` (active / scheduled counts) and a `CALTIME`. Split the page on the `<div tabindex='0'` openers; a lazy regex across boxes swallows neighbours.
+
+## Item loader response
+
+JSON `{"retHTML": "...", "rlist": "aid,aid,..."}`. `retHTML` is token-compressed HTML: `@A`=`<div class="AUCTION`, `@B`=`</div>`, `@C`=` class="`, `@E`=`AUCTION`, `@G`=`</td></tr>`, `@I`=`table`. After decoding, each item starts at `aid="NNN"` and holds a label/value table: `Case Status`, `Case #` (`25CV3315 (19840)` — the number in parentheses is the internal case id), `Parcel ID`, `Property Address`, an unlabeled row `CITY , ZIP0000` (zip is padded to 9 digits), `Appraised Value`, `Opening Bid`, `Deposit Requirement`.
+
+## Paging
+
+The first call uses `doR=1` (reset). Then repeat with `PageDir=1&doR=0` — the session remembers the current page — until the returned aids stop being new. Roughly 10 items per page. Counts match the calendar's `CALSCH` figure minus cancelled cases.
+
+## Traps
+
+- Without the PREVIEW call first, UPDATE answers `{"retHTML":"", "rlist":""}` — it looks like an empty day.
+- Only `AREA=W` returns the grid; `AREA=C` is the countdown strip.
+- `zaction=AUCTION&zmethod=UPDATE&VALUE=<aids>&LUDATE=` (what the page polls) is the bid-status refresher, not the listing.
+- The home page has no calendar link in its anchors (it's a JS menu); go to the calendar URL directly.

--- a/domain-skills/tax-sale-info/michigan-treasurer-auctions.md
+++ b/domain-skills/tax-sale-info/michigan-treasurer-auctions.md
@@ -1,0 +1,9 @@
+# tax-sale.info — Michigan county treasurer tax-foreclosure auctions (Title Check LLC)
+
+One statewide site runs the treasurer auctions for most Michigan counties. Server-rendered, no auth, normal UA.
+
+- Auction list: `GET https://www.tax-sale.info/auctions` → `<div class="entry clearfix">` blocks with the date and `/listings/catalog/<cid>` links named `<County>`, `<County> Re-Offer`, `<County> DNR`. A county's first sale is typically August/September; unsold lots roll into a later "Re-Offer" / no-reserve catalog.
+- Catalog CSV: `GET /catalog/getCsv/id/<cid>` — one row **per parcel** (a lot can span several parcels), address as `STREET␣␣CITY` with no zip, `Minimum Bid`, `Current Taxes`, SEV, parcel id, lat/lon (longitude written `W83.91…`), inspector comment.
+- Sold status only exists on the catalog HTML: `GET /listings/catalog/<cid>` → `<article class="portfolio-item pf-…">` with `Minimum Bid: $X` or `Sold for $X`; `pf-vacantLot` class marks vacant lots. The CSV and lot pages never say sold.
+- Record link: `https://www.tax-sale.info/lot/show/id/<lot_id>` (server-rendered).
+- Open-for-bidding feed statewide: `GET /map/geoJson[?county=<MI county number>&filter=n]` — empty once a county's sale has closed.

--- a/domain-skills/tolemi/publicity-land-bank-map.md
+++ b/domain-skills/tolemi/publicity-land-bank-map.md
@@ -1,0 +1,22 @@
+# Tolemi publiCity — land-bank / city-property maps (`<alias>-publicity.tolemi.com`)
+
+Summit County (Akron), Birmingham, Indianapolis, Buffalo, Dallas, Savannah, Baton Rouge, Pittsburgh, Louisville, Baltimore, Rochester and others publish parcel inventories on this deck.gl map. The canvas shows nothing to a DOM scraper; the data is one unauthenticated GraphQL endpoint.
+
+## Data call
+
+```
+POST https://cg.tolemi.com/q
+headers: content-type: application/json, apollo-require-preflight: true, city-alias: <alias>, product: publiCity
+body: {"operationName":"getAssetsWithPrograms","variables":{"params":{},"limit":500,"offset":0},
+       "query":"query getAssetsWithPrograms($params: JSON, $limit: Int, $offset: Int) { assets(params: $params, limit: $limit, offset: $offset) { id alias commonName address zipCode latitude longitude parcelId showOpportunityBanner gisCity { name state { abbreviation } } city { name state { abbreviation } } programEligibles { program { id name alias } } } }"}
+```
+
+Page with `offset` in steps of 500 until a short page. The alias is the subdomain before `-publicity` and also the `city-alias` header. No price is published.
+
+## Reading a tenant
+
+- Tenants with sale programs (`Side Lots`, `Infill`, `Standard Sale`, `Welcome Home`, `Dallas Land Bank Program`, `Substandard Lots` …) are for-sale inventories: `summit-county-oh` (488), `birmingham-land-bank-al` (1,415), `indianapolis-in` (167), `buffalo-ny` (327), `dallas-tx` (42), `savannah-ga` (41).
+- Tenants with **no** programs and thousands of parcels (`rochester-ny`, `albany-ny`, `louisville-ky`, `lancaster-pa`, `binghamton-ny`, `lorain-oh`, `rockford-il` with only `Rental Registration`, `baltimore-md` with `Water Access`) are whole-city parcel or code-enforcement registries, not sale lists. Do not treat them as inventory.
+- `akron-oh` is a separate tenant from `summit-county-oh` (0 id overlap) and is mostly parcels without house numbers.
+- An unknown alias returns an empty `assets` array, not an error.
+- `gisCity` is often null; fall back to `city` or a caller-supplied city. Many rows lack `zipCode`, which hurts downstream address verification.


### PR DESCRIPTION
Six domain skills for US county / land-bank property portals, each documenting the site's actual data call so the next agent can skip DOM scraping:

- **realauction** — Ohio sheriff sales (`<county>.sheriffsaleauction.ohio.gov`): calendar day markup, the session-cookie JSON item loader, its token-compressed HTML and paging.
- **epropertyplus** — land-bank inventories (`public-<tenant>.epropertyplus.com`): the `getPublishedProperties` GET, row fields, per-tenant status vocabularies.
- **civicsource** — Louisiana adjudicated-property auctions: `www.civicsource.com/api/search` by parish FIPS, plus the auth/TLS/polyfill traps.
- **civilview** — Orleans Parish layout on Tyler CivilView SalesWeb (differs from the Ohio counties).
- **jpso** — Jefferson Parish sheriff judicial sales: date-filter POST and table shape.
- **tolemi** — publiCity GraphQL endpoint and how to tell a for-sale inventory from a parcel registry.

No secrets, coordinates or run narration; URL patterns, payload shapes and traps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr88ixzvvi8Pbdjp47hZcJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds domain-skill docs for county property-portal data endpoints, the Mississippi tax-forfeited inventory service, PropStream export flows, and court-docket sources, so future agents call each site's real API instead of scraping rendered pages. Docs only — no behavior changes or secrets.

**Portal data calls**
- `aglba`: Augusta Land Bank — title-sorted RSS enumeration, reservation status via MyListing AJAX, tax-levy sales JSON, and a rate-limit trap.
- `realauction`: Ohio sheriff sales plus Florida `realforeclose`/`realtaxdeed` variants — session-cookie JSON item loader, calendar markup, and paging.
- `epropertyplus`: land-bank inventories — `getPublishedProperties` GET, row fields, per-tenant status vocab.
- `civicsource`: Louisiana adjudicated auctions — search API by parish FIPS, with auth/TLS/polyfill traps.
- `civilview`: Orleans Parish — same engine as the Ohio counties but the `Details` link is the last table cell, not the first.
- `jpso`: Jefferson Parish sheriff sales — date-filter POST and table shape.
- `tolemi`: publiCity GraphQL endpoint, and how to tell a for-sale inventory from a parcel registry.
- `countysuite`: Pennsylvania sheriff sale listings — date-table GET, JSON sale dates, poster PDF links.
- `tax-sale.info`: Michigan treasurer auctions — catalog CSV, lot pages, and statewide geo feed.
- `arcgis-county-portals`: shared query pattern for ArcGIS FeatureServer layers behind county property-map pages, with per-county layer notes and traps.

**Availability, courts, and exports**
- `ms-sos-tax-forfeited`: documents the ArcGIS FeatureServer behind the map, its token requirement, situs fields, and identifier-match traps — a 2025 Hinds roll check found 63 of 508 parcels (12%) already gone while still printed.
- PropStream: documents cash-buyer, pre-foreclosure, and vacant + high-equity + absentee export flows, plus CDP list-ID capture that replaces the virtual-scrolled sidebar path.
- `franklin-oh-courts`: foreclosure docket enumerated via treasurer name search, and probate estate index with decedent addresses.
- `duval-clerk`: CORE court case JSON web service and Acclaim lis pendens index, plus probe notes for other Florida counties.
- `court-dockets`: no-go notes for MiCOURT and OSCN, which are captcha-gated or lack address fields.

<sup>Written for commit 6a2424a7bab3a3892f2e2055bf5911073e81c53c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

