### PR TITLE
Add experimental Safari Apple Events adapter

### DIFF
--- a/.github/workflows/safari.yml
+++ b/.github/workflows/safari.yml
@@ -1,0 +1,32 @@
+name: Safari adapter checks
+
+on:
+  push:
+    paths:
+      - 'adapters/safari/**'
+      - '.github/workflows/safari.yml'
+  pull_request:
+    paths:
+      - 'adapters/safari/**'
+      - '.github/workflows/safari.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deterministic:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: adapters/safari
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: python -m unittest discover -s tests -v
+      - run: node --test tests/bridge.test.cjs

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ the checkbox so the agent can connect to your browser:
 - [`SKILL.md`](SKILL.md) teaches it the browser workflow.
 - [`src/browser_harness/`](src/browser_harness/) stays protected while the agent writes reusable helpers in its local workspace.
 
+## Experimental Safari adapter
+
+An optional [Safari adapter](adapters/safari/README.md) controls existing Safari
+tabs through macOS Apple Events. It ships as a separate `safari-harness` package
+with familiar helper names; the CDP implementation is unchanged. See its
+[verification notes](adapters/safari/verification.md) for tested behavior and the
+remaining tab-identity limitations.
+
 ## Scale with Browser Use Cloud
 
 Use your local browser for logged-in, personal work. When you want many browsers in parallel—with live previews, proxies, stealth, CAPTCHA solving, and more—scale with [Browser Use Cloud](https://cloud.browser-use.com/new-api-key).

--- a/adapters/safari/.gitignore
+++ b/adapters/safari/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+uv.lock
+__pycache__/
+*.pyc
+dist/

--- a/adapters/safari/README.md
+++ b/adapters/safari/README.md
@@ -1,0 +1,77 @@
+# Experimental Safari adapter
+
+`safari-harness` controls normal Safari tabs through macOS Apple Events, including
+existing sessions. It is a separate Python package with familiar helper names.
+Safari does not implement Chrome CDP; the existing `browser-harness` runtime and
+skill are unchanged.
+
+## Install
+
+Requires macOS, Safari, Python 3.12, and uv. From the repository root:
+
+```sh
+uv tool install --python 3.12 --editable ./adapters/safari
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/safari-harness"
+safari-harness skill > "${CODEX_HOME:-$HOME/.codex}/skills/safari-harness/SKILL.md"
+safari-harness doctor
+```
+
+macOS may request Automation permission to control Safari. Page JavaScript requires
+**Allow JavaScript from Apple Events** in Safari's developer settings. The adapter
+reports permission failures and does not change either setting. `doctor` checks
+the Apple Events connection only; it does not verify page JavaScript.
+
+## Use
+
+```sh
+safari-harness <<'PY'
+tabs = list_tabs()
+matches = [t for t in tabs if t['url'] == 'https://example.com/']
+if len(matches) != 1:
+    raise RuntimeError('Expected one uniquely matching tab')
+switch_tab(matches[0])
+print(page_info())
+print(get_page_content())
+PY
+```
+
+Helpers: `list_tabs`, `switch_tab`, `current_tab`, `page_info`, `new_tab`,
+`goto_url`, `js`, `get_page_content`, `click`, `fill`, and `scroll`.
+Selection lasts for one CLI invocation. `new_tab(url)` opens a normal window and
+may change focus. Failed `switch_tab()` or `new_tab()` calls clear the selection,
+including invalid arguments; explicitly select again before another page action.
+
+## Limits
+
+- References contain window ID, tab index, URL, and title. Changed references and
+  identical tabs within one window are rejected. Re-list and select after navigation
+  or title changes. Safari does not expose a stable tab/document ID through this API.
+- Page JS checks the exact URL immediately before evaluating the requested
+  expression. This does not distinguish replacement documents with the same URL,
+  opaque origins sharing a URL, or protect native navigation from concurrent changes.
+  Consequential unattended writes remain outside the verified scope.
+- Navigation is asynchronous. Clicks and input events are synthetic; verify the
+  resulting page state. Sites requiring trusted input may reject these events.
+- No CDP, screenshots, recordings, native file uploads, network interception,
+  cross-origin frame traversal, Promise results, or native dialog control.
+
+## Development and verification
+
+From `adapters/safari`, run the deterministic checks without a browser:
+
+```sh
+uv run --python 3.12 python -m unittest discover -s tests -v
+node --test tests/bridge.test.cjs
+```
+
+The opt-in live fixture requires macOS and Safari permissions. It serves a
+synthetic page on loopback, opens one window, and leaves it open. The server stops
+when the check exits. Optimized Python execution is rejected so assertions cannot
+silently disappear.
+
+```sh
+uv run --python 3.12 python scripts/smoke_safari.py
+```
+
+See [verification.md](verification.md) for the observed results and open gaps.
+No recordings, telemetry, cookies, or personal page-content logs are collected.

--- a/adapters/safari/pyproject.toml
+++ b/adapters/safari/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "safari-harness"
+version = "0.1.0"
+description = "Safari scripting adapter with browser-harness-style Python helpers"
+requires-python = ">=3.12"
+
+[project.scripts]
+safari-harness = "safari_harness:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["safari_harness"]

--- a/adapters/safari/safari_harness/SKILL.md
+++ b/adapters/safari/safari_harness/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: safari-harness
+description: Control existing Safari tabs on macOS using the local safari-harness Python CLI. Use for Safari navigation, page reading, DOM inspection, clicking, and form entry; it does not provide Chrome CDP or WebDriver isolation.
+---
+
+# Safari Harness
+
+Use `safari-harness` with Python on stdin. Helpers are pre-imported:
+
+```bash
+safari-harness <<'PY'
+tabs = list_tabs()
+print(tabs)
+# Select a known tab using its fresh dictionary, never assume the first is intended.
+PY
+```
+
+`switch_tab(tab_dict)` selects a fresh `list_tabs()` result without activating it.
+`new_tab(url)` opens a normal Safari window; this can move focus. It shares normal
+Safari browsing context, subject to Safari profile and site settings.
+`page_info()`, `current_tab()`, `goto_url(url)`, `get_page_content()`,
+`js(expression)`, `click(css_selector)`, `fill(css_selector, text)`, and
+`scroll(x=0, y=600)` act on the explicitly selected tab.
+Selection lasts only within one CLI invocation. Select again in subsequent calls.
+
+References include window, index, URL, and title. If a tab moves, navigates, or changes
+title, the adapter rejects the old reference. Re-list and identify the intended tab
+before selecting again. Identical tabs in the same window are rejected because
+Safari's scripting API cannot distinguish them reliably. Concurrent rearrangement
+can still race a command; avoid consequential unattended actions with this prototype.
+Navigation is asynchronous. After navigation or an action that changes URL/title,
+re-list tabs, verify the destination, and select the fresh result. Do not retry a
+mutation merely because subsequent verification encountered a stale reference.
+
+DOM clicks and input events are synthetic. Verify the resulting page state;
+sites requiring trusted input may reject them. `js()` takes a synchronous expression;
+wrap statements in an IIFE. Promises, raw CDP, screenshots, native file uploads,
+network interception, browser dialogs, and cross-origin frame access are unsupported.
+Do not claim these helpers provide those features. Use an appropriate supported tool
+if the task requires them; preserve the user's choice of Safari.
+
+Run `safari-harness doctor` to check the Apple Events connection; it does not prove
+page JavaScript works. macOS may ask for Automation permission to control Safari.
+JavaScript requires Safari > Develop > Allow JavaScript from Apple Events (location
+may vary by Safari version). Report the permission requirement if blocked; do not
+change security preferences through defaults or bypass the OS permission system.
+
+No recordings are collected, and this adapter does not alter browser-harness's
+recording preference. Do not install beta Safari or replace the default browser as
+an implicit workaround.

--- a/adapters/safari/safari_harness/__init__.py
+++ b/adapters/safari/safari_harness/__init__.py
@@ -1,0 +1,132 @@
+"""A deliberately limited Safari adapter; it does not emulate Chrome CDP."""
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+__version__ = "0.1.0"
+
+
+class SafariError(RuntimeError):
+    pass
+
+
+def _bridge(action, **kwargs):
+    payload = json.dumps({"action": action, **kwargs}, ensure_ascii=True)
+    # Keep page expressions and form values out of process argument listings.
+    source = Path(__file__).with_name("bridge.js").read_text()
+    source += "\nfunction run() { return dispatch(" + payload + "); }\n"
+    try:
+        result = subprocess.run(
+            ["/usr/bin/osascript", "-l", "JavaScript", "-"],
+            input=source, capture_output=True, text=True, timeout=30,
+        )
+    except FileNotFoundError as e:
+        raise SafariError("Safari automation requires macOS and /usr/bin/osascript.") from e
+    except subprocess.TimeoutExpired as e:
+        raise SafariError("Safari automation timed out. Check the macOS Automation permission prompt; do not blindly repeat a mutation.") from e
+    if result.returncode:
+        raise SafariError(result.stderr.strip())
+    try:
+        return json.loads(result.stdout)
+    except ValueError as e:
+        raise SafariError("Safari returned an invalid response") from e
+
+
+def _url(url):
+    if not isinstance(url, str) or urlsplit(url).scheme not in {"http", "https", "file", "about"}:
+        raise ValueError("Use an http, https, file, or about URL")
+    return url
+
+
+class Safari:
+    def __init__(self, transport=_bridge):
+        self._call = transport
+        self._target = None
+
+    def list_tabs(self):
+        return self._call("list")
+
+    def switch_tab(self, target):
+        """Select a fresh list_tabs() reference without foregrounding Safari."""
+        self._target = None
+        if not isinstance(target, dict) or not {"window", "index", "url", "title"} <= target.keys():
+            raise ValueError("Pass a tab dictionary returned by list_tabs()")
+        if (type(target['window']) is not int or type(target['index']) is not int
+                or target['index'] < 0 or not isinstance(target['url'], str)
+                or not isinstance(target['title'], str)):
+            raise ValueError("Invalid tab reference; use list_tabs()")
+        self._target = self._call("info", target=target)
+        return self._target.copy()
+
+    def current_tab(self):
+        if self._target is None:
+            raise SafariError("No tab selected. Use list_tabs()/switch_tab() or new_tab(url).")
+        return self._target.copy()
+
+    def page_info(self):
+        return self._call("info", target=self.current_tab())
+
+    def new_tab(self, url):
+        """Open a normal Safari window and select its tab. May move foreground focus."""
+        self._target = None
+        self._target = self._call("new", url=_url(url))
+        return self.current_tab()
+
+    def goto_url(self, url):
+        self._target = self._call("navigate", target=self.current_tab(), url=_url(url))
+        return self.current_tab()
+
+    def js(self, expression):
+        """Evaluate a synchronous expression. Promises are explicitly unsupported."""
+        code = "JSON.stringify((function(){const value=(" + expression + ");if(value && typeof value.then==='function')throw Error('Promises are unsupported');return value===undefined?null:value;})())"
+        raw = self._call("js", target=self.current_tab(), code=code)["result"]
+        return json.loads(raw) if raw is not None else None
+
+    def get_page_content(self):
+        return self.js("document.body ? document.body.innerText : ''")
+
+    def click(self, selector):
+        return self.js("(()=>{const e=document.querySelector(" + json.dumps(selector) + ");if(!e)throw Error('Element not found');e.click();return true;})()")
+
+    def fill(self, selector, value):
+        return self.js("(()=>{const e=document.querySelector(" + json.dumps(selector) + ");if(!e)throw Error('Element not found');if(e.disabled||e.readOnly)throw Error('Element is not editable');if(e.type==='file')throw Error('File uploads require a native interface');if(!(e instanceof HTMLInputElement || e instanceof HTMLTextAreaElement)||['checkbox','radio','button','submit','reset','image','hidden'].includes(e.type))throw Error('fill requires an editable text input or textarea');const p=e instanceof HTMLTextAreaElement?HTMLTextAreaElement.prototype:HTMLInputElement.prototype;const s=Object.getOwnPropertyDescriptor(p,'value').set;s.call(e," + json.dumps(str(value)) + ");e.dispatchEvent(new Event('input',{bubbles:true}));e.dispatchEvent(new Event('change',{bubbles:true}));return true;})()")
+
+    def scroll(self, x=0, y=600):
+        if not math.isfinite(float(x)) or not math.isfinite(float(y)):
+            raise ValueError("Scroll coordinates must be finite")
+        return self.js("(()=>{window.scrollBy(" + json.dumps(float(x)) + "," + json.dumps(float(y)) + ");return {x:scrollX,y:scrollY};})()")
+
+    def cdp(self, *args, **kwargs):
+        raise NotImplementedError("Safari does not implement Chrome CDP. Use the Safari helpers; CDP scripts are not compatible.")
+
+
+def main():
+    args = sys.argv[1:]
+    if args == ["--version"]:
+        print(__version__)
+        return
+    if args == ["skill"]:
+        print(Path(__file__).with_name("SKILL.md").read_text(), end="")
+        return
+    if args in (["--help"], ["-h"]):
+        print("safari-harness [skill|doctor|--version]\nOr pipe Python code on stdin. Start with list_tabs()/switch_tab() or new_tab(url).\nNo recordings are collected.")
+        return
+    safari = Safari()
+    try:
+        if args in (["doctor"], ["--doctor"]):
+            tabs = safari.list_tabs()
+            print(json.dumps({"automation": "connected", "tabs": len(tabs), "javascript": "unverified; requires Allow JavaScript from Apple Events", "recordings": "off"}))
+            return
+        if args:
+            raise SafariError("Unknown command; use --help")
+        if sys.stdin.isatty():
+            raise SafariError("Supply a Python script on stdin")
+        namespace = {name: getattr(safari, name) for name in ("list_tabs", "switch_tab", "current_tab", "page_info", "new_tab", "goto_url", "js", "get_page_content", "click", "fill", "scroll", "cdp")}
+        namespace["__name__"] = "__main__"
+        exec(compile(sys.stdin.read(), "<safari-harness>", "exec"), namespace)
+    except (SafariError, NotImplementedError) as e:
+        print(f"safari-harness: {e}", file=sys.stderr)
+        raise SystemExit(1)

--- a/adapters/safari/safari_harness/bridge.js
+++ b/adapters/safari/safari_harness/bridge.js
@@ -1,0 +1,51 @@
+function dispatch(request) {
+    const safari = Application('Safari');
+    if (!safari.running()) throw Error('Safari is not running. Open Safari and retry.');
+    const windows = safari.windows();
+    function describe(w, t, i) {
+        return {window: w.id(), index: i, url: t.url() || '', title: t.name() || ''};
+    }
+    if (request.action === 'list') {
+        const result = [];
+        windows.forEach(w => w.tabs().forEach((t, i) => result.push(describe(w, t, i))));
+        return JSON.stringify(result);
+    }
+    if (request.action === 'new') {
+        // A dedicated normal window avoids ambiguous insertion into a user's tab group.
+        const before = windows.map(w => w.id());
+        const doc = safari.Document({url: request.url});
+        safari.documents.push(doc);
+        const added = safari.windows().filter(w => !before.includes(w.id()));
+        if (added.length !== 1 || added[0].tabs().length !== 1)
+            throw Error('Created a document but cannot identify its new window. Do not repeat creation; inspect list_tabs().');
+        return JSON.stringify(describe(added[0], added[0].tabs[0], 0));
+    }
+    const ref = request.target;
+    const w = windows.find(w => w.id() === ref.window);
+    if (!w || ref.index < 0 || ref.index >= w.tabs().length)
+        throw Error('Stale tab reference: list_tabs() and switch_tab() again.');
+    const t = w.tabs[ref.index];
+    if ((t.url() || '') !== ref.url || (t.name() || '') !== ref.title)
+        throw Error('Tab changed or moved: list_tabs() and switch_tab() again.');
+    const matches = w.tabs().filter(other => (other.url() || '') === ref.url && (other.name() || '') === ref.title);
+    if (matches.length !== 1)
+        throw Error('Ambiguous identical tabs: Safari does not expose stable tab IDs. Select a uniquely identifiable tab.');
+    if (request.action === 'info') return JSON.stringify(describe(w, t, ref.index));
+    if (request.action === 'navigate') {
+        t.url = request.url;
+        return JSON.stringify(describe(w, t, ref.index));
+    }
+    if (request.action === 'js') {
+        // A tab can navigate after the Apple Event metadata checks above. Read
+        // browser-owned Location inside the same synchronous page operation,
+        // before evaluating any caller code. Top-level `this` avoids replaceable
+        // globalThis/self aliases. This is not a stable document or tab identity.
+        const guardedCode = '(function(__safariWindow){' +
+            'if(__safariWindow.location.href !== ' + JSON.stringify(ref.url) + ')' +
+            'throw "Target mismatch: URL changed before execution. List tabs and select again.";' +
+            'return (' + request.code + ');})(this)';
+        const result = safari.doJavaScript(guardedCode, {in: t});
+        return JSON.stringify({result: result === undefined ? null : result});
+    }
+    throw Error('Unsupported bridge action: ' + request.action);
+}

--- a/adapters/safari/scripts/smoke_safari.py
+++ b/adapters/safari/scripts/smoke_safari.py
@@ -1,0 +1,149 @@
+"""Opt-in live checks on one synthetic localhost window; leaves the window open."""
+import json
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from safari_harness import Safari, SafariError
+
+if not __debug__:
+    raise SafariError('Smoke verification requires assertions; run without -O/PYTHONOPTIMIZE.')
+
+FIXTURE_VERSION = 3
+CORPUS = [
+    'Safari test — "quotes" and \\slashes\nsecond line',
+    '\"; globalThis.pwned = true; //\n$(touch /tmp/safari-harness-must-not-run) `id`',
+    '日本語 🧪 </textarea><script>globalThis.pwned=true</script>',
+]
+
+
+def reference_state(tabs):
+    """Ignore window stacking order; retain every tab's identity and metadata."""
+    return sorted(tabs, key=lambda tab: (tab['window'], tab['index']))
+
+
+def reuse_probe():
+    """Run in a separate Python/CLI process against only the named fixture."""
+    request = json.load(sys.stdin)
+    safari = Safari()
+    matches = [t for t in safari.list_tabs()
+               if t['url'] == request['target']['url'] and t['title'] == request['target']['title']]
+    if len(matches) != 1 or matches[0] != request['target']:
+        raise SafariError('Fixture reference changed between CLI invocations')
+    safari.switch_tab(matches[0])
+    print(json.dumps(safari.js('({marker:document.querySelector("#marker").textContent,session:sessionStorage.getItem("safari-harness-fixture")})')))
+
+
+def main():
+    marker = 'safari-harness-' + uuid.uuid4().hex
+    title = 'Safari Harness Smoke ' + marker
+    page = ('''<!doctype html><meta charset="utf-8"><title>''' + title + '''</title>
+<label>Name <textarea id="name"></textarea></label>
+<button id="save" onclick="document.getElementById('result').textContent=document.getElementById('name').value;document.getElementById('count').textContent=Number(document.getElementById('count').textContent)+1">Save</button>
+<output id="result"></output><output id="count">0</output><output id="marker">''' + marker + '''</output>
+<script>sessionStorage.setItem('safari-harness-fixture', ''' + json.dumps(marker) + ''');</script>''').encode()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path != '/fixture.html':
+                self.send_error(404)
+                return
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html; charset=utf-8')
+            self.send_header('Content-Length', str(len(page)))
+            self.end_headers()
+            self.wfile.write(page)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        safari = Safari()
+        before = safari.list_tabs()
+        previous_windows = {t['window'] for t in before}
+        url = f'http://127.0.0.1:{server.server_port}/fixture.html'
+        started = time.monotonic()
+        created = safari.new_tab(url)
+        while time.monotonic() - started < 30:
+            tabs = safari.list_tabs()
+            matches = [t for t in tabs if t['window'] == created['window']
+                       and t['url'] == url and t['title'] == title]
+            if len(matches) == 1:
+                safari.switch_tab(matches[0])
+                if safari.js('document.readyState') == 'complete':
+                    break
+            time.sleep(0.25)
+        else:
+            raise SafariError('Smoke fixture did not finish loading within 30 seconds; inspect existing windows before retrying.')
+        target = safari.current_tab()
+        if {t['window'] for t in tabs} - previous_windows != {target['window']}:
+            raise SafariError('Expected exactly one new window; do not repeat creation.')
+        if reference_state([t for t in tabs if t['window'] in previous_windows]) != reference_state(before):
+            raise SafariError('Pre-existing tab metadata changed during fixture creation.')
+        assert safari.js('document.querySelector("#marker").textContent') == marker
+        reused = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve()), '--reuse-probe'],
+            input=json.dumps({'target': target}), capture_output=True, text=True, timeout=30,
+        )
+        if reused.returncode:
+            raise SafariError('Separate CLI fixture probe failed: ' + reused.stderr.strip())
+        assert json.loads(reused.stdout) == {'marker': marker, 'session': marker}
+        load_seconds = time.monotonic() - started
+        assert load_seconds <= 30, f'Create/load/reuse exceeded 30 seconds: {load_seconds:.2f}'
+
+        # Check the selection fix against real bridge rejection, then explicit recovery.
+        for fail in (lambda: safari.switch_tab(dict(target, index=1_000_000)),
+                     lambda: safari.new_tab('javascript:throw Error("must not run")')):
+            try:
+                fail()
+            except (SafariError, ValueError):
+                pass
+            else:
+                raise AssertionError('Expected selection/creation failure')
+            try:
+                safari.fill('#name', 'MUST_NOT_BE_INSERTED')
+            except SafariError as error:
+                assert 'No tab selected' in str(error)
+            else:
+                raise AssertionError('Mutation was accepted after failed selection')
+            matches = [t for t in safari.list_tabs() if t == target]
+            assert len(matches) == 1
+            safari.switch_tab(matches[0])
+            assert safari.js('document.querySelector("#name").value') == ''
+            assert safari.js('document.querySelector("#count").textContent') == '0'
+
+        for value in CORPUS:
+            safari.fill('#name', value)
+            assert safari.js('document.querySelector("#name").value') == value
+        safari.click('#save')
+        assert safari.js('document.querySelector("#result").textContent') == CORPUS[-1]
+        assert safari.js('document.querySelector("#count").textContent') == '1'
+        assert safari.js('typeof globalThis.pwned') == 'undefined'
+        assert CORPUS[-1] in safari.get_page_content()
+        after = safari.list_tabs()
+        assert reference_state([t for t in after if t['window'] in previous_windows]) == reference_state(before)
+        assert {t['window'] for t in after} - previous_windows == {target['window']}
+        print(json.dumps({'result': 'passed', 'fixture_version': FIXTURE_VERSION,
+                          'checks': ['new_window', 'load', 'separate_cli_reuse', 'session_marker',
+                                     'failed_selection_rejected', 'invalid_creation_url_rejected',
+                                     'exact_fill_corpus', 'single_click', 'read'],
+                          'load_reuse_seconds': round(load_seconds, 3), 'click_count': 1,
+                          'corpus_count': len(CORPUS), 'recordings': 'off'}))
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == '__main__':
+    if sys.argv[1:] == ['--reuse-probe']:
+        reuse_probe()
+    elif sys.argv[1:]:
+        raise SystemExit('Usage: python scripts/smoke_safari.py')
+    else:
+        main()

--- a/adapters/safari/tests/bridge.test.cjs
+++ b/adapters/safari/tests/bridge.test.cjs
@@ -1,0 +1,135 @@
+const {test} = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const source = fs.readFileSync('safari_harness/bridge.js', 'utf8');
+const ref = {window: 7, index: 0, url: 'https://example.com', title: 'Example'};
+function collection(items) {
+    const f = () => items;
+    items.forEach((item, i) => f[i] = item);
+    return f;
+}
+function tab(url = ref.url, title = ref.title) {
+    let value = url;
+    const t = {name: () => title};
+    Object.defineProperty(t, 'url', {get: () => () => value, set: v => {value = v;}});
+    return t;
+}
+function fixture(tabs = [tab()]) {
+    const calls = [];
+    let windows = [{id: () => 7, tabs: collection(tabs)}];
+    const safari = {
+        running: () => true,
+        windows: () => windows,
+        doJavaScript(code, options) { calls.push([code, options]); return 'true'; },
+        Document: x => x,
+        documents: {push(doc) { windows = [{id: () => 8, tabs: collection([tab(doc.url, '')])}, ...windows]; }}
+    };
+    const context = vm.createContext({Application: () => safari});
+    vm.runInContext(source, context);
+    return {safari, calls, run: req => JSON.parse(context.dispatch(req))};
+}
+function executionRaceFixture(expected, destination, spoofAliases = false) {
+    const selected = tab(expected.url, expected.title);
+    const f = fixture([selected]);
+    const observed = {transportCalls: 0, bodyExecutions: 0, writes: 0, value: ''};
+    const field = {};
+    Object.defineProperty(field, 'value', {
+        get: () => observed.value,
+        set(value) { observed.writes++; observed.value = value; }
+    });
+    const page = {
+        observed,
+        document: {querySelector: () => field}
+    };
+    // Model browser-owned Location accessors; this is executable page JS in a
+    // Node VM, not evidence of Safari's live Apple Event/reference semantics.
+    const location = {};
+    Object.defineProperty(location, 'href', {get: () => selected.url()});
+    Object.defineProperty(page, 'location', {get: () => location});
+    if (spoofAliases) {
+        page.globalThis = {location: {href: expected.url}};
+        page.self = {location: {href: expected.url}};
+    }
+    const pageContext = vm.createContext(page);
+    f.safari.doJavaScript = (code, options) => {
+        observed.transportCalls++;
+        assert.equal(options.in, selected);
+        // All bridge URL/title checks have finished when this Apple Event is
+        // delivered. Change the recipient's URL before evaluating the script.
+        selected.url = destination;
+        return vm.runInContext(code, pageContext);
+    };
+    const code = "JSON.stringify((function(){observed.bodyExecutions++;document.querySelector('#secret').value='SYNTHETIC_ORIGIN_VALUE';return true;})())";
+    return {observed, run: () => f.run({action: 'js', target: expected, code})};
+}
+function assertBlockedBeforeMutation(f) {
+    let failure;
+    try { f.run(); } catch (error) { failure = error; }
+    assert.deepEqual(f.observed, {transportCalls: 1, bodyExecutions: 0, writes: 0, value: ''});
+    assert.match(String(failure), /Target mismatch/);
+}
+test('listing returns references without executing page scripts', () => {
+    const f = fixture();
+    assert.deepEqual(f.run({action: 'list'}), [ref]);
+    assert.equal(f.calls.length, 0);
+});
+test('stale URL blocks page script execution', () => {
+    const f = fixture([tab('https://other.example')]);
+    assert.throws(() => f.run({action: 'js', target: ref, code: 'deleteStuff()'}), /changed or moved/);
+    assert.equal(f.calls.length, 0);
+});
+test('closed window blocks navigation', () => {
+    const f = fixture();
+    assert.throws(() => f.run({action: 'navigate', target: {...ref, window: 42}, url: 'https://new.example'}), /Stale tab/);
+});
+test('identical tabs are rejected', () => {
+    const f = fixture([tab(), tab()]);
+    assert.throws(() => f.run({action: 'js', target: ref, code: 'deleteStuff()'}), /Ambiguous/);
+    assert.equal(f.calls.length, 0);
+});
+test('new window is selected by identity', () => {
+    const f = fixture();
+    const created = f.run({action: 'new', url: 'https://new.example'});
+    assert.equal(created.window, 8);
+    assert.equal(created.url, 'https://new.example');
+});
+test('creation cannot silently attach to existing frontmost tab', () => {
+    const f = fixture();
+    f.safari.documents.push = () => {};
+    assert.throws(() => f.run({action: 'new', url: 'https://new.example'}), /cannot identify/);
+});
+test('navigation verifies old reference and returns new URL', () => {
+    const f = fixture();
+    const result = f.run({action: 'navigate', target: ref, url: 'https://new.example'});
+    assert.equal(result.url, 'https://new.example');
+});
+test('script targets the explicitly selected tab object', () => {
+    const t = tab();
+    const f = fixture([t]);
+    assert.deepEqual(f.run({action: 'js', target: ref, code: '1+1'}), {result: 'true'});
+    assert.equal(f.calls[0][1].in, t);
+});
+test('execution-time cross-origin redirect blocks the page operation', () => {
+    const expected = {...ref, url: 'https://intended.invalid/form', title: 'Intended'};
+    const f = executionRaceFixture(expected, 'https://recipient.invalid/form');
+    assertBlockedBeforeMutation(f);
+});
+test('execution-time same-origin URL change blocks the page operation', () => {
+    const expected = {...ref, url: 'https://intended.invalid/form', title: 'Intended'};
+    const f = executionRaceFixture(expected, 'https://intended.invalid/replacement');
+    assertBlockedBeforeMutation(f);
+});
+test('different origin and title variant blocks despite spoofed global aliases', () => {
+    const expected = {...ref, url: 'http://source.invalid:8080/alternate?x=1', title: 'Another fixture'};
+    const f = executionRaceFixture(expected, 'http://recipient.invalid:8081/alternate?x=1', true);
+    assertBlockedBeforeMutation(f);
+});
+test('matching execution-time URL evaluates the page operation exactly once', () => {
+    const expected = {...ref, url: 'https://intended.invalid/form', title: 'Intended'};
+    const f = executionRaceFixture(expected, expected.url);
+    assert.deepEqual(f.run(), {result: 'true'});
+    assert.deepEqual(f.observed, {
+        transportCalls: 1, bodyExecutions: 1, writes: 1, value: 'SYNTHETIC_ORIGIN_VALUE'
+    });
+});

--- a/adapters/safari/tests/test_adapter.py
+++ b/adapters/safari/tests/test_adapter.py
@@ -1,0 +1,177 @@
+import json
+import subprocess
+import unittest
+from unittest.mock import patch
+from safari_harness import Safari, SafariError, _bridge
+
+TAB = dict(window=9, index=0, url='https://example.com', title='Example')
+
+class AdapterTests(unittest.TestCase):
+    def test_no_implicit_user_tab(self):
+        with self.assertRaises(SafariError):
+            Safari().page_info()
+
+    def test_reject_executable_navigation_before_transport(self):
+        def transport(*a, **k):
+            self.fail('transport should not run')
+        with self.assertRaises(ValueError):
+            Safari(transport).new_tab('javascript:alert(1)')
+
+    def test_page_script_quotes_are_data(self):
+        calls = []
+        def transport(action, **kw):
+            calls.append((action, kw))
+            return TAB.copy() if action == 'info' else {'result': 'true'}
+        s = Safari(transport)
+        s.switch_tab(TAB)
+        value = '"; globalThis.pwned = true; //\n$(touch /tmp/no)'
+        s.fill('#name', value)
+        self.assertIn(json.dumps(value), calls[-1][1]['code'])
+        self.assertEqual(calls[-1][1]['target'], TAB)
+
+    def test_cdp_fails_explicitly(self):
+        with self.assertRaises(NotImplementedError):
+            Safari().cdp('Page.navigate', url='https://example.com')
+
+    @patch('safari_harness.subprocess.run')
+    def test_transport_passes_data_without_shell(self, run):
+        run.return_value = subprocess.CompletedProcess([], 0, '{"ok":true}', '')
+        self.assertEqual(_bridge('js', code='"; dangerous()'), {'ok': True})
+        args, kw = run.call_args
+        self.assertNotIn('shell', kw)
+        self.assertEqual(args[0], ['/usr/bin/osascript', '-l', 'JavaScript', '-'])
+        self.assertNotIn('dangerous()', ' '.join(args[0]))
+        self.assertIn(json.dumps('"; dangerous()'), kw['input'])
+
+    @patch('safari_harness.subprocess.run')
+    def test_timeout_does_not_retry_mutation(self, run):
+        run.side_effect = subprocess.TimeoutExpired('osascript', 30)
+        with self.assertRaisesRegex(SafariError, 'do not blindly repeat'):
+            _bridge('navigate', url='https://example.com')
+        self.assertEqual(run.call_count, 1)
+
+    @patch('safari_harness.subprocess.run')
+    def test_permission_failure_is_not_success(self, run):
+        run.return_value = subprocess.CompletedProcess([], 1, '', 'Not authorized (-1743)')
+        with self.assertRaisesRegex(SafariError, '-1743'):
+            _bridge('list')
+
+
+class SelectionSafetyTests(unittest.TestCase):
+    """D1: selection failures must never leave an old tab usable for writes."""
+
+    recovery_tab = dict(window=77, index=1, url='https://recovery.invalid/form', title='Recovery')
+
+    def harness(self, failure_action=None, failure_target=None, error=None):
+        calls = []
+
+        def transport(action, **kw):
+            # Retain only synthetic action/target metadata, never page code/content.
+            calls.append((action, kw.get('target')))
+            if action == failure_action and (failure_target is None or kw.get('target') == failure_target):
+                raise error
+            if action == 'info':
+                return kw['target'].copy()
+            if action == 'new':
+                return self.recovery_tab.copy()
+            if action == 'navigate':
+                return dict(kw['target'], url=kw['url'])
+            if action == 'js':
+                return {'result': 'true'}
+            self.fail(f'unexpected transport action: {action}')
+
+        return Safari(transport), calls
+
+    def mutations(self, safari):
+        return (
+            ('fill', lambda: safari.fill('#name', 'SYNTHETIC_D1_VALUE')),
+            ('click', lambda: safari.click('#submit')),
+            ('js', lambda: safari.js("document.body.dataset.d1 = 'SYNTHETIC_D1_VALUE'")),
+            ('navigation', lambda: safari.goto_url('https://recovery.invalid/next')),
+        )
+
+    def assert_locked_until_selection(self, safari, calls, *, create=False):
+        calls.clear()
+        with self.subTest(operation='current_tab'):
+            with self.assertRaisesRegex(SafariError, 'No tab selected'):
+                safari.current_tab()
+        for name, mutate in self.mutations(safari):
+            with self.subTest(operation=name):
+                before = len(calls)
+                with self.assertRaisesRegex(SafariError, 'No tab selected'):
+                    mutate()
+                self.assertEqual(len(calls), before, 'blocked mutation reached transport')
+        self.assertEqual(calls, [], 'transport must receive zero mutations before explicit selection')
+
+        # Recovery itself must be explicit and successful. Once selected, all four
+        # operations must use that new reference instead of the prior target.
+        if create:
+            selected = safari.new_tab(self.recovery_tab['url'])
+        else:
+            selected = safari.switch_tab(self.recovery_tab)
+        self.assertEqual(selected, self.recovery_tab)
+        calls.clear()
+        for _, mutate in self.mutations(safari):
+            mutate()
+        self.assertEqual([action for action, _ in calls], ['js', 'js', 'js', 'navigate'])
+        self.assertEqual([target for _, target in calls], [self.recovery_tab] * 4)
+
+    def test_no_selection_rejects_page_mutations_until_explicit_selection(self):
+        safari, calls = self.harness()
+        self.assert_locked_until_selection(safari, calls)
+
+    def test_failed_selection_clears_previous_target(self):
+        variants = (
+            (TAB, dict(TAB, window=10), SafariError('selected window closed')),
+            # Distinct URL/title and a reordered tab reference, not merely another
+            # copy of the original window-closure fixture.
+            (dict(window=31, index=2, url='http://variant.invalid/a', title='Variant β'),
+             dict(window=31, index=0, url='http://variant.invalid/b', title='Intended β'),
+             SafariError('tab reference changed after reorder')),
+        )
+        for old, intended, error in variants:
+            with self.subTest(intended=intended):
+                safari, calls = self.harness('info', intended, error)
+                safari.switch_tab(old)
+                calls.clear()
+                with self.assertRaisesRegex(SafariError, str(error)):
+                    safari.switch_tab(intended)
+                self.assertEqual(calls, [('info', intended)])
+                self.assert_locked_until_selection(safari, calls)
+
+    def test_local_selection_validation_failure_clears_previous_target(self):
+        invalid_targets = (None, {}, dict(TAB, index=-1), dict(TAB, window=True), dict(TAB, url=None))
+        for intended in invalid_targets:
+            with self.subTest(intended=intended):
+                safari, calls = self.harness()
+                safari.switch_tab(TAB)
+                calls.clear()
+                with self.assertRaises(ValueError):
+                    safari.switch_tab(intended)
+                self.assertEqual(calls, [], 'local validation must precede transport')
+                self.assert_locked_until_selection(safari, calls)
+
+    def test_failed_creation_clears_previous_target(self):
+        for message in ('Not authorized (-1743)', 'creation timed out; action outcome unknown'):
+            with self.subTest(failure=message):
+                safari, calls = self.harness('new', error=SafariError(message))
+                safari.switch_tab(TAB)
+                calls.clear()
+                with self.assertRaises(SafariError):
+                    safari.new_tab('https://intended.invalid/new')
+                self.assertEqual(calls, [('new', None)], 'creation must not be retried')
+                self.assert_locked_until_selection(safari, calls)
+
+    def test_local_creation_validation_failure_clears_previous_target(self):
+        for url in ('javascript:alert(1)', 'ftp://variant.invalid/new', None):
+            with self.subTest(url=url):
+                safari, calls = self.harness()
+                safari.switch_tab(TAB)
+                calls.clear()
+                with self.assertRaises(ValueError):
+                    safari.new_tab(url)
+                self.assertEqual(calls, [], 'local validation must precede transport')
+                self.assert_locked_until_selection(safari, calls, create=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/adapters/safari/tests/test_smoke.py
+++ b/adapters/safari/tests/test_smoke.py
@@ -1,0 +1,43 @@
+"""Live-runner regressions: window stacking is not tab identity."""
+import unittest
+
+from scripts.smoke_safari import reference_state
+
+
+class FixtureReferenceTests(unittest.TestCase):
+    def setUp(self):
+        self.before = [
+            dict(window=9, index=0, url='http://fixture.invalid/a', title='Fixture A'),
+            dict(window=9, index=1, url='http://fixture.invalid/b', title='Fixture B'),
+            dict(window=4, index=0, url='http://fixture.invalid/c', title='Fixture C'),
+        ]
+
+    def test_window_stacking_order_does_not_report_changed_tabs(self):
+        # Reproduced in live Safari: the references matched by window/index,
+        # but Safari enumerated the windows in a different order after JS calls.
+        after = [self.before[2], self.before[0], self.before[1]]
+        self.assertNotEqual(self.before, after)
+        self.assertEqual(reference_state(self.before), reference_state(after))
+        self.assertEqual(self.before[0]['window'], 9, 'comparison must not sort the input in place')
+
+    def test_real_reference_changes_are_still_rejected(self):
+        for field, value in [('window', 15), ('index', 7),
+                             ('url', 'https://changed.invalid/'), ('title', 'Changed')]:
+            with self.subTest(field=field):
+                after = [dict(tab) for tab in self.before]
+                after[0][field] = value
+                self.assertNotEqual(reference_state(self.before), reference_state(after))
+        # Swapping actual tab indices is a tab move, unlike window stacking.
+        after = [dict(tab) for tab in self.before]
+        after[0]['index'], after[1]['index'] = 1, 0
+        self.assertNotEqual(reference_state(self.before), reference_state(after))
+
+    def test_added_missing_and_duplicate_references_are_not_hidden(self):
+        for after in [self.before[:-1], self.before + [self.before[0]],
+                      self.before + [dict(self.before[0], window=55)]]:
+            with self.subTest(tab_count=len(after)):
+                self.assertNotEqual(reference_state(self.before), reference_state(after))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/adapters/safari/verification.md
+++ b/adapters/safari/verification.md
@@ -1,0 +1,52 @@
+# Verification and open gaps
+
+This adapter is experimental. Deterministic checks, controlled Safari tests, and
+agent/model-quality evaluations are separate evidence tracks.
+
+## Deterministic checks
+
+The package contains 15 Python and 12 Node tests. Relevant regression cases include:
+
+- **D1, selection failures:** no selection, failed transport/local selection and
+  creation, zero subsequent fill/click/JS/navigation transport calls, and explicit
+  successful recovery. Distinct tab references and error variants are covered.
+- **D2, stale references:** closed windows, changed URLs, and duplicate identical
+  tabs are rejected in bridge mocks. Same-URL/title replacement is not covered.
+- **D3, execution-time URL changes:** the actual bridge executes in a Node VM;
+  cross-origin and same-origin URL changes after host validation reject before
+  caller-body execution or synthetic writes. A matching-target control runs once.
+- Serialization, unsupported CDP, permission/timeout failures, and window-order
+  comparison have tests. Actual tab moves, metadata changes, missing/added tabs,
+  and duplicates remain unequal even when window stacking order is ignored.
+
+These tests do not establish live Safari race protection. Executable upload/Promise
+rejection, invalid-response coverage, and artifact/preference checks remain incomplete.
+
+## Controlled Safari runs
+
+Fixture v3 passed three consecutive runs on Safari 26.6.2 and macOS 26.6.2 using
+Python 3.12.14. Each run verified:
+
+- Exactly one new window and unchanged pre-existing tab references.
+- Load and reuse through a separate CLI process in under 30 seconds.
+- The synthetic same-origin sessionStorage marker in the existing Safari tab.
+- Stale-index rejection and invalid-creation-URL rejection followed by explicit recovery.
+- Three exact textarea values containing Unicode, quotes, backslashes, newlines,
+  HTML-shaped and shell-shaped text; exactly one click and an exact read afterward.
+
+Load plus reuse took 0.803, 0.781, and 0.780 seconds; each run observed a click count
+of one. The [recorded evidence](https://github.com/tompulsarlabs/browser-harness/blob/78463db777b24174cbaf4b7f1e10a71c771200b8/adapters/safari/evals/results/live-runs.json)
+contains timestamps, commands, synthetic stdout links, and source hashes. Runtime,
+skill, fixture, and regression sources in this contribution match those hashes.
+These are prior observed runs against identical source, not new runs on this branch.
+
+An earlier fixture failed because Safari enumerated unchanged windows in a different
+order. Instrumentation reproduced identical references by window/index with zero
+changed URL/title fields or added/missing references. Fixture v3 fixes that comparison;
+the three passes are a fresh sequence after the correction.
+
+## Unverified behavior
+
+Same-URL/title document replacement, live adversarial tab races, native navigation
+races, file-fixture loading, and multi-profile semantics remain unresolved. No
+agent/model-quality evaluations or general production-safety pass are claimed.


### PR DESCRIPTION
Safari cannot use the current CDP path. This proposes an optional macOS `safari-harness` package under `adapters/safari` for reading and interacting with existing Safari tabs through Apple Events. It provides familiar helper names, an agent skill, a disposable live fixture, and deterministic CI. The existing CDP runtime, package metadata, and skill are unchanged.

Opening as a draft for feedback on the separate-adapter approach before deeper integration. The contribution contains the adapter, tests, and concise documentation; the fork's project bookkeeping is outside this diff.

### Validation

- 15 adapter Python tests and 12 Node bridge tests passed in this contribution checkout.
- All 268 upstream unit tests passed with the declared MCP extra installed.
- Three prior controlled runs on Safari 26.6.2 passed exact form entry, one click, separate CLI reuse, synthetic session-marker checks, and selection-failure recovery. The runtime, skill, fixture, and tests here are byte-identical to the verified source. [Recorded live evidence with source hashes](https://github.com/tompulsarlabs/browser-harness/blob/78463db777b24174cbaf4b7f1e10a71c771200b8/adapters/safari/evals/results/live-runs.json).

### Experimental limitations

Failed selection clears the previous target. Page JS also checks the exact URL before evaluating the requested expression, with executable Node regressions for redirects between validation and execution. That guard does **not** establish stable document identity: same-URL/title replacement, opaque origins sharing a URL, and native navigation races remain unresolved. Live adversarial race protection and agent/model-quality evaluations are unverified; consequential unattended writes remain outside the verified scope.

The adapter reports permission requirements, collects no recordings, and does not change Safari settings. Its README documents unsupported capabilities and opt-in live-test instructions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safari doesn't implement Chrome CDP, so this adds an optional `safari-harness` package under `adapters/safari` that controls existing Safari tabs through macOS Apple Events. The existing CDP runtime, package metadata, and skill are unchanged; this is a draft to gather feedback on the separate-adapter approach.

**Experimental limitations**
- A failed selection clears the previous target, so re-list and select before another page action.
- Page JS checks the exact URL before evaluating, but that does not establish stable document identity; same-URL/title replacement, opaque origins, and native navigation races remain unresolved.
- Live adversarial race protection and agent/model-quality evaluations are unverified, so consequential unattended writes stay outside the verified scope.
- The adapter reports permission requirements, collects no recordings, and does not change Safari settings.

**Validation**
- 15 Python and 12 Node tests pass without a browser.
- All 268 upstream tests pass with the declared MCP extra installed.
- Three controlled runs on Safari 26.6.2 passed exact form entry, one click, separate CLI reuse, session markers, and selection-failure recovery.

<sup>Written for commit 87b62ff2578db9e0340aa69f766727bd1c595fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

