### PR TITLE
fix(daemon): exit after a stretch with no request

### DIFF
--- a/src/browser_harness/daemon.py
+++ b/src/browser_harness/daemon.py
@@ -35,6 +35,10 @@ SOCK = ipc.sock_addr(NAME)
 LOG = str(ipc.log_path(NAME))
 PID = str(ipc.pid_path(NAME))
 BUF = 500
+# The daemon detaches from whoever spawned it, so nothing tells it to stop when that
+# agent goes away and they pile up. Exit after a stretch with no request instead:
+# ensure_daemon() spawns a fresh one on the next call, so the cost is a restart.
+IDLE_EXIT = float(os.environ.get("BU_IDLE_EXIT", 1800))  # seconds, 0 disables
 _MAC_PROFILES = (
     "Library/Application Support/Google/Chrome",
     "Library/Application Support/Google/Chrome Canary",
@@ -438,6 +442,7 @@ class Daemon:
         self.events = deque(maxlen=BUF)
         self.dialog = None
         self.stop = None  # asyncio.Event, set inside start()
+        self.last_seen = time.monotonic()
 
     async def attach_first_page(self, replaces_session=None, enable_domains=True):
         """Attach to a real page (or any page). Sets self.session. Returns attached target or None."""
@@ -810,6 +815,7 @@ class Daemon:
 
 async def serve(d):
     async def handler(reader, writer):
+        d.last_seen = time.monotonic()
         try:
             line = await reader.readline()
             if not line: return
@@ -826,15 +832,23 @@ async def serve(d):
         finally:
             writer.close()
 
+    async def idle_watch():
+        while time.monotonic() - d.last_seen < IDLE_EXIT:
+            await asyncio.sleep(min(60.0, IDLE_EXIT))
+        log(f"no request for {IDLE_EXIT:.0f}s, exiting")
+
     serve_task = asyncio.create_task(ipc.serve(NAME, handler))
     stop_task = asyncio.create_task(d.stop.wait())
+    tasks = [serve_task, stop_task]
+    if IDLE_EXIT > 0:
+        tasks.append(asyncio.create_task(idle_watch()))
     await asyncio.sleep(0.05)  # let serve() bind so sock_addr() resolves to the live endpoint
     log(f"listening on {ipc.sock_addr(NAME)} (name={NAME}, remote={REMOTE_ID or 'local'})")
     try:
-        await asyncio.wait({serve_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
+        await asyncio.wait(set(tasks), return_when=asyncio.FIRST_COMPLETED)
         if serve_task.done(): await serve_task  # surfaces a serve crash
     finally:
-        for t in (serve_task, stop_task):
+        for t in tasks:
             t.cancel()
             try: await t
             except (asyncio.CancelledError, Exception): pass

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 
 import pytest
 
@@ -845,3 +846,47 @@ def test_explicit_stale_session_is_not_redirected():
     assert d.cdp.calls == [
         ("Runtime.evaluate", {"expression": "1"}, "explicit-stale-session")
     ]
+
+
+def _isolated(monkeypatch, idle):
+    """Unique BU_NAME so serve() binds its own socket and never unlinks a live daemon's."""
+    monkeypatch.setattr(daemon, "NAME", f"test-idle-{os.getpid()}")
+    monkeypatch.setattr(daemon, "IDLE_EXIT", idle)
+    d = _fresh_daemon()
+    d.stop = asyncio.Event()
+    d.last_seen = time.monotonic()
+    return d
+
+
+def test_serve_exits_by_itself_when_no_request_arrives(monkeypatch):
+    """Regression: the daemon detaches from whoever spawned it, so nothing stops it
+    when that agent goes away. They accumulate -- 90 were found alive on one machine,
+    the oldest three days old. serve() must return on its own after IDLE_EXIT seconds
+    without a request; ensure_daemon() spawns a fresh one on the next call."""
+    d = _isolated(monkeypatch, 0.2)
+
+    async def scenario():
+        # Without the idle watchdog serve() waits forever and this times out.
+        await asyncio.wait_for(daemon.serve(d), timeout=5)
+
+    asyncio.run(scenario())
+
+
+def test_serve_stays_alive_while_requests_keep_arriving(monkeypatch):
+    """The other half: an over-eager timeout would kill daemons mid-task and churn
+    a restart into every session. Each connection refreshes last_seen, so a daemon
+    in use must never hit the deadline."""
+    d = _isolated(monkeypatch, 0.3)
+
+    async def scenario():
+        task = asyncio.create_task(daemon.serve(d))
+        for _ in range(9):          # 0.9 s of traffic against a 0.3 s deadline
+            await asyncio.sleep(0.1)
+            d.last_seen = time.monotonic()
+        alive = not task.done()
+        d.stop.set()
+        await asyncio.wait_for(task, timeout=5)
+        return alive
+
+    assert asyncio.run(scenario()), "le daemon s'est arrete alors qu'il etait sollicite"
+


### PR DESCRIPTION
## Problem

The daemon detaches from whoever spawns it (`start_new_session`), so nothing stops it when that agent goes away. `meta: shutdown` exists and the skill tells agents to send it, but they don't always. Since each `BU_NAME` gets its own instance, they accumulate silently.

On one machine I found **90 daemons alive**, every one of them orphaned (PPID 1), the oldest three days old, and only one still holding a live CDP connection. They were a real contributor to system load on a 16 GB laptop.

Asking callers to clean up is already the current design, and it is the part that fails. This makes the cleanup automatic instead.

## Fix

`serve()` runs an idle watchdog alongside the server. Every connection refreshes `last_seen`; after `BU_IDLE_EXIT` seconds without one (default 1800, `0` disables) the daemon stops itself.

An unnecessary exit costs only a reconnect:

- `ensure_daemon()` spawns a fresh daemon on the next call
- the work tab is persisted client-side in `~/.browser-harness-work-tab`, so the restarted daemon re-attaches to the same tab

## Tests

Two in `tests/unit/test_daemon.py`, both using a unique `BU_NAME` so they never unlink a live daemon's socket:

- `test_serve_exits_by_itself_when_no_request_arrives` — fails by timeout when the watchdog is removed (checked by mutation, not assumed)
- `test_serve_stays_alive_while_requests_keep_arriving` — guards the other direction, so an over-eager deadline cannot churn a restart into every session

Full unit suite: 100 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The daemon now exits after a stretch with no requests, so orphaned daemons no longer accumulate silently when their spawning agent goes away.

Adds an idle watchdog to `serve()`: every connection refreshes `last_seen`, and the daemon stops itself after `BU_IDLE_EXIT` seconds without one (default 1800, `0` disables). Since `ensure_daemon()` spawns a fresh daemon on the next call and the work tab persists client-side, an unnecessary exit costs only a reconnect.

**Bug Fixes**
- Cleans up daemons automatically when callers don't send `meta: shutdown`, which previously left up to dozens of orphaned instances running for days.
- Adds two tests: one that times out if the watchdog is removed, and one guarding that active traffic never triggers the deadline.

<sup>Written for commit 025516977dc33054888355165b9ded7ce326c91c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

