### PR TITLE
Bump plugin manifest version to 0.1.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-harness",
-  "version": "0.1.0",
+  "version": "0.1.13",
   "description": "Direct browser control via CDP. Drives the user's real Chrome (or a Browser Use cloud browser) with coordinate clicks, screenshots, and Python helpers — no selector hunting. Requires the one-time `browser-harness` CLI install (see the skill's references/install.md).",
   "author": {
     "name": "Browser Use",


### PR DESCRIPTION
The Claude plugin manifest (`.claude-plugin/plugin.json`) was still declaring `0.1.0` — the value it was added with — while the CLI package in `pyproject.toml` has advanced to `0.1.13`. This aligns the two.

One-line change; no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFR3MzrZPKhvX7TdQUX4fA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Claude plugin manifest version with the CLI package version so both report `0.1.13`. The manifest was still on `0.1.0`, the value it was added with. No behavior change.

<sup>Written for commit ecfdb8db40fc39d2bd13d08af9275e0ec3d044e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

