### PR TITLE
fix: auto-launch Chrome on a true cold start

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -646,12 +646,16 @@ def ensure_daemon(wait=None, name=None, env=None):
                     "permission-blocked: the pending Chrome connection ended before approval; "
                     "browser-harness did not retry or create another connection."
                 )
-            if not (launched_browser is None and _chrome_not_running(msg)):
+            if p is None or launched_browser is not None or not _chrome_not_running(msg):
                 continue
-            # A true cold start: the daemon's first liveness check found no
-            # browser at all and it exited before this loop could see the
-            # message from a live process. Respawning the same daemon would
+            # A true cold start: the daemon this call spawned found no browser
+            # on its first liveness check and exited before the loop could see
+            # the message from a live process. Respawning the same daemon would
             # just repeat that, so fall through to the launch-and-retry below.
+            # Only the spawner recovers: a caller that was merely waiting on
+            # another process's pending daemon (p is None) keeps looping and
+            # picks up whatever the spawner brings up, so concurrent waiters
+            # never launch a second browser or stop each other's successor.
         if local and msg.startswith("handshake-wait"):
             # Leave it running: this daemon's connection is what holds the popup
             # on screen. Killing it dropped the popup and the retry raised a new

--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -646,7 +646,12 @@ def ensure_daemon(wait=None, name=None, env=None):
                     "permission-blocked: the pending Chrome connection ended before approval; "
                     "browser-harness did not retry or create another connection."
                 )
-            continue
+            if not (launched_browser is None and _chrome_not_running(msg)):
+                continue
+            # A true cold start: the daemon's first liveness check found no
+            # browser at all and it exited before this loop could see the
+            # message from a live process. Respawning the same daemon would
+            # just repeat that, so fall through to the launch-and-retry below.
         if local and msg.startswith("handshake-wait"):
             # Leave it running: this daemon's connection is what holds the popup
             # on screen. Killing it dropped the popup and the retry raised a new

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1505,3 +1505,52 @@ def test_ensure_daemon_launches_chrome_when_daemon_dies_on_a_cold_start(monkeypa
     assert calls["launch"] == 1
     assert calls["restart"] == 1
     assert calls["spawned"] == 1
+
+
+def test_ensure_daemon_waiter_on_anothers_dead_daemon_does_not_launch_chrome(monkeypatch, tmp_path):
+    """Only the caller that spawned the dead daemon recovers by launching Chrome;
+    a concurrent waiter on someone else's pending daemon keeps looping so two
+    callers never launch two browsers."""
+    import contextlib
+    from browser_harness import daemon
+
+    calls = {"launch": 0, "restart": 0}
+
+    class Lock:
+        fd = 1
+
+    @contextlib.contextmanager
+    def spawn_lock(_name=None, timeout=None):
+        yield Lock()
+
+    def launch():
+        calls["launch"] += 1
+        return (FakeProcess(pid=999), None)
+
+    monkeypatch.setattr(admin, "daemon_alive", lambda _name=None: False)
+    monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda _env=None: True)
+    monkeypatch.setattr(admin, "_daemon_wait_windows", lambda _wait, _local: (5, None))
+    monkeypatch.setattr(admin, "_spawn_lock", spawn_lock)
+    monkeypatch.setattr(admin, "_parked_daemon_pid", lambda _name=None: None)
+    monkeypatch.setattr(admin, "_starting_daemon_pid", lambda _name=None: 555)
+    monkeypatch.setattr(admin, "_pending_pid_record", lambda _path: None)
+    monkeypatch.setattr(admin, "_pid_number", lambda _path: None)
+    monkeypatch.setattr(admin, "_cleanup_unattached_browser_launch", lambda _launch: None)
+    monkeypatch.setattr(
+        admin,
+        "_log_tail",
+        lambda _name: "chrome-not-running: no supported Chromium-family browser is running -- start Chrome, then retry",
+    )
+    monkeypatch.setattr(admin, "restart_daemon", lambda _name=None, **_kwargs: calls.__setitem__("restart", calls["restart"] + 1))
+    monkeypatch.setattr(admin, "_launch_browser", launch)
+    monkeypatch.setattr(admin.ipc, "log_path", lambda _name: tmp_path / "bu.log")
+    monkeypatch.setattr(admin.ipc, "pid_path", lambda _name: tmp_path / "bu.pid")
+    monkeypatch.setattr(admin.ipc, "spawn_kwargs", lambda: {})
+    monkeypatch.setattr(daemon, "supported_browser_running", lambda: True)
+    monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="didn't come up"):
+        admin.ensure_daemon(name="default")
+
+    assert calls["launch"] == 0
+    assert calls["restart"] == 0

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -1448,3 +1448,60 @@ def test_restart_daemon_does_not_cancel_successor_generation(tmp_path, monkeypat
         admin_mod.restart_daemon("pending")
 
     assert pid_file.exists()
+
+
+def test_ensure_daemon_launches_chrome_when_daemon_dies_on_a_cold_start(monkeypatch, tmp_path):
+    """True cold start (#786): the daemon exits on its first liveness check
+    with chrome-not-running. That must reach the launch-and-retry branch,
+    not just respawn the same daemon three times."""
+    import contextlib
+    from browser_harness import daemon
+
+    calls = {"launch": 0, "restart": 0, "spawned": 0}
+
+    def daemon_alive(_name=None):
+        return calls["launch"] > 0
+
+    class Lock:
+        fd = 1
+
+    @contextlib.contextmanager
+    def spawn_lock(_name=None, timeout=None):
+        yield Lock()
+
+    def popen(*_args, **_kwargs):
+        calls["spawned"] += 1
+        return FakeProcess(pid=123, returncode=1)
+
+    def launch():
+        calls["launch"] += 1
+        return (FakeProcess(pid=999), None)
+
+    monkeypatch.setattr(admin, "daemon_alive", daemon_alive)
+    monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda _env=None: True)
+    monkeypatch.setattr(admin, "_daemon_wait_windows", lambda _wait, _local: (5, None))
+    monkeypatch.setattr(admin, "_spawn_lock", spawn_lock)
+    monkeypatch.setattr(admin, "_parked_daemon_pid", lambda _name=None: None)
+    monkeypatch.setattr(admin, "_starting_daemon_pid", lambda _name=None: None)
+    monkeypatch.setattr(admin, "_publish_pid", lambda _path, _pid: None)
+    monkeypatch.setattr(admin, "_pid_number", lambda _path: None)
+    monkeypatch.setattr(admin, "_cleanup_unattached_browser_launch", lambda _launch: None)
+    monkeypatch.setattr(
+        admin,
+        "_log_tail",
+        lambda _name: "chrome-not-running: no supported Chromium-family browser is running -- start Chrome, then retry",
+    )
+    monkeypatch.setattr(admin, "restart_daemon", lambda _name=None, **_kwargs: calls.__setitem__("restart", calls["restart"] + 1))
+    monkeypatch.setattr(admin, "_launch_browser", launch)
+    monkeypatch.setattr(admin.ipc, "log_path", lambda _name: tmp_path / "bu.log")
+    monkeypatch.setattr(admin.ipc, "pid_path", lambda _name: tmp_path / "bu.pid")
+    monkeypatch.setattr(admin.ipc, "spawn_kwargs", lambda: {})
+    monkeypatch.setattr(subprocess, "Popen", popen)
+    monkeypatch.setattr(daemon, "supported_browser_running", lambda: True)
+    monkeypatch.setattr(admin.time, "sleep", lambda _seconds: None)
+
+    admin.ensure_daemon(name="default")
+
+    assert calls["launch"] == 1
+    assert calls["restart"] == 1
+    assert calls["spawned"] == 1


### PR DESCRIPTION
Fixes #786.

When no Chromium-family browser is running at all, the daemon subprocess raises `chrome-not-running` on its very first liveness check and exits. `ensure_daemon`'s wait loop then takes the `pending_died` branch, which only cleans up the pid record and `continue`s, i.e. respawns the same daemon. The launch-and-retry branch (`if local and launched_browser is None and _chrome_not_running(msg)`) is only reached while the daemon is still alive and logging, so on a true cold start it never ran: three identical failures, then `daemon default didn't come up`. The "Chrome running but CDP port not up yet" case still worked because there the daemon keeps looping.

## Change

In the `pending_died` branch, after the permission-blocked check: when the dead daemon's last log line is `chrome-not-running` and no browser has been launched yet, fall through to the existing launch-and-retry branch instead of `continue`. That branch already does `restart_daemon`, `_launch_browser`, waits for `supported_browser_running`, and retries. Everything else in the branch (pid cleanup, permission-blocked handling) is unchanged, and a second cold-start failure after a launch still ends in the usual error.

## Tests

`tests/unit/test_admin.py::test_ensure_daemon_launches_chrome_when_daemon_dies_on_a_cold_start` drives `ensure_daemon` with a `Popen` stand-in that exits immediately, a `chrome-not-running` log tail and a fake `_launch_browser`; it asserts the browser is launched once, the daemon is restarted once and only one daemon spawn was needed. It fails on `main` (the launch never happens) and passes with the change. Full file: 89 passed.

The `--doctor` false positive on `chrome_crashpad_handler` mentioned at the end of the issue is not addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-launching Chrome on a true cold start, so the daemon no longer fails with `daemon default didn't come up` when no Chromium-family browser is running at all.

Previously, the daemon exited on its first liveness check with `chrome-not-running`, and `ensure_daemon` just respawned the same daemon three times. Now, when the dead daemon's last log line is `chrome-not-running` and no browser has been launched yet, the wait loop falls through to the existing launch-and-retry branch instead of respawning. This launches the browser, restarts the daemon, and retries once; a second cold-start failure still ends in the usual error.

**Bug Fixes**
- Only the caller that spawned the dead daemon recovers; a concurrent waiter on another process's pending daemon keeps looping and never launches a second browser.
- Adds unit tests for both the cold-start recovery and the waiter side.
- The `--doctor` false positive on `chrome_crashpad_handler` mentioned in the issue is not addressed here.

<sup>Written for commit bfbaa3272a8f25f8d6892aeb74a803a051802d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

