### PR TITLE
README: name the Browser Use CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ stdio, so any MCP client (Claude Code, Devin, Cursor, etc.) can drive the
 browser without writing a second CDP layer. See [docs/MCP.md](docs/MCP.md) for
 setup and client configuration.
 
+## Browser Use CLI
+
+`browser-harness` is the browser layer. The [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) is the packaged way to install and run it:
+
+```bash
+uv tool install browser-use
+browser-use skill install
+```
+
+That is one command per agent, and it is the shortest path to giving a chat agent a browser. A Telegram bot, a Slack bot, a cron job, a support inbox: anything that already takes text in and runs a coding agent. [Browser Use Box](https://github.com/browser-use/bux) is that pattern end to end: a $5 VPS, one install script, and you text your agent from Telegram while it drives a real Chrome.
+
 ## Contributing
 
 Bug fixes, documentation improvements, and agent-generated domain skills are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
The harness README never mentioned the Browser Use CLI. Anyone landing on this repo had no idea the one-command install path exists.

Adds a short `## Browser Use CLI` section before Contributing:

- `uv tool install browser-use` + `browser-use skill install` (verbatim from https://docs.browser-use.com/open-source/browser-use-cli)
- frames it as the shortest way to give a chat agent a browser, and points at [bux](https://github.com/browser-use/bux) as that pattern end to end

+11 / -0, README only. Draft until Magnus approves the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oComYHNbeV4e21v22Bbdn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `## Browser Use CLI` section to the README so the one-command install path is visible to anyone landing on the repo. The section covers `uv tool install browser-use` and `browser-use skill install` and points to [BUX](https://github.com/browser-use/bux) as an end-to-end example.

<sup>Written for commit 7455d4efa0698190e0e10ac77d5bded43a0bf296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

