### PR TITLE
Stop losing the remote-debugging diagnostic on Linux

### DIFF
--- a/src/browser_harness/admin.py
+++ b/src/browser_harness/admin.py
@@ -646,7 +646,12 @@ def ensure_daemon(wait=None, name=None, env=None):
                     "permission-blocked: the pending Chrome connection ended before approval; "
                     "browser-harness did not retry or create another connection."
                 )
-            continue
+            # A daemon that died for a diagnosable reason -- Chrome closed, or
+            # remote debugging never enabled -- must reach the branches below.
+            # Retrying it three times and then reporting the generic "didn't
+            # come up" buries the one message that tells the user what to do.
+            if not (_chrome_not_running(msg) or _needs_chrome_remote_debugging_prompt(msg)):
+                continue
         if local and msg.startswith("handshake-wait"):
             # Leave it running: this daemon's connection is what holds the popup
             # on screen. Killing it dropped the popup and the retry raised a new
@@ -692,7 +697,13 @@ def ensure_daemon(wait=None, name=None, env=None):
                     "permission-blocked: Chrome did not approve the connection; browser-harness did not retry or create another connection."
                 )
             restart_daemon(name)
-            _open_chrome_inspect_once()
+            where = (
+                "opened chrome://inspect/#remote-debugging in Chrome"
+                if _open_chrome_inspect_once()
+                else "ask the user to open chrome://inspect/#remote-debugging in Chrome themselves "
+                "(type or paste it in the address bar -- Chrome refuses chrome:// URLs from the "
+                "command line, so browser-harness cannot open it for them)"
+            )
             if remote_debugging_toggle_profiles():
                 # Toggle already ticked from a previous run, but Chrome 144+
                 # wants new Allow for this browser run.
@@ -700,7 +711,7 @@ def ensure_daemon(wait=None, name=None, env=None):
             else:
                 todo = 'tick "Allow remote debugging for this browser instance" and click Allow on the popup'
             raise RuntimeError(
-                f"remote-debugging-setup: opened chrome://inspect/#remote-debugging in Chrome -- ask the user to {todo}. "
+                f"remote-debugging-setup: {where} -- then {todo}. "
                 "Warn them Chrome shows ONE more Allow popup when the harness connects on the next attempt (per-connection approval; it is expected, not a re-ask). "
                 "Retry after the user confirms; do not retry before."
             )
@@ -1362,7 +1373,7 @@ def _cleanup_unattached_browser_launch(launch):
 
 def _open_chrome_inspect():
     """Open chrome://inspect/#remote-debugging so the user can tick the checkbox."""
-    import platform, subprocess, webbrowser
+    import platform, subprocess
     url = "chrome://inspect/#remote-debugging"
     if platform.system() == "Darwin":
         try:
@@ -1375,10 +1386,13 @@ def _open_chrome_inspect():
                 return True
         except Exception:
             pass
-    try:
-        return bool(webbrowser.open(url, new=2))
-    except Exception:
-        return False
+    # Off macOS the only way to hand Chrome a URL is the command line
+    # (webbrowser.open shells out to `chrome <url>`), and Chrome silently
+    # rewrites *any* chrome:// argument to chrome://newtab. The user lands on
+    # the New Tab Page, never sees the toggle, and the caller is told the page
+    # was opened. Report the failure so the message can tell them to paste the
+    # URL into the address bar themselves.
+    return False
 
 
 INSPECT_REOPEN_TTL = 180.0  # seconds open new chrome://inspect tab
@@ -1389,16 +1403,17 @@ def _open_chrome_inspect_once():
     marker = paths.inspect_marker()
     try:
         if time.time() - marker.stat().st_mtime < INSPECT_REOPEN_TTL:
-            return
+            return True
     except OSError:
         pass
     if not _open_chrome_inspect():
-        return
+        return False
     try:
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.touch()
     except OSError:
         pass
+    return True
 
 
 def run_doctor():


### PR DESCRIPTION
Follow-up to browser-use/browser-use#5718 (@SoCkEt7, "cannot list tabs on Wayland").

**Wayland is not the cause.** Reproduced in Docker on Debian 12 with a real compositor (`weston --backend=headless`) and no GPU (`drmGetDevices2()` finds no devices). Chrome on `--ozone-platform=wayland` with failed Vulkan init stays alive, and `list_tabs()`, `page_info()`, `capture_screenshot()` and `ensure_real_tab()` all work. His paste has the Vulkan warnings but not `Failed to initialize Wayland platform` / `The platform failed to initialize. Exiting.`, so his Chrome was running fine.

What is real are two Linux bugs that turn "remote debugging was never enabled" into an unactionable error:

1. `admin.py` — the `pending_died` branch `continue`d before the `_chrome_not_running` and `_needs_chrome_remote_debugging_prompt` branches. The one message that says what to do was unreachable; you got 3 retries and `daemon <name> didn't come up -- check <log>`.
2. `_open_chrome_inspect()` — fell back to `webbrowser.open()` off macOS, which shells out to `chrome <url>`. Chrome rewrites **any** `chrome://` command-line argument to `chrome://newtab`, so the user stared at a New Tab Page while we reported the page as opened.

Before, on Linux:
```
daemon msg2 didn't come up -- check /root/.config/browser-harness/tmp/bu-msg2.log
```
After:
```
remote-debugging-setup: ask the user to open chrome://inspect/#remote-debugging in Chrome
themselves (type or paste it in the address bar -- Chrome refuses chrome:// URLs from the
command line, so browser-harness cannot open it for them) -- then tick "Allow remote
debugging for this browser instance" and click Allow on the popup.
```

macOS is unchanged: the osascript path still opens the page and still reports success.

+25 / -10, one file. 268 unit tests pass.

Draft: #5718 still needs Antonin to confirm what his launch script contained before his fix, since `browser-use list-tabs` is not a real subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oComYHNbeV4e21v22Bbdn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Linux bugs that turned “remote debugging was never enabled” into an unactionable error, so `browser-harness` now shows the user what to do instead of a generic “didn’t come up” message.

- The `pending_died` branch in `admin.py` skipped the diagnostic branches, so users got three silent retries and “daemon wasn’t up” instead of the instruction to allow remote debugging.
- `_open_chrome_inspect()` on Linux fell back to `webbrowser.open()`, which shells out to `chrome <url>`; Chrome rewrites any `chrome://` argument to `chrome://newtab`. It now fails honestly and the message asks the user to paste the URL into the address bar.

macOS behavior is unchanged: the osascript path still opens the page and reports success.

<sup>Written for commit ab6ff03cfd0600242ab9c116551b1a283b55f12d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

